### PR TITLE
Fix unified inbox column layout and long account label overlap

### DIFF
--- a/packages/renderer-main/routes/unified-inbox.tsx
+++ b/packages/renderer-main/routes/unified-inbox.tsx
@@ -54,7 +54,7 @@ const createColumns = ({ showSenderIcons }: { showSenderIcons: boolean }) => [
 
       return (
         <div
-          className="w-36 flex items-center gap-2"
+          className="flex items-center gap-2 max-w-36"
           title={[props.row.original.author, ...props.row.original.contributors]
             .map(({ name, email }) => `${name} <${email}>`)
             .join(", ")}

--- a/packages/renderer-main/routes/unified-inbox.tsx
+++ b/packages/renderer-main/routes/unified-inbox.tsx
@@ -187,7 +187,7 @@ function UnifiedInboxTable({
                 {row.getVisibleCells().map((cell) => (
                   <TableCell
                     key={cell.id}
-                    className={cn("px-3 py-3", cell.column.id === "subject" && "w-full")}
+                    className={cn("px-3 py-3", cell.column.id === "subject" && "w-full max-w-0")}
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>

--- a/packages/renderer-main/routes/unified-inbox.tsx
+++ b/packages/renderer-main/routes/unified-inbox.tsx
@@ -44,6 +44,7 @@ const columnHelper = createColumnHelper<UnifiedInboxMessage>();
 
 const createColumns = ({ showSenderIcons }: { showSenderIcons: boolean }) => [
   columnHelper.accessor("account.label", {
+    id: "account",
     cell: (props) => (
       <AccountBadge label={props.getValue()} color={props.row.original.account.color} />
     ),
@@ -187,7 +188,12 @@ function UnifiedInboxTable({
                 {row.getVisibleCells().map((cell) => (
                   <TableCell
                     key={cell.id}
-                    className={cn("px-3 py-3", cell.column.id === "subject" && "w-full max-w-0")}
+                    className={cn(
+                      "px-3 py-3",
+                      cell.column.id === "account" && "w-32",
+                      cell.column.id === "subject" && "w-full max-w-0",
+                      cell.column.id === "receivedAt" && "text-right",
+                    )}
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>

--- a/packages/renderer-main/routes/unified-inbox.tsx
+++ b/packages/renderer-main/routes/unified-inbox.tsx
@@ -18,7 +18,7 @@ import {
   ChevronsRightIcon,
   InboxIcon,
 } from "lucide-react";
-import { Fragment, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   type PaginationState,
   createColumnHelper,
@@ -37,15 +37,15 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from "@meru/ui/components/empty";
+import { Table, TableBody, TableCell, TableRow } from "@meru/ui/components/table";
+import { cn } from "@meru/ui/lib/utils";
 
 const columnHelper = createColumnHelper<UnifiedInboxMessage>();
 
 const createColumns = ({ showSenderIcons }: { showSenderIcons: boolean }) => [
   columnHelper.accessor("account.label", {
     cell: (props) => (
-      <div className="w-20">
-        <AccountBadge label={props.getValue()} color={props.row.original.account.color} />
-      </div>
+      <AccountBadge label={props.getValue()} color={props.row.original.account.color} />
     ),
   }),
   columnHelper.accessor("author.name", {
@@ -169,26 +169,33 @@ function UnifiedInboxTable({
 
   return (
     <>
-      <div className="text-sm border rounded-lg overflow-hidden">
-        {table.getRowModel().rows.map((row) => (
-          <div
-            key={row.id}
-            className="flex items-center gap-6 not-last:border-b p-3 whitespace-nowrap hover:bg-muted/50 transition-colors cursor-default"
-            onClick={() => {
-              ipc.main.send("settings.toggleIsOpen", false);
+      <div className="border rounded-lg overflow-hidden">
+        <Table>
+          <TableBody>
+            {table.getRowModel().rows.map((row) => (
+              <TableRow
+                key={row.id}
+                className="cursor-default"
+                onClick={() => {
+                  ipc.main.send("settings.toggleIsOpen", false);
 
-              ipc.main.send("accounts.selectAccount", row.original.account.id);
+                  ipc.main.send("accounts.selectAccount", row.original.account.id);
 
-              ipc.main.send("gmail.openMessage", row.original.id);
-            }}
-          >
-            {row.getVisibleCells().map((cell) => (
-              <Fragment key={cell.id}>
-                {flexRender(cell.column.columnDef.cell, cell.getContext())}
-              </Fragment>
+                  ipc.main.send("gmail.openMessage", row.original.id);
+                }}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell
+                    key={cell.id}
+                    className={cn("px-3 py-3", cell.column.id === "subject" && "w-full")}
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
             ))}
-          </div>
-        ))}
+          </TableBody>
+        </Table>
       </div>
       <div className="flex justify-between mt-4">
         <div className="flex gap-2 items-center">

--- a/packages/renderer-main/routes/unified-inbox.tsx
+++ b/packages/renderer-main/routes/unified-inbox.tsx
@@ -44,7 +44,6 @@ const columnHelper = createColumnHelper<UnifiedInboxMessage>();
 
 const createColumns = ({ showSenderIcons }: { showSenderIcons: boolean }) => [
   columnHelper.accessor("account.label", {
-    id: "account",
     cell: (props) => (
       <AccountBadge label={props.getValue()} color={props.row.original.account.color} />
     ),
@@ -190,7 +189,6 @@ function UnifiedInboxTable({
                     key={cell.id}
                     className={cn(
                       "px-3 py-3",
-                      cell.column.id === "account" && "w-32",
                       cell.column.id === "subject" && "w-full max-w-0",
                       cell.column.id === "receivedAt" && "text-right",
                     )}

--- a/packages/ui/components/account-badge.tsx
+++ b/packages/ui/components/account-badge.tsx
@@ -11,10 +11,8 @@ type AccountBadgeProps = {
 export function AccountBadge({ label, color }: AccountBadgeProps) {
   return (
     <Badge variant="secondary">
-      {color && (
-        <div className={cn("size-2 shrink-0 rounded-full", accountColorsMap[color].className)} />
-      )}
-      <span className="truncate">{label}</span>
+      {color && <div className={cn("size-2 rounded-full", accountColorsMap[color].className)} />}
+      {label}
     </Badge>
   );
 }

--- a/packages/ui/components/account-badge.tsx
+++ b/packages/ui/components/account-badge.tsx
@@ -11,8 +11,10 @@ type AccountBadgeProps = {
 export function AccountBadge({ label, color }: AccountBadgeProps) {
   return (
     <Badge variant="secondary">
-      {color && <div className={cn("size-2 rounded-full", accountColorsMap[color].className)} />}
-      {label}
+      {color && (
+        <div className={cn("size-2 shrink-0 rounded-full", accountColorsMap[color].className)} />
+      )}
+      <span className="truncate">{label}</span>
     </Badge>
   );
 }


### PR DESCRIPTION
Fixes #559

In the unified inbox, a long account label overflowed its fixed-width column and overlapped the adjacent content. The root cause was the custom flex layout with hardcoded column widths, which couldn't size or align columns to their content. This reworks the table to render with the semantic table components and lets the columns size themselves.

## Changes

- Render the rows with the `Table`, `TableBody`, `TableRow`, and `TableCell` components from `@meru/ui/components/table` instead of a custom flex layout. Row borders, last-row border removal, and hover come from those components.
- **Account column** now sizes to the account label width instead of a fixed `w-20`, so long labels no longer overlap the sender/subject area.
- **Sender column** sizes to the longest sender across the visible rows, capped at `max-w-36` and truncated with an ellipsis beyond that (previously a fixed `w-36`).
- **Subject column** absorbs the remaining width (`w-full`) and truncates the subject/summary with an ellipsis (`max-w-0` gives the cell a definite width so truncation engages).
- **Date column** is right-aligned.

https://claude.ai/code/session_019zFEjvUWt1zD3Tja2oryiX