### PR TITLE
Refactor openExternalUrl to use options object

### DIFF
--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -209,7 +209,10 @@ export class GoogleApp {
       return { action: "deny" };
     }
 
-    openExternalUrl(url, Boolean(matchedSupportedGoogleApp));
+    openExternalUrl(url, {
+      trustedLink: Boolean(matchedSupportedGoogleApp),
+      activate: disposition !== "background-tab",
+    });
 
     return { action: "deny" };
   }
@@ -468,7 +471,7 @@ export class GoogleApp {
   }
 
   openInBrowser() {
-    openExternalUrl(this.view.webContents.getURL(), true);
+    openExternalUrl(this.view.webContents.getURL(), { trustedLink: true });
   }
 
   get account() {

--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -211,7 +211,7 @@ export class GoogleApp {
 
     openExternalUrl(url, {
       skipTrustedHostCheck: Boolean(matchedSupportedGoogleApp),
-      activate: disposition !== "background-tab",
+      focusBrowser: disposition !== "background-tab",
     });
 
     return { action: "deny" };

--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -210,7 +210,7 @@ export class GoogleApp {
     }
 
     openExternalUrl(url, {
-      trustedLink: Boolean(matchedSupportedGoogleApp),
+      skipTrustedHostCheck: Boolean(matchedSupportedGoogleApp),
       activate: disposition !== "background-tab",
     });
 
@@ -471,7 +471,7 @@ export class GoogleApp {
   }
 
   openInBrowser() {
-    openExternalUrl(this.view.webContents.getURL(), { trustedLink: true });
+    openExternalUrl(this.view.webContents.getURL(), { skipTrustedHostCheck: true });
   }
 
   get account() {

--- a/packages/app/main.ts
+++ b/packages/app/main.ts
@@ -109,7 +109,7 @@ class Main {
     }
 
     this.window.webContents.setWindowOpenHandler(({ url }) => {
-      openExternalUrl(url, { trustedLink: true });
+      openExternalUrl(url, { skipTrustedHostCheck: true });
 
       return {
         action: "deny",

--- a/packages/app/main.ts
+++ b/packages/app/main.ts
@@ -109,7 +109,7 @@ class Main {
     }
 
     this.window.webContents.setWindowOpenHandler(({ url }) => {
-      openExternalUrl(url, true);
+      openExternalUrl(url, { trustedLink: true });
 
       return {
         action: "deny",

--- a/packages/app/trial.ts
+++ b/packages/app/trial.ts
@@ -72,7 +72,7 @@ class Trial {
       });
 
       if (response === 0) {
-        openExternalUrl("https://meru.so/#pricing", { trustedLink: true });
+        openExternalUrl("https://meru.so/#pricing", { skipTrustedHostCheck: true });
       }
 
       if (response === 2) {

--- a/packages/app/trial.ts
+++ b/packages/app/trial.ts
@@ -72,7 +72,7 @@ class Trial {
       });
 
       if (response === 0) {
-        openExternalUrl("https://meru.so/#pricing", true);
+        openExternalUrl("https://meru.so/#pricing", { trustedLink: true });
       }
 
       if (response === 2) {

--- a/packages/app/url.ts
+++ b/packages/app/url.ts
@@ -14,7 +14,7 @@ const MAX_EXTERNAL_URL_LENGTH = 256;
 
 export async function openExternalUrl(
   url: string,
-  options?: { skipTrustedHostCheck?: boolean; activate?: boolean },
+  options?: { skipTrustedHostCheck?: boolean; focusBrowser?: boolean },
 ) {
   const cleanUrl = getCleanUrl(url);
 
@@ -48,5 +48,5 @@ export async function openExternalUrl(
     }
   }
 
-  shell.openExternal(cleanUrl, { activate: options?.activate ?? true });
+  shell.openExternal(cleanUrl, { activate: options?.focusBrowser ?? true });
 }

--- a/packages/app/url.ts
+++ b/packages/app/url.ts
@@ -14,7 +14,7 @@ const MAX_EXTERNAL_URL_LENGTH = 256;
 
 export async function openExternalUrl(
   url: string,
-  options?: { trustedLink?: boolean; activate?: boolean },
+  options?: { skipTrustedHostCheck?: boolean; activate?: boolean },
 ) {
   const cleanUrl = getCleanUrl(url);
 
@@ -22,7 +22,7 @@ export async function openExternalUrl(
     const { origin } = new URL(cleanUrl);
     const trustedHosts = config.get("externalLinks.trustedHosts");
 
-    if (!options?.trustedLink && !trustedHosts.includes(origin)) {
+    if (!options?.skipTrustedHostCheck && !trustedHosts.includes(origin)) {
       const { response, checkboxChecked } = await dialog.showMessageBox({
         type: "info",
         buttons: ["Open Link", "Copy Link", "Cancel"],

--- a/packages/app/url.ts
+++ b/packages/app/url.ts
@@ -48,5 +48,5 @@ export async function openExternalUrl(
     }
   }
 
-  shell.openExternal(cleanUrl, { activate: options?.focusBrowser ?? true });
+  shell.openExternal(cleanUrl, { activate: options?.focusBrowser });
 }

--- a/packages/app/url.ts
+++ b/packages/app/url.ts
@@ -12,14 +12,17 @@ export function getCleanUrl(url: string): string {
 
 const MAX_EXTERNAL_URL_LENGTH = 256;
 
-export async function openExternalUrl(url: string, trustedLink?: boolean) {
+export async function openExternalUrl(
+  url: string,
+  options?: { trustedLink?: boolean; activate?: boolean },
+) {
   const cleanUrl = getCleanUrl(url);
 
   if (licenseKey.isValid && config.get("externalLinks.confirm")) {
     const { origin } = new URL(cleanUrl);
     const trustedHosts = config.get("externalLinks.trustedHosts");
 
-    if (!trustedLink && !trustedHosts.includes(origin)) {
+    if (!options?.trustedLink && !trustedHosts.includes(origin)) {
       const { response, checkboxChecked } = await dialog.showMessageBox({
         type: "info",
         buttons: ["Open Link", "Copy Link", "Cancel"],
@@ -45,5 +48,5 @@ export async function openExternalUrl(url: string, trustedLink?: boolean) {
     }
   }
 
-  shell.openExternal(cleanUrl);
+  shell.openExternal(cleanUrl, { activate: options?.activate ?? true });
 }


### PR DESCRIPTION
Replace the boolean `trustedLink` parameter in `openExternalUrl` with a structured options object, enabling better control over external link behavior and improving API clarity.

## Changes

- **Function signature**: Changed `openExternalUrl(url, trustedLink?)` to `openExternalUrl(url, options?)` where options is `{ skipTrustedHostCheck?: boolean; focusBrowser?: boolean }`
- **Trusted host check**: Renamed the boolean parameter to `skipTrustedHostCheck` for clarity about what the flag controls
- **Browser focus**: Added new `focusBrowser` option to control whether the opened browser window receives focus (passed to `shell.openExternal`)
- **Call sites updated**: Updated all callers in `google-app.ts`, `main.ts`, and `trial.ts` to use the new options object syntax
- **Smart focus behavior**: In `google-app.ts`, the `focusBrowser` option is set based on link disposition — background tabs don't steal focus, while foreground links do

## Implementation Details

The refactoring maintains backward compatibility in behavior while improving the API surface. The options object pattern allows for future extensibility without adding more parameters. The `focusBrowser` option is now intelligently set based on context (e.g., respecting the user's intent when they open a link in a background tab).

https://claude.ai/code/session_019BD7iFiGb4uS9SCzzbdiYV