### PR TITLE
Handle Gmail URL navigation in Google App

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -859,6 +859,16 @@ export class Gmail {
     this.view.webContents.executeJavaScript(`window.location.hash = "#search/${query}"`);
   }
 
+  navigateToHash(urlOrHash: string) {
+    const hash = urlOrHash.startsWith("https://") ? new URL(urlOrHash).hash : urlOrHash;
+
+    if (!hash) {
+      return;
+    }
+
+    this.view.webContents.executeJavaScript(`window.location.hash = ${JSON.stringify(hash)}`);
+  }
+
   openGoogleApp(app: GoogleAppsPinnedApp) {
     this.view.webContents.executeJavaScript(`window.open("${getGoogleAppUrl(app)}", "_blank")`);
   }

--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -1,4 +1,5 @@
 import { APP_TITLEBAR_HEIGHT, GOOGLE_ACCOUNTS_URL } from "@meru/shared/constants";
+import { GMAIL_URL } from "@meru/shared/gmail";
 import type { AccountConfig } from "@meru/shared/schemas";
 import { supportedGoogleApps, type SupportedGoogleApp } from "@meru/shared/types";
 import {
@@ -161,6 +162,18 @@ export class GoogleApp {
           return newWindow.webContents;
         },
       };
+    }
+
+    if (url.startsWith(GMAIL_URL) && disposition !== "background-tab") {
+      const account = accounts.getAccount(accountId);
+
+      account.instance.gmail.navigateToHash(url);
+
+      accounts.selectAccount(accountId);
+
+      main.show();
+
+      return { action: "deny" };
     }
 
     if (url.startsWith(`${GOOGLE_ACCOUNTS_URL}/AddSession`)) {


### PR DESCRIPTION
## Summary
Add support for navigating to Gmail hash URLs when they're opened from external sources (e.g., links in other Google apps). This allows the app to intercept Gmail URLs and navigate within the existing Gmail view instead of opening them in a new tab.

## Changes
- **GoogleApp**: Added URL interception for Gmail links that redirects navigation to the Gmail instance via the new `navigateToHash` method, then brings the app to focus
- **Gmail**: Added `navigateToHash` method to handle navigation to hash-based URLs (e.g., `#search/query`), extracting the hash from full URLs or using the hash directly if already provided

## Implementation Details
- The Gmail URL check in `GoogleApp` only applies when the link isn't explicitly opened as a background tab, preserving user intent
- The `navigateToHash` method safely handles both full URLs and hash strings, extracting the hash component and executing it via `window.location.hash`
- Returns `{ action: "deny" }` to prevent the default link-opening behavior after handling the navigation

https://claude.ai/code/session_01JjDehjbEVFz7Gw2AnWMk2T