### PR TITLE
Add option to hide Gmail upgrade button

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -68,6 +68,7 @@ export const config = new Store<Config>({
     "gmail.hideGmailLogo": true,
     "gmail.hideInboxFooter": true,
     "gmail.hideOutOfOfficeBanner": false,
+    "gmail.hideUpgradeButton": true,
     "gmail.reverseConversation": false,
     "gmail.savedSearches": [],
     "gmail.unreadCountPreference": "inbox",

--- a/packages/app/gmail/gmail.css
+++ b/packages/app/gmail/gmail.css
@@ -38,3 +38,8 @@ html.meru-reverse-conversation div[role="list"]:has(div[role="listitem"]) {
 html.meru-hide-out-of-office-banner #\:7 {
   display: none !important;
 }
+
+/* Gmail Upgrade Button */
+html.meru-hide-gmail-upgrade div[data-pep-id="global-pep-gmail"] {
+  display: none !important;
+}

--- a/packages/app/gmail/gmail.css
+++ b/packages/app/gmail/gmail.css
@@ -39,7 +39,6 @@ html.meru-hide-out-of-office-banner #\:7 {
   display: none !important;
 }
 
-/* Gmail Upgrade Button */
 html.meru-hide-gmail-upgrade div[data-pep-id="global-pep-gmail"] {
   display: none !important;
 }

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -314,6 +314,10 @@ export class Gmail {
         additionalArguments.push(GMAIL_PRELOAD_ARGUMENTS.hideOutOfOfficeBanner);
       }
 
+      if (config.get("gmail.hideUpgradeButton")) {
+        additionalArguments.push(GMAIL_PRELOAD_ARGUMENTS.hideUpgradeButton);
+      }
+
       if (config.get("gmail.moveAttachmentsToTop")) {
         additionalArguments.push(GMAIL_PRELOAD_ARGUMENTS.moveAttachmentsToTop);
       }

--- a/packages/preload-gmail/css.ts
+++ b/packages/preload-gmail/css.ts
@@ -16,4 +16,8 @@ export function initCss() {
   if (process.argv.includes(GMAIL_PRELOAD_ARGUMENTS.hideOutOfOfficeBanner)) {
     document.documentElement.classList.add("meru-hide-out-of-office-banner");
   }
+
+  if (process.argv.includes(GMAIL_PRELOAD_ARGUMENTS.hideUpgradeButton)) {
+    document.documentElement.classList.add("meru-hide-gmail-upgrade");
+  }
 }

--- a/packages/renderer-main/routes/settings/gmail.tsx
+++ b/packages/renderer-main/routes/settings/gmail.tsx
@@ -60,6 +60,13 @@ export function GmailSettings() {
               restartRequired
               licenseKeyRequired
             />
+            <ConfigSwitchField
+              label="Hide Upgrade Button"
+              description="Hides the Upgrade button in Gmail."
+              configKey="gmail.hideUpgradeButton"
+              restartRequired
+              licenseKeyRequired
+            />
           </FieldSet>
           <FieldSeparator />
           <FieldSet>

--- a/packages/shared/gmail.ts
+++ b/packages/shared/gmail.ts
@@ -18,6 +18,7 @@ export const GMAIL_PRELOAD_ARGUMENTS = {
   openComposeInNewWindow: "--meru-open-compose-in-new-window",
   showSenderIcons: "--meru-show-sender-icons",
   hideOutOfOfficeBanner: "--meru-hide-out-of-office-banner",
+  hideUpgradeButton: "--meru-hide-gmail-upgrade",
   moveAttachmentsToTop: "--meru-move-attachments-to-top",
   closeComposeWindowAfterSend: "--meru-close-compose-after-send",
   replyForwardInPopOut: "--meru-reply-forward-in-pop-out",

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -133,6 +133,7 @@ export type Config = {
   "gmail.hideGmailLogo": boolean;
   "gmail.hideInboxFooter": boolean;
   "gmail.hideOutOfOfficeBanner": boolean;
+  "gmail.hideUpgradeButton": boolean;
   "gmail.reverseConversation": boolean;
   "gmail.savedSearches": GmailSavedSearches;
   "gmail.unreadCountPreference": "first-section" | "inbox";


### PR DESCRIPTION
Adds a new configuration option to hide the Gmail upgrade button in the interface.

## Changes

- Added `gmail.hideUpgradeButton` config key (enabled by default) to `packages/app/config.ts`
- Added type definition for the new config key in `packages/shared/types.ts`
- Added preload argument constant `hideUpgradeButton` in `packages/shared/gmail.ts`
- Implemented CSS rule to hide the upgrade button element via `meru-hide-gmail-upgrade` class in `packages/app/gmail/gmail.css`
- Added preload logic to apply the CSS class when the config is enabled in `packages/preload-gmail/css.ts`
- Added config check and preload argument passing in `packages/app/gmail/index.ts`
- Added UI toggle in settings under Gmail settings in `packages/renderer-main/routes/settings/gmail.tsx`

## Implementation Details

The feature follows the existing pattern for Gmail UI hiding options (similar to `hideOutOfOfficeBanner`):
- Uses a CSS selector targeting `data-pep-id="global-pep-gmail"` to hide the upgrade button
- Enabled by default to provide a cleaner Gmail experience
- Requires license key and restart to take effect, consistent with other Gmail customization options

https://claude.ai/code/session_016sqpUkwEgTwME2PJoQMjAv