### PR TITLE
Add keyboard navigation to unified inbox table

### DIFF
--- a/packages/renderer-main/routes/unified-inbox.tsx
+++ b/packages/renderer-main/routes/unified-inbox.tsx
@@ -173,8 +173,6 @@ function UnifiedInboxTable({
 
   const rows = table.getRowModel().rows;
 
-  const containerRef = useRef<HTMLDivElement>(null);
-
   const focusedRowRef = useRef<HTMLTableRowElement>(null);
 
   const isGPrefixActiveRef = useRef(false);
@@ -189,7 +187,7 @@ function UnifiedInboxTable({
     ipc.main.send("gmail.openMessage", message.id);
   };
 
-  useHotkeys("j", (event) => {
+  useHotkeys(["j", "down"], (event) => {
     event.preventDefault();
 
     if (focusedIndex < rows.length - 1) {
@@ -201,7 +199,7 @@ function UnifiedInboxTable({
     }
   });
 
-  useHotkeys("k", (event) => {
+  useHotkeys(["k", "up"], (event) => {
     event.preventDefault();
 
     if (focusedIndex > 0) {
@@ -270,12 +268,10 @@ function UnifiedInboxTable({
   }, [rows.length]);
 
   useEffect(() => {
+    focusedRowRef.current?.focus({ preventScroll: true });
+
     focusedRowRef.current?.scrollIntoView({ block: "nearest" });
   }, [focusedIndex]);
-
-  useEffect(() => {
-    containerRef.current?.focus({ preventScroll: true });
-  }, []);
 
   useEffect(() => {
     return () => {
@@ -285,19 +281,16 @@ function UnifiedInboxTable({
 
   return (
     <>
-      <div
-        ref={containerRef}
-        tabIndex={-1}
-        className="border rounded-lg overflow-hidden outline-none"
-      >
+      <div className="border rounded-lg overflow-hidden">
         <Table>
           <TableBody>
             {rows.map((row, index) => (
               <TableRow
                 key={row.id}
                 ref={index === focusedIndex ? focusedRowRef : undefined}
+                tabIndex={index === focusedIndex ? -1 : undefined}
                 data-state={index === focusedIndex ? "selected" : undefined}
-                className="cursor-default"
+                className="cursor-default outline-none"
                 onClick={() => {
                   openMessage(row.original);
                 }}

--- a/packages/renderer-main/routes/unified-inbox.tsx
+++ b/packages/renderer-main/routes/unified-inbox.tsx
@@ -18,7 +18,9 @@ import {
   ChevronsRightIcon,
   InboxIcon,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+import { ms } from "@meru/shared/ms";
 import {
   type PaginationState,
   createColumnHelper,
@@ -151,6 +153,8 @@ function UnifiedInboxTable({
     pageSize: rowsPerPage,
   });
 
+  const [focusedIndex, setFocusedIndex] = useState(0);
+
   const columns = useMemo(() => createColumns({ showSenderIcons }), [showSenderIcons]);
 
   const table = useReactTable({
@@ -167,21 +171,125 @@ function UnifiedInboxTable({
 
   const configMutation = useConfigMutation();
 
+  const rows = table.getRowModel().rows;
+
+  const focusedRowRef = useRef<HTMLTableRowElement>(null);
+
+  const isGPrefixActiveRef = useRef(false);
+
+  const gPrefixTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const openMessage = (message: UnifiedInboxMessage) => {
+    ipc.main.send("settings.toggleIsOpen", false);
+
+    ipc.main.send("accounts.selectAccount", message.account.id);
+
+    ipc.main.send("gmail.openMessage", message.id);
+  };
+
+  useHotkeys("j", (event) => {
+    event.preventDefault();
+
+    if (focusedIndex < rows.length - 1) {
+      setFocusedIndex(focusedIndex + 1);
+    } else if (table.getCanNextPage()) {
+      table.nextPage();
+
+      setFocusedIndex(0);
+    }
+  });
+
+  useHotkeys("k", (event) => {
+    event.preventDefault();
+
+    if (focusedIndex > 0) {
+      setFocusedIndex(focusedIndex - 1);
+    } else if (table.getCanPreviousPage()) {
+      table.previousPage();
+
+      setFocusedIndex(table.getState().pagination.pageSize - 1);
+    }
+  });
+
+  useHotkeys(["enter", "o"], (event) => {
+    event.preventDefault();
+
+    const focusedMessage = rows[focusedIndex]?.original;
+
+    if (focusedMessage) {
+      openMessage(focusedMessage);
+    }
+  });
+
+  useHotkeys("g", () => {
+    isGPrefixActiveRef.current = true;
+
+    clearTimeout(gPrefixTimeoutRef.current);
+
+    gPrefixTimeoutRef.current = setTimeout(() => {
+      isGPrefixActiveRef.current = false;
+    }, ms("1s"));
+  });
+
+  useHotkeys("n", () => {
+    if (!isGPrefixActiveRef.current) {
+      return;
+    }
+
+    isGPrefixActiveRef.current = false;
+
+    clearTimeout(gPrefixTimeoutRef.current);
+
+    if (table.getCanNextPage()) {
+      table.nextPage();
+
+      setFocusedIndex(0);
+    }
+  });
+
+  useHotkeys("p", () => {
+    if (!isGPrefixActiveRef.current) {
+      return;
+    }
+
+    isGPrefixActiveRef.current = false;
+
+    clearTimeout(gPrefixTimeoutRef.current);
+
+    if (table.getCanPreviousPage()) {
+      table.previousPage();
+
+      setFocusedIndex(0);
+    }
+  });
+
+  useEffect(() => {
+    setFocusedIndex((current) => Math.min(current, Math.max(rows.length - 1, 0)));
+  }, [rows.length]);
+
+  useEffect(() => {
+    focusedRowRef.current?.scrollIntoView({ block: "nearest" });
+  }, [focusedIndex]);
+
+  useEffect(() => {
+    return () => {
+      clearTimeout(gPrefixTimeoutRef.current);
+    };
+  }, []);
+
   return (
     <>
       <div className="border rounded-lg overflow-hidden">
         <Table>
           <TableBody>
-            {table.getRowModel().rows.map((row) => (
+            {rows.map((row, index) => (
               <TableRow
                 key={row.id}
+                ref={index === focusedIndex ? focusedRowRef : undefined}
+                data-state={index === focusedIndex ? "selected" : undefined}
                 className="cursor-default"
                 onClick={() => {
-                  ipc.main.send("settings.toggleIsOpen", false);
-
-                  ipc.main.send("accounts.selectAccount", row.original.account.id);
-
-                  ipc.main.send("gmail.openMessage", row.original.id);
+                  openMessage(row.original);
                 }}
               >
                 {row.getVisibleCells().map((cell) => (

--- a/packages/renderer-main/routes/unified-inbox.tsx
+++ b/packages/renderer-main/routes/unified-inbox.tsx
@@ -173,6 +173,8 @@ function UnifiedInboxTable({
 
   const rows = table.getRowModel().rows;
 
+  const containerRef = useRef<HTMLDivElement>(null);
+
   const focusedRowRef = useRef<HTMLTableRowElement>(null);
 
   const isGPrefixActiveRef = useRef(false);
@@ -272,6 +274,10 @@ function UnifiedInboxTable({
   }, [focusedIndex]);
 
   useEffect(() => {
+    containerRef.current?.focus({ preventScroll: true });
+  }, []);
+
+  useEffect(() => {
     return () => {
       clearTimeout(gPrefixTimeoutRef.current);
     };
@@ -279,7 +285,11 @@ function UnifiedInboxTable({
 
   return (
     <>
-      <div className="border rounded-lg overflow-hidden">
+      <div
+        ref={containerRef}
+        tabIndex={-1}
+        className="border rounded-lg overflow-hidden outline-none"
+      >
         <Table>
           <TableBody>
             {rows.map((row, index) => (


### PR DESCRIPTION
Adds vim-style keyboard shortcuts to the unified inbox table for efficient navigation and message opening.

## Changes

- **Keyboard navigation**: Added `j`/`k` shortcuts to move down/up through messages, with automatic pagination when reaching table boundaries
- **Message opening**: Added `enter`/`o` shortcuts to open the focused message
- **Pagination shortcuts**: Added `g` prefix with `n`/`p` for next/previous page navigation (Gmail-style)
- **Visual feedback**: Focused row is highlighted with `data-state="selected"` and automatically scrolled into view
- **Focus management**: Container div receives focus to enable keyboard input, with cleanup on unmount

## Implementation Details

- Uses `react-hotkeys-hook` for keyboard event handling
- Maintains `focusedIndex` state to track the currently selected row
- Implements a 1-second timeout for the `g` prefix to allow `gn`/`gp` two-key sequences
- Automatically adjusts focused index when page size changes to prevent out-of-bounds selection
- Extracted message opening logic into a reusable `openMessage` function

https://claude.ai/code/session_01829yBW6gBUmamUdLJD8nDm