### PR TITLE
Sync window background color with theme changes

### DIFF
--- a/packages/app/lib/window.ts
+++ b/packages/app/lib/window.ts
@@ -42,11 +42,15 @@ export function getPreloadPath(name: string) {
   return path.join(__dirname, `preload-${name}.js`);
 }
 
+export function getBackgroundColor() {
+  return nativeTheme.shouldUseDarkColors ? "#0a0a0a" : "#ffffff";
+}
+
 export function getTitleBarOptions() {
   const titleBarOverlay =
     !platform.isLinux || isLinuxWindowControlsEnabled()
       ? {
-          color: nativeTheme.shouldUseDarkColors ? "#0a0a0a" : "#ffffff",
+          color: getBackgroundColor(),
           symbolColor: nativeTheme.shouldUseDarkColors ? "#fafafa" : "#0a0a0a",
           height: APP_TITLEBAR_HEIGHT - 1,
         }
@@ -61,6 +65,7 @@ export function getTitleBarOptions() {
 export function getCommonBrowserWindowOptions() {
   return {
     ...getTitleBarOptions(),
+    backgroundColor: getBackgroundColor(),
     darkTheme: nativeTheme.shouldUseDarkColors,
     webPreferences: {
       preload: getPreloadPath("renderer"),

--- a/packages/app/lib/window.ts
+++ b/packages/app/lib/window.ts
@@ -83,6 +83,18 @@ export function createBrowserWindow(options: BrowserWindowConstructorOptions) {
     browserWindow.show();
   });
 
+  if (options.backgroundColor) {
+    const updateBackgroundColor = () => {
+      browserWindow.setBackgroundColor(getBackgroundColor());
+    };
+
+    nativeTheme.on("updated", updateBackgroundColor);
+
+    browserWindow.on("closed", () => {
+      nativeTheme.off("updated", updateBackgroundColor);
+    });
+  }
+
   return browserWindow;
 }
 

--- a/packages/app/lib/window.ts
+++ b/packages/app/lib/window.ts
@@ -90,7 +90,7 @@ export function createBrowserWindow(options: BrowserWindowConstructorOptions) {
 
     nativeTheme.on("updated", updateBackgroundColor);
 
-    browserWindow.on("closed", () => {
+    browserWindow.once("closed", () => {
       nativeTheme.off("updated", updateBackgroundColor);
     });
   }

--- a/packages/app/theme.ts
+++ b/packages/app/theme.ts
@@ -1,6 +1,7 @@
 import { nativeTheme } from "electron";
 import { config } from "@/config";
 import { ipc } from "@/ipc";
+import { getBackgroundColor } from "@/lib/window";
 import { main } from "@/main";
 import { appTray } from "@/tray";
 
@@ -14,6 +15,8 @@ class Theme {
         "theme.darkModeChanged",
         nativeTheme.shouldUseDarkColors,
       );
+
+      main.window.setBackgroundColor(getBackgroundColor());
 
       main.updateTitlebarOverlay();
 

--- a/packages/app/theme.ts
+++ b/packages/app/theme.ts
@@ -1,7 +1,6 @@
 import { nativeTheme } from "electron";
 import { config } from "@/config";
 import { ipc } from "@/ipc";
-import { getBackgroundColor } from "@/lib/window";
 import { main } from "@/main";
 import { appTray } from "@/tray";
 
@@ -15,8 +14,6 @@ class Theme {
         "theme.darkModeChanged",
         nativeTheme.shouldUseDarkColors,
       );
-
-      main.window.setBackgroundColor(getBackgroundColor());
 
       main.updateTitlebarOverlay();
 


### PR DESCRIPTION
Extracts the background color logic into a reusable function and ensures the browser window background color updates when the system theme changes.

**Changes:**
- Extract `getBackgroundColor()` function to centralize theme-aware color selection (`#0a0a0a` for dark, `#ffffff` for light)
- Use `getBackgroundColor()` in title bar options instead of inline color logic
- Add `backgroundColor` to common browser window options
- Listen to `nativeTheme.on("updated")` events and update the window background color when the theme changes, cleaning up the listener when the window closes

This ensures the window background stays in sync with the system theme without requiring a restart.

https://claude.ai/code/session_01EWXvNLHnSRQ61G6BQvTNNX