### PR TITLE
fix arrayMove using wrong splice index

### DIFF
--- a/packages/shared/utils.ts
+++ b/packages/shared/utils.ts
@@ -10,7 +10,7 @@ export function arrayMove<ValueType>(
   if (startIndex >= 0 && startIndex < array.length) {
     const endIndex = toIndex < 0 ? array.length + toIndex : toIndex;
 
-    const [item] = newArray.splice(fromIndex, 1);
+    const [item] = newArray.splice(startIndex, 1);
 
     if (item) {
       newArray.splice(endIndex, 0, item);


### PR DESCRIPTION
## Problem

`arrayMove` in `packages/shared/utils.ts` computes `startIndex` (the negative-index–normalized position) for its bounds guard, but then calls `splice(fromIndex, 1)` with the raw `fromIndex` instead of `startIndex`.

Today this produces correct results only by coincidence — `Array.prototype.splice` happens to normalize negative indices the same way, and every current caller (`google-apps.tsx`, `saved-searches.tsx`) passes non-negative indices. It is a latent bug: the computed `startIndex` is silently ignored, so any future negative-index caller or refactor would break.

## Fix

Use the already-computed `startIndex` in the `splice` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAsuPAE62AyM7ms5aUk6nM)_