### PR TITLE
fix stale state in unified inbox keyboard navigation

### DIFF
--- a/packages/renderer-main/routes/unified-inbox.tsx
+++ b/packages/renderer-main/routes/unified-inbox.tsx
@@ -187,39 +187,51 @@ function UnifiedInboxTable({
     ipc.main.send("gmail.openMessage", message.id);
   };
 
-  useHotkeys(["j", "down"], (event) => {
-    event.preventDefault();
+  useHotkeys(
+    ["j", "down"],
+    (event) => {
+      event.preventDefault();
 
-    if (focusedIndex < rows.length - 1) {
-      setFocusedIndex(focusedIndex + 1);
-    } else if (table.getCanNextPage()) {
-      table.nextPage();
+      if (focusedIndex < rows.length - 1) {
+        setFocusedIndex(focusedIndex + 1);
+      } else if (table.getCanNextPage()) {
+        table.nextPage();
 
-      setFocusedIndex(0);
-    }
-  });
+        setFocusedIndex(0);
+      }
+    },
+    [focusedIndex, rows],
+  );
 
-  useHotkeys(["k", "up"], (event) => {
-    event.preventDefault();
+  useHotkeys(
+    ["k", "up"],
+    (event) => {
+      event.preventDefault();
 
-    if (focusedIndex > 0) {
-      setFocusedIndex(focusedIndex - 1);
-    } else if (table.getCanPreviousPage()) {
-      table.previousPage();
+      if (focusedIndex > 0) {
+        setFocusedIndex(focusedIndex - 1);
+      } else if (table.getCanPreviousPage()) {
+        table.previousPage();
 
-      setFocusedIndex(table.getState().pagination.pageSize - 1);
-    }
-  });
+        setFocusedIndex(table.getState().pagination.pageSize - 1);
+      }
+    },
+    [focusedIndex],
+  );
 
-  useHotkeys(["enter", "o"], (event) => {
-    event.preventDefault();
+  useHotkeys(
+    ["enter", "o"],
+    (event) => {
+      event.preventDefault();
 
-    const focusedMessage = rows[focusedIndex]?.original;
+      const focusedMessage = rows[focusedIndex]?.original;
 
-    if (focusedMessage) {
-      openMessage(focusedMessage);
-    }
-  });
+      if (focusedMessage) {
+        openMessage(focusedMessage);
+      }
+    },
+    [focusedIndex, rows],
+  );
 
   useHotkeys("g", () => {
     isGPrefixActiveRef.current = true;


### PR DESCRIPTION
## Problem

`react-hotkeys-hook` memoizes the hotkey callback with a dependency array that **defaults to `[]`**, so a callback referencing React state captures its first-render value unless the relevant state is listed in the deps array.

In `UnifiedInboxTable` the `j`/`down`, `k`/`up`, and `enter`/`o` handlers read `focusedIndex` and `rows` with **no deps array**:

- `j`/`k` read a stale `focusedIndex`, so `setFocusedIndex(focusedIndex + 1)` can never advance past the first step.
- `enter`/`o` read a stale `rows[focusedIndex]` — if `messages` load after mount, `rows` stays the initial (empty) array forever and Enter opens nothing.

(The `g`/`n`/`p` handlers are unaffected — they only touch refs and the stable `table` instance.)

## Fix

Pass dependency arrays to the three affected handlers (`[focusedIndex, rows]` / `[focusedIndex]`).

## Verifying

Open the Unified Inbox, press `j`/`k` repeatedly and confirm focus advances past row 1; press Enter on a focused row and confirm it opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAsuPAE62AyM7ms5aUk6nM)_