### PR TITLE
clamp gmail view zoom to min and max

### DIFF
--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -34,8 +34,8 @@ import { licenseKey } from "./license-key";
 import { main } from "./main";
 import { openExternalUrl } from "./url";
 
-const MIN_ZOOM_FACTOR = 0.1;
-const MAX_ZOOM_FACTOR = 3;
+export const MIN_ZOOM_FACTOR = 0.1;
+export const MAX_ZOOM_FACTOR = 3;
 
 const GOOGLE_CHAT_ATTACHMENT_URL_REGEXP = /chat\.google\.com\/u\/\d\/api\/get_attachment_url/;
 

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { is, platform } from "@electron-toolkit/utils";
 import { GITHUB_REPO_URL, WEBSITE_URL } from "@meru/shared/constants";
+import { clamp } from "@meru/shared/utils";
 import {
   app,
   BrowserWindow,
@@ -14,7 +15,7 @@ import {
 import { accounts } from "@/accounts";
 import { config } from "@/config";
 import { showRestartDialog } from "@/dialogs";
-import { GoogleApp } from "@/google-app";
+import { GoogleApp, MAX_ZOOM_FACTOR, MIN_ZOOM_FACTOR } from "@/google-app";
 import { ipc } from "@/ipc";
 import { log } from "@/lib/log";
 import { main } from "@/main";
@@ -120,7 +121,11 @@ export class AppMenu {
         return;
       }
 
-      const zoomFactor = config.get("gmail.zoomFactor") + 0.1;
+      const zoomFactor = clamp(
+        config.get("gmail.zoomFactor") + 0.1,
+        MIN_ZOOM_FACTOR,
+        MAX_ZOOM_FACTOR,
+      );
 
       for (const [_accountId, instance] of accounts.instances) {
         instance.gmail.view.webContents.setZoomFactor(zoomFactor);
@@ -136,15 +141,17 @@ export class AppMenu {
         return;
       }
 
-      const zoomFactor = config.get("gmail.zoomFactor") - 0.1;
+      const zoomFactor = clamp(
+        config.get("gmail.zoomFactor") - 0.1,
+        MIN_ZOOM_FACTOR,
+        MAX_ZOOM_FACTOR,
+      );
 
-      if (zoomFactor > 0) {
-        for (const [_accountId, instance] of accounts.instances) {
-          instance.gmail.view.webContents.setZoomFactor(zoomFactor);
-        }
-
-        config.set("gmail.zoomFactor", zoomFactor);
+      for (const [_accountId, instance] of accounts.instances) {
+        instance.gmail.view.webContents.setZoomFactor(zoomFactor);
       }
+
+      config.set("gmail.zoomFactor", zoomFactor);
     };
 
     const selectedAccount = accounts.getSelectedAccount();


### PR DESCRIPTION
## Problem

`GoogleApp.setZoomFactor` clamps the zoom factor to `MIN_ZOOM_FACTOR` (0.1)–`MAX_ZOOM_FACTOR` (3) via `clamp()`, but the application menu's Gmail-view zoom does not apply the same bounds:

- `zoomIn` has **no upper bound** — repeated zoom-in can exceed 3×.
- `zoomOut` only guards `zoomFactor > 0` instead of the 0.1 minimum.

## Fix

Export `MIN_ZOOM_FACTOR` / `MAX_ZOOM_FACTOR` from `google-app.ts` and reuse the shared `clamp()` helper in `menu.ts`, mirroring `GoogleApp.setZoomFactor`.

## Verifying

Zoom in/out (Cmd/Ctrl +/-) past the limits and confirm the Gmail view stops at 0.1× and 3×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAsuPAE62AyM7ms5aUk6nM)_