### PR TITLE
fix menu popup state tracking after menu recreation

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -48,14 +48,6 @@ export class AppMenu {
 
     this._subscribeToSelectedAccount();
 
-    this.menu.on("menu-will-show", () => {
-      this._isPopupOpen = true;
-    });
-
-    this.menu.on("menu-will-close", () => {
-      this._isPopupOpen = false;
-    });
-
     Menu.setApplicationMenu(this.menu);
 
     config.onDidChange("accounts", () => {
@@ -77,6 +69,8 @@ export class AppMenu {
     for (const unsubscribe of this._selectedAccountUnsubscribeFns) {
       unsubscribe();
     }
+
+    this._selectedAccountUnsubscribeFns.clear();
 
     const selectedAccount = accounts.getSelectedAccount();
 
@@ -718,7 +712,17 @@ export class AppMenu {
       },
     ];
 
-    return Menu.buildFromTemplate(template);
+    const menu = Menu.buildFromTemplate(template);
+
+    menu.on("menu-will-show", () => {
+      this._isPopupOpen = true;
+    });
+
+    menu.on("menu-will-close", () => {
+      this._isPopupOpen = false;
+    });
+
+    return menu;
   }
 
   togglePopup() {


### PR DESCRIPTION
## Problem

The `menu-will-show` / `menu-will-close` listeners that maintain `_isPopupOpen` were attached only to the **initial** menu inside `init()`. Every menu recreation — `config.onDidChange("accounts")`, `app.on("browser-window-focus")` (which fires early and often), and the `messageId` subscription — assigns a fresh `Menu` to `this._menu` **without re-attaching** those listeners.

After the first focus event, `_isPopupOpen` is frozen at `false`, so `togglePopup()` can open the popup but never closes it.

Separately, `_subscribeToSelectedAccount()` iterated the unsubscribe set and called each function but never cleared it, so the set accumulated stale (already-called) unsubscribe functions on every accounts/messageId change.

## Fix

- Attach the `menu-will-show` / `menu-will-close` listeners inside `createMenu()` so every menu instance gets them.
- Clear `_selectedAccountUnsubscribeFns` after running the unsubscribe loop.

## Verifying

Trigger the menu popup shortcut twice and confirm the second press closes the popup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAsuPAE62AyM7ms5aUk6nM)_