### PR TITLE
use ms helper for url preview timeout

### DIFF
--- a/packages/preload-gmail/url-preview.ts
+++ b/packages/preload-gmail/url-preview.ts
@@ -1,4 +1,5 @@
 import { GMAIL_URL } from "@meru/shared/gmail";
+import { ms } from "@meru/shared/ms";
 
 let urlPreviewElement: HTMLElement | null = null;
 
@@ -54,7 +55,7 @@ function createUrlPreviewElement(href: string) {
     if (urlPreviewElement) {
       urlPreviewElement.setAttribute("data-long-hover", "true");
     }
-  }, 1500);
+  }, ms("1.5s"));
 }
 
 function lookupHref(target: HTMLElement) {


### PR DESCRIPTION
## Problem

The URL-preview long-hover timeout used a hard-coded `1500` magic number instead of the shared `ms` helper, which the project conventions (CLAUDE.md) require for duration values.

## Fix

Use `ms("1.5s")` from `@meru/shared/ms`. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAsuPAE62AyM7ms5aUk6nM)_