### PR TITLE
extract notification listener helper

### DIFF
--- a/packages/app/notifications.ts
+++ b/packages/app/notifications.ts
@@ -5,6 +5,21 @@ import { licenseKey } from "./license-key";
 import { checkWithinNotificationTimes } from "./lib/notifications";
 import { main } from "./main";
 
+function attachNotificationListeners(
+  notification: Notification,
+  { click, action }: { click?: () => void; action?: (index: number) => void },
+) {
+  if (click) {
+    notification.once("click", click);
+  }
+
+  if (action) {
+    notification.once("action", (_event, index) => {
+      action(index);
+    });
+  }
+}
+
 export function isWithinNotificationTimes() {
   if (!licenseKey.isValid) {
     return true;
@@ -33,15 +48,7 @@ export function createNewEmailNotification({
     ...options,
   });
 
-  if (click) {
-    notification.once("click", click);
-  }
-
-  if (action) {
-    notification.once("action", (_event, index) => {
-      action(index);
-    });
-  }
+  attachNotificationListeners(notification, { click, action });
 
   if (sound !== "system" && playSound) {
     notification.once("show", () => {
@@ -71,15 +78,7 @@ export function createNotification({
 
   const notification = new Notification(options);
 
-  if (click) {
-    notification.once("click", click);
-  }
-
-  if (action) {
-    notification.once("action", (_event, index) => {
-      action(index);
-    });
-  }
+  attachNotificationListeners(notification, { click, action });
 
   notification.show();
 


### PR DESCRIPTION
## What

`createNewEmailNotification` and `createNotification` in `packages/app/notifications.ts` contained the identical `click`/`action` listener-attach block. Extracted it into a file-local `attachNotificationListeners` helper used by both.

Pure refactor — no behavior change.

## Verification

- `bun types:ci` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLR2En52FSuFbvTub3qKGH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLR2En52FSuFbvTub3qKGH)_