### PR TITLE
extract selected account view refresh into method

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -72,24 +72,22 @@ class Accounts {
 
     // When window is closed/minimized, the account views sometimes don't render after showing/restoring window
     main.window.on("show", () => {
-      const selectedAccount = this.getSelectedAccount();
-
-      main.window.contentView.removeChildView(selectedAccount.instance.gmail.view);
-      main.window.contentView.addChildView(selectedAccount.instance.gmail.view);
-
-      selectedAccount.instance.gmail.updateViewBounds();
-      selectedAccount.instance.gmail.view.webContents.focus();
+      this.refreshSelectedAccountView();
     });
 
     main.window.on("restore", () => {
-      const selectedAccount = this.getSelectedAccount();
-
-      main.window.contentView.removeChildView(selectedAccount.instance.gmail.view);
-      main.window.contentView.addChildView(selectedAccount.instance.gmail.view);
-
-      selectedAccount.instance.gmail.updateViewBounds();
-      selectedAccount.instance.gmail.view.webContents.focus();
+      this.refreshSelectedAccountView();
     });
+  }
+
+  refreshSelectedAccountView() {
+    const selectedAccount = this.getSelectedAccount();
+
+    main.window.contentView.removeChildView(selectedAccount.instance.gmail.view);
+    main.window.contentView.addChildView(selectedAccount.instance.gmail.view);
+
+    selectedAccount.instance.gmail.updateViewBounds();
+    selectedAccount.instance.gmail.view.webContents.focus();
   }
 
   getAccountConfigs() {


### PR DESCRIPTION
## What

The `main.window.on("show", ...)` and `main.window.on("restore", ...)` handlers in `packages/app/accounts.ts` were byte-identical. Extracted the shared logic into a `refreshSelectedAccountView()` method and call it from both listeners.

Pure refactor — no behavior change.

## Verification

- `bun types:ci` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLR2En52FSuFbvTub3qKGH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLR2En52FSuFbvTub3qKGH)_