### PR TITLE
extract shift-click re-emit helper

### DIFF
--- a/packages/preload-gmail/compose.ts
+++ b/packages/preload-gmail/compose.ts
@@ -3,6 +3,7 @@ import { $ } from "select-dom";
 import {
   createNotMatchingAttributeSelector,
   createElementAttributeFromPreloadArgument,
+  reEmitClickWithShiftKey,
 } from "./lib/utils";
 
 const isOpenComposeInNewWindowEnabled = process.argv.includes(
@@ -31,26 +32,5 @@ export async function openComposeInNewWindow() {
 
   composeButtonElement.setAttribute(composeButtonProcessedAttribute, "");
 
-  let isClicked = false;
-
-  composeButtonElement.addEventListener("click", (event) => {
-    if (isClicked) {
-      isClicked = false;
-
-      return;
-    }
-
-    isClicked = true;
-
-    event.stopPropagation();
-
-    const clickEvent = new MouseEvent("click", {
-      bubbles: true,
-      cancelable: true,
-      view: window,
-      shiftKey: true,
-    });
-
-    composeButtonElement.dispatchEvent(clickEvent);
-  });
+  reEmitClickWithShiftKey(composeButtonElement);
 }

--- a/packages/preload-gmail/lib/utils.ts
+++ b/packages/preload-gmail/lib/utils.ts
@@ -5,3 +5,28 @@ export function createElementAttributeFromPreloadArgument(preloadArgument: strin
 export function createNotMatchingAttributeSelector(selector: string, attribute: string) {
   return `${selector}:not([${attribute}])`;
 }
+
+export function reEmitClickWithShiftKey(element: Element) {
+  let isClicked = false;
+
+  element.addEventListener("click", (event) => {
+    if (isClicked) {
+      isClicked = false;
+
+      return;
+    }
+
+    isClicked = true;
+
+    event.stopPropagation();
+
+    element.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        shiftKey: true,
+      }),
+    );
+  });
+}

--- a/packages/preload-gmail/reply-forward.ts
+++ b/packages/preload-gmail/reply-forward.ts
@@ -2,6 +2,7 @@ import { GMAIL_PRELOAD_ARGUMENTS } from "@meru/shared/gmail";
 import {
   createElementAttributeFromPreloadArgument,
   createNotMatchingAttributeSelector,
+  reEmitClickWithShiftKey,
 } from "./lib/utils";
 import { $, $$ } from "select-dom";
 
@@ -42,27 +43,6 @@ export function replyForwardInPopOut() {
   }
 
   for (const replyForwardButton of replyForwardButtons) {
-    let isClicked = false;
-
-    replyForwardButton.addEventListener("click", (event) => {
-      if (isClicked) {
-        isClicked = false;
-
-        return;
-      }
-
-      isClicked = true;
-
-      event.stopPropagation();
-
-      const clickEvent = new MouseEvent("click", {
-        bubbles: true,
-        cancelable: true,
-        view: window,
-        shiftKey: true,
-      });
-
-      replyForwardButton.dispatchEvent(clickEvent);
-    });
+    reEmitClickWithShiftKey(replyForwardButton);
   }
 }


### PR DESCRIPTION
## What

`compose.ts` and `reply-forward.ts` in `packages/preload-gmail` each contained the same ~20-line block that intercepts the first click on a button, re-dispatches it with `shiftKey: true`, and ignores the re-dispatched event. Extracted it into a `reEmitClickWithShiftKey(element)` helper in `lib/utils.ts` (alongside the other preload DOM helpers) and use it in both places.

Pure refactor — no behavior change.

## Verification

- `bun types:ci` passes.
- Behavior to spot-check: "open compose in new window" and "reply/forward in pop-out" still trigger the shift-click flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLR2En52FSuFbvTub3qKGH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLR2En52FSuFbvTub3qKGH)_