### PR TITLE
extract useCopied hook

### DIFF
--- a/packages/renderer-google-app/index.tsx
+++ b/packages/renderer-google-app/index.tsx
@@ -1,5 +1,5 @@
 import { ipc } from "@meru/shared/renderer/ipc";
-import { ms } from "@meru/shared/ms";
+import { useCopied } from "@meru/shared/renderer/hooks";
 import { renderApp } from "@meru/shared/renderer/react";
 import { AccountBadge } from "@meru/ui/components/account-badge";
 import { FindInPage } from "@meru/ui/components/find-in-page";
@@ -84,24 +84,14 @@ function ReloadButton() {
 }
 
 function CopyUrlButton() {
-  const [copied, setCopied] = useState(false);
-
-  useEffect(() => {
-    if (!copied) {
-      return;
-    }
-
-    const timeout = setTimeout(() => setCopied(false), ms("1.5s"));
-
-    return () => clearTimeout(timeout);
-  }, [copied]);
+  const { copied, markCopied } = useCopied();
 
   return (
     <TitlebarIconButton
       title="Copy URL"
       onClick={() => {
         ipc.main.send("googleApp.copyUrl");
-        setCopied(true);
+        markCopied();
       }}
     >
       {copied ? <CheckIcon /> : <CopyIcon />}

--- a/packages/renderer-main/components/copy-button.tsx
+++ b/packages/renderer-main/components/copy-button.tsx
@@ -1,7 +1,7 @@
-import { ms } from "@meru/shared/ms";
+import { useCopied } from "@meru/shared/renderer/hooks";
 import { Button } from "@meru/ui/components/button";
 import { CheckIcon, CopyIcon } from "lucide-react";
-import { type ComponentProps, useEffect, useRef, useState } from "react";
+import type { ComponentProps } from "react";
 
 export function CopyButton({
   value,
@@ -9,17 +9,7 @@ export function CopyButton({
   size = "icon",
   ...props
 }: { value: string } & ComponentProps<typeof Button>) {
-  const [copied, setCopied] = useState(false);
-
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-    };
-  }, []);
+  const { copied, markCopied } = useCopied();
 
   return (
     <Button
@@ -29,15 +19,7 @@ export function CopyButton({
       onClick={() => {
         navigator.clipboard.writeText(value);
 
-        setCopied(true);
-
-        if (timeoutRef.current) {
-          clearTimeout(timeoutRef.current);
-        }
-
-        timeoutRef.current = setTimeout(() => {
-          setCopied(false);
-        }, ms("2s"));
+        markCopied();
       }}
     >
       {copied ? <CheckIcon /> : <CopyIcon />}

--- a/packages/shared/renderer/hooks.ts
+++ b/packages/shared/renderer/hooks.ts
@@ -1,0 +1,30 @@
+import { ms } from "@meru/shared/ms";
+import { useEffect, useRef, useState } from "react";
+
+export function useCopied() {
+  const [copied, setCopied] = useState(false);
+
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const markCopied = () => {
+    setCopied(true);
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      setCopied(false);
+    }, ms("2s"));
+  };
+
+  return { copied, markCopied };
+}


### PR DESCRIPTION
## What

`CopyButton` (`packages/renderer-main/components/copy-button.tsx`) and `CopyUrlButton` (`packages/renderer-google-app/index.tsx`) both managed a `copied` boolean that auto-resets after a delay. Extracted the shared state logic into a new `useCopied` hook in `packages/shared/renderer/hooks.ts` and rewired both components to use it; the copy mechanism (clipboard write vs `ipc.main.send`) and button shells stay per-component.

## Behavior note

The hook resets after a fixed `ms("2s")`. This changes `CopyUrlButton`'s reset from its previous 1.5s to 2s (intentional — keeping a single shared timing).

## Verification

- `bun types:ci` passes.
- Behavior to spot-check: copy buttons in settings (e.g. license) and the Google-app titlebar still flip to the check icon and reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLR2En52FSuFbvTub3qKGH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLR2En52FSuFbvTub3qKGH)_