### PR TITLE
share inbox anchor element selector constant

### DIFF
--- a/packages/preload-gmail/inbox.ts
+++ b/packages/preload-gmail/inbox.ts
@@ -1,13 +1,12 @@
 import { GMAIL_ACTION_CODE_MAP, GMAIL_URL } from "@meru/shared/gmail";
 import { $ } from "select-dom";
+import { inboxAnchorElementSelector } from "./lib/selectors";
 
 declare global {
   interface Window {
     GM_ID_KEY: string;
   }
 }
-
-const inboxAnchorElementSelector = 'span > a[href*="#inbox"]';
 
 let gmailIdKey: string | undefined;
 

--- a/packages/preload-gmail/lib/selectors.ts
+++ b/packages/preload-gmail/lib/selectors.ts
@@ -1,0 +1,1 @@
+export const inboxAnchorElementSelector = 'span > a[href*="#inbox"]';

--- a/packages/preload-gmail/unread-count.ts
+++ b/packages/preload-gmail/unread-count.ts
@@ -1,8 +1,7 @@
 import { ipcMain } from "./ipc";
+import { inboxAnchorElementSelector } from "./lib/selectors";
 
 let previousUnreadCountString: string = "";
-
-const inboxAnchorElementSelector = 'span > a[href*="#inbox"]';
 
 export function observeUnreadCount() {
   const currentUnreadCountString =


### PR DESCRIPTION
## What

`const inboxAnchorElementSelector = 'span > a[href*="#inbox"]'` was defined separately in `packages/preload-gmail/inbox.ts` and `unread-count.ts`. Exported it once from `packages/preload-gmail/lib/utils.ts` and imported it in both.

Pure refactor — no behavior change.

## Verification

- `bun types:ci` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLR2En52FSuFbvTub3qKGH

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLR2En52FSuFbvTub3qKGH)_