### PR TITLE
Upgrade dnd-kit to v0.5 with new React API

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,9 +6,8 @@
       "name": "meru",
       "devDependencies": {
         "@base-ui/react": "^1.4.0",
-        "@dnd-kit/core": "^6.3.1",
-        "@dnd-kit/sortable": "^10.0.0",
-        "@dnd-kit/utilities": "^3.2.2",
+        "@dnd-kit/helpers": "^0.5.0",
+        "@dnd-kit/react": "^0.5.0",
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/typed-ipc": "^1.0.2",
         "@electron-toolkit/utils": "^4.0.0",
@@ -182,13 +181,19 @@
 
     "@develar/schema-utils": ["@develar/schema-utils@2.6.5", "", { "dependencies": { "ajv": "^6.12.0", "ajv-keywords": "^3.4.1" } }, "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig=="],
 
-    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+    "@dnd-kit/abstract": ["@dnd-kit/abstract@0.5.0", "", { "dependencies": { "@dnd-kit/geometry": "^0.5.0", "@dnd-kit/state": "^0.5.0", "tslib": "^2.6.2" } }, "sha512-hi13iMJgjPX/KDYVKg5VeDIhmYiV6buc9bAX+tCLYf4QdyYjPbsXjn2sPo6m7fQ6SGJBEFgHJ2PemeKDUbwBaA=="],
 
-    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+    "@dnd-kit/collision": ["@dnd-kit/collision@0.5.0", "", { "dependencies": { "@dnd-kit/abstract": "^0.5.0", "@dnd-kit/geometry": "^0.5.0", "tslib": "^2.6.2" } }, "sha512-xUqRn3lS7oqLkT0AnnHS/STh/Czvwe1UapZFYiLbsUGxopMsQd4teaPCzPouOThoMdGEe+dHWjfqJl6t9iG4mQ=="],
 
-    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+    "@dnd-kit/dom": ["@dnd-kit/dom@0.5.0", "", { "dependencies": { "@dnd-kit/abstract": "^0.5.0", "@dnd-kit/collision": "^0.5.0", "@dnd-kit/geometry": "^0.5.0", "@dnd-kit/state": "^0.5.0", "tslib": "^2.6.2" } }, "sha512-f2xFJp5SYQ8EW/Fbtaa8iBb66hpkWc7qa8vU826KW11/tb44sH+AisZnGtwOOTWTQ0GraqBDr5ixTErww+eKXw=="],
 
-    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
+    "@dnd-kit/geometry": ["@dnd-kit/geometry@0.5.0", "", { "dependencies": { "@dnd-kit/state": "^0.5.0", "tslib": "^2.6.2" } }, "sha512-ubHQS1CiSDH8ssYH2xG5BnpwPSFP1tStXXjug7/Ba6qnQdu/EUH47l6QXKIksQnnanfVfDf0aGeevRxgZlj28A=="],
+
+    "@dnd-kit/helpers": ["@dnd-kit/helpers@0.5.0", "", { "dependencies": { "@dnd-kit/abstract": "^0.5.0", "tslib": "^2.6.2" } }, "sha512-i4y+51/icSw+OHMr/su19qhnmNhAzh8PnBwXvapFYTd+64oodIyJRiRkB+hhfxAfnur7RYSW8qacDTrXjg2XOg=="],
+
+    "@dnd-kit/react": ["@dnd-kit/react@0.5.0", "", { "dependencies": { "@dnd-kit/abstract": "^0.5.0", "@dnd-kit/dom": "^0.5.0", "@dnd-kit/state": "^0.5.0", "tslib": "^2.6.2" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-abQPLI8lmfVE+v/n+pqy5WFxrw6T2Yg0UQZsL78dp5DKci7dKTVDjvLWqvass+XTFtzJmsZEjk1NdqE6xG8Jiw=="],
+
+    "@dnd-kit/state": ["@dnd-kit/state@0.5.0", "", { "dependencies": { "@preact/signals-core": "^1.10.0", "tslib": "^2.6.2" } }, "sha512-y7XbabQqjF58Lk8YmDQuR8l6QjN+Kh4qlGEjUvHuIeasLk1QP+9L5diXS98VMxQIivyMmUtX2//f+3N7qPJX4w=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.57.1", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-iKXuo8Nes9Ft4zF3AZOT4FHkl6OV8bHqn61a67qHokkBzSEurnKZAlOkT0FYrRNVGvE6nCfZMtYswyjfXCR1MQ=="],
 
@@ -479,6 +484,8 @@
     "@peculiar/webcrypto": ["@peculiar/webcrypto@1.7.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/json-schema": "^1.1.12", "@peculiar/utils": "^2.0.2", "tslib": "^2.8.1", "webcrypto-core": "^1.9.2" } }, "sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@preact/signals-core": ["@preact/signals-core@1.14.3", "", {}, "sha512-m0K3vnbSLC5rHs2ZVfeAMvBtT1zIyq4mxx5OlNncSgMj5Iz6W5Rn3kPrDxAC+iIKmiVe0lSl6U37t5ZkEWoVAw=="],
 
     "@remusao/guess-url-type": ["@remusao/guess-url-type@2.1.0", "", {}, "sha512-zI3dlTUxpjvx2GCxp9nLOSK5yEIqDCpxlAVGwb2Y49RKkS72oeNaxxo+VWS5+XQ5+Mf8Zfp9ZXIlk+G5eoEN8A=="],
 

--- a/package.json
+++ b/package.json
@@ -26,9 +26,8 @@
   },
   "devDependencies": {
     "@base-ui/react": "^1.4.0",
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^10.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
+    "@dnd-kit/helpers": "^0.5.0",
+    "@dnd-kit/react": "^0.5.0",
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/typed-ipc": "^1.0.2",
     "@electron-toolkit/utils": "^4.0.0",

--- a/packages/renderer-main/routes/settings/google-apps.tsx
+++ b/packages/renderer-main/routes/settings/google-apps.tsx
@@ -1,11 +1,6 @@
-import { closestCenter, DndContext, PointerSensor, useSensor } from "@dnd-kit/core";
-import {
-  arrayMove,
-  SortableContext,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
+import { move } from "@dnd-kit/helpers";
+import { DragDropProvider } from "@dnd-kit/react";
+import { useSortable } from "@dnd-kit/react/sortable";
 import { useConfig, useConfigMutation } from "@meru/shared/renderer/react-query";
 import {
   type GoogleAppsPinnedApp,
@@ -40,34 +35,26 @@ import { useIsLicenseKeyValid } from "@/lib/hooks";
 
 function SortablePinnedAppItem({
   app,
+  index,
   onUnpin,
   disabled,
 }: {
   app: GoogleAppsPinnedApp;
+  index: number;
   onUnpin: () => void;
   disabled: boolean;
 }) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: app,
-  });
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.5 : 1,
-    zIndex: isDragging ? 1 : undefined,
-  };
+  const { ref, handleRef, isDragging } = useSortable({ id: app, index, disabled });
 
   return (
-    <Item ref={setNodeRef} style={style} variant="outline" size="xs">
+    <Item ref={ref} style={{ opacity: isDragging ? 0.5 : 1 }} variant="outline" size="xs">
       <Button
+        ref={handleRef}
         size="icon-xs"
         variant="ghost"
         className="cursor-grab touch-none"
         disabled={disabled}
         aria-label={`Drag ${googleAppsPinnedApps[app]} to reorder`}
-        {...attributes}
-        {...listeners}
       >
         <GripVerticalIcon />
       </Button>
@@ -98,8 +85,6 @@ export function GoogleAppsSettings() {
   const configMutation = useConfigMutation();
 
   const isLicenseKeyValid = useIsLicenseKeyValid();
-
-  const pointerSensor = useSensor(PointerSensor);
 
   if (!config) {
     return;
@@ -228,43 +213,33 @@ export function GoogleAppsSettings() {
                     No pinned apps. Add apps from Available below.
                   </p>
                 ) : (
-                  <DndContext
-                    sensors={[pointerSensor]}
-                    collisionDetection={closestCenter}
+                  <DragDropProvider
                     onDragEnd={(event) => {
-                      const { active, over } = event;
-
-                      if (!over || active.id === over.id) {
+                      if (event.canceled) {
                         return;
                       }
 
-                      const oldIndex = pinnedApps.indexOf(active.id as GoogleAppsPinnedApp);
-                      const newIndex = pinnedApps.indexOf(over.id as GoogleAppsPinnedApp);
-
                       configMutation.mutate({
-                        "googleApps.pinnedApps": arrayMove(pinnedApps, oldIndex, newIndex),
+                        "googleApps.pinnedApps": move(pinnedApps, event),
                       });
                     }}
                   >
-                    <SortableContext items={pinnedApps} strategy={verticalListSortingStrategy}>
-                      <ItemGroup>
-                        {pinnedApps.map((app) => (
-                          <SortablePinnedAppItem
-                            key={app}
-                            app={app}
-                            onUnpin={() => {
-                              configMutation.mutate({
-                                "googleApps.pinnedApps": pinnedApps.filter(
-                                  (value) => value !== app,
-                                ),
-                              });
-                            }}
-                            disabled={!isLicenseKeyValid}
-                          />
-                        ))}
-                      </ItemGroup>
-                    </SortableContext>
-                  </DndContext>
+                    <ItemGroup>
+                      {pinnedApps.map((app, index) => (
+                        <SortablePinnedAppItem
+                          key={app}
+                          app={app}
+                          index={index}
+                          onUnpin={() => {
+                            configMutation.mutate({
+                              "googleApps.pinnedApps": pinnedApps.filter((value) => value !== app),
+                            });
+                          }}
+                          disabled={!isLicenseKeyValid}
+                        />
+                      ))}
+                    </ItemGroup>
+                  </DragDropProvider>
                 )}
               </div>
               {availableApps.length > 0 && (

--- a/packages/renderer-main/routes/settings/google-apps.tsx
+++ b/packages/renderer-main/routes/settings/google-apps.tsx
@@ -24,7 +24,6 @@ import {
   FieldSeparator,
 } from "@meru/ui/components/field";
 import { Item, ItemActions, ItemContent, ItemGroup, ItemTitle } from "@meru/ui/components/item";
-import { cn } from "@meru/ui/lib/utils";
 import { ChevronDownIcon, GripVerticalIcon, PlusIcon, XIcon } from "lucide-react";
 import type { Entries } from "type-fest";
 import { ConfigSwitchField } from "@/components/config-switch-field";
@@ -48,7 +47,7 @@ function SortablePinnedAppItem({
   const { ref, handleRef, isDragging } = useSortable({ id: app, index, disabled });
 
   return (
-    <Item ref={ref} className={cn(isDragging && "opacity-50")} variant="outline" size="xs">
+    <Item ref={ref} className={isDragging ? "opacity-50" : undefined} variant="outline" size="xs">
       <Button
         ref={handleRef}
         size="icon-xs"

--- a/packages/renderer-main/routes/settings/google-apps.tsx
+++ b/packages/renderer-main/routes/settings/google-apps.tsx
@@ -24,6 +24,7 @@ import {
   FieldSeparator,
 } from "@meru/ui/components/field";
 import { Item, ItemActions, ItemContent, ItemGroup, ItemTitle } from "@meru/ui/components/item";
+import { cn } from "@meru/ui/lib/utils";
 import { ChevronDownIcon, GripVerticalIcon, PlusIcon, XIcon } from "lucide-react";
 import type { Entries } from "type-fest";
 import { ConfigSwitchField } from "@/components/config-switch-field";
@@ -47,7 +48,7 @@ function SortablePinnedAppItem({
   const { ref, handleRef, isDragging } = useSortable({ id: app, index, disabled });
 
   return (
-    <Item ref={ref} style={{ opacity: isDragging ? 0.5 : 1 }} variant="outline" size="xs">
+    <Item ref={ref} className={cn(isDragging && "opacity-50")} variant="outline" size="xs">
       <Button
         ref={handleRef}
         size="icon-xs"


### PR DESCRIPTION
Upgrades the drag-and-drop library from dnd-kit v6/v10 to the new v0.5 React-first API, simplifying the Google Apps pinned list reordering implementation.

**Key changes:**
- Replaced `@dnd-kit/core`, `@dnd-kit/sortable`, and `@dnd-kit/utilities` with `@dnd-kit/react` and `@dnd-kit/helpers`
- Migrated from `DndContext` + `SortableContext` to the new `DragDropProvider` component
- Simplified `useSortable` hook usage: now returns `ref`, `handleRef`, and `isDragging` directly instead of requiring manual style transforms via `CSS.Transform`
- Updated drag end handler to use the new event structure with `move()` helper instead of manually calculating `arrayMove()`
- Removed sensor configuration (`PointerSensor`) — now handled automatically by the provider
- Removed manual drag styling logic in favor of conditional `className` binding

The new API reduces boilerplate while maintaining the same drag-to-reorder functionality for pinned Google Apps.

https://claude.ai/code/session_01NoXNXTBFyfhUg3W8CM5Me6