### PR TITLE
Replace table UI with drag-and-drop list for saved searches

### DIFF
--- a/packages/renderer-main/routes/settings/saved-searches.tsx
+++ b/packages/renderer-main/routes/settings/saved-searches.tsx
@@ -1,11 +1,6 @@
-import { closestCenter, DndContext, PointerSensor, useSensor } from "@dnd-kit/core";
-import {
-  arrayMove,
-  SortableContext,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
+import { move } from "@dnd-kit/helpers";
+import { DragDropProvider } from "@dnd-kit/react";
+import { useSortable } from "@dnd-kit/react/sortable";
 import {
   type GmailSavedSearch,
   type GmailSavedSearchInput,
@@ -231,36 +226,28 @@ function SavedSearchMenuButton({
 
 function SortableSavedSearchItem({
   savedSearch,
+  index,
   onDelete,
   onEdit,
   disabled,
 }: {
   savedSearch: GmailSavedSearch;
+  index: number;
   onDelete: () => void;
   onEdit: (editedSavedSearch: GmailSavedSearch) => void;
   disabled: boolean;
 }) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: savedSearch.id,
-  });
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.5 : 1,
-    zIndex: isDragging ? 1 : undefined,
-  };
+  const { ref, handleRef, isDragging } = useSortable({ id: savedSearch.id, index, disabled });
 
   return (
-    <Item ref={setNodeRef} style={style} variant="muted">
+    <Item ref={ref} className={isDragging ? "opacity-50" : undefined} variant="muted">
       <Button
+        ref={handleRef}
         size="icon"
         className="size-8 cursor-grab touch-none p-0"
         variant="ghost"
         disabled={disabled}
         aria-label={`Drag ${savedSearch.label} to reorder`}
-        {...attributes}
-        {...listeners}
       >
         <GripVerticalIcon />
       </Button>
@@ -282,8 +269,6 @@ export function SavedSearchesSettings() {
 
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
-  const pointerSensor = useSensor(PointerSensor);
-
   if (!config) {
     return;
   }
@@ -297,60 +282,44 @@ export function SavedSearchesSettings() {
         <LicenseKeyRequiredBanner>
           Upgrade to Meru Pro to add saved searches
         </LicenseKeyRequiredBanner>
-        <DndContext
-          sensors={[pointerSensor]}
-          collisionDetection={closestCenter}
+        <DragDropProvider
           onDragEnd={(event) => {
-            const { active, over } = event;
-
-            if (!over || active.id === over.id) {
+            if (event.canceled) {
               return;
             }
 
-            const oldIndex = config["gmail.savedSearches"].findIndex(
-              (savedSearch) => savedSearch.id === active.id,
-            );
-
-            const newIndex = config["gmail.savedSearches"].findIndex(
-              (savedSearch) => savedSearch.id === over.id,
-            );
-
             configMutation.mutate({
-              "gmail.savedSearches": arrayMove(config["gmail.savedSearches"], oldIndex, newIndex),
+              "gmail.savedSearches": move(config["gmail.savedSearches"], event),
             });
           }}
         >
-          <SortableContext
-            items={config["gmail.savedSearches"].map((savedSearch) => savedSearch.id)}
-            strategy={verticalListSortingStrategy}
-          >
-            <ItemGroup className="mb-4">
-              {config["gmail.savedSearches"].map((savedSearch) => (
-                <SortableSavedSearchItem
-                  key={savedSearch.id}
-                  savedSearch={savedSearch}
-                  disabled={!isLicenseKeyValid}
-                  onDelete={() => {
-                    const deleteSavedSearchId = savedSearch.id;
+          <ItemGroup className="mb-4">
+            {config["gmail.savedSearches"].map((savedSearch, index) => (
+              <SortableSavedSearchItem
+                key={savedSearch.id}
+                savedSearch={savedSearch}
+                index={index}
+                disabled={!isLicenseKeyValid}
+                onDelete={() => {
+                  const deleteSavedSearchId = savedSearch.id;
 
-                    configMutation.mutate({
-                      "gmail.savedSearches": config["gmail.savedSearches"].filter(
-                        (savedSearch) => savedSearch.id !== deleteSavedSearchId,
-                      ),
-                    });
-                  }}
-                  onEdit={(editedSavedSearch) => {
-                    configMutation.mutate({
-                      "gmail.savedSearches": config["gmail.savedSearches"].map((savedSearch) =>
-                        savedSearch.id === editedSavedSearch.id ? editedSavedSearch : savedSearch,
-                      ),
-                    });
-                  }}
-                />
-              ))}
-            </ItemGroup>
-          </SortableContext>
-        </DndContext>
+                  configMutation.mutate({
+                    "gmail.savedSearches": config["gmail.savedSearches"].filter(
+                      (savedSearch) => savedSearch.id !== deleteSavedSearchId,
+                    ),
+                  });
+                }}
+                onEdit={(editedSavedSearch) => {
+                  configMutation.mutate({
+                    "gmail.savedSearches": config["gmail.savedSearches"].map((savedSearch) =>
+                      savedSearch.id === editedSavedSearch.id ? editedSavedSearch : savedSearch,
+                    ),
+                  });
+                }}
+              />
+            ))}
+          </ItemGroup>
+        </DragDropProvider>
         <div className="flex justify-end">
           <AddSavedSearchButton
             onAdd={(savedSearch) => {

--- a/packages/renderer-main/routes/settings/saved-searches.tsx
+++ b/packages/renderer-main/routes/settings/saved-searches.tsx
@@ -14,12 +14,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@meru/ui/components/dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@meru/ui/components/dropdown-menu";
 import { EmojiPickerButton } from "@meru/ui/components/emoji-picker-button";
 import { Input } from "@meru/ui/components/input";
 import {
@@ -30,7 +24,7 @@ import {
   ItemGroup,
   ItemTitle,
 } from "@meru/ui/components/item";
-import { EllipsisIcon, GripVerticalIcon } from "lucide-react";
+import { GripVerticalIcon, PencilIcon, TrashIcon } from "lucide-react";
 import { useState } from "react";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
@@ -158,51 +152,24 @@ export function AddSavedSearchButton({
   );
 }
 
-function SavedSearchMenuButton({
+function EditSavedSearchButton({
   savedSearch,
-  onDelete,
   onEdit,
 }: {
   savedSearch: GmailSavedSearch;
-  onDelete: () => void;
   onEdit: (editedSavedSearch: GmailSavedSearch) => void;
 }) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          render={
-            <Button size="icon" className="size-8 p-0" variant="ghost">
-              <EllipsisIcon />
-            </Button>
-          }
-        />
-        <DropdownMenuContent>
-          <DropdownMenuItem
-            onClick={() => {
-              setIsOpen(true);
-            }}
-          >
-            Edit
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="text-destructive-foreground focus:bg-destructive/90 focus:text-destructive-foreground"
-            onClick={() => {
-              const confirmed = window.confirm(
-                `Are you sure you want to delete ${savedSearch.label}?`,
-              );
-
-              if (confirmed) {
-                onDelete();
-              }
-            }}
-          >
-            Delete
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DialogTrigger
+        render={
+          <Button size="icon" className="size-8 p-0" variant="outline">
+            <PencilIcon />
+          </Button>
+        }
+      />
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Edit Saved Search</DialogTitle>
@@ -215,7 +182,7 @@ function SavedSearchMenuButton({
               ...values,
             });
 
-            setIsOpen(false);
+            setIsDialogOpen(false);
           }}
           type="edit"
         />
@@ -256,7 +223,23 @@ function SortableSavedSearchItem({
         <ItemDescription>{savedSearch.query}</ItemDescription>
       </ItemContent>
       <ItemActions>
-        <SavedSearchMenuButton savedSearch={savedSearch} onDelete={onDelete} onEdit={onEdit} />
+        <EditSavedSearchButton savedSearch={savedSearch} onEdit={onEdit} />
+        <Button
+          size="icon"
+          className="size-8 p-0"
+          variant="outline"
+          onClick={() => {
+            const confirmed = window.confirm(
+              `Are you sure you want to delete ${savedSearch.label}?`,
+            );
+
+            if (confirmed) {
+              onDelete();
+            }
+          }}
+        >
+          <TrashIcon />
+        </Button>
       </ItemActions>
     </Item>
   );

--- a/packages/renderer-main/routes/settings/saved-searches.tsx
+++ b/packages/renderer-main/routes/settings/saved-searches.tsx
@@ -1,9 +1,16 @@
+import { closestCenter, DndContext, PointerSensor, useSensor } from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import {
   type GmailSavedSearch,
   type GmailSavedSearchInput,
   gmailSavedSearchInputSchema,
 } from "@meru/shared/schemas";
-import { arrayMove } from "@meru/shared/utils";
 import { Button } from "@meru/ui/components/button";
 import {
   Dialog,
@@ -21,14 +28,14 @@ import {
 import { EmojiPickerButton } from "@meru/ui/components/emoji-picker-button";
 import { Input } from "@meru/ui/components/input";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@meru/ui/components/table";
-import { ArrowDownIcon, ArrowUpIcon, EllipsisIcon } from "lucide-react";
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemTitle,
+} from "@meru/ui/components/item";
+import { EllipsisIcon, GripVerticalIcon } from "lucide-react";
 import { useState } from "react";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
@@ -222,28 +229,64 @@ function SavedSearchMenuButton({
   );
 }
 
+function SortableSavedSearchItem({
+  savedSearch,
+  onDelete,
+  onEdit,
+  disabled,
+}: {
+  savedSearch: GmailSavedSearch;
+  onDelete: () => void;
+  onEdit: (editedSavedSearch: GmailSavedSearch) => void;
+  disabled: boolean;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: savedSearch.id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    zIndex: isDragging ? 1 : undefined,
+  };
+
+  return (
+    <Item ref={setNodeRef} style={style} variant="muted">
+      <Button
+        size="icon"
+        className="size-8 cursor-grab touch-none p-0"
+        variant="ghost"
+        disabled={disabled}
+        aria-label={`Drag ${savedSearch.label} to reorder`}
+        {...attributes}
+        {...listeners}
+      >
+        <GripVerticalIcon />
+      </Button>
+      <ItemContent>
+        <ItemTitle>{savedSearch.label}</ItemTitle>
+        <ItemDescription>{savedSearch.query}</ItemDescription>
+      </ItemContent>
+      <ItemActions>
+        <SavedSearchMenuButton savedSearch={savedSearch} onDelete={onDelete} onEdit={onEdit} />
+      </ItemActions>
+    </Item>
+  );
+}
+
 export function SavedSearchesSettings() {
   const { config } = useConfig();
 
   const configMutation = useConfigMutation();
 
+  const isLicenseKeyValid = useIsLicenseKeyValid();
+
+  const pointerSensor = useSensor(PointerSensor);
+
   if (!config) {
     return;
   }
-
-  const moveSavedSearch = (savedSearchId: string, direction: "up" | "down") => {
-    const savedSearchIndex = config["gmail.savedSearches"].findIndex(
-      (savedSearch) => savedSearch.id === savedSearchId,
-    );
-
-    configMutation.mutate({
-      "gmail.savedSearches": arrayMove(
-        config["gmail.savedSearches"],
-        savedSearchIndex,
-        direction === "up" ? savedSearchIndex - 1 : savedSearchIndex + 1,
-      ),
-    });
-  };
 
   return (
     <>
@@ -254,70 +297,60 @@ export function SavedSearchesSettings() {
         <LicenseKeyRequiredBanner>
           Upgrade to Meru Pro to add saved searches
         </LicenseKeyRequiredBanner>
-        <Table className="mb-4">
-          <TableHeader>
-            <TableRow>
-              <TableHead>Label</TableHead>
-              <TableHead>Query</TableHead>
-              <TableHead />
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {config["gmail.savedSearches"].map((savedSearch, index) => (
-              <TableRow key={savedSearch.id}>
-                <TableCell>{savedSearch.label}</TableCell>
-                <TableCell>{savedSearch.query}</TableCell>
-                <TableCell className="flex justify-end">
-                  {config["gmail.savedSearches"].length > 1 && (
-                    <>
-                      <Button
-                        size="icon"
-                        className="size-8 p-0"
-                        variant="ghost"
-                        disabled={index === 0}
-                        onClick={() => {
-                          moveSavedSearch(savedSearch.id, "up");
-                        }}
-                      >
-                        <ArrowUpIcon />
-                      </Button>
-                      <Button
-                        size="icon"
-                        className="size-8 p-0"
-                        variant="ghost"
-                        disabled={index + 1 === config["gmail.savedSearches"].length}
-                        onClick={() => {
-                          moveSavedSearch(savedSearch.id, "down");
-                        }}
-                      >
-                        <ArrowDownIcon />
-                      </Button>
-                    </>
-                  )}
-                  <SavedSearchMenuButton
-                    savedSearch={savedSearch}
-                    onDelete={() => {
-                      const deleteSavedSearchId = savedSearch.id;
+        <DndContext
+          sensors={[pointerSensor]}
+          collisionDetection={closestCenter}
+          onDragEnd={(event) => {
+            const { active, over } = event;
 
-                      configMutation.mutate({
-                        "gmail.savedSearches": config["gmail.savedSearches"].filter(
-                          (savedSearch) => savedSearch.id !== deleteSavedSearchId,
-                        ),
-                      });
-                    }}
-                    onEdit={(editedSavedSearch) => {
-                      configMutation.mutate({
-                        "gmail.savedSearches": config["gmail.savedSearches"].map((savedSearch) =>
-                          savedSearch.id === editedSavedSearch.id ? editedSavedSearch : savedSearch,
-                        ),
-                      });
-                    }}
-                  />
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
+            if (!over || active.id === over.id) {
+              return;
+            }
+
+            const oldIndex = config["gmail.savedSearches"].findIndex(
+              (savedSearch) => savedSearch.id === active.id,
+            );
+
+            const newIndex = config["gmail.savedSearches"].findIndex(
+              (savedSearch) => savedSearch.id === over.id,
+            );
+
+            configMutation.mutate({
+              "gmail.savedSearches": arrayMove(config["gmail.savedSearches"], oldIndex, newIndex),
+            });
+          }}
+        >
+          <SortableContext
+            items={config["gmail.savedSearches"].map((savedSearch) => savedSearch.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <ItemGroup className="mb-4">
+              {config["gmail.savedSearches"].map((savedSearch) => (
+                <SortableSavedSearchItem
+                  key={savedSearch.id}
+                  savedSearch={savedSearch}
+                  disabled={!isLicenseKeyValid}
+                  onDelete={() => {
+                    const deleteSavedSearchId = savedSearch.id;
+
+                    configMutation.mutate({
+                      "gmail.savedSearches": config["gmail.savedSearches"].filter(
+                        (savedSearch) => savedSearch.id !== deleteSavedSearchId,
+                      ),
+                    });
+                  }}
+                  onEdit={(editedSavedSearch) => {
+                    configMutation.mutate({
+                      "gmail.savedSearches": config["gmail.savedSearches"].map((savedSearch) =>
+                        savedSearch.id === editedSavedSearch.id ? editedSavedSearch : savedSearch,
+                      ),
+                    });
+                  }}
+                />
+              ))}
+            </ItemGroup>
+          </SortableContext>
+        </DndContext>
         <div className="flex justify-end">
           <AddSavedSearchButton
             onAdd={(savedSearch) => {


### PR DESCRIPTION
Replaces the table-based UI for managing saved searches with a drag-and-drop list interface using `@dnd-kit`. This provides a more intuitive way to reorder saved searches.

## Changes

- Migrated from `@meru/ui/components/table` to `@meru/ui/components/item` compound components for better list semantics
- Integrated `@dnd-kit/react` and `@dnd-kit/helpers` for drag-and-drop functionality
- Replaced arrow button controls (up/down) with a visual drag handle (`GripVerticalIcon`)
- Extracted `SortableSavedSearchItem` component to encapsulate individual list item rendering with drag state
- Simplified reordering logic by using `@dnd-kit`'s `move` helper instead of custom `arrayMove` utility
- Added `disabled` prop to prevent drag operations when license key is invalid
- Removed manual index-based movement functions in favor of declarative drag-end handler

## Implementation Details

- The `SortableSavedSearchItem` component uses `useSortable` hook to manage drag state and provides visual feedback (opacity change) while dragging
- Drag handle button includes proper accessibility label and respects the disabled state
- List items use the `Item` compound component structure with `ItemContent` (title + description) and `ItemActions` (menu button) for consistent layout
- Drag-and-drop is wrapped in `DragDropProvider` at the list level with a single `onDragEnd` handler that persists reordered searches to config

https://claude.ai/code/session_01EzQ6GcUw4cSnjA7e8fuqg9