### PR TITLE
Replace account reordering buttons with drag-and-drop

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -285,23 +285,6 @@ class Accounts {
     );
   }
 
-  reorderAccounts(accountIds: string[]) {
-    const accountConfigs = config.get("accounts");
-
-    config.set(
-      "accounts",
-      accountIds.map((accountId) => {
-        const accountConfig = accountConfigs.find((account) => account.id === accountId);
-
-        if (!accountConfig) {
-          throw new Error("Could not find account config");
-        }
-
-        return accountConfig;
-      }),
-    );
-  }
-
   hide() {
     for (const account of this.instances.values()) {
       account.gmail.view.setVisible(false);

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -285,30 +285,21 @@ class Accounts {
     );
   }
 
-  moveAccount(selectedAccountId: string, direction: "up" | "down") {
+  reorderAccounts(accountIds: string[]) {
     const accountConfigs = config.get("accounts");
 
-    const selectedAccountConfigIndex = accountConfigs.findIndex(
-      (account) => account.id === selectedAccountId,
+    config.set(
+      "accounts",
+      accountIds.map((accountId) => {
+        const accountConfig = accountConfigs.find((account) => account.id === accountId);
+
+        if (!accountConfig) {
+          throw new Error("Could not find account config");
+        }
+
+        return accountConfig;
+      }),
     );
-
-    const selectedAccountConfig = accountConfigs.splice(selectedAccountConfigIndex, 1)[0];
-
-    if (!selectedAccountConfig) {
-      throw new Error("Could not find selected account config");
-    }
-
-    accountConfigs.splice(
-      direction === "up"
-        ? selectedAccountConfigIndex - 1
-        : direction === "down"
-          ? selectedAccountConfigIndex + 1
-          : selectedAccountConfigIndex,
-      0,
-      selectedAccountConfig,
-    );
-
-    config.set("accounts", accountConfigs);
   }
 
   hide() {

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -90,10 +90,6 @@ class Ipc {
       accounts.updateAccount(updatedAccount);
     });
 
-    this.main.on("accounts.reorderAccounts", (_event, accountIds) => {
-      accounts.reorderAccounts(accountIds);
-    });
-
     this.main.on("gmail.moveNavigationHistory", (_event, action) => {
       accounts
         .getSelectedAccount()

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -90,8 +90,8 @@ class Ipc {
       accounts.updateAccount(updatedAccount);
     });
 
-    this.main.on("accounts.moveAccount", (_event, movedAccountId, direction) => {
-      accounts.moveAccount(movedAccountId, direction);
+    this.main.on("accounts.reorderAccounts", (_event, accountIds) => {
+      accounts.reorderAccounts(accountIds);
     });
 
     this.main.on("gmail.moveNavigationHistory", (_event, action) => {

--- a/packages/renderer-main/routes/settings/accounts.tsx
+++ b/packages/renderer-main/routes/settings/accounts.tsx
@@ -1,6 +1,9 @@
+import { move } from "@dnd-kit/helpers";
+import { DragDropProvider } from "@dnd-kit/react";
+import { useSortable } from "@dnd-kit/react/sortable";
 import { ipc } from "@meru/shared/renderer/ipc";
 import { accountColorsMap } from "@meru/shared/accounts";
-import type { AccountConfig } from "@meru/shared/schemas";
+import type { AccountConfig, AccountInstance } from "@meru/shared/schemas";
 import { type AccountConfigInput, accountConfigInputSchema } from "@meru/shared/schemas";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
@@ -11,15 +14,9 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@meru/ui/components/dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@meru/ui/components/dropdown-menu";
 import { EmojiPickerButton } from "@meru/ui/components/emoji-picker-button";
 import { Input } from "@meru/ui/components/input";
-import { Item, ItemActions, ItemContent, ItemTitle } from "@meru/ui/components/item";
+import { Item, ItemActions, ItemContent, ItemGroup, ItemTitle } from "@meru/ui/components/item";
 import {
   Select,
   SelectContent,
@@ -29,7 +26,7 @@ import {
 } from "@meru/ui/components/select";
 import { Switch } from "@meru/ui/components/switch";
 import { cn } from "@meru/ui/lib/utils";
-import { ArrowDownIcon, ArrowUpIcon, EllipsisIcon, XIcon } from "lucide-react";
+import { GripVerticalIcon, PencilIcon, TrashIcon, XIcon } from "lucide-react";
 import { useState } from "react";
 import type { Entries } from "type-fest";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
@@ -249,45 +246,18 @@ function AddAccountButton() {
   );
 }
 
-function AccountMenuButton({ account, removable }: { account: AccountConfig; removable: boolean }) {
-  const [isOpen, setIsOpen] = useState(false);
+function EditAccountButton({ account }: { account: AccountConfig }) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          render={
-            <Button size="icon" className="size-8 p-0" variant="outline">
-              <EllipsisIcon />
-            </Button>
-          }
-        />
-        <DropdownMenuContent>
-          <DropdownMenuItem
-            onClick={() => {
-              setIsOpen(true);
-            }}
-          >
-            Edit
-          </DropdownMenuItem>
-          {removable && (
-            <DropdownMenuItem
-              className="text-destructive-foreground focus:bg-destructive/90 focus:text-destructive-foreground"
-              onClick={() => {
-                const confirmed = window.confirm(
-                  `Are you sure you want to remove ${account.label}?`,
-                );
-
-                if (confirmed) {
-                  ipc.main.send("accounts.removeAccount", account.id);
-                }
-              }}
-            >
-              Remove
-            </DropdownMenuItem>
-          )}
-        </DropdownMenuContent>
-      </DropdownMenu>
+    <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+      <DialogTrigger
+        render={
+          <Button size="icon" className="size-8 p-0" variant="outline">
+            <PencilIcon />
+          </Button>
+        }
+      />
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Edit Account</DialogTitle>
@@ -301,7 +271,7 @@ function AccountMenuButton({ account, removable }: { account: AccountConfig; rem
               gmail: { ...account.gmail, ...values.gmail },
             });
 
-            setIsOpen(false);
+            setIsDialogOpen(false);
 
             if (
               account.gmail.unreadBadge !== values.gmail.unreadBadge ||
@@ -315,6 +285,76 @@ function AccountMenuButton({ account, removable }: { account: AccountConfig; rem
         />
       </DialogContent>
     </Dialog>
+  );
+}
+
+function SortableAccountItem({
+  account,
+  index,
+  removable,
+  disabled,
+}: {
+  account: AccountInstance;
+  index: number;
+  removable: boolean;
+  disabled: boolean;
+}) {
+  const { ref, handleRef, isDragging } = useSortable({ id: account.config.id, index, disabled });
+
+  return (
+    <Item ref={ref} className={isDragging ? "opacity-50" : undefined} variant="muted">
+      <Button
+        ref={handleRef}
+        size="icon"
+        className="size-8 cursor-grab touch-none p-0"
+        variant="ghost"
+        disabled={disabled}
+        aria-label={`Drag ${account.config.label} to reorder`}
+      >
+        <GripVerticalIcon />
+      </Button>
+      <ItemContent className="gap-2">
+        <ItemTitle>
+          <div
+            className={cn(
+              "size-2 rounded-full",
+              account.config.color
+                ? `${accountColorsMap[account.config.color].className}`
+                : "border",
+            )}
+          />
+          {account.config.label}
+        </ItemTitle>
+        {(account.config.gmail.unreadBadge || account.config.notifications) && (
+          <div className="flex gap-2">
+            {account.config.gmail.unreadBadge && <Badge variant="outline">Unread Badge</Badge>}
+            {account.config.gmail.unifiedInbox && <Badge variant="outline">Unified Inbox</Badge>}
+            {account.config.notifications && <Badge variant="outline">Notifications</Badge>}
+          </div>
+        )}
+      </ItemContent>
+      <ItemActions>
+        <EditAccountButton account={account.config} />
+        {removable && (
+          <Button
+            size="icon"
+            className="size-8 p-0"
+            variant="outline"
+            onClick={() => {
+              const confirmed = window.confirm(
+                `Are you sure you want to remove ${account.config.label}?`,
+              );
+
+              if (confirmed) {
+                ipc.main.send("accounts.removeAccount", account.config.id);
+              }
+            }}
+          >
+            <TrashIcon />
+          </Button>
+        )}
+      </ItemActions>
+    </Item>
   );
 }
 
@@ -335,65 +375,33 @@ export function AccountsSettings() {
         <LicenseKeyRequiredBanner>
           Upgrade to Meru Pro to add more accounts
         </LicenseKeyRequiredBanner>
-        <div className="space-y-4">
-          {accounts.map((account, index) => (
-            <Item key={account.config.id} variant="muted">
-              <ItemContent className="gap-2">
-                <ItemTitle>
-                  <div
-                    className={cn(
-                      "size-2 rounded-full",
-                      account.config.color
-                        ? `${accountColorsMap[account.config.color].className}`
-                        : "border",
-                    )}
-                  />
-                  {account.config.label}
-                </ItemTitle>
-                {(account.config.gmail.unreadBadge || account.config.notifications) && (
-                  <div className="flex gap-2">
-                    {account.config.gmail.unreadBadge && (
-                      <Badge variant="outline">Unread Badge</Badge>
-                    )}
-                    {account.config.gmail.unifiedInbox && (
-                      <Badge variant="outline">Unified Inbox</Badge>
-                    )}
-                    {account.config.notifications && <Badge variant="outline">Notifications</Badge>}
-                  </div>
-                )}
-              </ItemContent>
-              <ItemActions>
-                {accounts.length > 1 && (
-                  <>
-                    <Button
-                      size="icon"
-                      className="size-8 p-0"
-                      variant="outline"
-                      disabled={index === 0}
-                      onClick={() => {
-                        ipc.main.send("accounts.moveAccount", account.config.id, "up");
-                      }}
-                    >
-                      <ArrowUpIcon />
-                    </Button>
-                    <Button
-                      size="icon"
-                      className="size-8 p-0"
-                      variant="outline"
-                      disabled={index + 1 === accounts.length}
-                      onClick={() => {
-                        ipc.main.send("accounts.moveAccount", account.config.id, "down");
-                      }}
-                    >
-                      <ArrowDownIcon />
-                    </Button>
-                  </>
-                )}
-                <AccountMenuButton account={account.config} removable={accounts.length > 1} />
-              </ItemActions>
-            </Item>
-          ))}
-        </div>
+        <DragDropProvider
+          onDragEnd={(event) => {
+            if (event.canceled) {
+              return;
+            }
+
+            ipc.main.send(
+              "accounts.reorderAccounts",
+              move(
+                accounts.map((account) => account.config.id),
+                event,
+              ),
+            );
+          }}
+        >
+          <ItemGroup>
+            {accounts.map((account, index) => (
+              <SortableAccountItem
+                key={account.config.id}
+                account={account}
+                index={index}
+                removable={accounts.length > 1}
+                disabled={accounts.length < 2}
+              />
+            ))}
+          </ItemGroup>
+        </DragDropProvider>
       </SettingsContent>
     </>
   );

--- a/packages/renderer-main/routes/settings/accounts.tsx
+++ b/packages/renderer-main/routes/settings/accounts.tsx
@@ -3,7 +3,7 @@ import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { ipc } from "@meru/shared/renderer/ipc";
 import { accountColorsMap } from "@meru/shared/accounts";
-import type { AccountConfig, AccountInstance } from "@meru/shared/schemas";
+import type { AccountConfig } from "@meru/shared/schemas";
 import { type AccountConfigInput, accountConfigInputSchema } from "@meru/shared/schemas";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
@@ -31,7 +31,7 @@ import { useState } from "react";
 import type { Entries } from "type-fest";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
-import { useConfig } from "@meru/shared/renderer/react-query";
+import { useConfig, useConfigMutation } from "@meru/shared/renderer/react-query";
 import { useAccountsStore, useTrialStore } from "@/lib/stores";
 import { restartRequiredToast } from "@/lib/toast";
 import { useForm } from "@tanstack/react-form";
@@ -294,12 +294,12 @@ function SortableAccountItem({
   removable,
   disabled,
 }: {
-  account: AccountInstance;
+  account: AccountConfig;
   index: number;
   removable: boolean;
   disabled: boolean;
 }) {
-  const { ref, handleRef, isDragging } = useSortable({ id: account.config.id, index, disabled });
+  const { ref, handleRef, isDragging } = useSortable({ id: account.id, index, disabled });
 
   return (
     <Item ref={ref} className={isDragging ? "opacity-50" : undefined} variant="muted">
@@ -309,7 +309,7 @@ function SortableAccountItem({
         className="size-8 cursor-grab touch-none p-0"
         variant="ghost"
         disabled={disabled}
-        aria-label={`Drag ${account.config.label} to reorder`}
+        aria-label={`Drag ${account.label} to reorder`}
       >
         <GripVerticalIcon />
       </Button>
@@ -318,35 +318,31 @@ function SortableAccountItem({
           <div
             className={cn(
               "size-2 rounded-full",
-              account.config.color
-                ? `${accountColorsMap[account.config.color].className}`
-                : "border",
+              account.color ? `${accountColorsMap[account.color].className}` : "border",
             )}
           />
-          {account.config.label}
+          {account.label}
         </ItemTitle>
-        {(account.config.gmail.unreadBadge || account.config.notifications) && (
+        {(account.gmail.unreadBadge || account.notifications) && (
           <div className="flex gap-2">
-            {account.config.gmail.unreadBadge && <Badge variant="outline">Unread Badge</Badge>}
-            {account.config.gmail.unifiedInbox && <Badge variant="outline">Unified Inbox</Badge>}
-            {account.config.notifications && <Badge variant="outline">Notifications</Badge>}
+            {account.gmail.unreadBadge && <Badge variant="outline">Unread Badge</Badge>}
+            {account.gmail.unifiedInbox && <Badge variant="outline">Unified Inbox</Badge>}
+            {account.notifications && <Badge variant="outline">Notifications</Badge>}
           </div>
         )}
       </ItemContent>
       <ItemActions>
-        <EditAccountButton account={account.config} />
+        <EditAccountButton account={account} />
         {removable && (
           <Button
             size="icon"
             className="size-8 p-0"
             variant="outline"
             onClick={() => {
-              const confirmed = window.confirm(
-                `Are you sure you want to remove ${account.config.label}?`,
-              );
+              const confirmed = window.confirm(`Are you sure you want to remove ${account.label}?`);
 
               if (confirmed) {
-                ipc.main.send("accounts.removeAccount", account.config.id);
+                ipc.main.send("accounts.removeAccount", account.id);
               }
             }}
           >
@@ -359,9 +355,11 @@ function SortableAccountItem({
 }
 
 export function AccountsSettings() {
-  const accounts = useAccountsStore((state) => state.accounts);
+  const { config } = useConfig();
 
-  if (!accounts.length) {
+  const configMutation = useConfigMutation();
+
+  if (!config) {
     return;
   }
 
@@ -381,23 +379,19 @@ export function AccountsSettings() {
               return;
             }
 
-            ipc.main.send(
-              "accounts.reorderAccounts",
-              move(
-                accounts.map((account) => account.config.id),
-                event,
-              ),
-            );
+            configMutation.mutate({
+              accounts: move(config.accounts, event),
+            });
           }}
         >
           <ItemGroup>
-            {accounts.map((account, index) => (
+            {config.accounts.map((account, index) => (
               <SortableAccountItem
-                key={account.config.id}
+                key={account.id}
                 account={account}
                 index={index}
-                removable={accounts.length > 1}
-                disabled={accounts.length < 2}
+                removable={config.accounts.length > 1}
+                disabled={config.accounts.length < 2}
               />
             ))}
           </ItemGroup>

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -190,7 +190,6 @@ export type IpcMainEvents =
       "accounts.addAccount": [account: AccountConfigInput];
       "accounts.removeAccount": [accountId: AccountConfig["id"]];
       "accounts.updateAccount": [account: AccountConfig];
-      "accounts.reorderAccounts": [accountIds: AccountConfig["id"][]];
       "settings.toggleIsOpen": [open?: boolean];
       "gmail.moveNavigationHistory": [move: "back" | "forward"];
       "gmail.unreadCountChanged": [unreadCountString: string];

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -190,7 +190,7 @@ export type IpcMainEvents =
       "accounts.addAccount": [account: AccountConfigInput];
       "accounts.removeAccount": [accountId: AccountConfig["id"]];
       "accounts.updateAccount": [account: AccountConfig];
-      "accounts.moveAccount": [accountId: AccountConfig["id"], direction: "up" | "down"];
+      "accounts.reorderAccounts": [accountIds: AccountConfig["id"][]];
       "settings.toggleIsOpen": [open?: boolean];
       "gmail.moveNavigationHistory": [move: "back" | "forward"];
       "gmail.unreadCountChanged": [unreadCountString: string];

--- a/packages/shared/utils.ts
+++ b/packages/shared/utils.ts
@@ -1,25 +1,3 @@
-export function arrayMove<ValueType>(
-  array: readonly ValueType[],
-  fromIndex: number,
-  toIndex: number,
-): ValueType[] {
-  const newArray = [...array];
-
-  const startIndex = fromIndex < 0 ? array.length + fromIndex : fromIndex;
-
-  if (startIndex >= 0 && startIndex < array.length) {
-    const endIndex = toIndex < 0 ? array.length + toIndex : toIndex;
-
-    const [item] = newArray.splice(startIndex, 1);
-
-    if (item) {
-      newArray.splice(endIndex, 0, item);
-    }
-  }
-
-  return newArray;
-}
-
 export function wait(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
Replaces the up/down arrow buttons for reordering accounts with a drag-and-drop interface using `@dnd-kit`. This provides a more intuitive and modern UX for managing account order.

## Key changes

- **Added drag-and-drop support**: Integrated `@dnd-kit/react` and `@dnd-kit/react/sortable` to enable dragging accounts to reorder them
- **Refactored account list UI**: 
  - Extracted `SortableAccountItem` component to handle individual draggable account items with grip handle
  - Replaced separate up/down arrow buttons with a single drag handle (`GripVerticalIcon`)
  - Wrapped account list in `DragDropProvider` to manage drag state
- **Simplified account actions**:
  - Split `AccountMenuButton` into `EditAccountButton` (edit dialog trigger only)
  - Moved delete action to a separate button in `ItemActions`
  - Removed dropdown menu in favor of direct button access
- **Updated icon usage**: Replaced `ArrowUpIcon`, `ArrowDownIcon`, and `EllipsisIcon` with `GripVerticalIcon`, `PencilIcon`, and `TrashIcon`
- **Removed IPC handlers**: Deleted `accounts.moveAccount` IPC handler and the corresponding `moveAccount` method from the `Accounts` class, as reordering now uses `useConfigMutation()` directly
- **Updated data source**: Changed from `useAccountsStore` to `useConfig()` for accessing the accounts list, ensuring the UI reflects the persisted config state

## Implementation details

- The drag handle is disabled when there are fewer than 2 accounts (no reordering needed)
- Dragged items show reduced opacity (`opacity-50`) for visual feedback
- Account reordering is persisted immediately via `configMutation.mutate()` on drop
- The `ItemGroup` component wraps the sortable items for proper styling

https://claude.ai/code/session_014324EjQ3tBCm2orWFFhEbY