### PR TITLE
Replace Item components with ButtonGroup in Google Apps settings

### DIFF
--- a/packages/renderer-main/routes/settings/google-apps.tsx
+++ b/packages/renderer-main/routes/settings/google-apps.tsx
@@ -23,7 +23,7 @@ import {
   FieldLabel,
   FieldSeparator,
 } from "@meru/ui/components/field";
-import { Item, ItemActions, ItemContent, ItemGroup, ItemTitle } from "@meru/ui/components/item";
+import { cn } from "@meru/ui/lib/utils";
 import { ChevronDownIcon, GripVerticalIcon, PlusIcon, XIcon } from "lucide-react";
 import type { Entries } from "type-fest";
 import { ConfigSwitchField } from "@/components/config-switch-field";
@@ -47,35 +47,30 @@ function SortablePinnedAppItem({
   const { ref, handleRef, isDragging } = useSortable({ id: app, index, disabled });
 
   return (
-    <Item ref={ref} className={isDragging ? "opacity-50" : undefined} variant="outline" size="xs">
+    <div ref={ref} className={cn("flex items-center", isDragging && "opacity-50")}>
       <Button
         ref={handleRef}
-        size="icon-xs"
-        variant="ghost"
-        className="cursor-grab touch-none"
+        variant="outline"
+        size="xs"
+        className="cursor-grab touch-none rounded-r-none"
         disabled={disabled}
         aria-label={`Drag ${googleAppsPinnedApps[app]} to reorder`}
       >
         <GripVerticalIcon />
+        <GoogleAppIcon app={app} className="size-3.5" />
+        {googleAppsPinnedApps[app]}
       </Button>
-      <ItemContent>
-        <ItemTitle>
-          <GoogleAppIcon app={app} className="size-3.5" />
-          {googleAppsPinnedApps[app]}
-        </ItemTitle>
-      </ItemContent>
-      <ItemActions>
-        <Button
-          size="icon-xs"
-          variant="ghost"
-          onClick={onUnpin}
-          disabled={disabled}
-          aria-label={`Unpin ${googleAppsPinnedApps[app]}`}
-        >
-          <XIcon />
-        </Button>
-      </ItemActions>
-    </Item>
+      <Button
+        variant="outline"
+        size="icon-xs"
+        className="-ml-px rounded-l-none"
+        onClick={onUnpin}
+        disabled={disabled}
+        aria-label={`Unpin ${googleAppsPinnedApps[app]}`}
+      >
+        <XIcon />
+      </Button>
+    </div>
   );
 }
 
@@ -224,7 +219,7 @@ export function GoogleAppsSettings() {
                       });
                     }}
                   >
-                    <ItemGroup>
+                    <div className="flex flex-row flex-wrap gap-2">
                       {pinnedApps.map((app, index) => (
                         <SortablePinnedAppItem
                           key={app}
@@ -238,7 +233,7 @@ export function GoogleAppsSettings() {
                           disabled={!isLicenseKeyValid}
                         />
                       ))}
-                    </ItemGroup>
+                    </div>
                   </DragDropProvider>
                 )}
               </div>

--- a/packages/renderer-main/routes/settings/google-apps.tsx
+++ b/packages/renderer-main/routes/settings/google-apps.tsx
@@ -245,33 +245,26 @@ export function GoogleAppsSettings() {
               {availableApps.length > 0 && (
                 <div className="flex flex-col gap-2">
                   <div className="text-xs font-medium text-muted-foreground">Available</div>
-                  <ItemGroup className="grid grid-cols-2">
+                  <div className="flex flex-row flex-wrap gap-2">
                     {availableApps.map((app) => (
-                      <Item key={app} variant="outline" size="xs">
-                        <ItemContent>
-                          <ItemTitle>
-                            <GoogleAppIcon app={app} className="size-3.5" />
-                            {googleAppsPinnedApps[app]}
-                          </ItemTitle>
-                        </ItemContent>
-                        <ItemActions>
-                          <Button
-                            size="icon-xs"
-                            variant="ghost"
-                            onClick={() => {
-                              configMutation.mutate({
-                                "googleApps.pinnedApps": [...pinnedApps, app],
-                              });
-                            }}
-                            disabled={!isLicenseKeyValid}
-                            aria-label={`Pin ${googleAppsPinnedApps[app]}`}
-                          >
-                            <PlusIcon />
-                          </Button>
-                        </ItemActions>
-                      </Item>
+                      <Button
+                        key={app}
+                        variant="outline"
+                        size="xs"
+                        onClick={() => {
+                          configMutation.mutate({
+                            "googleApps.pinnedApps": [...pinnedApps, app],
+                          });
+                        }}
+                        disabled={!isLicenseKeyValid}
+                        aria-label={`Pin ${googleAppsPinnedApps[app]}`}
+                      >
+                        <GoogleAppIcon app={app} className="size-3.5" />
+                        {googleAppsPinnedApps[app]}
+                        <PlusIcon />
+                      </Button>
                     ))}
-                  </ItemGroup>
+                  </div>
                 </div>
               )}
             </div>

--- a/packages/renderer-main/routes/settings/google-apps.tsx
+++ b/packages/renderer-main/routes/settings/google-apps.tsx
@@ -23,7 +23,7 @@ import {
   FieldLabel,
   FieldSeparator,
 } from "@meru/ui/components/field";
-import { cn } from "@meru/ui/lib/utils";
+import { ButtonGroup } from "@meru/ui/components/button-group";
 import { ChevronDownIcon, GripVerticalIcon, PlusIcon, XIcon } from "lucide-react";
 import type { Entries } from "type-fest";
 import { ConfigSwitchField } from "@/components/config-switch-field";
@@ -47,12 +47,12 @@ function SortablePinnedAppItem({
   const { ref, handleRef, isDragging } = useSortable({ id: app, index, disabled });
 
   return (
-    <div ref={ref} className={cn("flex items-center", isDragging && "opacity-50")}>
+    <ButtonGroup ref={ref} className={isDragging ? "opacity-50" : undefined}>
       <Button
         ref={handleRef}
         variant="outline"
         size="xs"
-        className="cursor-grab touch-none rounded-r-none"
+        className="cursor-grab touch-none"
         disabled={disabled}
         aria-label={`Drag ${googleAppsPinnedApps[app]} to reorder`}
       >
@@ -63,14 +63,13 @@ function SortablePinnedAppItem({
       <Button
         variant="outline"
         size="icon-xs"
-        className="-ml-px rounded-l-none"
         onClick={onUnpin}
         disabled={disabled}
         aria-label={`Unpin ${googleAppsPinnedApps[app]}`}
       >
         <XIcon />
       </Button>
-    </div>
+    </ButtonGroup>
   );
 }
 

--- a/packages/ui/components/button-group.tsx
+++ b/packages/ui/components/button-group.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import * as React from "react";
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../lib/utils";
+import { Separator } from "./separator";
+
+const buttonGroupVariants = cva(
+  "flex w-fit items-stretch [&>*]:focus-visible:z-10 [&>*]:focus-visible:relative [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1 has-[>[data-slot=button-group]]:gap-2",
+  {
+    variants: {
+      orientation: {
+        horizontal:
+          "[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none",
+        vertical:
+          "flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none",
+      },
+    },
+    defaultVariants: {
+      orientation: "horizontal",
+    },
+  },
+);
+
+function ButtonGroup({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) {
+  return (
+    <div
+      data-slot="button-group"
+      data-orientation={orientation}
+      role="group"
+      className={cn(buttonGroupVariants({ orientation }), className)}
+      {...props}
+    />
+  );
+}
+
+function ButtonGroupText({ className, render, ...props }: useRender.ComponentProps<"div">) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">(
+      {
+        className: cn(
+          "bg-muted flex items-center gap-2 rounded-lg border px-4 text-sm font-medium shadow-xs [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+          className,
+        ),
+      },
+      props,
+    ),
+    render,
+  });
+}
+
+function ButtonGroupSeparator({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="button-group-separator"
+      orientation={orientation}
+      className={cn("bg-input relative !m-0 self-stretch data-vertical:h-auto", className)}
+      {...props}
+    />
+  );
+}
+
+export { ButtonGroup, ButtonGroupSeparator, ButtonGroupText, buttonGroupVariants };


### PR DESCRIPTION
Refactors the Google Apps settings UI to use a new `ButtonGroup` component instead of the `Item` compound component family, simplifying the layout and improving consistency.

## Changes

- **New component**: Added `ButtonGroup` component (`packages/ui/components/button-group.tsx`) with support for horizontal/vertical orientation, designed for grouping related buttons with merged borders and focus management
- **Pinned apps list**: Replaced `Item`/`ItemContent`/`ItemActions`/`ItemTitle` with `ButtonGroup` containing two buttons (drag handle + app name, and unpin action)
- **Available apps list**: Replaced `Item` grid layout with simple flex-wrapped buttons, each with icon, name, and pin action inline
- **Removed imports**: Eliminated unused `Item`, `ItemActions`, `ItemContent`, `ItemGroup`, and `ItemTitle` imports from the settings file
- **Layout simplification**: Changed container from `ItemGroup` to plain `div` with flex layout for both pinned and available app sections

## Implementation Details

The new `ButtonGroup` component provides:
- Automatic border merging between adjacent buttons (removes duplicate borders)
- Focus ring z-index management to prevent overlap
- Support for both horizontal and vertical orientations
- Optional `ButtonGroupText` and `ButtonGroupSeparator` sub-components for more complex layouts

The refactored UI is more direct — buttons now contain their full content (icon + label) rather than delegating to nested `ItemContent`/`ItemTitle` wrappers, reducing component nesting and improving maintainability.

https://claude.ai/code/session_01BGY2GbFvMbhdz3exAkhEjR