### PR TITLE
Extract general settings to dedicated route

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -186,7 +186,7 @@ export class AppMenu {
           {
             label: "Settings...",
             click: () => {
-              main.navigate("/settings/accounts");
+              main.navigate("/settings/general");
             },
           },
           {

--- a/packages/renderer-main/components/app-sidebar.tsx
+++ b/packages/renderer-main/components/app-sidebar.tsx
@@ -8,6 +8,7 @@ import { AccountsSettings } from "@/routes/settings/accounts";
 import { AboutSettings } from "@/routes/settings/about";
 import { AdvancedSettings } from "@/routes/settings/advanced";
 import { AppearanceSettings } from "@/routes/settings/appearance";
+import { GeneralSettings } from "@/routes/settings/general";
 import { BlockerSettings } from "@/routes/settings/blocker";
 import { DownloadHistory } from "@/routes/download-history";
 import { DownloadsSettings } from "@/routes/settings/downloads";
@@ -32,6 +33,11 @@ export const sidebarNavItems: SidebarNavItemProps[] = [
   },
   {
     type: "separator",
+  },
+  {
+    label: "General",
+    path: "/settings/general",
+    component: GeneralSettings,
   },
   {
     label: "Accounts",

--- a/packages/renderer-main/routes/settings/advanced.tsx
+++ b/packages/renderer-main/routes/settings/advanced.tsx
@@ -1,123 +1,8 @@
-import { ipc } from "@meru/shared/renderer/ipc";
 import { platform } from "@meru/shared/renderer/utils";
-import {
-  Field,
-  FieldContent,
-  FieldDescription,
-  FieldGroup,
-  FieldLabel,
-  FieldLegend,
-  FieldSeparator,
-  FieldSet,
-} from "@meru/ui/components/field";
-import { Switch } from "@meru/ui/components/switch";
-import { useMutation, useQuery } from "@tanstack/react-query";
-import type { LoginItemSettings } from "electron";
-import { useId } from "react";
+import { FieldGroup, FieldLegend, FieldSeparator, FieldSet } from "@meru/ui/components/field";
 import { ConfigSwitchField } from "@/components/config-switch-field";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
-import { LicenseKeyRequiredFieldBadge } from "@/components/license-key-required-field-badge";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
-import { useIsLicenseKeyValid } from "@/lib/hooks";
-import { queryClient } from "@meru/shared/renderer/react-query";
-
-function LaunchAtLoginField() {
-  const queryKey = ["login-item-settings"];
-
-  const { data: loginItemSettings } = useQuery({
-    queryKey,
-    queryFn: () => ipc.main.invoke("app.getLoginItemSettings"),
-  });
-
-  const loginItemSettingsMutation = useMutation({
-    mutationFn: (settings: Partial<LoginItemSettings>) =>
-      ipc.main.invoke("app.setLoginItemSettings", settings),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey,
-      });
-    },
-  });
-
-  const fieldId = useId();
-
-  if (platform.isLinux || !loginItemSettings) {
-    return;
-  }
-
-  return (
-    <Field orientation="horizontal">
-      <FieldContent>
-        <FieldLabel htmlFor={fieldId}>Launch at Login</FieldLabel>
-        <FieldDescription>
-          Enable this option to automatically start the application when you log into your computer.
-        </FieldDescription>
-      </FieldContent>
-      <Switch
-        id={fieldId}
-        checked={loginItemSettings.openAtLogin}
-        onCheckedChange={(checked) => {
-          loginItemSettingsMutation.mutate({
-            openAtLogin: checked,
-          });
-        }}
-      />
-    </Field>
-  );
-}
-
-function DefaultMailClientField() {
-  const queryKey = ["default-mailto-client"];
-
-  const { data: isDefaultMailtoClient } = useQuery({
-    queryKey,
-    queryFn: () => ipc.main.invoke("app.getIsDefaultMailtoClient"),
-  });
-
-  const isDefaultMailtoClientMutation = useMutation({
-    mutationFn: () => ipc.main.invoke("app.setAsDefaultMailtoClient"),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey,
-      });
-    },
-  });
-
-  const fieldId = useId();
-
-  const isLicenseKeyValid = useIsLicenseKeyValid();
-
-  if (typeof isDefaultMailtoClient !== "boolean") {
-    return;
-  }
-
-  return (
-    <Field orientation="horizontal">
-      <FieldContent>
-        <FieldLabel htmlFor={fieldId}>
-          Default Mail Client <LicenseKeyRequiredFieldBadge />
-        </FieldLabel>
-        <FieldDescription>
-          {isDefaultMailtoClient
-            ? "Meru is set as default mail client."
-            : "Set Meru as the default mail client to handle email links and related protocols."}
-        </FieldDescription>
-      </FieldContent>
-      {!isDefaultMailtoClient && (
-        <Switch
-          id={fieldId}
-          checked={isDefaultMailtoClient}
-          onCheckedChange={(checked) => {
-            if (checked) {
-              isDefaultMailtoClientMutation.mutate();
-            }
-          }}
-          disabled={!isLicenseKeyValid}
-        />
-      )}
-    </Field>
-  );
-}
 
 export function AdvancedSettings() {
   return (
@@ -128,23 +13,6 @@ export function AdvancedSettings() {
       <SettingsContent>
         <LicenseKeyRequiredBanner />
         <FieldGroup>
-          <FieldSet>
-            <FieldLegend>General</FieldLegend>
-            <FieldGroup>
-              <DefaultMailClientField />
-            </FieldGroup>
-          </FieldSet>
-          <FieldSeparator />
-          <FieldSet>
-            <FieldLegend>Startup</FieldLegend>
-            <LaunchAtLoginField />
-            <ConfigSwitchField
-              label="Launch Minimized"
-              description="Enable this option to start the application in a minimized state."
-              configKey="launchMinimized"
-            />
-          </FieldSet>
-          <FieldSeparator />
           {platform.isMacOS && (
             <FieldSet>
               <FieldLegend>Screen Sharing</FieldLegend>

--- a/packages/renderer-main/routes/settings/general.tsx
+++ b/packages/renderer-main/routes/settings/general.tsx
@@ -1,0 +1,146 @@
+import { ipc } from "@meru/shared/renderer/ipc";
+import { queryClient } from "@meru/shared/renderer/react-query";
+import { platform } from "@meru/shared/renderer/utils";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+} from "@meru/ui/components/field";
+import { Switch } from "@meru/ui/components/switch";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import type { LoginItemSettings } from "electron";
+import { useId } from "react";
+import { ConfigSwitchField } from "@/components/config-switch-field";
+import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
+import { LicenseKeyRequiredFieldBadge } from "@/components/license-key-required-field-badge";
+import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
+import { useIsLicenseKeyValid } from "@/lib/hooks";
+
+function LaunchAtLoginField() {
+  const queryKey = ["login-item-settings"];
+
+  const { data: loginItemSettings } = useQuery({
+    queryKey,
+    queryFn: () => ipc.main.invoke("app.getLoginItemSettings"),
+  });
+
+  const loginItemSettingsMutation = useMutation({
+    mutationFn: (settings: Partial<LoginItemSettings>) =>
+      ipc.main.invoke("app.setLoginItemSettings", settings),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey,
+      });
+    },
+  });
+
+  const fieldId = useId();
+
+  if (platform.isLinux || !loginItemSettings) {
+    return;
+  }
+
+  return (
+    <Field orientation="horizontal">
+      <FieldContent>
+        <FieldLabel htmlFor={fieldId}>Launch at Login</FieldLabel>
+        <FieldDescription>
+          Enable this option to automatically start the application when you log into your computer.
+        </FieldDescription>
+      </FieldContent>
+      <Switch
+        id={fieldId}
+        checked={loginItemSettings.openAtLogin}
+        onCheckedChange={(checked) => {
+          loginItemSettingsMutation.mutate({
+            openAtLogin: checked,
+          });
+        }}
+      />
+    </Field>
+  );
+}
+
+function DefaultMailClientField() {
+  const queryKey = ["default-mailto-client"];
+
+  const { data: isDefaultMailtoClient } = useQuery({
+    queryKey,
+    queryFn: () => ipc.main.invoke("app.getIsDefaultMailtoClient"),
+  });
+
+  const isDefaultMailtoClientMutation = useMutation({
+    mutationFn: () => ipc.main.invoke("app.setAsDefaultMailtoClient"),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey,
+      });
+    },
+  });
+
+  const fieldId = useId();
+
+  const isLicenseKeyValid = useIsLicenseKeyValid();
+
+  if (typeof isDefaultMailtoClient !== "boolean") {
+    return;
+  }
+
+  return (
+    <Field orientation="horizontal">
+      <FieldContent>
+        <FieldLabel htmlFor={fieldId}>
+          Default Mail Client <LicenseKeyRequiredFieldBadge />
+        </FieldLabel>
+        <FieldDescription>
+          {isDefaultMailtoClient
+            ? "Meru is set as default mail client."
+            : "Set Meru as the default mail client to handle email links and related protocols."}
+        </FieldDescription>
+      </FieldContent>
+      {!isDefaultMailtoClient && (
+        <Switch
+          id={fieldId}
+          checked={isDefaultMailtoClient}
+          onCheckedChange={(checked) => {
+            if (checked) {
+              isDefaultMailtoClientMutation.mutate();
+            }
+          }}
+          disabled={!isLicenseKeyValid}
+        />
+      )}
+    </Field>
+  );
+}
+
+export function GeneralSettings() {
+  return (
+    <Settings>
+      <SettingsHeader>
+        <SettingsTitle>General</SettingsTitle>
+      </SettingsHeader>
+      <SettingsContent>
+        <LicenseKeyRequiredBanner />
+        <FieldGroup>
+          <DefaultMailClientField />
+          <FieldSeparator />
+          <FieldSet>
+            <FieldLegend>Startup</FieldLegend>
+            <LaunchAtLoginField />
+            <ConfigSwitchField
+              label="Launch Minimized"
+              description="Enable this option to start the application in a minimized state."
+              configKey="launchMinimized"
+            />
+          </FieldSet>
+        </FieldGroup>
+      </SettingsContent>
+    </Settings>
+  );
+}


### PR DESCRIPTION
Reorganize settings by creating a new "General" settings page and moving startup/mail client configuration from Advanced settings.

## Changes

- **New file**: `packages/renderer-main/routes/settings/general.tsx`
  - Created `GeneralSettings` component housing general application settings
  - Moved `LaunchAtLoginField` and `DefaultMailClientField` from Advanced settings
  - Moved `Launch Minimized` config field from Advanced settings
  - Organized fields under "General" and "Startup" sections with appropriate separators

- **Modified**: `packages/renderer-main/routes/settings/advanced.tsx`
  - Removed `LaunchAtLoginField` and `DefaultMailClientField` components
  - Removed "General" and "Startup" field sets
  - Kept platform-specific settings (Screen Sharing, etc.)
  - Cleaned up unused imports

- **Modified**: `packages/renderer-main/components/app-sidebar.tsx`
  - Added "General" settings route to sidebar navigation
  - Imported `GeneralSettings` component
  - Positioned before "Accounts" in the navigation order

- **Modified**: `packages/app/menu.ts`
  - Updated Settings menu to navigate to `/settings/general` instead of `/settings/accounts`

## Implementation Details

The refactoring maintains all existing functionality while improving settings organization. General application settings (launch behavior, default mail client) are now grouped separately from advanced/technical settings, providing a clearer hierarchy for users.

https://claude.ai/code/session_01JL3igrYkVpY5JLeUdbXCtM