### PR TITLE
fix window position resetting after Windows reboot

### DIFF
--- a/packages/app/lib/window.ts
+++ b/packages/app/lib/window.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { is, platform } from "@electron-toolkit/utils";
 import { APP_TITLEBAR_HEIGHT } from "@meru/shared/constants";
+import type { Config } from "@meru/shared/types";
 import {
   BrowserWindow,
   type BrowserWindowConstructorOptions,
@@ -36,6 +37,33 @@ export function getCascadedWindowBounds({ width, height }: { width: number; heig
   }
 
   return { x, y, width, height };
+}
+
+export function isWindowVisibleOnConnectedDisplay(bounds: Config["window.lastState"]["bounds"]) {
+  if (typeof bounds.x !== "number" || typeof bounds.y !== "number") {
+    return true;
+  }
+
+  const windowX = bounds.x;
+  const windowY = bounds.y;
+  const windowWidth = bounds.width;
+  const windowHeight = bounds.height;
+
+  return screen.getAllDisplays().some((display) => {
+    const {
+      x: workAreaX,
+      y: workAreaY,
+      width: workAreaWidth,
+      height: workAreaHeight,
+    } = display.workArea;
+
+    return (
+      windowX < workAreaX + workAreaWidth &&
+      windowX + windowWidth > workAreaX &&
+      windowY < workAreaY + workAreaHeight &&
+      windowY + windowHeight > workAreaY
+    );
+  });
 }
 
 export function getPreloadPath(name: string) {

--- a/packages/app/main.ts
+++ b/packages/app/main.ts
@@ -3,7 +3,12 @@ import { platform } from "@electron-toolkit/utils";
 import { app, BrowserWindow, screen } from "electron";
 import { accounts } from "@/accounts";
 import { config, DEFAULT_WINDOW_STATE_BOUNDS } from "@/config";
-import { getCommonBrowserWindowOptions, getTitleBarOptions, loadRenderer } from "@/lib/window";
+import {
+  getCommonBrowserWindowOptions,
+  getTitleBarOptions,
+  isWindowVisibleOnConnectedDisplay,
+  loadRenderer,
+} from "@/lib/window";
 import { appState } from "@/state";
 import { openExternalUrl } from "@/url";
 import { ipc } from "./ipc";
@@ -74,10 +79,7 @@ class Main {
     const lastWindowState = config.get("window.lastState");
     const restrictWindowMinimumSize = config.get("window.restrictMinimumSize");
 
-    if (
-      typeof lastWindowState.displayId === "number" &&
-      !screen.getAllDisplays().some((display) => display.id === lastWindowState.displayId)
-    ) {
+    if (!isWindowVisibleOnConnectedDisplay(lastWindowState.bounds)) {
       lastWindowState.bounds = DEFAULT_WINDOW_STATE_BOUNDS;
     }
 


### PR DESCRIPTION
## Summary

Fixes #575 — the main window's saved position/size is restored after a normal app restart but resets to the default position after a full Windows reboot (notably with an external monitor).

## Root cause

On Windows, the bounds are already persisted on every `resized`/`moved`/`maximize`/`unmaximize` event, so the latest position *is* saved before a reboot. The reset happens at **restore time**, in `Main.init()`:

```ts
if (
  typeof lastWindowState.displayId === "number" &&
  !screen.getAllDisplays().some((display) => display.id === lastWindowState.displayId)
) {
  lastWindowState.bounds = DEFAULT_WINDOW_STATE_BOUNDS;
}
```

The guard discards the saved bounds whenever the stored `displayId` no longer matches a connected display. But **Electron/Windows display IDs are not stable across an OS reboot** — the same physical monitor gets a different `display.id`, so the check fails and the window falls back to the default position. A normal app restart keeps the same IDs, which is why the bug only reproduces after a Windows reboot.

## Fix

Replace the fragile `displayId` equality check with a geometry check that verifies the saved window rectangle still overlaps a connected display's work area (standard AABB intersection). This is reboot-stable because it relies on geometry rather than volatile IDs, while preserving the original intent of not restoring a window onto a disconnected/off-screen monitor.

- Window coordinates are copied into local `const` numbers before the `.some()` callback so they stay narrowed to `number` inside the closure (avoids non-null assertions, which the repo lint rules ban).
- The check is skipped when no explicit position was saved (`x`/`y` undefined), letting Electron center the window as before.
- The `displayId` field is left in place for backward compatibility; it just no longer drives the restore decision.

## Testing

- `bun types:ci` passes.
- Geometry reasoning:
  - Bounds inside a connected display's work area → preserved.
  - Bounds entirely off every work area (disconnected monitor) → reset to default.
  - Bounds with `x`/`y` undefined (fresh state) → check skipped, window centered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)