### PR TITLE
Fix context menu popup to use focused frame

### DIFF
--- a/patches/electron-context-menu@4.1.0.patch
+++ b/patches/electron-context-menu@4.1.0.patch
@@ -7,6 +7,9 @@ index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2
 diff --git a/node_modules/electron-context-menu/.bun-tag-b553a854f9ef0c9f b/.bun-tag-b553a854f9ef0c9f
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/electron-context-menu/.bun-tag-ed88adbba809482d b/.bun-tag-ed88adbba809482d
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/index.d.ts b/index.d.ts
 index 657d3776641c554d8c0188e3cd7192fe5a1e1ce0..7a52ea17aec36bcab6e2e0640c8fadb3d0782b2a 100644
 --- a/index.d.ts
@@ -26,7 +29,7 @@ index 657d3776641c554d8c0188e3cd7192fe5a1e1ce0..7a52ea17aec36bcab6e2e0640c8fadb3
  	Show the `Save Video` menu item when right-clicking on a video.
  
 diff --git a/index.js b/index.js
-index 8ec2624b2ed049733788311aed0852432dbefb42..1274e0d8e2b125821689cc214dc0b8c08ba01fdd 100644
+index 8ec2624b2ed049733788311aed0852432dbefb42..4f8124fbd4f036cece184b4e3f580aef7d1bb131 100644
 --- a/index.js
 +++ b/index.js
 @@ -117,6 +117,23 @@ const create = (win, options) => {
@@ -93,7 +96,18 @@ index 8ec2624b2ed049733788311aed0852432dbefb42..1274e0d8e2b125821689cc214dc0b8c0
  			defaultActions.separator(),
  			options.showCopyLink !== false && defaultActions.copyLink(),
  			options.showSaveLinkAs && defaultActions.saveLinkAs(),
-@@ -354,7 +390,7 @@ const create = (win, options) => {
+@@ -343,7 +379,9 @@ const create = (win, options) => {
+ 				menu.on('menu-will-close', options.onClose);
+ 			}
+ 
+-			menu.popup(win);
++			menu.popup({
++				frame: webContents(win).focusedFrame,
++			});
+ 		}
+ 	};
+ 
+@@ -354,7 +392,7 @@ const create = (win, options) => {
  			return;
  		}
  


### PR DESCRIPTION
Updates the electron-context-menu patch to properly handle context menu popups in multi-frame scenarios by targeting the focused frame instead of the window root.

## Changes

- Modified `menu.popup()` call to pass a configuration object specifying `frame: webContents(win).focusedFrame` instead of relying on the default window-level popup behavior
- This ensures context menus appear in the correct frame when multiple frames are present (e.g., iframes)
- Updated the patch file hash to reflect the code changes

## Implementation Details

The change replaces a simple `menu.popup(win)` call with `menu.popup({ frame: webContents(win).focusedFrame })`, which explicitly targets the currently focused frame within the window's web contents. This is necessary for proper context menu positioning and behavior in documents with embedded frames.

https://claude.ai/code/session_01CgFT3jE8axyvuJaLSr3Ug7