### PR TITLE
Add ability to disable accounts

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -38,7 +38,13 @@ class Accounts {
       }
     }
 
-    for (const accountConfig of this.getAccountConfigs()) {
+    const enabledAccountConfigs = accountConfigs.filter((accountConfig) => !accountConfig.disabled);
+
+    const accountConfigsToLoad = licenseKey.isValid
+      ? enabledAccountConfigs
+      : enabledAccountConfigs.slice(0, 1);
+
+    for (const accountConfig of accountConfigsToLoad) {
       const account = new Account(accountConfig);
 
       this.instances.set(accountConfig.id, account);
@@ -109,7 +115,7 @@ class Accounts {
   getAccountConfigs() {
     const accountConfigs = config
       .get("accounts")
-      .filter((accountConfig) => !accountConfig.disabled);
+      .filter((accountConfig) => this.instances.has(accountConfig.id));
 
     if (!licenseKey.isValid) {
       return accountConfigs.slice(0, 1);

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -22,6 +22,22 @@ class Accounts {
       config.set("accounts", accountConfigs);
     }
 
+    const hasSelectedEnabledAccount = accountConfigs.some(
+      (accountConfig) => !accountConfig.disabled && accountConfig.selected,
+    );
+
+    if (!hasSelectedEnabledAccount) {
+      const firstEnabledAccount = accountConfigs.find((accountConfig) => !accountConfig.disabled);
+
+      if (firstEnabledAccount) {
+        for (const accountConfig of accountConfigs) {
+          accountConfig.selected = accountConfig.id === firstEnabledAccount.id;
+        }
+
+        config.set("accounts", accountConfigs);
+      }
+    }
+
     for (const accountConfig of this.getAccountConfigs()) {
       const account = new Account(accountConfig);
 
@@ -91,7 +107,9 @@ class Accounts {
   }
 
   getAccountConfigs() {
-    const accountConfigs = config.get("accounts");
+    const accountConfigs = config
+      .get("accounts")
+      .filter((accountConfig) => !accountConfig.disabled);
 
     if (!licenseKey.isValid) {
       return accountConfigs.slice(0, 1);
@@ -224,6 +242,7 @@ class Accounts {
       ...accountDetails,
       id: randomUUID(),
       selected: false,
+      disabled: false,
       gmail: {
         unreadBadge: accountDetails.gmail.unreadBadge,
         unifiedInbox: accountDetails.gmail.unifiedInbox,

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -21,6 +21,7 @@ export const config = new Store<Config>({
         label: "Default",
         color: null,
         selected: true,
+        disabled: false,
         notifications: true,
         gmail: {
           unreadBadge: true,
@@ -310,6 +311,25 @@ export const config = new Store<Config>({
 
         // @ts-expect-error
         store.delete("hardwareAcceleration");
+      }
+    },
+    ">3.54.0": (store) => {
+      const accounts = store.get("accounts");
+
+      if (Array.isArray(accounts)) {
+        let accountsMigrated = false;
+
+        for (const account of accounts) {
+          if (typeof account.disabled !== "boolean") {
+            account.disabled = false;
+
+            accountsMigrated = true;
+          }
+        }
+
+        if (accountsMigrated) {
+          store.set("accounts", accounts);
+        }
       }
     },
   },

--- a/packages/renderer-main/routes/settings/accounts.tsx
+++ b/packages/renderer-main/routes/settings/accounts.tsx
@@ -27,11 +27,11 @@ import {
   SelectValue,
 } from "@meru/ui/components/select";
 import { Switch } from "@meru/ui/components/switch";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@meru/ui/components/tooltip";
 import { cn } from "@meru/ui/lib/utils";
 import { useForm } from "@tanstack/react-form";
-import { GripVerticalIcon, PencilIcon, TrashIcon, XIcon } from "lucide-react";
+import { GripVerticalIcon, InfoIcon, PencilIcon, TrashIcon, XIcon } from "lucide-react";
 import { useState } from "react";
-import { toast } from "sonner";
 import type { Entries } from "type-fest";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
@@ -49,11 +49,13 @@ function AccountForm({
   placeholder = "Work",
   onSubmit,
   type,
+  isOnlyEnabledAccount = false,
 }: {
   account?: AccountConfigInput;
   placeholder?: string;
   onSubmit: (values: AccountConfigInput) => void;
   type: "add" | "edit";
+  isOnlyEnabledAccount?: boolean;
 }) {
   const form = useForm({
     defaultValues: account,
@@ -211,8 +213,17 @@ function AccountForm({
                     name={field.name}
                     checked={field.state.value}
                     onCheckedChange={field.handleChange}
+                    disabled={isOnlyEnabledAccount}
                   />
                   <FieldLabel>Disabled</FieldLabel>
+                  {isOnlyEnabledAccount && (
+                    <Tooltip>
+                      <TooltipTrigger className="text-muted-foreground">
+                        <InfoIcon className="size-4" />
+                      </TooltipTrigger>
+                      <TooltipContent>At least one account must stay enabled.</TooltipContent>
+                    </Tooltip>
+                  )}
                 </Field>
               )}
             </form.Field>
@@ -268,6 +279,10 @@ function EditAccountButton({ account }: { account: AccountConfig }) {
 
   const { config } = useConfig();
 
+  const isOnlyEnabledAccount =
+    !account.disabled &&
+    (config?.accounts.filter((accountConfig) => !accountConfig.disabled).length ?? 0) <= 1;
+
   return (
     <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
       <DialogTrigger
@@ -283,18 +298,8 @@ function EditAccountButton({ account }: { account: AccountConfig }) {
         </DialogHeader>
         <AccountForm
           account={account}
+          isOnlyEnabledAccount={isOnlyEnabledAccount}
           onSubmit={(values) => {
-            if (values.disabled && !account.disabled) {
-              const enabledAccountsCount =
-                config?.accounts.filter((accountConfig) => !accountConfig.disabled).length ?? 0;
-
-              if (enabledAccountsCount <= 1) {
-                toast.error("Cannot disable the only enabled account");
-
-                return;
-              }
-            }
-
             ipc.main.send("accounts.updateAccount", {
               ...account,
               ...values,

--- a/packages/renderer-main/routes/settings/accounts.tsx
+++ b/packages/renderer-main/routes/settings/accounts.tsx
@@ -31,6 +31,7 @@ import { cn } from "@meru/ui/lib/utils";
 import { useForm } from "@tanstack/react-form";
 import { GripVerticalIcon, PencilIcon, TrashIcon, XIcon } from "lucide-react";
 import { useState } from "react";
+import { toast } from "sonner";
 import type { Entries } from "type-fest";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
@@ -42,6 +43,7 @@ function AccountForm({
     label: "",
     color: null,
     gmail: { unreadBadge: true, unifiedInbox: true },
+    disabled: false,
     notifications: true,
   },
   placeholder = "Work",
@@ -200,6 +202,21 @@ function AccountForm({
               </Field>
             )}
           </form.Field>
+          {type === "edit" && (
+            <form.Field name="disabled">
+              {(field) => (
+                <Field orientation="horizontal" className="w-fit">
+                  <Switch
+                    id={field.name}
+                    name={field.name}
+                    checked={field.state.value}
+                    onCheckedChange={field.handleChange}
+                  />
+                  <FieldLabel>Disabled</FieldLabel>
+                </Field>
+              )}
+            </form.Field>
+          )}
         </FieldSet>
       </FieldGroup>
       <div className="flex items-center justify-end">
@@ -249,6 +266,8 @@ function AddAccountButton() {
 function EditAccountButton({ account }: { account: AccountConfig }) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
+  const { config } = useConfig();
+
   return (
     <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
       <DialogTrigger
@@ -265,6 +284,17 @@ function EditAccountButton({ account }: { account: AccountConfig }) {
         <AccountForm
           account={account}
           onSubmit={(values) => {
+            if (values.disabled && !account.disabled) {
+              const enabledAccountsCount =
+                config?.accounts.filter((accountConfig) => !accountConfig.disabled).length ?? 0;
+
+              if (enabledAccountsCount <= 1) {
+                toast.error("Cannot disable the only enabled account");
+
+                return;
+              }
+            }
+
             ipc.main.send("accounts.updateAccount", {
               ...account,
               ...values,
@@ -276,7 +306,8 @@ function EditAccountButton({ account }: { account: AccountConfig }) {
             if (
               account.gmail.unreadBadge !== values.gmail.unreadBadge ||
               account.gmail.unifiedInbox !== values.gmail.unifiedInbox ||
-              account.notifications !== values.notifications
+              account.notifications !== values.notifications ||
+              account.disabled !== values.disabled
             ) {
               restartRequiredToast();
             }
@@ -323,8 +354,9 @@ function SortableAccountItem({
           />
           {account.label}
         </ItemTitle>
-        {(account.gmail.unreadBadge || account.notifications) && (
+        {(account.disabled || account.gmail.unreadBadge || account.notifications) && (
           <div className="flex gap-2">
+            {account.disabled && <Badge variant="outline">Disabled</Badge>}
             {account.gmail.unreadBadge && <Badge variant="outline">Unread Badge</Badge>}
             {account.gmail.unifiedInbox && <Badge variant="outline">Unified Inbox</Badge>}
             {account.notifications && <Badge variant="outline">Notifications</Badge>}

--- a/packages/shared/schemas.ts
+++ b/packages/shared/schemas.ts
@@ -25,6 +25,7 @@ export const accountConfigSchema = z.object({
   label: z.string(),
   color: z.enum(accountColors).nullable(),
   selected: z.boolean(),
+  disabled: z.boolean(),
   notifications: z.boolean(),
   gmail: z.object({
     unreadBadge: z.boolean(),
@@ -41,6 +42,7 @@ export const accountConfigInputSchema = accountConfigSchema
   .pick({
     label: true,
     color: true,
+    disabled: true,
     notifications: true,
   })
   .extend({


### PR DESCRIPTION
## Summary
Adds the ability to disable individual accounts while keeping them in the configuration. Disabled accounts are excluded from loading and selection logic, with safeguards to ensure at least one account remains enabled.

## Key Changes
- **UI**: Added "Disabled" toggle to the account edit form with a tooltip preventing disabling the only enabled account
- **Account Management**: Modified `Accounts` class to filter out disabled accounts when loading instances and selecting defaults
- **Config**: Added `disabled` boolean field to account config schema with migration for existing accounts
- **Selection Logic**: Ensures a selected enabled account exists; if all selected accounts are disabled, automatically selects the first enabled account
- **License Handling**: Respects disabled status when applying license-based account limits (only loads enabled accounts, up to the license limit)
- **UI Indicators**: Shows "Disabled" badge on account items in the settings list

## Implementation Details
- The "Disabled" toggle is only shown in edit mode and is disabled when it's the only enabled account
- Disabled accounts are filtered at the `Accounts` level, not just the UI, ensuring they're never loaded as instances
- A config migration (v3.54.0+) ensures existing accounts have the `disabled` field set to `false`
- The selection fallback logic prevents orphaned selections when accounts are disabled

https://claude.ai/code/session_01E4pAraN4YaspYqzr5J4AZu