### PR TITLE
apply dark theme to gmail compose popups

### DIFF
--- a/packages/preload-gmail/dark-theme/compose.css
+++ b/packages/preload-gmail/dark-theme/compose.css
@@ -1,0 +1,9 @@
+/* More options in reply container */
+.J-M:has([data-dark-theme]) {
+  background-color: rgb(19, 19, 19) !important;
+}
+
+.HQ .Un:after {
+  background-image: url(//ssl.gstatic.com/ui/v1/icons/mail/gm3/1x/arrow_drop_down_baseline_nv700_20dp.png) !important;
+  filter: invert(1) !important;
+}

--- a/packages/preload-gmail/dark-theme/compose.ts
+++ b/packages/preload-gmail/dark-theme/compose.ts
@@ -1,0 +1,36 @@
+import { applyDarkTheme, type DarkThemeController } from "@meru/dark-theme";
+import { GMAIL_PRELOAD_ARGUMENTS } from "@meru/shared/gmail";
+import { $$ } from "select-dom";
+
+const isFullDarkThemeEnabled = process.argv.includes(GMAIL_PRELOAD_ARGUMENTS.fullDarkTheme);
+
+const controllers = new Map<HTMLDivElement, DarkThemeController>();
+
+export function darkThemeCompose() {
+  if (!isFullDarkThemeEnabled) {
+    return;
+  }
+
+  const composeElements = $$("div.AD");
+  const composeElementSet = new Set(composeElements);
+
+  for (const [composeElement, controller] of controllers) {
+    if (!composeElementSet.has(composeElement)) {
+      controller.destroy();
+      controllers.delete(composeElement);
+    }
+  }
+
+  for (const composeElement of composeElements) {
+    if (controllers.has(composeElement)) {
+      continue;
+    }
+
+    controllers.set(
+      composeElement,
+      applyDarkTheme(composeElement, {
+        backgroundColor: "rgb(19, 19, 19)",
+      }),
+    );
+  }
+}

--- a/packages/preload-gmail/dark-theme/compose.ts
+++ b/packages/preload-gmail/dark-theme/compose.ts
@@ -1,6 +1,7 @@
 import { applyDarkTheme, type DarkThemeController } from "@meru/dark-theme";
 import { GMAIL_PRELOAD_ARGUMENTS } from "@meru/shared/gmail";
 import { $$ } from "select-dom";
+import composeCss from "./compose.css";
 
 const isFullDarkThemeEnabled = process.argv.includes(GMAIL_PRELOAD_ARGUMENTS.fullDarkTheme);
 
@@ -30,6 +31,7 @@ export function darkThemeCompose() {
       composeElement,
       applyDarkTheme(composeElement, {
         backgroundColor: "rgb(19, 19, 19)",
+        css: composeCss,
       }),
     );
   }

--- a/packages/preload-gmail/index.ts
+++ b/packages/preload-gmail/index.ts
@@ -4,6 +4,7 @@ import { observeBodyMutations } from "@meru/shared/dom";
 import { moveAttachmentsToTop } from "./attachments";
 import { openComposeInNewWindow } from "./compose";
 import { initCss } from "./css";
+import { darkThemeCompose } from "./dark-theme/compose";
 import { darkThemeMessage } from "./dark-theme/message";
 import { observeOutOfOfficeBanner } from "./out-of-office";
 import { replyForwardInPopOut } from "./reply-forward";
@@ -22,6 +23,7 @@ const features = [
   setUserEmail,
   replyForwardInPopOut,
   darkThemeMessage,
+  darkThemeCompose,
 ];
 
 function runFeatures() {


### PR DESCRIPTION
Extends the Gmail full dark theme to the compose/reply popups docked at the bottom-right of the window, which previously stayed on a white background in dark mode.

## Changes

- Add `packages/preload-gmail/dark-theme/compose.ts` — a new preload feature that themes every open compose popup (`div.AD`). Unlike `message.ts` (single reading pane), this tracks a `Map<HTMLDivElement, DarkThemeController>` because several popups can be open at once:
  - On each mutation pass it destroys controllers for popups that have closed, then applies the theme once to any newly-opened popup (guarded by `controllers.has(...)`).
  - Uses `backgroundColor: "rgb(19, 19, 19)"` to match the message pane's surface.
- Add `packages/preload-gmail/dark-theme/compose.css` — scoped state-style fixes the inline-override engine can't reach: the "more options" menu surface, and inverting the send-dropdown arrow icon.
- Wire `darkThemeCompose` into the `features` array in `packages/preload-gmail/index.ts`.

Gated behind the existing `GMAIL_PRELOAD_ARGUMENTS.fullDarkTheme` flag, so it only runs when the full dark theme is enabled.

## Verification

- `bun types:ci` passes across all packages.
- Manual: with the full dark theme enabled, open one or more compose/reply popups — each renders on the dark surface; closing a popup releases its controller with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1Cir9w5bxQqyW6UKvyvt9)_