### PR TITLE
Improve image analysis and cache memory management

### DIFF
--- a/packages/dark-theme/image.ts
+++ b/packages/dark-theme/image.ts
@@ -289,31 +289,68 @@ function shouldBuildDataURL(details: ImageDetails): boolean {
   return details.isLight && !details.isTransparent && !details.solidColor;
 }
 
-// Bounded because entries can carry a base64 dataURL of the full image — in a
-// long-lived mail client an unbounded per-url cache would accumulate megabytes.
+// Bounded by total text length, not just entry count: an entry can carry a
+// base64 dataURL of the full image, and a data: source url is itself the whole
+// image (it is the cache key even when analysis fails), so counting entries
+// alone would let a few hundred multi-megabyte strings pin tens of megabytes in
+// a long-lived mail client.
 const IMAGE_DETAILS_CACHE_MAX_ENTRIES = 256;
-const imageDetailsCache = new Map<string, ImageDetails | null>();
+const IMAGE_DETAILS_CACHE_MAX_TEXT_LENGTH = 8 * 1024 * 1024;
 
-function rememberImageDetails(url: string, details: ImageDetails | null) {
-  if (imageDetailsCache.size >= IMAGE_DETAILS_CACHE_MAX_ENTRIES) {
-    const oldestUrl = imageDetailsCache.keys().next().value;
+type ImageDetailsCacheEntry = {
+  details: ImageDetails | null;
+  textLength: number;
+};
 
-    if (oldestUrl !== undefined) {
-      imageDetailsCache.delete(oldestUrl);
-    }
+const imageDetailsCache = new Map<string, ImageDetailsCacheEntry>();
+let imageDetailsCacheTextLength = 0;
+
+function getImageDetailsTextLength(url: string, details: ImageDetails | null): number {
+  if (!details || details.dataURL === url) {
+    return url.length;
   }
 
-  imageDetailsCache.set(url, details);
+  return url.length + details.dataURL.length;
+}
+
+function evictOldestImageDetails() {
+  const oldestUrl = imageDetailsCache.keys().next().value;
+
+  if (oldestUrl === undefined) {
+    return;
+  }
+
+  imageDetailsCacheTextLength -= imageDetailsCache.get(oldestUrl)?.textLength ?? 0;
+  imageDetailsCache.delete(oldestUrl);
+}
+
+function rememberImageDetails(url: string, details: ImageDetails | null) {
+  const textLength = getImageDetailsTextLength(url, details);
+
+  if (textLength > IMAGE_DETAILS_CACHE_MAX_TEXT_LENGTH) {
+    return;
+  }
+
+  while (
+    imageDetailsCache.size > 0 &&
+    (imageDetailsCache.size >= IMAGE_DETAILS_CACHE_MAX_ENTRIES ||
+      imageDetailsCacheTextLength + textLength > IMAGE_DETAILS_CACHE_MAX_TEXT_LENGTH)
+  ) {
+    evictOldestImageDetails();
+  }
+
+  imageDetailsCache.set(url, { details, textLength });
+  imageDetailsCacheTextLength += textLength;
 }
 
 export async function getImageDetails(url: string): Promise<ImageDetails | null> {
-  if (imageDetailsCache.has(url)) {
-    const cached = imageDetailsCache.get(url) ?? null;
+  const cachedEntry = imageDetailsCache.get(url);
 
+  if (cachedEntry !== undefined) {
     imageDetailsCache.delete(url);
-    imageDetailsCache.set(url, cached);
+    imageDetailsCache.set(url, cachedEntry);
 
-    return cached;
+    return cachedEntry.details;
   }
 
   let details: ImageDetails | null = null;

--- a/packages/dark-theme/image.ts
+++ b/packages/dark-theme/image.ts
@@ -346,16 +346,12 @@ function rememberImageDetails(url: string, details: ImageDetails | null) {
   imageDetailsCacheTextLength += textLength;
 }
 
-export async function getImageDetails(url: string): Promise<ImageDetails | null> {
-  const cachedEntry = imageDetailsCache.get(url);
+// The same url often appears many times in one batch (a logo repeated through a
+// message, a sprite shared by many elements); deduping in-flight analyses keeps
+// that from spawning parallel fetches and full decodes of the same image.
+const pendingImageDetailsByUrl = new Map<string, Promise<ImageDetails | null>>();
 
-  if (cachedEntry !== undefined) {
-    imageDetailsCache.delete(url);
-    imageDetailsCache.set(url, cachedEntry);
-
-    return cachedEntry.details;
-  }
-
+async function loadAndAnalyzeImage(url: string): Promise<ImageDetails | null> {
   let details: ImageDetails | null = null;
 
   try {
@@ -382,6 +378,31 @@ export async function getImageDetails(url: string): Promise<ImageDetails | null>
   rememberImageDetails(url, details);
 
   return details;
+}
+
+export async function getImageDetails(url: string): Promise<ImageDetails | null> {
+  const cachedEntry = imageDetailsCache.get(url);
+
+  if (cachedEntry !== undefined) {
+    imageDetailsCache.delete(url);
+    imageDetailsCache.set(url, cachedEntry);
+
+    return cachedEntry.details;
+  }
+
+  const pendingDetails = pendingImageDetailsByUrl.get(url);
+
+  if (pendingDetails) {
+    return pendingDetails;
+  }
+
+  const detailsPromise = loadAndAnalyzeImage(url).finally(() => {
+    pendingImageDetailsByUrl.delete(url);
+  });
+
+  pendingImageDetailsByUrl.set(url, detailsPromise);
+
+  return detailsPromise;
 }
 
 const xmlEscapes: Record<string, string> = {

--- a/packages/dark-theme/image.ts
+++ b/packages/dark-theme/image.ts
@@ -259,6 +259,10 @@ function imageToDataURL(image: HTMLImageElement): string {
   }
 }
 
+export function isImageElementLarge(image: HTMLImageElement): boolean {
+  return image.naturalWidth * image.naturalHeight > LARGE_IMAGE_PIXEL_COUNT;
+}
+
 // A dark, mostly-transparent image is treated as a logo or icon that would
 // vanish against the dark background, so it gets inverted — unless it is large
 // or spans a photographic tonal range, which marks it as a photo (e.g. a dark

--- a/packages/dark-theme/image.ts
+++ b/packages/dark-theme/image.ts
@@ -235,12 +235,11 @@ function loadImage(url: string): Promise<HTMLImageElement> {
   });
 }
 
-let snapshotCanvas: HTMLCanvasElement | null = null;
-
+// Created per call so the backing bitmap is released afterwards — a module-level
+// canvas would keep the last snapshotted image's pixels allocated for the
+// renderer's lifetime.
 function imageToDataURL(image: HTMLImageElement): string {
-  if (!snapshotCanvas) {
-    snapshotCanvas = document.createElement("canvas");
-  }
+  const snapshotCanvas = document.createElement("canvas");
 
   snapshotCanvas.width = image.naturalWidth;
   snapshotCanvas.height = image.naturalHeight;

--- a/packages/dark-theme/index.ts
+++ b/packages/dark-theme/index.ts
@@ -3,7 +3,7 @@ import { parseColorWithCache } from "./color";
 import { replaceColorTokens } from "./css-value";
 import { getCSSFilterValue } from "./filter";
 import { coversProperty, type IgnorePropertyRule } from "./ignore";
-import { getImageDetails, shouldInvertDarkImage } from "./image";
+import { getImageDetails, isImageElementLarge, shouldInvertDarkImage } from "./image";
 import { modifyBackgroundColor, modifyBorderColor, modifyForegroundColor } from "./modify-colors";
 import { buildDarkStateOverrides } from "./state-rules";
 import { INJECTED_STYLE_ATTRIBUTE } from "./stylesheets";
@@ -714,20 +714,42 @@ export function applyDarkTheme(root: HTMLElement, options?: DarkThemeOptions): D
   };
 }
 
+// Analysis re-fetches the image with an anonymous crossOrigin request — a
+// second copy the browser caches separately from the one the page already
+// rendered. A large image is never inverted (it reads as a photo), and a broken
+// one has nothing to analyze, so both are skipped before that fetch by reading
+// the natural size off the element — which means waiting for its own load
+// instead of racing it with an immediate parallel fetch.
 function invertDarkImageElement(image: HTMLImageElement, theme: Theme, isCancelled: () => boolean) {
-  const source = image.currentSrc || image.src;
+  const analyzeLoadedImage = () => {
+    const source = image.currentSrc || image.src;
 
-  if (!source) {
-    return;
-  }
-
-  getImageDetails(source).then((details) => {
-    if (isCancelled() || !details) {
+    if (!source || image.naturalWidth === 0 || isImageElementLarge(image)) {
       return;
     }
 
-    if (shouldInvertDarkImage(details)) {
-      image.style.setProperty("filter", getCSSFilterValue(theme), "important");
-    }
-  });
+    getImageDetails(source).then((details) => {
+      if (isCancelled() || !details) {
+        return;
+      }
+
+      if (shouldInvertDarkImage(details)) {
+        image.style.setProperty("filter", getCSSFilterValue(theme), "important");
+      }
+    });
+  };
+
+  if (image.complete) {
+    analyzeLoadedImage();
+  } else {
+    image.addEventListener(
+      "load",
+      () => {
+        if (!isCancelled()) {
+          analyzeLoadedImage();
+        }
+      },
+      { once: true },
+    );
+  }
 }

--- a/packages/dark-theme/index.ts
+++ b/packages/dark-theme/index.ts
@@ -533,6 +533,37 @@ export function applyDarkTheme(root: HTMLElement, options?: DarkThemeOptions): D
     flushPseudoRules();
   };
 
+  // Without pruning, elements the page removes stay strongly held by the
+  // original-style map until revert()/destroy() — a detached-subtree leak that
+  // grows for as long as the controller lives — and their pseudo rules bloat
+  // the injected sheet forever. A node that was merely moved is connected again
+  // by the time the mutation records are processed, so it is kept; a pruned
+  // element that later re-attaches comes back through the refresh path, which
+  // rebuilds its pseudo rules from the still-alive weak caches.
+  const pruneRemovedElements = (removedRoots: Iterable<HTMLElement>) => {
+    let didPrunePseudoRules = false;
+
+    for (const removedRoot of removedRoots) {
+      if (removedRoot.isConnected) {
+        continue;
+      }
+
+      for (const element of [removedRoot, ...removedRoot.querySelectorAll<HTMLElement>("*")]) {
+        originalStyles.delete(element);
+
+        const pseudoId = element.getAttribute(PSEUDO_ATTRIBUTE);
+
+        if (pseudoId != null && pseudoRulesById.delete(pseudoId)) {
+          didPrunePseudoRules = true;
+        }
+      }
+    }
+
+    if (didPrunePseudoRules) {
+      flushPseudoRules();
+    }
+  };
+
   // Same read-then-write batching as processBatch: snapshotting after another
   // element's inline writes would force a style recalc per element.
   const refreshElements = (elements: Iterable<HTMLElement>) => {
@@ -596,16 +627,34 @@ export function applyDarkTheme(root: HTMLElement, options?: DarkThemeOptions): D
       // inside an added ancestor), which would otherwise be snapshotted twice.
       const addedElements = new Set<HTMLElement>();
       const refreshTargets = new Set<HTMLElement>();
+      const removedElements = new Set<HTMLElement>();
+
+      // An added node that was already processed is a re-attachment (the page
+      // moved or restored it); it goes through the refresh path instead so the
+      // pseudo rules pruned while it was detached are rebuilt.
+      const collectAddedElement = (element: HTMLElement) => {
+        if (element.hasAttribute(PROCESSED_ATTRIBUTE)) {
+          refreshTargets.add(element);
+        } else {
+          addedElements.add(element);
+        }
+      };
 
       for (const mutation of mutations) {
         if (mutation.type === "childList") {
           for (const node of mutation.addedNodes) {
             if (node instanceof HTMLElement) {
-              addedElements.add(node);
+              collectAddedElement(node);
 
               for (const descendant of node.querySelectorAll<HTMLElement>("*")) {
-                addedElements.add(descendant);
+                collectAddedElement(descendant);
               }
+            }
+          }
+
+          for (const node of mutation.removedNodes) {
+            if (node instanceof HTMLElement) {
+              removedElements.add(node);
             }
           }
         } else if (mutation.type === "attributes" && mutation.target instanceof HTMLElement) {
@@ -619,6 +668,10 @@ export function applyDarkTheme(root: HTMLElement, options?: DarkThemeOptions): D
 
       if (refreshTargets.size > 0) {
         refreshElements(refreshTargets);
+      }
+
+      if (removedElements.size > 0) {
+        pruneRemovedElements(removedElements);
       }
     });
 

--- a/packages/dark-theme/modify-colors.ts
+++ b/packages/dark-theme/modify-colors.ts
@@ -203,6 +203,10 @@ function isPackableChannel(channelValue: number): boolean {
   return Number.isInteger(channelValue) && channelValue >= 0 && channelValue <= 255;
 }
 
+// Bounded like the parse cache: arbitrary email HTML feeds an open-ended stream
+// of distinct colors, and dropping entries only costs recomputation.
+const COLOR_CACHE_MAX_ENTRIES = 4096;
+
 function remapThroughCache(
   rgb: RGBA,
   themeState: ThemeState,
@@ -232,6 +236,11 @@ function remapThroughCache(
     a === 1
       ? rgbToHexString({ r: red, g: green, b: blue })
       : rgbToString({ r: red, g: green, b: blue, a });
+
+  if (cache.packed.size + cache.keyed.size >= COLOR_CACHE_MAX_ENTRIES) {
+    cache.packed.clear();
+    cache.keyed.clear();
+  }
 
   if (isPackable) {
     cache.packed.set(packedKey, color);


### PR DESCRIPTION
Optimizes memory usage and performance in the dark theme image processing pipeline through several targeted improvements:

**Key changes:**

- **Canvas memory management**: Changed `imageToDataURL()` to create a new canvas per call instead of reusing a module-level instance, allowing the backing bitmap to be released after use rather than persisting for the renderer's lifetime.

- **Image cache bounds**: Replaced entry-count-based cache eviction with text-length-based bounds. The cache now tracks total string length (including base64 dataURLs) and evicts oldest entries when either the entry count or total text length exceeds limits, preventing multi-megabyte accumulation in long-lived mail clients.

- **In-flight deduplication**: Added `pendingImageDetailsByUrl` map to deduplicate concurrent image analysis requests. When the same URL appears multiple times in a batch (e.g., a logo repeated through a message), subsequent requests await the first analysis instead of spawning parallel fetches and decodes.

- **Large image optimization**: Extracted `isImageElementLarge()` helper and added early-exit logic in `invertDarkImageElement()` to skip analysis for large images (which are never inverted) before fetching, reducing unnecessary network requests.

- **Load event handling**: Modified `invertDarkImageElement()` to wait for the image's load event before analyzing, ensuring `naturalWidth` and `naturalHeight` are available for the large-image check.

- **DOM cleanup**: Added `pruneRemovedElements()` to clean up detached elements from the `originalStyles` map and their pseudo rules, preventing memory leaks in long-lived controllers. Re-attached elements are refreshed to rebuild pruned pseudo rules from weak caches.

- **Re-attachment detection**: Enhanced mutation handling to distinguish between newly added elements and re-attached ones (already processed), routing re-attachments through the refresh path to rebuild their pseudo rules.

- **Color cache bounds**: Added `COLOR_CACHE_MAX_ENTRIES` limit to the color remapping cache with clearing logic, preventing unbounded growth from arbitrary email HTML.

https://claude.ai/code/session_01EAMy8S2G8xqhZejSyVzrfN