### PR TITLE
Add RPM build target for Linux distributions

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,13 @@
             "x64",
             "arm64"
           ]
+        },
+        {
+          "target": "rpm",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
         }
       ],
       "synopsis": "The Gmail experience you deserve",


### PR DESCRIPTION
Adds RPM package format support to the Electron builder configuration, enabling distribution of the application to RPM-based Linux systems (Red Hat, Fedora, CentOS, etc.).

**Changes:**
- Added RPM build target to the `build.linux` configuration in `package.json`
- Configured RPM builds for both x64 and arm64 architectures, matching the existing distribution targets

This complements the existing Linux build targets and expands platform coverage for Linux users.

https://claude.ai/code/session_01QGNmDEJdG3TmrVH8yoWe2A