### PR TITLE
Support multiple message elements in Gmail dark theme

### DIFF
--- a/packages/preload-gmail/dark-theme/message.ts
+++ b/packages/preload-gmail/dark-theme/message.ts
@@ -1,54 +1,60 @@
 import { applyDarkTheme, type DarkThemeController } from "@meru/dark-theme";
 import { GMAIL_PRELOAD_ARGUMENTS } from "@meru/shared/gmail";
-import { $ } from "select-dom";
+import { $$ } from "select-dom";
 import messageCss from "./message.css";
 
 const isFullDarkThemeEnabled = process.argv.includes(GMAIL_PRELOAD_ARGUMENTS.fullDarkTheme);
 
-let themedElement: HTMLElement | null = null;
-let controller: DarkThemeController | null = null;
+const controllers = new Map<HTMLElement, DarkThemeController>();
 
 export function darkThemeMessage() {
   if (!isFullDarkThemeEnabled) {
     return;
   }
 
-  const messageElement = $(".nH.id:has(h2[data-legacy-thread-id])") ?? null;
+  const messageElements = $$(".nH.id:has(h2[data-legacy-thread-id])");
+  const messageElementSet = new Set(messageElements);
 
-  if (messageElement === themedElement) {
-    return;
+  for (const [messageElement, controller] of controllers) {
+    if (!messageElementSet.has(messageElement)) {
+      controller.revert();
+      controllers.delete(messageElement);
+    }
   }
 
-  controller?.revert();
-  controller = null;
-  themedElement = messageElement;
+  for (const messageElement of messageElements) {
+    if (controllers.has(messageElement)) {
+      continue;
+    }
 
-  if (messageElement) {
-    controller = applyDarkTheme(messageElement, {
-      backgroundColor: "rgb(19, 19, 19)",
-      ignore: [
-        // Conversation labels inside message
-        ".edeTZ",
-        // Reply container
-        { selector: ".HM .I5", properties: ["border-color"] },
-        // "More options" button in reply container
-        { selector: ".J-JN-M-I", properties: ["background-color"] },
-        // "More options" menu items
-        { selector: ".J-N", properties: ["background-color"] },
-        // "Send" button in reply container
-        { selector: ".dC", properties: ["background-color"] },
-      ],
-      invertImageUrls: [
-        "https://www.gstatic.com/images/icons/material/system_gm/",
-        "https://ssl.gstatic.com/ui/v1/icons/mail/gm3/",
-      ],
-      invertImageExcludeFilenames: [
-        "star_googyellow500_20dp.png",
-        "archive_white_20dp.png",
-        "schedule_send_googblue_20dp.png",
-        "label_important_fill_googyellow500_20dp.png",
-      ],
-      css: messageCss,
-    });
+    controllers.set(
+      messageElement,
+      applyDarkTheme(messageElement, {
+        backgroundColor: "rgb(19, 19, 19)",
+        ignore: [
+          // Conversation labels inside message
+          ".edeTZ",
+          // Reply container
+          { selector: ".HM .I5", properties: ["border-color"] },
+          // "More options" button in reply container
+          { selector: ".J-JN-M-I", properties: ["background-color"] },
+          // "More options" menu items
+          { selector: ".J-N", properties: ["background-color"] },
+          // "Send" button in reply container
+          { selector: ".dC", properties: ["background-color"] },
+        ],
+        invertImageUrls: [
+          "https://www.gstatic.com/images/icons/material/system_gm/",
+          "https://ssl.gstatic.com/ui/v1/icons/mail/gm3/",
+        ],
+        invertImageExcludeFilenames: [
+          "star_googyellow500_20dp.png",
+          "archive_white_20dp.png",
+          "schedule_send_googblue_20dp.png",
+          "label_important_fill_googyellow500_20dp.png",
+        ],
+        css: messageCss,
+      }),
+    );
   }
 }


### PR DESCRIPTION
Refactor the Gmail message dark theme handler to support multiple message elements simultaneously instead of tracking only a single element.

## Summary
The dark theme message handler previously tracked a single message element and would revert its theme when a different element was encountered. This change updates it to maintain dark theme controllers for multiple message elements, enabling proper theming when multiple messages are visible in the DOM.

## Key Changes
- Changed from single `themedElement` and `controller` variables to a `Map<HTMLElement, DarkThemeController>` for tracking multiple elements
- Updated selector from `$()` (single element) to `$$()` (multiple elements)
- Implemented cleanup logic that reverts themes for removed elements and applies themes to new elements
- Maintains a `Set` of current message elements to efficiently detect which controllers should be cleaned up

## Implementation Details
- The function now iterates through existing controllers and removes those whose elements are no longer in the DOM
- For each current message element, it checks if a controller already exists before creating a new one, avoiding duplicate theme applications
- The dark theme configuration remains unchanged; only the lifecycle management was refactored

https://claude.ai/code/session_01Q3HANa7VjTStHLgCT1USHa