### PR TITLE
show current version badges in version history

### DIFF
--- a/packages/renderer-main/routes/settings/version-history.tsx
+++ b/packages/renderer-main/routes/settings/version-history.tsx
@@ -1,4 +1,6 @@
 import { dayjs } from "@meru/shared/renderer/date";
+import { ipc } from "@meru/shared/renderer/ipc";
+import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import { Empty, EmptyContent, EmptyHeader, EmptyTitle } from "@meru/ui/components/empty";
 import { Item, ItemContent, ItemDescription, ItemTitle } from "@meru/ui/components/item";
@@ -11,6 +13,13 @@ import z from "zod";
 import { SettingsHeader, SettingsTitle } from "@/components/settings";
 
 export function VersionHistorySettings() {
+  const { data: info } = useQuery({
+    queryKey: ["about", "info"],
+    queryFn: () => ipc.main.invoke("about.getInfo"),
+  });
+
+  const currentTagName = info ? `v${info.version}` : undefined;
+
   const { data, isPending, isError, refetch } = useQuery({
     queryKey: ["github", "releases"],
     queryFn: async () => {
@@ -64,7 +73,10 @@ export function VersionHistorySettings() {
     return data.map((release) => (
       <Item key={release.id} variant="muted">
         <ItemContent>
-          <ItemTitle className="text-2xl font-semibold">{release.tag_name}</ItemTitle>
+          <div className="flex items-center justify-between gap-2">
+            <ItemTitle className="text-2xl font-semibold">{release.tag_name}</ItemTitle>
+            {release.tag_name === currentTagName ? <Badge>Current version</Badge> : null}
+          </div>
           <ItemDescription>{dayjs(release.published_at).fromNow()}</ItemDescription>
           <div className="prose dark:prose-invert prose-h3:text-lg prose-li:marker:text-white prose-li:pl-0 mt-6 text-sm">
             <Markdown
@@ -84,8 +96,9 @@ export function VersionHistorySettings() {
 
   return (
     <>
-      <SettingsHeader>
+      <SettingsHeader className="flex-col items-start justify-start gap-2">
         <SettingsTitle>Version History</SettingsTitle>
+        {info ? <Badge variant="secondary">v{info.version}</Badge> : null}
       </SettingsHeader>
       <div className="space-y-8">{renderContent()}</div>
     </>

--- a/packages/renderer-main/routes/settings/version-history.tsx
+++ b/packages/renderer-main/routes/settings/version-history.tsx
@@ -10,7 +10,7 @@ import { useQuery } from "@tanstack/react-query";
 import Markdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import z from "zod";
-import { SettingsHeader, SettingsTitle } from "@/components/settings";
+import { SettingsDescription, SettingsHeader, SettingsTitle } from "@/components/settings";
 
 export function VersionHistorySettings() {
   const { data: info } = useQuery({
@@ -96,10 +96,10 @@ export function VersionHistorySettings() {
 
   return (
     <>
-      <SettingsHeader className="flex-col items-start justify-start gap-2">
+      <SettingsHeader className="flex-col items-start justify-start gap-1">
         <SettingsTitle>Version History</SettingsTitle>
         {info ? (
-          <Badge variant="secondary">Currently installed version v{info.version}</Badge>
+          <SettingsDescription>Currently installed version v{info.version}</SettingsDescription>
         ) : null}
       </SettingsHeader>
       <div className="space-y-8">{renderContent()}</div>

--- a/packages/renderer-main/routes/settings/version-history.tsx
+++ b/packages/renderer-main/routes/settings/version-history.tsx
@@ -98,7 +98,9 @@ export function VersionHistorySettings() {
     <>
       <SettingsHeader className="flex-col items-start justify-start gap-2">
         <SettingsTitle>Version History</SettingsTitle>
-        {info ? <Badge variant="secondary">v{info.version}</Badge> : null}
+        {info ? (
+          <Badge variant="secondary">Currently installed version v{info.version}</Badge>
+        ) : null}
       </SettingsHeader>
       <div className="space-y-8">{renderContent()}</div>
     </>

--- a/packages/renderer-main/routes/settings/version-history.tsx
+++ b/packages/renderer-main/routes/settings/version-history.tsx
@@ -99,7 +99,10 @@ export function VersionHistorySettings() {
       <SettingsHeader className="flex-col items-start justify-start gap-1">
         <SettingsTitle>Version History</SettingsTitle>
         {info ? (
-          <SettingsDescription>Currently installed version v{info.version}</SettingsDescription>
+          <div className="flex items-center gap-2">
+            <SettingsDescription>Current version:</SettingsDescription>
+            <Badge variant="secondary">v{info.version}</Badge>
+          </div>
         ) : null}
       </SettingsHeader>
       <div className="space-y-8">{renderContent()}</div>

--- a/packages/renderer-main/routes/settings/version-history.tsx
+++ b/packages/renderer-main/routes/settings/version-history.tsx
@@ -98,12 +98,7 @@ export function VersionHistorySettings() {
     <>
       <SettingsHeader className="flex-col items-start justify-start gap-1">
         <SettingsTitle>Version History</SettingsTitle>
-        {info ? (
-          <div className="flex items-center gap-2">
-            <SettingsDescription>Current version:</SettingsDescription>
-            <Badge variant="secondary">v{info.version}</Badge>
-          </div>
-        ) : null}
+        {info ? <SettingsDescription>Current version: v{info.version}</SettingsDescription> : null}
       </SettingsHeader>
       <div className="space-y-8">{renderContent()}</div>
     </>


### PR DESCRIPTION
Addresses a Pro user's request: when an update is available, the "Update Available" button and release notes are visible, but it's unclear which version they're currently on. This surfaces the installed version on the **Settings → Version History** page (the release notes reached from the update prompt's "What's New?" button).

## Changes

- Added a badge below the "Version History" title reading **"Currently installed version v<version>"**.
- Added a **"Current version"** badge, pinned top-right on the title row, to the release entry that matches the installed version.

## How it works

- Reuses the existing `about.getInfo` IPC (`app.getVersion()`) via a `useQuery` sharing the `["about", "info"]` cache key — no new plumbing.
- Matches GitHub's prefixed `tag_name` (`v3.56.3`) against the unprefixed installed version by comparing to `` `v${info.version}` ``.
- Badges render only once version info resolves; if the installed version isn't among the fetched releases (e.g. a dev build), no per-release badge shows and the top badge still displays the version.

Single file changed: `packages/renderer-main/routes/settings/version-history.tsx`. `bun types:ci` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdrG8QppGRxWrUmC4zEj1p)_