### PR TITLE
Extract selected account view refresh into dedicated method

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -171,12 +171,7 @@ class Accounts {
       }),
     );
 
-    const selectedAccount = this.getSelectedAccount();
-
-    main.window.contentView.addChildView(selectedAccount.instance.gmail.view);
-
-    selectedAccount.instance.gmail.updateViewBounds();
-    selectedAccount.instance.gmail.view.webContents.focus();
+    this.refreshSelectedAccountView();
   }
 
   selectPreviousAccount() {


### PR DESCRIPTION
Refactors the account view initialization logic by extracting the repeated pattern of getting the selected account, adding its view to the window, updating bounds, and focusing into a dedicated `refreshSelectedAccountView()` method.

**Changes:**
- Replaced inline view setup code with a call to `this.refreshSelectedAccountView()`
- Improves code reusability and maintainability by centralizing the view refresh logic

This change reduces duplication and makes it easier to update the view refresh behavior in one place if needed in the future.

https://claude.ai/code/session_01WpBejbzAfAmooTo7KfFkre