### PR TITLE
register account view resize listener once at the accounts level

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -70,6 +70,10 @@ class Accounts {
       account.instance.gmail.view.webContents.setBackgroundThrottling(true);
     }
 
+    main.window.on("resize", () => {
+      this.updateAllViewBounds();
+    });
+
     // When window is closed/minimized, the account views sometimes don't render after showing/restoring window
     main.window.on("show", () => {
       this.refreshSelectedAccountView();
@@ -78,6 +82,12 @@ class Accounts {
     main.window.on("restore", () => {
       this.refreshSelectedAccountView();
     });
+  }
+
+  updateAllViewBounds() {
+    for (const account of this.instances.values()) {
+      account.gmail.updateViewBounds();
+    }
   }
 
   refreshSelectedAccountView() {
@@ -264,9 +274,7 @@ class Accounts {
 
     config.set("accounts", updatedAccounts);
 
-    for (const account of this.instances.values()) {
-      account.gmail.updateViewBounds();
-    }
+    this.updateAllViewBounds();
   }
 
   updateAccount(accountDetails: AccountConfig) {

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -389,10 +389,6 @@ export class Gmail {
 
     this.updateViewBounds();
 
-    main.window.on("resize", () => {
-      this.updateViewBounds();
-    });
-
     this.view.webContents.on("dom-ready", () => {
       if (this.view.webContents.getURL().startsWith(GMAIL_URL)) {
         this.view.webContents.insertCSS(gmailCSS);


### PR DESCRIPTION
`Gmail.createView` registered a `main.window` `"resize"` listener per created view and never removed it. `Gmail.destroy` clears listeners on the view and its `webContents`, but not the closure registered on `main.window`, so removing an account leaks a listener that keeps calling `updateViewBounds` on a destroyed view.

It also went against the manager-level listener rule in `CLAUDE.md` — N accounts meant N listeners for the same event.

## Changes

- Add `Accounts.updateAllViewBounds()`, which iterates the account instances.
- Register a single `main.window.on("resize")` listener in `Accounts.createViews()`, alongside the existing `show`/`restore` listeners.
- Reuse `updateAllViewBounds()` in `removeAccount` instead of its inline loop.

No behaviour change. The listener is registered after view creation completes, which is also where the existing `show`/`restore` listeners live — the window is not shown until `ready-to-show`, so there is no window in which a resize can be missed.

## Verification

- `bun types:ci` passes
- `bun test` passes (120 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)