### PR TITLE
fix google meet shortcuts when multiple meet windows are open

### DIFF
--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -38,6 +38,10 @@ import { openExternalUrl } from "./url";
 export const MIN_ZOOM_FACTOR = 0.1;
 export const MAX_ZOOM_FACTOR = 3;
 
+const GOOGLE_MEET_TOGGLE_MICROPHONE_ACCELERATOR = "CommandOrControl+Shift+1";
+
+const GOOGLE_MEET_TOGGLE_CAMERA_ACCELERATOR = "CommandOrControl+Shift+2";
+
 const GOOGLE_CHAT_ATTACHMENT_URL_REGEXP = /chat\.google\.com\/u\/\d\/api\/get_attachment_url/;
 
 const GOOGLE_PDF_VIEWER_URL_REGEXP = /googleusercontent\.com\/viewer\/secure\/pdf/;
@@ -231,6 +235,37 @@ export class GoogleApp {
     return { action: "deny" };
   }
 
+  private static getMeetInstances() {
+    return Array.from(GoogleApp.instances.values()).filter((instance) => instance.app === "meet");
+  }
+
+  private static getMostRecentMeetInstance() {
+    return GoogleApp.getMeetInstances().at(-1);
+  }
+
+  private static registerMeetShortcuts() {
+    globalShortcut.register(GOOGLE_MEET_TOGGLE_MICROPHONE_ACCELERATOR, () => {
+      const meetInstance = GoogleApp.getMostRecentMeetInstance();
+
+      if (meetInstance) {
+        ipc.renderer.send(meetInstance.view.webContents, "googleMeet.toggleMicrophone");
+      }
+    });
+
+    globalShortcut.register(GOOGLE_MEET_TOGGLE_CAMERA_ACCELERATOR, () => {
+      const meetInstance = GoogleApp.getMostRecentMeetInstance();
+
+      if (meetInstance) {
+        ipc.renderer.send(meetInstance.view.webContents, "googleMeet.toggleCamera");
+      }
+    });
+  }
+
+  private static unregisterMeetShortcuts() {
+    globalShortcut.unregister(GOOGLE_MEET_TOGGLE_MICROPHONE_ACCELERATOR);
+    globalShortcut.unregister(GOOGLE_MEET_TOGGLE_CAMERA_ACCELERATOR);
+  }
+
   accountId: AccountConfig["id"];
 
   app: SupportedGoogleApp | undefined;
@@ -261,14 +296,19 @@ export class GoogleApp {
       }
     });
 
+    GoogleApp.instances.set(this.window.webContents.id, this);
+
     this.window.on("resize", this.updateViewBounds);
     this.window.on("close", this.handleClose);
+    this.window.on("focus", () => {
+      GoogleApp.instances.delete(this.window.webContents.id);
+
+      GoogleApp.instances.set(this.window.webContents.id, this);
+    });
 
     this.account.instance.windows.add(this.window);
 
     this.setupApp();
-
-    GoogleApp.instances.set(this.window.webContents.id, this);
   }
 
   private createBrowserWindow(options?: BrowserWindowConstructorOptions) {
@@ -359,13 +399,9 @@ export class GoogleApp {
     if (this.app === "meet") {
       this.powerSaveBlockerId = powerSaveBlocker.start("prevent-display-sleep");
 
-      globalShortcut.register("CommandOrControl+Shift+1", () => {
-        ipc.renderer.send(this.view.webContents, "googleMeet.toggleMicrophone");
-      });
-
-      globalShortcut.register("CommandOrControl+Shift+2", () => {
-        ipc.renderer.send(this.view.webContents, "googleMeet.toggleCamera");
-      });
+      if (GoogleApp.getMeetInstances().length === 1) {
+        GoogleApp.registerMeetShortcuts();
+      }
     }
   }
 
@@ -375,8 +411,9 @@ export class GoogleApp {
         powerSaveBlocker.stop(this.powerSaveBlockerId);
       }
 
-      globalShortcut.unregister("CommandOrControl+Shift+1");
-      globalShortcut.unregister("CommandOrControl+Shift+2");
+      if (GoogleApp.getMeetInstances().length === 1) {
+        GoogleApp.unregisterMeetShortcuts();
+      }
     }
   }
 


### PR DESCRIPTION
With more than one Meet window open, the mic/camera shortcuts are broken in two separate ways.

`GoogleApp.setupApp` registered `CommandOrControl+Shift+1` and `CommandOrControl+Shift+2` per instance, each closing over that instance's `view.webContents`:

- **Registration** — both windows register the same accelerators, so only one registration is in effect and the other window's shortcuts silently do nothing. `teardownApp` then unregisters them unconditionally, so closing *any* Meet window kills the shortcuts for every remaining one.
- **Targeting** — whichever registration won owns the shortcut forever, so it keeps toggling its own call regardless of which one you were actually using.

## Changes

- Register the shortcuts once when the first Meet window opens, unregister once the last one closes. Meet instances are derived from the existing `instances` map via `instance.app === "meet"` rather than tracked in a parallel collection.
- Focusing a Google app window moves it to the end of `instances`, so the map is ordered by recency of use and the shortcuts dispatch to the most recently focused Meet window. This also removes the need for a `getFocusedWindow()` check — a focused Meet window is already last, so the lookup collapses to `getMeetInstances().at(-1)`.
- Move `GoogleApp.instances.set` above `setupApp()` in the constructor so both the register and unregister checks read symmetrically as "am I the only Meet window" (`length === 1`).
- Extract the accelerator strings into module constants so the register/unregister pair can't drift.

`powerSaveBlocker` is deliberately left alone: `start()` already returns a distinct id per instance and each `teardownApp` stops its own, and overlapping blockers are fine.

## Review notes

The `length === 1` checks are only correct because of *where* they sit relative to the map mutations — `instances.set` precedes `setupApp()` in the constructor, and `teardownApp()` precedes `instances.delete` in `handleClose`. Reordering those lines silently stops the shortcuts registering. Nothing tests this.

Dispatching to the most recently focused window rather than the focused one matters more than it looks: `getFocusedWindow()` is *not* a Meet window in the two most common cases — no Meru window focused at all (the whole reason the shortcut is global), and the main window focused while a call runs in the background.

Ordering `instances` by focus has one knock-on effect: `reuseWindowByHostname` takes the *first* match, which under the new ordering is the least recently used matching window. Merging this on its own means clicking a Docs link with two Docs windows open goes to the one you touched longest ago. The PR above fixes that, so prefer landing the stack together.

## Verification

- `bun types:ci`, `bun test` (120 tests), `oxfmt`, `oxlint` all pass
- CI green, including builds on ubuntu and windows
- Not yet exercised in a running app with two live Meet calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)