### PR TITLE
reuse the most recently used google app window

### DIFF
--- a/packages/app/google-app.ts
+++ b/packages/app/google-app.ts
@@ -85,20 +85,23 @@ export class GoogleApp {
   static reuseWindowByHostname(accountId: AccountConfig["id"], url: string) {
     const urlHostname = new URL(url).hostname;
 
-    for (const instance of GoogleApp.instances.values()) {
-      if (
-        instance.accountId === accountId &&
-        new URL(instance.view.webContents.getURL()).hostname === urlHostname
-      ) {
-        instance.view.webContents.loadURL(url);
+    const reusableInstance = Array.from(GoogleApp.instances.values())
+      .reverse()
+      .find(
+        (instance) =>
+          instance.accountId === accountId &&
+          new URL(instance.view.webContents.getURL()).hostname === urlHostname,
+      );
 
-        instance.window.focus();
-
-        return true;
-      }
+    if (!reusableInstance) {
+      return false;
     }
 
-    return false;
+    reusableInstance.view.webContents.loadURL(url);
+
+    reusableInstance.window.focus();
+
+    return true;
   }
 
   static handleNavigate(url: string) {


### PR DESCRIPTION
The PR below makes focusing a Google app window move it to the end of the `instances` map, so the map becomes ordered by recency of use.

`reuseWindowByHostname` iterates that map and takes the **first** match, which under the new ordering is the *least* recently used matching window. With two Docs windows open, clicking a Docs link would bounce you to whichever one you touched longest ago — the opposite of what you'd expect.

Take the last match instead, so clicking a link returns to the window you were most recently using. That is what the focus ordering already expresses; this just reads it in the right direction.

`findLast` would read better, but it is ES2023 and `lib` is `es2022`, so this reverses a copy and uses `find`.

## Verification

- `bun types:ci`, `bun test` (120 tests), `oxfmt`, `oxlint` all pass
- CI green
- Not yet exercised in a running app with two windows of the same app open

🤖 Generated with [Claude Code](https://claude.com/claude-code)