### PR TITLE
add embedded workspace app tabs to the main window

### DIFF
--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -16,12 +16,15 @@ import { config } from "./config";
 import { Gmail } from "./gmail";
 import { createBrowserWindow, getPreloadPath, loadRenderer } from "./lib/window";
 import { licenseKey } from "./license-key";
+import { Tabs } from "./tabs";
 import { WorkspaceApp } from "./workspace-app";
 
 export class Account {
   session: Session;
 
   gmail: Gmail;
+
+  tabs: Tabs;
 
   windows: Set<BrowserWindow | WebContentsView> = new Set();
 
@@ -45,6 +48,8 @@ export class Account {
       unifiedInboxEnabled: accountConfig.gmail.unifiedInbox,
       delegatedAccountId: accountConfig.gmail.delegatedAccountId,
     });
+
+    this.tabs = new Tabs(this.gmail);
   }
 
   setSpellCheckerLanguages() {

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { platform } from "@electron-toolkit/utils";
+import { APP_TAB_STRIP_WIDTH } from "@meru/shared/constants";
 import type { AccountConfig } from "@meru/shared/schemas";
 import { Account } from "./account";
 import { config } from "./config";
@@ -84,20 +85,29 @@ class Accounts {
     });
   }
 
+  getTabStripWidth() {
+    return this.getSelectedAccount().instance.tabs.hasWorkspaceTabs ? APP_TAB_STRIP_WIDTH : 0;
+  }
+
   updateAllViewBounds() {
     for (const account of this.instances.values()) {
-      account.gmail.updateViewBounds();
+      for (const tab of account.tabs.tabs) {
+        tab.updateViewBounds();
+      }
     }
   }
 
   refreshSelectedAccountView() {
-    const selectedAccount = this.getSelectedAccount();
+    const activeTab = this.getSelectedAccount().instance.tabs.activeTab;
 
-    main.window.contentView.removeChildView(selectedAccount.instance.gmail.view);
-    main.window.contentView.addChildView(selectedAccount.instance.gmail.view);
+    main.window.contentView.removeChildView(activeTab.view);
+    main.window.contentView.addChildView(activeTab.view);
 
-    selectedAccount.instance.gmail.updateViewBounds();
-    selectedAccount.instance.gmail.view.webContents.focus();
+    activeTab.updateViewBounds();
+
+    if (!appState.isSettingsOpen) {
+      activeTab.view.webContents.focus();
+    }
   }
 
   getAccountConfigs() {
@@ -181,6 +191,8 @@ class Accounts {
       }),
     );
 
+    this.updateAllViewBounds();
+
     this.refreshSelectedAccountView();
   }
 
@@ -246,6 +258,8 @@ class Accounts {
 
     this.selectAccount(createdAccount.id);
 
+    this.sendTabsChangedToRenderer();
+
     this.show();
 
     appState.setIsSettingsOpen(false);
@@ -253,6 +267,8 @@ class Accounts {
 
   async removeAccount(selectedAccountId: string) {
     const account = this.getAccount(selectedAccountId);
+
+    account.instance.tabs.closeAll();
 
     account.instance.gmail.destroy();
 
@@ -275,6 +291,8 @@ class Accounts {
     config.set("accounts", updatedAccounts);
 
     this.updateAllViewBounds();
+
+    this.sendTabsChangedToRenderer();
   }
 
   updateAccount(accountDetails: AccountConfig) {
@@ -290,13 +308,17 @@ class Accounts {
 
   hide() {
     for (const account of this.instances.values()) {
-      account.gmail.view.setVisible(false);
+      for (const tab of account.tabs.tabs) {
+        tab.view.setVisible(false);
+      }
     }
   }
 
   show() {
     for (const account of this.instances.values()) {
-      account.gmail.view.setVisible(true);
+      for (const tab of account.tabs.tabs) {
+        tab.view.setVisible(true);
+      }
     }
   }
 
@@ -320,6 +342,17 @@ class Accounts {
         }
       }
     }
+  }
+
+  sendTabsChangedToRenderer() {
+    ipc.renderer.send(
+      main.window.webContents,
+      "tabs.changed",
+      this.getAccounts().map((account) => ({
+        accountId: account.config.id,
+        tabs: account.instance.tabs.serialize(),
+      })),
+    );
   }
 
   sendAccountsChangedToRenderer() {

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { platform } from "@electron-toolkit/utils";
-import { APP_TAB_STRIP_WIDTH } from "@meru/shared/constants";
 import type { AccountConfig } from "@meru/shared/schemas";
+import { getTabStripWidth } from "@meru/shared/types";
 import { Account } from "./account";
 import { config } from "./config";
 import { ipc } from "./ipc";
@@ -86,7 +86,7 @@ class Accounts {
   }
 
   getTabStripWidth() {
-    return this.getSelectedAccount().instance.tabs.hasWorkspaceTabs ? APP_TAB_STRIP_WIDTH : 0;
+    return getTabStripWidth(this.getSelectedAccount().instance.tabs.serialize());
   }
 
   updateAllViewBounds() {

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -12,9 +12,7 @@ import {
   generateGmailLabelColorsCss,
   parseGmailMessageId,
 } from "@meru/shared/gmail";
-import { getWorkspaceAppUrl } from "@meru/shared/google";
 import { ms } from "@meru/shared/ms";
-import type { WorkspaceAppsPinnedApp } from "@meru/shared/types";
 import { wait } from "@meru/shared/utils";
 import {
   app,
@@ -474,10 +472,12 @@ export class Gmail {
   updateViewBounds() {
     const { width, height } = main.getWindowBounds();
 
+    const tabStripWidth = accounts.getTabStripWidth();
+
     this.view.setBounds({
-      x: 0,
+      x: tabStripWidth,
       y: APP_TITLEBAR_HEIGHT,
-      width,
+      width: width - tabStripWidth,
       height: height - APP_TITLEBAR_HEIGHT,
     });
   }
@@ -546,6 +546,7 @@ export class Gmail {
               url,
               window: { width: 800, height: 600 },
               view: options,
+              asWindow: true,
             });
 
             return workspaceApp.view.webContents;
@@ -871,6 +872,7 @@ export class Gmail {
       accountId: this.accountId,
       url: `${GMAIL_URL}/?extsrc=mailto&url=${encodeURIComponent(url)}`,
       window: { width: 800, height: 600 },
+      asWindow: true,
     });
   }
 
@@ -886,9 +888,5 @@ export class Gmail {
     }
 
     this.view.webContents.executeJavaScript(`window.location.hash = ${JSON.stringify(hash)}`);
-  }
-
-  openWorkspaceApp(app: WorkspaceAppsPinnedApp) {
-    this.view.webContents.executeJavaScript(`window.open("${getWorkspaceAppUrl(app)}", "_blank")`);
   }
 }

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { IpcEmitter, IpcListener } from "@electron-toolkit/typed-ipc/main";
 import { MAX_RECENT_DOWNLOAD_HISTORY_ITEMS } from "@meru/shared/constants";
+import { getWorkspaceAppUrl } from "@meru/shared/google";
 import type { IpcMainEvents, IpcRendererEvent } from "@meru/shared/types";
 import {
   app,
@@ -131,11 +132,10 @@ class Ipc {
     });
 
     this.main.on("findInPage", (event, text, options) => {
-      const workspaceApp = WorkspaceApp.tryFromWebContents(event.sender);
-
-      const targetWebContents = workspaceApp
-        ? workspaceApp.view.webContents
-        : accounts.getSelectedAccount().instance.gmail.view.webContents;
+      const targetWebContents = (
+        WorkspaceApp.tryFromWebContents(event.sender) ??
+        accounts.getSelectedAccount().instance.tabs.activeTab
+      ).view.webContents;
 
       if (!text) {
         targetWebContents.stopFindInPage("clearSelection");
@@ -212,6 +212,28 @@ class Ipc {
 
     ipc.main.on("workspaceApp.openInBrowser", (event) => {
       WorkspaceApp.fromWebContents(event.sender).openInBrowser();
+    });
+
+    ipc.main.on("tabs.selectTab", (_event, accountId, tabId) => {
+      const account = accounts.getAccount(accountId);
+
+      account.instance.tabs.activateTab(tabId);
+
+      if (account.config.selected) {
+        accounts.refreshSelectedAccountView();
+      } else {
+        accounts.selectAccount(accountId);
+      }
+    });
+
+    ipc.main.on("tabs.closeTab", (_event, accountId, tabId) => {
+      const account = accounts.getAccount(accountId);
+
+      account.instance.tabs.closeTab(tabId);
+
+      if (account.config.selected) {
+        accounts.refreshSelectedAccountView();
+      }
     });
 
     ipc.main.handle("config.getConfig", () => config.store);
@@ -311,8 +333,17 @@ class Ipc {
       });
     });
 
-    ipc.main.on("workspaceApps.openApp", (_event, app) => {
-      accounts.getSelectedAccount().instance.gmail.openWorkspaceApp(app);
+    ipc.main.on("workspaceApps.openApp", (_event, app, disposition) => {
+      const selectedAccount = accounts.getSelectedAccount();
+
+      WorkspaceApp.handleWindowOpen({
+        accountId: selectedAccount.config.id,
+        details: {
+          url: getWorkspaceAppUrl(app),
+          disposition: disposition ?? "foreground-tab",
+        },
+        webContents: selectedAccount.instance.gmail.view.webContents,
+      });
     });
 
     ipc.main.on("doNotDisturb.toggle", () => {

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -8,6 +8,7 @@ import { WorkspaceApp } from "./workspace-app";
 export type Tab = {
   id: string;
   app: SupportedWorkspaceApp | undefined;
+  title: string;
   view: WebContentsView;
   updateViewBounds: () => void;
 };
@@ -22,6 +23,7 @@ export class Tabs {
       {
         id: GMAIL_TAB_ID,
         app: undefined,
+        title: "Gmail",
         get view() {
           return gmail.view;
         },
@@ -92,6 +94,7 @@ export class Tabs {
     return this.tabs.map((tab) => ({
       id: tab.id,
       app: tab.app,
+      title: tab.title,
       active: tab.id === this.activeTabId,
     }));
   }

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -1,0 +1,108 @@
+import { GMAIL_TAB_ID, type SupportedWorkspaceApp, type TabState } from "@meru/shared/types";
+import type { WebContentsView } from "electron";
+import { accounts } from "./accounts";
+import type { Gmail } from "./gmail";
+import { main } from "./main";
+import { WorkspaceApp } from "./workspace-app";
+
+export type Tab = {
+  id: string;
+  app: SupportedWorkspaceApp | undefined;
+  view: WebContentsView;
+  updateViewBounds: () => void;
+};
+
+export class Tabs {
+  tabs: Tab[];
+
+  activeTabId: string = GMAIL_TAB_ID;
+
+  constructor(gmail: Gmail) {
+    this.tabs = [
+      {
+        id: GMAIL_TAB_ID,
+        app: undefined,
+        get view() {
+          return gmail.view;
+        },
+        updateViewBounds: () => {
+          gmail.updateViewBounds();
+        },
+      },
+    ];
+  }
+
+  get hasWorkspaceTabs() {
+    return this.tabs.length > 1;
+  }
+
+  get activeTab() {
+    const activeTab = this.getTab(this.activeTabId);
+
+    if (!activeTab) {
+      throw new Error(`Could not find active tab ${this.activeTabId}`);
+    }
+
+    return activeTab;
+  }
+
+  getTab(tabId: string) {
+    return this.tabs.find((tab) => tab.id === tabId);
+  }
+
+  addTab(workspaceApp: WorkspaceApp) {
+    this.tabs.push(workspaceApp);
+
+    this.broadcastTabsChanged();
+  }
+
+  removeTab(tabId: string) {
+    this.tabs = this.tabs.filter((tab) => tab.id !== tabId);
+
+    if (this.activeTabId === tabId) {
+      this.activeTabId = GMAIL_TAB_ID;
+    }
+
+    this.broadcastTabsChanged();
+  }
+
+  activateTab(tabId: string) {
+    this.activeTabId = tabId;
+
+    this.broadcastTabsChanged();
+  }
+
+  closeTab(tabId: string) {
+    const closableTab = this.getTab(tabId);
+
+    if (closableTab instanceof WorkspaceApp) {
+      closableTab.close();
+    }
+  }
+
+  closeAll() {
+    for (const tab of this.tabs.slice()) {
+      if (tab instanceof WorkspaceApp) {
+        tab.close();
+      }
+    }
+  }
+
+  serialize(): TabState[] {
+    return this.tabs.map((tab) => ({
+      id: tab.id,
+      app: tab.app,
+      active: tab.id === this.activeTabId,
+    }));
+  }
+
+  private broadcastTabsChanged() {
+    if (main.window.isDestroyed()) {
+      return;
+    }
+
+    accounts.updateAllViewBounds();
+
+    accounts.sendTabsChangedToRenderer();
+  }
+}

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -532,18 +532,24 @@ export class WorkspaceApp {
     });
   };
 
+  get title() {
+    return this.view.webContents.getTitle() || (this.app ? supportedWorkspaceApps[this.app] : "");
+  }
+
   handlePageTitleUpdated = () => {
     if (!this._window) {
+      accounts.sendTabsChangedToRenderer();
+
       return;
     }
 
-    const pageTitle = this.view.webContents.getTitle();
+    ipc.renderer.send(
+      this.chromeWebContents,
+      "workspaceApp.pageTitleChanged",
+      this.view.webContents.getTitle(),
+    );
 
-    ipc.renderer.send(this.chromeWebContents, "workspaceApp.pageTitleChanged", pageTitle);
-
-    const title = pageTitle || (this.app ? supportedWorkspaceApps[this.app] : "");
-
-    if (!title) {
+    if (!this.title) {
       this.window.setTitle(app.name);
 
       return;
@@ -552,7 +558,7 @@ export class WorkspaceApp {
     const accountLabelPrefix =
       config.get("accounts").length > 1 ? `[${this.account.config.label}] ` : "";
 
-    this.window.setTitle(`${accountLabelPrefix}${title} - ${app.name}`);
+    this.window.setTitle(`${accountLabelPrefix}${this.title} - ${app.name}`);
   };
 
   broadcastLoadingState = () => {

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -2,7 +2,11 @@ import { randomUUID } from "node:crypto";
 import { APP_TITLEBAR_HEIGHT, GOOGLE_ACCOUNTS_URL } from "@meru/shared/constants";
 import { GMAIL_URL } from "@meru/shared/gmail";
 import type { AccountConfig } from "@meru/shared/schemas";
-import { supportedWorkspaceApps, type SupportedWorkspaceApp } from "@meru/shared/types";
+import {
+  supportedWorkspaceApps,
+  type SupportedWorkspaceApp,
+  workspaceAppsAlwaysOpenAsWindow,
+} from "@meru/shared/types";
 import { clamp } from "@meru/shared/utils";
 import {
   app,
@@ -219,7 +223,10 @@ export class WorkspaceApp {
       !config.get("workspaceApps.openInAppExcludedApps").includes(matchedSupportedWorkspaceApp);
 
     if (isWorkspaceAppEnabledToOpenInApp) {
-      if (disposition === "background-tab") {
+      if (
+        disposition === "background-tab" &&
+        !workspaceAppsAlwaysOpenAsWindow.includes(matchedSupportedWorkspaceApp)
+      ) {
         new WorkspaceApp({
           accountId,
           url,

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -34,6 +34,7 @@ import {
 } from "./lib/window";
 import { licenseKey } from "./license-key";
 import { main } from "./main";
+import { appState } from "./state";
 import { openExternalUrl } from "./url";
 
 export const MIN_ZOOM_FACTOR = 0.1;
@@ -60,6 +61,7 @@ type WorkspaceAppOptions = {
   url: string;
   window?: BrowserWindowConstructorOptions;
   view?: WebContentsViewConstructorOptions;
+  asWindow?: boolean;
 };
 
 export class WorkspaceApp {
@@ -143,7 +145,7 @@ export class WorkspaceApp {
     webContents,
   }: {
     accountId: AccountConfig["id"];
-    details: Electron.HandlerDetails;
+    details: Pick<Electron.HandlerDetails, "url" | "disposition">;
     webContents: WebContents;
   }): ReturnType<Parameters<WebContents["setWindowOpenHandler"]>[0]> {
     const { url, disposition } = details;
@@ -203,7 +205,7 @@ export class WorkspaceApp {
     }
 
     if (GOOGLE_PDF_VIEWER_URL_REGEXP.test(url) && disposition !== "background-tab") {
-      new WorkspaceApp({ accountId, url });
+      new WorkspaceApp({ accountId, url, asWindow: true });
 
       return { action: "deny" };
     }
@@ -216,7 +218,16 @@ export class WorkspaceApp {
       config.get("workspaceApps.openInApp") &&
       !config.get("workspaceApps.openInAppExcludedApps").includes(matchedSupportedWorkspaceApp);
 
-    if (isWorkspaceAppEnabledToOpenInApp && disposition !== "background-tab") {
+    if (isWorkspaceAppEnabledToOpenInApp) {
+      if (disposition === "background-tab") {
+        new WorkspaceApp({
+          accountId,
+          url,
+        });
+
+        return { action: "deny" };
+      }
+
       if (
         !config.get("workspaceApps.openAppsInNewWindow") &&
         WorkspaceApp.reuseWindowByHostname(accountId, url)
@@ -227,6 +238,7 @@ export class WorkspaceApp {
       new WorkspaceApp({
         accountId,
         url,
+        asWindow: true,
       });
 
       return { action: "deny" };
@@ -305,11 +317,14 @@ export class WorkspaceApp {
 
   private viewDestroyed = false;
 
-  constructor({ accountId, url, window, view }: WorkspaceAppOptions) {
+  constructor({ accountId, url, window, view, asWindow }: WorkspaceAppOptions) {
     this.accountId = accountId;
     this.app = getWorkspaceAppFromUrl(url);
 
-    this._window = this.createBrowserWindow(window);
+    if (asWindow) {
+      this._window = this.createBrowserWindow(window);
+    }
+
     this.view = this.createView({ url, options: view });
 
     this.updateViewBounds();
@@ -318,22 +333,38 @@ export class WorkspaceApp {
     this.view.webContents.once("destroyed", () => {
       this.viewDestroyed = true;
 
-      if (this._window && !this._window.isDestroyed()) {
-        this._window.close();
+      if (this._window) {
+        if (!this._window.isDestroyed()) {
+          this._window.close();
+        }
+
+        return;
       }
+
+      this.close();
     });
 
     WorkspaceApp.instances.set(this.id, this);
 
-    this.window.on("resize", this.updateViewBounds);
-    this.window.on("close", this.handleClose);
-    this.window.on("focus", () => {
-      WorkspaceApp.instances.delete(this.id);
+    if (this._window) {
+      this.window.on("resize", this.updateViewBounds);
+      this.window.on("close", this.handleClose);
+      this.window.on("focus", () => {
+        WorkspaceApp.instances.delete(this.id);
 
-      WorkspaceApp.instances.set(this.id, this);
-    });
+        WorkspaceApp.instances.set(this.id, this);
+      });
 
-    this.account.instance.windows.add(this.window);
+      this.account.instance.windows.add(this.window);
+    } else {
+      this.account.instance.windows.add(this.view);
+
+      if (appState.isSettingsOpen) {
+        this.view.setVisible(false);
+      }
+
+      this.account.instance.tabs.addTab(this);
+    }
 
     this.setupApp();
   }
@@ -381,7 +412,11 @@ export class WorkspaceApp {
       },
     });
 
-    this.window.contentView.addChildView(view);
+    if (this._window) {
+      this._window.contentView.addChildView(view);
+    } else {
+      main.window.contentView.addChildView(view, 0);
+    }
 
     setupWindowContextMenu(view);
 
@@ -413,6 +448,16 @@ export class WorkspaceApp {
       this.unregisterViewListeners();
 
       this.view.webContents.close();
+    }
+
+    if (!this._window) {
+      if (!main.window.isDestroyed()) {
+        main.window.contentView.removeChildView(this.view);
+      }
+
+      this.account.instance.windows.delete(this.view);
+
+      this.account.instance.tabs.removeTab(this.id);
     }
 
     this.teardownApp();
@@ -477,6 +522,10 @@ export class WorkspaceApp {
   };
 
   broadcastNavigationState = () => {
+    if (!this._window) {
+      return;
+    }
+
     ipc.renderer.send(this.chromeWebContents, "workspaceApp.navigationStateChanged", {
       canGoBack: this.view.webContents.navigationHistory.canGoBack(),
       canGoForward: this.view.webContents.navigationHistory.canGoForward(),
@@ -484,13 +533,13 @@ export class WorkspaceApp {
   };
 
   handlePageTitleUpdated = () => {
-    const pageTitle = this.view.webContents.getTitle();
-
-    ipc.renderer.send(this.chromeWebContents, "workspaceApp.pageTitleChanged", pageTitle);
-
     if (!this._window) {
       return;
     }
+
+    const pageTitle = this.view.webContents.getTitle();
+
+    ipc.renderer.send(this.chromeWebContents, "workspaceApp.pageTitleChanged", pageTitle);
 
     const title = pageTitle || (this.app ? supportedWorkspaceApps[this.app] : "");
 
@@ -507,6 +556,10 @@ export class WorkspaceApp {
   };
 
   broadcastLoadingState = () => {
+    if (!this._window) {
+      return;
+    }
+
     ipc.renderer.send(
       this.chromeWebContents,
       "workspaceApp.loadingStateChanged",
@@ -515,6 +568,21 @@ export class WorkspaceApp {
   };
 
   updateViewBounds = () => {
+    if (!this._window) {
+      const { width, height } = main.getWindowBounds();
+
+      const tabStripWidth = accounts.getTabStripWidth();
+
+      this.view.setBounds({
+        x: tabStripWidth,
+        y: APP_TITLEBAR_HEIGHT,
+        width: width - tabStripWidth,
+        height: height - APP_TITLEBAR_HEIGHT,
+      });
+
+      return;
+    }
+
     const { width, height } = this.window.getContentBounds();
 
     this.view.setBounds({

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -539,22 +539,22 @@ export class WorkspaceApp {
     });
   };
 
+  private pageTitle = "";
+
   get title() {
-    return this.view.webContents.getTitle() || (this.app ? supportedWorkspaceApps[this.app] : "");
+    return this.pageTitle || (this.app ? supportedWorkspaceApps[this.app] : "");
   }
 
-  handlePageTitleUpdated = () => {
+  handlePageTitleUpdated = (_event: Electron.Event, pageTitle: string, explicitSet: boolean) => {
+    this.pageTitle = explicitSet ? pageTitle : "";
+
     if (!this._window) {
       accounts.sendTabsChangedToRenderer();
 
       return;
     }
 
-    ipc.renderer.send(
-      this.chromeWebContents,
-      "workspaceApp.pageTitleChanged",
-      this.view.webContents.getTitle(),
-    );
+    ipc.renderer.send(this.chromeWebContents, "workspaceApp.pageTitleChanged", this.title);
 
     if (!this.title) {
       this.window.setTitle(app.name);

--- a/packages/renderer-main/app.tsx
+++ b/packages/renderer-main/app.tsx
@@ -5,6 +5,7 @@ import { useHashLocation } from "wouter/use-hash-location";
 import { AppMain } from "@/components/app-main";
 import { AppTitlebar } from "@/components/app-titlebar";
 import { AppSidebar } from "./components/app-sidebar";
+import { AppTabStrip } from "./components/app-tab-strip";
 import { useMouseAccountSwitching } from "./lib/hooks";
 
 export function App() {
@@ -27,6 +28,7 @@ export function App() {
           <div className="flex h-screen flex-col">
             <AppTitlebar />
             <div className="flex flex-1 overflow-hidden">
+              <AppTabStrip />
               <AppSidebar />
               <AppMain />
             </div>

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -1,10 +1,22 @@
-import { APP_TAB_STRIP_WIDTH } from "@meru/shared/constants";
+import { APP_TAB_STRIP_WIDE_WIDTH } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
-import { GMAIL_TAB_ID } from "@meru/shared/types";
+import { GMAIL_TAB_ID, getTabStripWidth, type TabState } from "@meru/shared/types";
 import { Button } from "@meru/ui/components/button";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { GlobeIcon, XIcon } from "lucide-react";
 import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
+
+function TabIcon({ tab }: { tab: TabState }) {
+  if (tab.id === GMAIL_TAB_ID) {
+    return <WorkspaceAppIcon app="gmail" className="size-4" />;
+  }
+
+  if (tab.app && tab.app !== "myaccount") {
+    return <WorkspaceAppIcon app={tab.app} className="size-4" />;
+  }
+
+  return <GlobeIcon />;
+}
 
 export function AppTabStrip() {
   const accounts = useAccountsStore((state) => state.accounts);
@@ -17,19 +29,18 @@ export function AppTabStrip() {
     (accountTabs) => accountTabs.accountId === selectedAccount?.config.id,
   );
 
-  if (
-    isSettingsOpen ||
-    !selectedAccount ||
-    !selectedAccountTabs ||
-    selectedAccountTabs.tabs.length <= 1
-  ) {
+  const tabStripWidth = selectedAccountTabs ? getTabStripWidth(selectedAccountTabs.tabs) : 0;
+
+  if (isSettingsOpen || !selectedAccount || !selectedAccountTabs || tabStripWidth === 0) {
     return;
   }
+
+  const isWide = tabStripWidth === APP_TAB_STRIP_WIDE_WIDTH;
 
   return (
     <div
       className="flex flex-col gap-1 border-r p-2"
-      style={{ width: APP_TAB_STRIP_WIDTH, minWidth: APP_TAB_STRIP_WIDTH }}
+      style={{ width: tabStripWidth, minWidth: tabStripWidth }}
     >
       {selectedAccountTabs.tabs.map((tab) => {
         if (tab.id === GMAIL_TAB_ID) {
@@ -37,15 +48,15 @@ export function AppTabStrip() {
             <Button
               key={tab.id}
               variant={tab.active ? "secondary" : "ghost"}
-              size="sm"
-              className="w-full justify-start"
+              size={isWide ? "sm" : "icon"}
+              className={isWide ? "w-full justify-start" : undefined}
               title={tab.title}
               onClick={() => {
                 ipc.main.send("tabs.selectTab", selectedAccount.config.id, tab.id);
               }}
             >
-              <WorkspaceAppIcon app="gmail" className="size-4" />
-              <span className="truncate">{tab.title}</span>
+              <TabIcon tab={tab} />
+              {isWide && <span className="truncate">{tab.title}</span>}
             </Button>
           );
         }
@@ -54,24 +65,24 @@ export function AppTabStrip() {
           <div key={tab.id} className="group relative">
             <Button
               variant={tab.active ? "secondary" : "ghost"}
-              size="sm"
-              className="w-full justify-start pr-7"
+              size={isWide ? "sm" : "icon"}
+              className={isWide ? "w-full justify-start pr-7" : undefined}
               title={tab.title}
               onClick={() => {
                 ipc.main.send("tabs.selectTab", selectedAccount.config.id, tab.id);
               }}
             >
-              {tab.app && tab.app !== "myaccount" ? (
-                <WorkspaceAppIcon app={tab.app} className="size-4" />
-              ) : (
-                <GlobeIcon />
-              )}
-              <span className="truncate">{tab.title}</span>
+              <TabIcon tab={tab} />
+              {isWide && <span className="truncate">{tab.title}</span>}
             </Button>
             <Button
               variant="secondary"
               size="icon"
-              className="absolute top-1/2 right-1 hidden size-5 -translate-y-1/2 group-hover:flex"
+              className={
+                isWide
+                  ? "absolute top-1/2 right-1 hidden size-5 -translate-y-1/2 group-hover:flex"
+                  : "absolute -top-1 -right-1 hidden size-4 rounded-full group-hover:flex"
+              }
               title="Close Tab"
               onClick={() => {
                 ipc.main.send("tabs.closeTab", selectedAccount.config.id, tab.id);

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -3,7 +3,7 @@ import { ipc } from "@meru/shared/renderer/ipc";
 import { GMAIL_TAB_ID } from "@meru/shared/types";
 import { Button } from "@meru/ui/components/button";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
-import { GlobeIcon, MailIcon, XIcon } from "lucide-react";
+import { GlobeIcon, XIcon } from "lucide-react";
 import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
 
 export function AppTabStrip() {
@@ -43,7 +43,7 @@ export function AppTabStrip() {
                 ipc.main.send("tabs.selectTab", selectedAccount.config.id, tab.id);
               }}
             >
-              <MailIcon />
+              <WorkspaceAppIcon app="gmail" className="size-4" />
             </Button>
           );
         }

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -3,6 +3,7 @@ import { ipc } from "@meru/shared/renderer/ipc";
 import { GMAIL_TAB_ID, getTabStripWidth, type TabState } from "@meru/shared/types";
 import { Button } from "@meru/ui/components/button";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
+import { cn } from "@meru/ui/lib/utils";
 import { GlobeIcon, XIcon } from "lucide-react";
 import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
 
@@ -78,11 +79,12 @@ export function AppTabStrip() {
             <Button
               variant="secondary"
               size="icon"
-              className={
+              className={cn(
+                "absolute hidden group-hover:flex",
                 isWide
-                  ? "absolute top-1/2 right-1 hidden size-5 -translate-y-1/2 group-hover:flex"
-                  : "absolute -top-1 -right-1 hidden size-4 rounded-full group-hover:flex"
-              }
+                  ? "top-1/2 right-1 size-5 -translate-y-1/2"
+                  : "-top-1 -right-1 size-4 rounded-full",
+              )}
               title="Close Tab"
               onClick={() => {
                 ipc.main.send("tabs.closeTab", selectedAccount.config.id, tab.id);

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -1,0 +1,83 @@
+import { APP_TAB_STRIP_WIDTH } from "@meru/shared/constants";
+import { ipc } from "@meru/shared/renderer/ipc";
+import { GMAIL_TAB_ID, supportedWorkspaceApps } from "@meru/shared/types";
+import { Button } from "@meru/ui/components/button";
+import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
+import { GlobeIcon, MailIcon, XIcon } from "lucide-react";
+import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
+
+export function AppTabStrip() {
+  const accounts = useAccountsStore((state) => state.accounts);
+  const accountsTabs = useTabsStore((state) => state.accountsTabs);
+  const isSettingsOpen = useSettingsStore((state) => state.isOpen);
+
+  const selectedAccount = accounts.find((account) => account.config.selected);
+
+  const selectedAccountTabs = accountsTabs.find(
+    (accountTabs) => accountTabs.accountId === selectedAccount?.config.id,
+  );
+
+  if (
+    isSettingsOpen ||
+    !selectedAccount ||
+    !selectedAccountTabs ||
+    selectedAccountTabs.tabs.length <= 1
+  ) {
+    return;
+  }
+
+  return (
+    <div
+      className="flex flex-col items-center gap-2 border-r py-2"
+      style={{ width: APP_TAB_STRIP_WIDTH, minWidth: APP_TAB_STRIP_WIDTH }}
+    >
+      {selectedAccountTabs.tabs.map((tab) => {
+        if (tab.id === GMAIL_TAB_ID) {
+          return (
+            <Button
+              key={tab.id}
+              variant={tab.active ? "secondary" : "ghost"}
+              size="icon"
+              title="Gmail"
+              onClick={() => {
+                ipc.main.send("tabs.selectTab", selectedAccount.config.id, tab.id);
+              }}
+            >
+              <MailIcon />
+            </Button>
+          );
+        }
+
+        return (
+          <div key={tab.id} className="group relative">
+            <Button
+              variant={tab.active ? "secondary" : "ghost"}
+              size="icon"
+              title={tab.app ? supportedWorkspaceApps[tab.app] : undefined}
+              onClick={() => {
+                ipc.main.send("tabs.selectTab", selectedAccount.config.id, tab.id);
+              }}
+            >
+              {tab.app && tab.app !== "myaccount" ? (
+                <WorkspaceAppIcon app={tab.app} className="size-4" />
+              ) : (
+                <GlobeIcon />
+              )}
+            </Button>
+            <Button
+              variant="secondary"
+              size="icon"
+              className="absolute -top-1 -right-1 hidden size-4 rounded-full group-hover:flex"
+              title="Close Tab"
+              onClick={() => {
+                ipc.main.send("tabs.closeTab", selectedAccount.config.id, tab.id);
+              }}
+            >
+              <XIcon className="size-3" />
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -40,7 +40,7 @@ export function AppTabStrip() {
 
   return (
     <div
-      className="flex flex-col gap-1 border-r p-2"
+      className={cn("flex flex-col border-r", isWide ? "gap-1 p-2" : "items-center gap-2 py-2")}
       style={{ width: tabStripWidth, minWidth: tabStripWidth }}
     >
       {selectedAccountTabs.tabs.map((tab) => {

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -1,6 +1,6 @@
 import { APP_TAB_STRIP_WIDTH } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
-import { GMAIL_TAB_ID, supportedWorkspaceApps } from "@meru/shared/types";
+import { GMAIL_TAB_ID } from "@meru/shared/types";
 import { Button } from "@meru/ui/components/button";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { GlobeIcon, MailIcon, XIcon } from "lucide-react";
@@ -38,7 +38,7 @@ export function AppTabStrip() {
               key={tab.id}
               variant={tab.active ? "secondary" : "ghost"}
               size="icon"
-              title="Gmail"
+              title={tab.title}
               onClick={() => {
                 ipc.main.send("tabs.selectTab", selectedAccount.config.id, tab.id);
               }}
@@ -53,7 +53,7 @@ export function AppTabStrip() {
             <Button
               variant={tab.active ? "secondary" : "ghost"}
               size="icon"
-              title={tab.app ? supportedWorkspaceApps[tab.app] : undefined}
+              title={tab.title}
               onClick={() => {
                 ipc.main.send("tabs.selectTab", selectedAccount.config.id, tab.id);
               }}

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -28,7 +28,7 @@ export function AppTabStrip() {
 
   return (
     <div
-      className="flex flex-col items-center gap-2 border-r py-2"
+      className="flex flex-col gap-1 border-r p-2"
       style={{ width: APP_TAB_STRIP_WIDTH, minWidth: APP_TAB_STRIP_WIDTH }}
     >
       {selectedAccountTabs.tabs.map((tab) => {
@@ -37,13 +37,15 @@ export function AppTabStrip() {
             <Button
               key={tab.id}
               variant={tab.active ? "secondary" : "ghost"}
-              size="icon"
+              size="sm"
+              className="w-full justify-start"
               title={tab.title}
               onClick={() => {
                 ipc.main.send("tabs.selectTab", selectedAccount.config.id, tab.id);
               }}
             >
               <WorkspaceAppIcon app="gmail" className="size-4" />
+              <span className="truncate">{tab.title}</span>
             </Button>
           );
         }
@@ -52,7 +54,8 @@ export function AppTabStrip() {
           <div key={tab.id} className="group relative">
             <Button
               variant={tab.active ? "secondary" : "ghost"}
-              size="icon"
+              size="sm"
+              className="w-full justify-start pr-7"
               title={tab.title}
               onClick={() => {
                 ipc.main.send("tabs.selectTab", selectedAccount.config.id, tab.id);
@@ -63,11 +66,12 @@ export function AppTabStrip() {
               ) : (
                 <GlobeIcon />
               )}
+              <span className="truncate">{tab.title}</span>
             </Button>
             <Button
               variant="secondary"
               size="icon"
-              className="absolute -top-1 -right-1 hidden size-4 rounded-full group-hover:flex"
+              className="absolute top-1/2 right-1 hidden size-5 -translate-y-1/2 group-hover:flex"
               title="Close Tab"
               onClick={() => {
                 ipc.main.send("tabs.closeTab", selectedAccount.config.id, tab.id);

--- a/packages/renderer-main/components/app-titlebar.tsx
+++ b/packages/renderer-main/components/app-titlebar.tsx
@@ -155,8 +155,16 @@ function PinnedWorkspaceApps() {
       {config["workspaceApps.pinnedApps"].map((app) => (
         <TitlebarIconButton
           key={app}
-          onClick={() => {
-            ipc.main.send("workspaceApps.openApp", app);
+          onClick={(event) => {
+            ipc.main.send(
+              "workspaceApps.openApp",
+              app,
+              event.metaKey || event.ctrlKey
+                ? "background-tab"
+                : event.shiftKey
+                  ? "new-window"
+                  : "foreground-tab",
+            );
           }}
           title={workspaceAppsPinnedApps[app]}
         >

--- a/packages/renderer-main/lib/stores.ts
+++ b/packages/renderer-main/lib/stores.ts
@@ -2,6 +2,7 @@ import { ipc } from "@meru/shared/renderer/ipc";
 import { getConfig } from "@meru/shared/renderer/react-query";
 import { accountsSearchParam, trialDaysLeftSearchParam } from "@meru/shared/renderer/search-params";
 import type { AccountInstances } from "@meru/shared/schemas";
+import type { AccountTabsState } from "@meru/shared/types";
 import { toast } from "sonner";
 import { navigate } from "wouter/use-hash-location";
 import { create } from "zustand";
@@ -40,6 +41,16 @@ ipc.renderer.on("accounts.openAddAccountDialog", async (_event) => {
   }
 
   useAccountsStore.setState({ isAddAccountDialogOpen: true });
+});
+
+export const useTabsStore = create<{
+  accountsTabs: AccountTabsState[];
+}>(() => ({
+  accountsTabs: [],
+}));
+
+ipc.renderer.on("tabs.changed", (_event, accountsTabs) => {
+  useTabsStore.setState({ accountsTabs });
 });
 
 export const useSettingsStore = create<{

--- a/packages/shared/constants.ts
+++ b/packages/shared/constants.ts
@@ -4,7 +4,7 @@ export const BASE_SPACING = 8;
 
 export const APP_TITLEBAR_HEIGHT = BASE_SPACING * 5;
 
-export const APP_TAB_STRIP_WIDTH = BASE_SPACING * 8;
+export const APP_TAB_STRIP_WIDTH = BASE_SPACING * 28;
 
 export const GOOGLE_ACCOUNTS_URL = "https://accounts.google.com";
 

--- a/packages/shared/constants.ts
+++ b/packages/shared/constants.ts
@@ -4,7 +4,9 @@ export const BASE_SPACING = 8;
 
 export const APP_TITLEBAR_HEIGHT = BASE_SPACING * 5;
 
-export const APP_TAB_STRIP_WIDTH = BASE_SPACING * 28;
+export const APP_TAB_STRIP_NARROW_WIDTH = BASE_SPACING * 8;
+
+export const APP_TAB_STRIP_WIDE_WIDTH = BASE_SPACING * 28;
 
 export const GOOGLE_ACCOUNTS_URL = "https://accounts.google.com";
 

--- a/packages/shared/constants.ts
+++ b/packages/shared/constants.ts
@@ -4,6 +4,8 @@ export const BASE_SPACING = 8;
 
 export const APP_TITLEBAR_HEIGHT = BASE_SPACING * 5;
 
+export const APP_TAB_STRIP_WIDTH = BASE_SPACING * 8;
+
 export const GOOGLE_ACCOUNTS_URL = "https://accounts.google.com";
 
 export const GOOGLE_MEET_URL = "https://meet.google.com";

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -89,6 +89,7 @@ export const GMAIL_TAB_ID = "gmail";
 export type TabState = {
   id: string;
   app: SupportedWorkspaceApp | undefined;
+  title: string;
   active: boolean;
 };
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -1,5 +1,6 @@
 import type { LoginItemSettings } from "electron";
 import type { accountColorsMap } from "./accounts";
+import { APP_TAB_STRIP_NARROW_WIDTH, APP_TAB_STRIP_WIDE_WIDTH } from "./constants";
 import type { GMAIL_ACTION_CODE_MAP } from "./gmail";
 import type {
   AccountConfig,
@@ -99,6 +100,26 @@ export type AccountTabsState = {
   accountId: AccountConfig["id"];
   tabs: TabState[];
 };
+
+export function getTabStripWidth(tabs: Pick<TabState, "app">[]) {
+  if (tabs.length <= 1) {
+    return 0;
+  }
+
+  const workspaceAppTabCounts = new Map<SupportedWorkspaceApp, number>();
+
+  for (const tab of tabs) {
+    if (tab.app) {
+      workspaceAppTabCounts.set(tab.app, (workspaceAppTabCounts.get(tab.app) ?? 0) + 1);
+    }
+  }
+
+  const hasWorkspaceAppWithMultipleTabs = Array.from(workspaceAppTabCounts.values()).some(
+    (workspaceAppTabCount) => workspaceAppTabCount > 1,
+  );
+
+  return hasWorkspaceAppWithMultipleTabs ? APP_TAB_STRIP_WIDE_WIDTH : APP_TAB_STRIP_NARROW_WIDTH;
+}
 
 type GmailHashLocation =
   | "inbox"

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -82,6 +82,21 @@ export const workspaceAppsPinnedApps = Object.fromEntries(
   workspaceAppsPinnedAppKeys.map((key) => [key, supportedWorkspaceApps[key]]),
 ) as Pick<typeof supportedWorkspaceApps, WorkspaceAppsPinnedApp>;
 
+export type WorkspaceAppOpenDisposition = "foreground-tab" | "background-tab" | "new-window";
+
+export const GMAIL_TAB_ID = "gmail";
+
+export type TabState = {
+  id: string;
+  app: SupportedWorkspaceApp | undefined;
+  active: boolean;
+};
+
+export type AccountTabsState = {
+  accountId: AccountConfig["id"];
+  tabs: TabState[];
+};
+
 type GmailHashLocation =
   | "inbox"
   | "starred"
@@ -216,7 +231,12 @@ export type IpcMainEvents =
       "app.relaunch": [];
       "theme.setTheme": [theme: "system" | "light" | "dark"];
       "notifications.showTestNotification": [];
-      "workspaceApps.openApp": [app: WorkspaceAppsPinnedApp];
+      "workspaceApps.openApp": [
+        app: WorkspaceAppsPinnedApp,
+        disposition?: WorkspaceAppOpenDisposition,
+      ];
+      "tabs.selectTab": [accountId: AccountConfig["id"], tabId: string];
+      "tabs.closeTab": [accountId: AccountConfig["id"], tabId: string];
       "doNotDisturb.toggle": [];
       "doNotDisturb.showOptions": [];
       "downloads.toggleRecentDownloadHistoryPopup": [];
@@ -257,6 +277,7 @@ export type IpcRendererEvent = {
   "gmail.undoMessageSent": [];
   "theme.darkModeChanged": [darkMode: boolean];
   "accounts.changed": [accounts: AccountInstances];
+  "tabs.changed": [accountsTabs: AccountTabsState[]];
   "accounts.openAddAccountDialog": [];
   "findInPage.activate": [];
   "findInPage.result": [result: { activeMatch: number; totalMatches: number }];

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -84,6 +84,8 @@ export const workspaceAppsPinnedApps = Object.fromEntries(
 
 export type WorkspaceAppOpenDisposition = "foreground-tab" | "background-tab" | "new-window";
 
+export const workspaceAppsAlwaysOpenAsWindow: SupportedWorkspaceApp[] = ["myaccount"];
+
 export const GMAIL_TAB_ID = "gmail";
 
 export type TabState = {

--- a/packages/ui/components/workspace-app-icon.tsx
+++ b/packages/ui/components/workspace-app-icon.tsx
@@ -4,7 +4,7 @@ import type { ComponentProps } from "react";
 export function WorkspaceAppIcon({
   app,
   ...props
-}: { app: WorkspaceAppsPinnedApp } & ComponentProps<"svg">) {
+}: { app: WorkspaceAppsPinnedApp | "gmail" } & ComponentProps<"svg">) {
   switch (app) {
     case "calendar": {
       return (
@@ -762,6 +762,58 @@ export function WorkspaceAppIcon({
             <clipPath id="clip0_2007_90">
               <rect width={22} height={22} fill="white" transform="translate(1 1)" />
             </clipPath>
+          </defs>
+        </svg>
+      );
+    }
+    case "gmail": {
+      return (
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" {...props}>
+          <path
+            d="M18.25 5.25003H23V19C23 19.8284 22.3283 20.5 21.5 20.5H19C18.8011 20.5 18.6103 20.421 18.4696 20.2803C18.329 20.1397 18.25 19.9489 18.25 19.75V5.25003Z"
+            fill="url(#paint0_linear_2010_2)"
+          />
+          <path
+            d="M5.75001 5.25003H1.00002V19C1.00002 19.8284 1.67165 20.5 2.50002 20.5H5.00001C5.19892 20.5 5.38969 20.421 5.53034 20.2803C5.67099 20.1397 5.75001 19.9489 5.75001 19.75V5.25003Z"
+            fill="#FC413D"
+          />
+          <path
+            d="M4.90326 3.55703C3.89914 2.71304 2.40102 2.84279 1.55702 3.84691C0.713024 4.8509 0.842774 6.34903 1.8469 7.19315L11.3566 15.1868C11.5368 15.3382 11.7647 15.4213 12.0001 15.4213C12.2355 15.4213 12.4633 15.3382 12.6435 15.1868L22.1532 7.19302C23.1572 6.34903 23.287 4.8509 22.443 3.84678C21.599 2.84278 20.1008 2.71304 19.0968 3.55703L12 9.52252L4.90326 3.55703Z"
+            fill="url(#paint1_linear_2010_2)"
+          />
+          <defs>
+            <linearGradient
+              id="paint0_linear_2010_2"
+              x1={20.625}
+              y1={5.25003}
+              x2={20.625}
+              y2={20.5}
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop stopColor="#60D673" />
+              <stop offset={0.17} stopColor="#42C868" />
+              <stop offset={0.39} stopColor="#0EBC5F" />
+              <stop offset={0.62} stopColor="#00A9BB" />
+              <stop offset={0.86} stopColor="#3C90FF" />
+              <stop offset={1} stopColor="#3186FF" />
+            </linearGradient>
+            <linearGradient
+              id="paint1_linear_2010_2"
+              x1={1.00002}
+              y1={5.51628}
+              x2={23}
+              y2={5.51628}
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop offset={0.08} stopColor="#FF63A0" />
+              <stop offset={0.3} stopColor="#FC413D" />
+              <stop offset={0.5} stopColor="#FC413D" />
+              <stop offset={0.65} stopColor="#FC413D" />
+              <stop offset={0.72} stopColor="#FC5C30" />
+              <stop offset={0.86} stopColor="#FEB10C" />
+              <stop offset={0.91} stopColor="#FEC700" />
+              <stop offset={0.96} stopColor="#FFDB0F" />
+            </linearGradient>
           </defs>
         </svg>
       );


### PR DESCRIPTION
## Problem

Meru is repositioning from "a Gmail app with workspace apps support" to "an app for Google Workspace with focus on Gmail". Workspace apps should be able to live as tabs inside the main window — each a `WebContentsView` child view, like the Gmail account views — instead of only opening in separate windows. This is the first slice of that direction, building on #626.

## Changes

**Cmd/Ctrl+click on a workspace-app link — or on a pinned titlebar app — now opens it as a background embedded tab** in the main window. Plain click keeps today's behavior (workspace-app window); Shift+click on a pinned app forces a new window.

- New `Tabs` (`packages/app/tabs.ts`): per-account tab list plus an active-tab id. The list holds a unified `Tab` shape (`id`, `app`, `view`, `updateViewBounds`); Gmail is seeded as a permanent default tab (`GMAIL_TAB_ID`, a thin adapter over the account's `Gmail` instance, not closeable — tab lifecycle never owns the Gmail view), and embedded `WorkspaceApp` instances satisfy the shape directly. Every mutation re-broadcasts bounds and tab state.
- `WorkspaceApp` construction defaults to an embedded tab; windowed call sites (foreground opens, PDF viewer, Gmail compose windows) pass an explicit `asWindow: true`. For embedded instances no `BrowserWindow` is created and the view attaches to the main window at z-order index 0 (`addChildView(view, 0)`), so a background tab never covers the active view. Embedded instances skip the id-less `workspaceApp.*Changed` broadcasts (they can't be demultiplexed in the shared main renderer yet — ids come in the next slice).
- Pinned titlebar apps no longer round-trip through an `executeJavaScript`'d `window.open` in the Gmail view (which always produced a `foreground-tab` disposition and swallowed modifiers). The renderer now sends the click's modifiers as a disposition over `workspaceApps.openApp`, and the handler feeds `WorkspaceApp.handleWindowOpen` directly — same gates, same reuse logic.
- Vertical tab strip (`AppTabStrip`): a narrow 64px icon rail while every open app is unique, switching to 224px browser-style rows with truncated page titles as soon as any app has multiple tabs (e.g. two Docs) — the shared `getTabStripWidth(tabs)` makes the renderer and the main-process bounds math agree on the width. Active state and hover-close in both modes; tab state carries the page title (app name until the page sets one). Rendered only when the **selected** account has at least one workspace-app tab. The x-offset applies to **all** attached views (every account, every tab) whenever the strip is visible — non-selected accounts' views sit above the renderer UI, so per-account offsets would let them bleed into the strip column — and all bounds are recomputed on every account switch. Gmail-only selected account ⇒ no strip, full-width views, exactly today's layout.
- Tab switching funnels through `Accounts.refreshSelectedAccountView()`, which raises the selected account's active tab view — the same z-order mechanism account switching already uses, now branch-free since Gmail is just the default tab. Per-account tab lists swap with the account; `hide`/`show`/`updateAllViewBounds` iterate the unified tab list.
- New IPC: `tabs.changed` (all accounts' tab lists → zustand store in renderer-main), `tabs.selectTab` / `tabs.closeTab` with explicit account and tab ids. Tab state carries the page title, shown in the tab row and kept in sync via `page-title-updated`.
- `workspaceAppsAlwaysOpenAsWindow` lists apps that never open as a tab — currently `myaccount` — which fall through to a window even on Cmd/Ctrl+click.
- Integrations: settings overlay hides/shows all tab views; find-in-page from the main window targets the active tab (Gmail or embedded, uniformly); account removal closes its tabs before wiping the session; `refreshSelectedAccountView` no longer steals focus while settings are open.

Everything stays behind the existing gates: without a valid license (or with `workspaceApps.openInApp` off / the app excluded), Cmd/Ctrl+click keeps opening the browser and the strip never appears.

## Deliberately deferred (per the phased plan)

- Loading spinners and id-parameterized `workspaceApp.*` IPC — next slice.
- A `workspaceApps.openBehavior` config (`tab` default / `newWindow` / `backgroundTab`) replacing `openAppsInNewWindow`, and Shift+click handling for in-page links — the flip to tabs-by-default lands there.
- Menu integration: View > Reload/Back/Forward/zoom still target Gmail while a tab is active.
- Pinned/persistent tabs, drag reorder, tab context menu.
- User-configurable tab strip width override (always narrow / always wide) on top of the automatic switching.

## Known gaps

- Embedded Meet works (power-save blocker, shortcuts) but the screen-share picker won't find a parent window (`Account`'s display-media handler only matches `BrowserWindow` Meet instances) — planned for the polish phase.
- Activating a tab while the recent-downloads popup is open raises the tab above the popup; the popup closes on blur, so impact is minor.

## Verification

- `bun types:ci` passes; dev build compiles.
- Manually tested on Linux (in progress): Cmd/Ctrl+click on a pinned titlebar app opens a background embedded tab; multi-account strip overlap fixed by global bounds offset. Remaining manual script: Cmd/Ctrl+click a Docs link in an email; switch/close tabs; open/close settings with a tab open; resize with a tab active; remove an account with open tabs; free tier still opens the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



