### PR TITLE
document pull request follow-up commit workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,7 @@ This installs dependencies and runs postinstall scripts (including the lefthook 
 ## Pull Requests
 
 - Titles follow the same style as commit summaries: short, lowercase, imperative, no type prefix.
+- Keep a pull request to a single logical commit. Apply review feedback and follow-up fixes by amending that commit and force-pushing (`git push --force-with-lease`) — never stack fixup commits on a pull request branch.
 - Keep the title and description accurate at all times. They describe what the branch contains **now**, not what it contained when the pull request was opened.
 - Whenever the branch changes, update the title and description in the same step — never leave them describing an earlier version. This applies to reworks after review feedback, added or dropped scope, and rebases that change what the diff means.
 - The description should cover the problem being solved, the changes made, and anything a reviewer needs in order to judge them — including deliberate omissions, known risks, and what has not been verified.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ This installs dependencies and runs postinstall scripts (including the lefthook 
 ## Pull Requests
 
 - Titles follow the same style as commit summaries: short, lowercase, imperative, no type prefix.
-- Keep a pull request to a single logical commit. Apply review feedback and follow-up fixes by amending that commit and force-pushing (`git push --force-with-lease`) — never stack fixup commits on a pull request branch.
+- Once a pull request is open, make further changes as new commits — don't amend and force-push. Incremental commits let the reviewer see what changed since their last look; pull requests are squash-merged, so `main` stays clean regardless.
 - Keep the title and description accurate at all times. They describe what the branch contains **now**, not what it contained when the pull request was opened.
 - Whenever the branch changes, update the title and description in the same step — never leave them describing an earlier version. This applies to reworks after review feedback, added or dropped scope, and rebases that change what the diff means.
 - The description should cover the problem being solved, the changes made, and anything a reviewer needs in order to judge them — including deliberate omissions, known risks, and what has not been verified.


### PR DESCRIPTION
## Problem

CLAUDE.md's Pull Requests section covers titles and description accuracy, but not how commits on an open pull request branch should be managed.

## Changes

Adds one guideline to the Pull Requests section: once a pull request is open, make further changes as new commits instead of amending and force-pushing — incremental commits let the reviewer see what changed since their last look, and squash-merging keeps `main` clean regardless.

(The first commit on this branch documented the opposite, amend-based workflow; the follow-up commit replaces it with the intended guideline.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)