### PR TITLE
document cn helper for conditional class names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,15 +94,7 @@ This installs dependencies and runs postinstall scripts (including the lefthook 
 ## UI Components
 
 - Components in `packages/ui` follow shadcn conventions. Many are compound components with named sub-components (e.g. `Item` → `ItemContent`, `ItemActions`, `ItemTitle`, `ItemDescription`). Always read the component file before use to find available sub-components and use them instead of plain `<div>` wrappers.
-- When a `className` depends on a condition, never write a ternary whose branches repeat shared classes. Hoist the common classes and combine them with the `cn` helper (`@meru/ui/lib/utils`), keeping only the differing classes in the ternary:
-
-  ```tsx
-  // correct
-  className={cn("absolute hidden group-hover:flex", isWide ? "size-5" : "size-4 rounded-full")}
-
-  // wrong
-  className={isWide ? "absolute hidden group-hover:flex size-5" : "absolute hidden group-hover:flex size-4 rounded-full"}
-  ```
+- Never repeat shared classes across the branches of a conditional `className`. Hoist them and merge with the `cn` helper (`@meru/ui/lib/utils`): `cn("absolute hidden", isWide ? "size-5" : "size-4")`.
 
 ## React State
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,15 @@ This installs dependencies and runs postinstall scripts (including the lefthook 
 ## UI Components
 
 - Components in `packages/ui` follow shadcn conventions. Many are compound components with named sub-components (e.g. `Item` → `ItemContent`, `ItemActions`, `ItemTitle`, `ItemDescription`). Always read the component file before use to find available sub-components and use them instead of plain `<div>` wrappers.
+- When a `className` depends on a condition, never write a ternary whose branches repeat shared classes. Hoist the common classes and combine them with the `cn` helper (`@meru/ui/lib/utils`), keeping only the differing classes in the ternary:
+
+  ```tsx
+  // correct
+  className={cn("absolute hidden group-hover:flex", isWide ? "size-5" : "size-4 rounded-full")}
+
+  // wrong
+  className={isWide ? "absolute hidden group-hover:flex size-5" : "absolute hidden group-hover:flex size-4 rounded-full"}
+  ```
 
 ## React State
 


### PR DESCRIPTION
## Problem

A conditional `className` was written as a ternary whose branches duplicated the shared classes, differing only in a few — easy to misread and easy to let the branches drift apart when one is edited.

## Changes

Adds a guideline to CLAUDE.md's UI Components section: hoist the common classes and combine them with the `cn` helper, keeping only the differing classes in the ternary, with a correct/wrong example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)