### PR TITLE
restructure workspace app definitions into one map with capability flags

### DIFF
--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -2,11 +2,7 @@ import { randomUUID } from "node:crypto";
 import { APP_TITLEBAR_HEIGHT, GOOGLE_ACCOUNTS_URL } from "@meru/shared/constants";
 import { GMAIL_URL } from "@meru/shared/gmail";
 import type { AccountConfig } from "@meru/shared/schemas";
-import {
-  supportedWorkspaceApps,
-  type SupportedWorkspaceApp,
-  workspaceAppsAlwaysOpenAsWindow,
-} from "@meru/shared/types";
+import { type SupportedWorkspaceApp, workspaceApps } from "@meru/shared/types";
 import { clamp } from "@meru/shared/utils";
 import {
   app,
@@ -53,7 +49,7 @@ const GOOGLE_CHAT_ATTACHMENT_URL_REGEXP = /chat\.google\.com\/u\/\d\/api\/get_at
 const GOOGLE_PDF_VIEWER_URL_REGEXP = /googleusercontent\.com\/viewer\/secure\/pdf/;
 
 const SUPPORTED_WORKSPACE_APPS_URL_REGEXP = new RegExp(
-  `(${Object.keys(supportedWorkspaceApps).join("|")})(?:\\.usercontent)?\\.google\\.com`,
+  `(${Object.keys(workspaceApps).join("|")})(?:\\.usercontent)?\\.google\\.com`,
 );
 
 function getWorkspaceAppFromUrl(url: string) {
@@ -225,7 +221,7 @@ export class WorkspaceApp {
     if (isWorkspaceAppEnabledToOpenInApp) {
       if (
         disposition === "background-tab" &&
-        !workspaceAppsAlwaysOpenAsWindow.includes(matchedSupportedWorkspaceApp)
+        !workspaceApps[matchedSupportedWorkspaceApp].alwaysOpenAsWindow
       ) {
         new WorkspaceApp({
           accountId,
@@ -542,7 +538,7 @@ export class WorkspaceApp {
   private pageTitle = "";
 
   get title() {
-    return this.pageTitle || (this.app ? supportedWorkspaceApps[this.app] : "");
+    return this.pageTitle || (this.app ? workspaceApps[this.app].label : "");
   }
 
   handlePageTitleUpdated = (_event: Electron.Event, pageTitle: string, explicitSet: boolean) => {

--- a/packages/renderer-main/components/app-titlebar.tsx
+++ b/packages/renderer-main/components/app-titlebar.tsx
@@ -2,7 +2,7 @@ import { accountColorsMap } from "@meru/shared/accounts";
 import { WEBSITE_URL } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
 import { useConfig } from "@meru/shared/renderer/react-query";
-import { workspaceAppsPinnedApps } from "@meru/shared/types";
+import { pinnableWorkspaceApps } from "@meru/shared/types";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import { FindInPage as UiFindInPage } from "@meru/ui/components/find-in-page";
@@ -166,7 +166,7 @@ function PinnedWorkspaceApps() {
                   : "foreground-tab",
             );
           }}
-          title={workspaceAppsPinnedApps[app]}
+          title={pinnableWorkspaceApps[app]}
         >
           <WorkspaceAppIcon app={app} />
         </TitlebarIconButton>

--- a/packages/renderer-main/routes/settings/workspace-apps.tsx
+++ b/packages/renderer-main/routes/settings/workspace-apps.tsx
@@ -3,8 +3,8 @@ import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { useConfig, useConfigMutation } from "@meru/shared/renderer/react-query";
 import {
-  type WorkspaceAppsPinnedApp,
-  workspaceAppsPinnedApps,
+  type PinnableWorkspaceApp,
+  pinnableWorkspaceApps,
   type SupportedWorkspaceApp,
   workspaceApps,
 } from "@meru/shared/types";
@@ -39,7 +39,7 @@ function SortablePinnedAppItem({
   onUnpin,
   disabled,
 }: {
-  app: WorkspaceAppsPinnedApp;
+  app: PinnableWorkspaceApp;
   index: number;
   onUnpin: () => void;
   disabled: boolean;
@@ -54,18 +54,18 @@ function SortablePinnedAppItem({
         size="xs"
         className="cursor-grab touch-none"
         disabled={disabled}
-        aria-label={`Drag ${workspaceAppsPinnedApps[app]} to reorder`}
+        aria-label={`Drag ${pinnableWorkspaceApps[app]} to reorder`}
       >
         <GripVerticalIcon />
         <WorkspaceAppIcon app={app} className="size-3.5" />
-        {workspaceAppsPinnedApps[app]}
+        {pinnableWorkspaceApps[app]}
       </Button>
       <Button
         variant="outline"
         size="icon-xs"
         onClick={onUnpin}
         disabled={disabled}
-        aria-label={`Unpin ${workspaceAppsPinnedApps[app]}`}
+        aria-label={`Unpin ${pinnableWorkspaceApps[app]}`}
       >
         <XIcon />
       </Button>
@@ -86,7 +86,7 @@ export function WorkspaceAppsSettings() {
 
   const pinnedApps = config["workspaceApps.pinnedApps"];
 
-  const availableApps = (Object.keys(workspaceAppsPinnedApps) as WorkspaceAppsPinnedApp[]).filter(
+  const availableApps = (Object.keys(pinnableWorkspaceApps) as PinnableWorkspaceApp[]).filter(
     (app) => !pinnedApps.includes(app),
   );
 
@@ -254,10 +254,10 @@ export function WorkspaceAppsSettings() {
                           });
                         }}
                         disabled={!isLicenseKeyValid}
-                        aria-label={`Pin ${workspaceAppsPinnedApps[app]}`}
+                        aria-label={`Pin ${pinnableWorkspaceApps[app]}`}
                       >
                         <WorkspaceAppIcon app={app} className="size-3.5" />
-                        {workspaceAppsPinnedApps[app]}
+                        {pinnableWorkspaceApps[app]}
                         <PlusIcon />
                       </Button>
                     ))}

--- a/packages/renderer-main/routes/settings/workspace-apps.tsx
+++ b/packages/renderer-main/routes/settings/workspace-apps.tsx
@@ -6,7 +6,7 @@ import {
   type WorkspaceAppsPinnedApp,
   workspaceAppsPinnedApps,
   type SupportedWorkspaceApp,
-  supportedWorkspaceApps,
+  workspaceApps,
 } from "@meru/shared/types";
 import { Button } from "@meru/ui/components/button";
 import { ButtonGroup } from "@meru/ui/components/button-group";
@@ -92,9 +92,9 @@ export function WorkspaceAppsSettings() {
 
   const excludedApps = config["workspaceApps.openInAppExcludedApps"];
 
-  const excludedAppLabels = (Object.keys(supportedWorkspaceApps) as SupportedWorkspaceApp[])
+  const excludedAppLabels = (Object.keys(workspaceApps) as SupportedWorkspaceApp[])
     .filter((app) => excludedApps.includes(app))
-    .map((app) => supportedWorkspaceApps[app]);
+    .map((app) => workspaceApps[app].label);
 
   const visibleExcludedAppLabels = excludedAppLabels.slice(0, 3);
 
@@ -151,28 +151,26 @@ export function WorkspaceAppsSettings() {
                     }
                   />
                   <DropdownMenuContent align="end">
-                    {(
-                      Object.entries(supportedWorkspaceApps) as Entries<
-                        typeof supportedWorkspaceApps
-                      >
-                    ).map(([app, label]) => (
-                      <DropdownMenuCheckboxItem
-                        key={app}
-                        checked={config["workspaceApps.openInAppExcludedApps"].includes(app)}
-                        closeOnClick={false}
-                        onCheckedChange={(checked) => {
-                          configMutation.mutate({
-                            "workspaceApps.openInAppExcludedApps": checked
-                              ? [...config["workspaceApps.openInAppExcludedApps"], app]
-                              : config["workspaceApps.openInAppExcludedApps"].filter(
-                                  (value) => value !== app,
-                                ),
-                          });
-                        }}
-                      >
-                        {label}
-                      </DropdownMenuCheckboxItem>
-                    ))}
+                    {(Object.entries(workspaceApps) as Entries<typeof workspaceApps>).map(
+                      ([app, { label }]) => (
+                        <DropdownMenuCheckboxItem
+                          key={app}
+                          checked={config["workspaceApps.openInAppExcludedApps"].includes(app)}
+                          closeOnClick={false}
+                          onCheckedChange={(checked) => {
+                            configMutation.mutate({
+                              "workspaceApps.openInAppExcludedApps": checked
+                                ? [...config["workspaceApps.openInAppExcludedApps"], app]
+                                : config["workspaceApps.openInAppExcludedApps"].filter(
+                                    (value) => value !== app,
+                                  ),
+                            });
+                          }}
+                        >
+                          {label}
+                        </DropdownMenuCheckboxItem>
+                      ),
+                    )}
                   </DropdownMenuContent>
                 </DropdownMenu>
               </Field>

--- a/packages/renderer-workspace-app/index.tsx
+++ b/packages/renderer-workspace-app/index.tsx
@@ -2,7 +2,7 @@ import { useCopied } from "@meru/shared/renderer/hooks";
 import { ipc } from "@meru/shared/renderer/ipc";
 import { renderApp } from "@meru/shared/renderer/react";
 import { useConfig } from "@meru/shared/renderer/react-query";
-import type { WorkspaceAppsPinnedApp } from "@meru/shared/types";
+import type { PinnableWorkspaceApp } from "@meru/shared/types";
 import { AccountBadge } from "@meru/ui/components/account-badge";
 import { FindInPage } from "@meru/ui/components/find-in-page";
 import {
@@ -192,7 +192,7 @@ function App() {
     (accountConfig) => accountConfig.id === searchParams.get("accountId"),
   );
 
-  const workspaceApp = searchParams.get("workspaceApp") as WorkspaceAppsPinnedApp | null;
+  const workspaceApp = searchParams.get("workspaceApp") as PinnableWorkspaceApp | null;
 
   return (
     <Titlebar>

--- a/packages/renderer-workspace-app/index.tsx
+++ b/packages/renderer-workspace-app/index.tsx
@@ -2,7 +2,7 @@ import { useCopied } from "@meru/shared/renderer/hooks";
 import { ipc } from "@meru/shared/renderer/ipc";
 import { renderApp } from "@meru/shared/renderer/react";
 import { useConfig } from "@meru/shared/renderer/react-query";
-import type { PinnableWorkspaceApp } from "@meru/shared/types";
+import type { SupportedWorkspaceApp } from "@meru/shared/types";
 import { AccountBadge } from "@meru/ui/components/account-badge";
 import { FindInPage } from "@meru/ui/components/find-in-page";
 import {
@@ -192,7 +192,7 @@ function App() {
     (accountConfig) => accountConfig.id === searchParams.get("accountId"),
   );
 
-  const workspaceApp = searchParams.get("workspaceApp") as PinnableWorkspaceApp | null;
+  const workspaceApp = searchParams.get("workspaceApp") as SupportedWorkspaceApp | null;
 
   return (
     <Titlebar>

--- a/packages/shared/google.ts
+++ b/packages/shared/google.ts
@@ -1,6 +1,6 @@
-import type { PinnableWorkspaceApp } from "./types";
+import type { SupportedWorkspaceApp } from "./types";
 
-export function getWorkspaceAppUrl(app: PinnableWorkspaceApp) {
+export function getWorkspaceAppUrl(app: SupportedWorkspaceApp) {
   return `https://${app}.google.com`;
 }
 

--- a/packages/shared/google.ts
+++ b/packages/shared/google.ts
@@ -1,6 +1,6 @@
-import type { WorkspaceAppsPinnedApp } from "./types";
+import type { PinnableWorkspaceApp } from "./types";
 
-export function getWorkspaceAppUrl(app: WorkspaceAppsPinnedApp) {
+export function getWorkspaceAppUrl(app: PinnableWorkspaceApp) {
   return `https://${app}.google.com`;
 }
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -34,58 +34,48 @@ export type NotificationTime = {
   days?: number[]; // 0=Sun,1=Mon,...,6=Sat; undefined/empty = all days
 };
 
-export const supportedWorkspaceApps = {
-  calendar: "Calendar",
-  chat: "Chat",
-  classroom: "Classroom",
-  contacts: "Contacts",
-  docs: "Docs",
-  drive: "Drive",
-  forms: "Forms",
-  gemini: "Gemini",
-  groups: "Groups",
-  keep: "Keep",
-  meet: "Meet",
-  myaccount: "My Account",
-  notebooklm: "NotebookLM",
-  sheets: "Sheets",
-  sites: "Sites",
-  slides: "Slides",
-  tasks: "Tasks",
-  voice: "Voice",
-} as const;
+type WorkspaceAppDefinition = {
+  label: string;
+  pinnable: boolean;
+  alwaysOpenAsWindow: boolean;
+};
 
-export type SupportedWorkspaceApp = keyof typeof supportedWorkspaceApps;
+export const workspaceApps = {
+  calendar: { label: "Calendar", pinnable: true, alwaysOpenAsWindow: false },
+  chat: { label: "Chat", pinnable: true, alwaysOpenAsWindow: false },
+  classroom: { label: "Classroom", pinnable: true, alwaysOpenAsWindow: false },
+  contacts: { label: "Contacts", pinnable: true, alwaysOpenAsWindow: false },
+  docs: { label: "Docs", pinnable: true, alwaysOpenAsWindow: false },
+  drive: { label: "Drive", pinnable: true, alwaysOpenAsWindow: false },
+  forms: { label: "Forms", pinnable: true, alwaysOpenAsWindow: false },
+  gemini: { label: "Gemini", pinnable: true, alwaysOpenAsWindow: false },
+  groups: { label: "Groups", pinnable: true, alwaysOpenAsWindow: false },
+  keep: { label: "Keep", pinnable: true, alwaysOpenAsWindow: false },
+  meet: { label: "Meet", pinnable: true, alwaysOpenAsWindow: false },
+  myaccount: { label: "My Account", pinnable: false, alwaysOpenAsWindow: true },
+  notebooklm: { label: "NotebookLM", pinnable: true, alwaysOpenAsWindow: false },
+  sheets: { label: "Sheets", pinnable: true, alwaysOpenAsWindow: false },
+  sites: { label: "Sites", pinnable: true, alwaysOpenAsWindow: false },
+  slides: { label: "Slides", pinnable: true, alwaysOpenAsWindow: false },
+  tasks: { label: "Tasks", pinnable: true, alwaysOpenAsWindow: false },
+  voice: { label: "Voice", pinnable: true, alwaysOpenAsWindow: false },
+} as const satisfies Record<string, WorkspaceAppDefinition>;
 
-const workspaceAppsPinnedAppKeys = [
-  "calendar",
-  "chat",
-  "classroom",
-  "contacts",
-  "docs",
-  "drive",
-  "forms",
-  "gemini",
-  "groups",
-  "keep",
-  "meet",
-  "notebooklm",
-  "sheets",
-  "sites",
-  "slides",
-  "tasks",
-  "voice",
-] as const satisfies readonly SupportedWorkspaceApp[];
+export type SupportedWorkspaceApp = keyof typeof workspaceApps;
 
-export type WorkspaceAppsPinnedApp = (typeof workspaceAppsPinnedAppKeys)[number];
+export type WorkspaceAppsPinnedApp = {
+  [App in SupportedWorkspaceApp]: (typeof workspaceApps)[App]["pinnable"] extends true
+    ? App
+    : never;
+}[SupportedWorkspaceApp];
 
 export const workspaceAppsPinnedApps = Object.fromEntries(
-  workspaceAppsPinnedAppKeys.map((key) => [key, supportedWorkspaceApps[key]]),
-) as Pick<typeof supportedWorkspaceApps, WorkspaceAppsPinnedApp>;
+  Object.entries(workspaceApps)
+    .filter(([, workspaceAppDefinition]) => workspaceAppDefinition.pinnable)
+    .map(([workspaceApp, workspaceAppDefinition]) => [workspaceApp, workspaceAppDefinition.label]),
+) as Record<WorkspaceAppsPinnedApp, string>;
 
 export type WorkspaceAppOpenDisposition = "foreground-tab" | "background-tab" | "new-window";
-
-export const workspaceAppsAlwaysOpenAsWindow: SupportedWorkspaceApp[] = ["myaccount"];
 
 export const GMAIL_TAB_ID = "gmail";
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -34,7 +34,7 @@ export type NotificationTime = {
   days?: number[]; // 0=Sun,1=Mon,...,6=Sat; undefined/empty = all days
 };
 
-type WorkspaceAppDefinition = {
+type WorkspaceApp = {
   label: string;
   pinnable?: boolean;
   alwaysOpenAsWindow?: boolean;
@@ -59,7 +59,7 @@ const workspaceAppDefinitions = {
   slides: { label: "Slides" },
   tasks: { label: "Tasks" },
   voice: { label: "Voice" },
-} as const satisfies Record<string, WorkspaceAppDefinition>;
+} as const satisfies Record<string, WorkspaceApp>;
 
 export type SupportedWorkspaceApp = keyof typeof workspaceAppDefinitions;
 
@@ -69,8 +69,7 @@ export type PinnableWorkspaceApp = {
     : App;
 }[SupportedWorkspaceApp];
 
-export const workspaceApps: Record<SupportedWorkspaceApp, WorkspaceAppDefinition> =
-  workspaceAppDefinitions;
+export const workspaceApps: Record<SupportedWorkspaceApp, WorkspaceApp> = workspaceAppDefinitions;
 
 export const pinnableWorkspaceApps = Object.fromEntries(
   Object.entries(workspaceApps)

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -34,7 +34,7 @@ export type NotificationTime = {
   days?: number[]; // 0=Sun,1=Mon,...,6=Sat; undefined/empty = all days
 };
 
-type WorkspaceApp = {
+type WorkspaceAppDefinition = {
   label: string;
   pinnable?: boolean;
   alwaysOpenAsWindow?: boolean;
@@ -59,7 +59,7 @@ const workspaceAppDefinitions = {
   slides: { label: "Slides" },
   tasks: { label: "Tasks" },
   voice: { label: "Voice" },
-} as const satisfies Record<string, WorkspaceApp>;
+} as const satisfies Record<string, WorkspaceAppDefinition>;
 
 export type SupportedWorkspaceApp = keyof typeof workspaceAppDefinitions;
 
@@ -69,7 +69,8 @@ export type PinnableWorkspaceApp = {
     : App;
 }[SupportedWorkspaceApp];
 
-export const workspaceApps: Record<SupportedWorkspaceApp, WorkspaceApp> = workspaceAppDefinitions;
+export const workspaceApps: Record<SupportedWorkspaceApp, WorkspaceAppDefinition> =
+  workspaceAppDefinitions;
 
 export const pinnableWorkspaceApps = Object.fromEntries(
   Object.entries(workspaceApps)

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -63,7 +63,7 @@ const workspaceAppDefinitions = {
 
 export type SupportedWorkspaceApp = keyof typeof workspaceAppDefinitions;
 
-export type WorkspaceAppsPinnedApp = {
+export type PinnableWorkspaceApp = {
   [App in SupportedWorkspaceApp]: (typeof workspaceAppDefinitions)[App] extends { pinnable: false }
     ? never
     : App;
@@ -72,11 +72,11 @@ export type WorkspaceAppsPinnedApp = {
 export const workspaceApps: Record<SupportedWorkspaceApp, WorkspaceAppDefinition> =
   workspaceAppDefinitions;
 
-export const workspaceAppsPinnedApps = Object.fromEntries(
+export const pinnableWorkspaceApps = Object.fromEntries(
   Object.entries(workspaceApps)
     .filter(([, workspaceAppDefinition]) => workspaceAppDefinition.pinnable !== false)
     .map(([workspaceApp, workspaceAppDefinition]) => [workspaceApp, workspaceAppDefinition.label]),
-) as Record<WorkspaceAppsPinnedApp, string>;
+) as Record<PinnableWorkspaceApp, string>;
 
 export type WorkspaceAppOpenDisposition = "foreground-tab" | "background-tab" | "new-window";
 
@@ -198,7 +198,7 @@ export type Config = {
   "workspaceApps.openInApp": boolean;
   "workspaceApps.openInAppExcludedApps": SupportedWorkspaceApp[];
   "workspaceApps.openAppsInNewWindow": boolean;
-  "workspaceApps.pinnedApps": WorkspaceAppsPinnedApp[];
+  "workspaceApps.pinnedApps": PinnableWorkspaceApp[];
   "workspaceApps.showAccountColor": boolean;
   "workspaceApps.showAccountLabel": boolean;
   "verificationCodes.autoCopy": boolean;
@@ -249,7 +249,7 @@ export type IpcMainEvents =
       "theme.setTheme": [theme: "system" | "light" | "dark"];
       "notifications.showTestNotification": [];
       "workspaceApps.openApp": [
-        app: WorkspaceAppsPinnedApp,
+        app: PinnableWorkspaceApp,
         disposition?: WorkspaceAppOpenDisposition,
       ];
       "tabs.selectTab": [accountId: AccountConfig["id"], tabId: string];

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -36,42 +36,45 @@ export type NotificationTime = {
 
 type WorkspaceAppDefinition = {
   label: string;
-  pinnable: boolean;
-  alwaysOpenAsWindow: boolean;
+  pinnable?: boolean;
+  alwaysOpenAsWindow?: boolean;
 };
 
-export const workspaceApps = {
-  calendar: { label: "Calendar", pinnable: true, alwaysOpenAsWindow: false },
-  chat: { label: "Chat", pinnable: true, alwaysOpenAsWindow: false },
-  classroom: { label: "Classroom", pinnable: true, alwaysOpenAsWindow: false },
-  contacts: { label: "Contacts", pinnable: true, alwaysOpenAsWindow: false },
-  docs: { label: "Docs", pinnable: true, alwaysOpenAsWindow: false },
-  drive: { label: "Drive", pinnable: true, alwaysOpenAsWindow: false },
-  forms: { label: "Forms", pinnable: true, alwaysOpenAsWindow: false },
-  gemini: { label: "Gemini", pinnable: true, alwaysOpenAsWindow: false },
-  groups: { label: "Groups", pinnable: true, alwaysOpenAsWindow: false },
-  keep: { label: "Keep", pinnable: true, alwaysOpenAsWindow: false },
-  meet: { label: "Meet", pinnable: true, alwaysOpenAsWindow: false },
+const workspaceAppDefinitions = {
+  calendar: { label: "Calendar" },
+  chat: { label: "Chat" },
+  classroom: { label: "Classroom" },
+  contacts: { label: "Contacts" },
+  docs: { label: "Docs" },
+  drive: { label: "Drive" },
+  forms: { label: "Forms" },
+  gemini: { label: "Gemini" },
+  groups: { label: "Groups" },
+  keep: { label: "Keep" },
+  meet: { label: "Meet" },
   myaccount: { label: "My Account", pinnable: false, alwaysOpenAsWindow: true },
-  notebooklm: { label: "NotebookLM", pinnable: true, alwaysOpenAsWindow: false },
-  sheets: { label: "Sheets", pinnable: true, alwaysOpenAsWindow: false },
-  sites: { label: "Sites", pinnable: true, alwaysOpenAsWindow: false },
-  slides: { label: "Slides", pinnable: true, alwaysOpenAsWindow: false },
-  tasks: { label: "Tasks", pinnable: true, alwaysOpenAsWindow: false },
-  voice: { label: "Voice", pinnable: true, alwaysOpenAsWindow: false },
+  notebooklm: { label: "NotebookLM" },
+  sheets: { label: "Sheets" },
+  sites: { label: "Sites" },
+  slides: { label: "Slides" },
+  tasks: { label: "Tasks" },
+  voice: { label: "Voice" },
 } as const satisfies Record<string, WorkspaceAppDefinition>;
 
-export type SupportedWorkspaceApp = keyof typeof workspaceApps;
+export type SupportedWorkspaceApp = keyof typeof workspaceAppDefinitions;
 
 export type WorkspaceAppsPinnedApp = {
-  [App in SupportedWorkspaceApp]: (typeof workspaceApps)[App]["pinnable"] extends true
-    ? App
-    : never;
+  [App in SupportedWorkspaceApp]: (typeof workspaceAppDefinitions)[App] extends { pinnable: false }
+    ? never
+    : App;
 }[SupportedWorkspaceApp];
+
+export const workspaceApps: Record<SupportedWorkspaceApp, WorkspaceAppDefinition> =
+  workspaceAppDefinitions;
 
 export const workspaceAppsPinnedApps = Object.fromEntries(
   Object.entries(workspaceApps)
-    .filter(([, workspaceAppDefinition]) => workspaceAppDefinition.pinnable)
+    .filter(([, workspaceAppDefinition]) => workspaceAppDefinition.pinnable !== false)
     .map(([workspaceApp, workspaceAppDefinition]) => [workspaceApp, workspaceAppDefinition.label]),
 ) as Record<WorkspaceAppsPinnedApp, string>;
 

--- a/packages/ui/components/workspace-app-icon.tsx
+++ b/packages/ui/components/workspace-app-icon.tsx
@@ -1,10 +1,10 @@
-import type { PinnableWorkspaceApp } from "@meru/shared/types";
+import type { SupportedWorkspaceApp } from "@meru/shared/types";
 import type { ComponentProps } from "react";
 
 export function WorkspaceAppIcon({
   app,
   ...props
-}: { app: PinnableWorkspaceApp | "gmail" } & ComponentProps<"svg">) {
+}: { app: SupportedWorkspaceApp | "gmail" } & ComponentProps<"svg">) {
   switch (app) {
     case "calendar": {
       return (

--- a/packages/ui/components/workspace-app-icon.tsx
+++ b/packages/ui/components/workspace-app-icon.tsx
@@ -1,10 +1,10 @@
-import type { WorkspaceAppsPinnedApp } from "@meru/shared/types";
+import type { PinnableWorkspaceApp } from "@meru/shared/types";
 import type { ComponentProps } from "react";
 
 export function WorkspaceAppIcon({
   app,
   ...props
-}: { app: WorkspaceAppsPinnedApp | "gmail" } & ComponentProps<"svg">) {
+}: { app: PinnableWorkspaceApp | "gmail" } & ComponentProps<"svg">) {
   switch (app) {
     case "calendar": {
       return (


### PR DESCRIPTION
## Problem

Workspace-app metadata was scattered across several parallel structures in `packages/shared/types.ts`: `supportedWorkspaceApps` (key → label), `workspaceAppsPinnedAppKeys` + `workspaceAppsPinnedApps` (the pinnable subset, duplicating every key), and `workspaceAppsAlwaysOpenAsWindow` (apps that never open as a tab). Adding or reclassifying an app meant touching multiple lists that could drift apart.

## Changes

Pure refactor, no behavior change:

- One source-of-truth map: each entry carries its `label` plus optional capability flags `pinnable` and `alwaysOpenAsWindow`, enforced by a `WorkspaceAppDefinition` shape via `as const satisfies`. Entries declare only exceptions — an omitted flag means the default (`pinnable`, opens as tab), so 17 of 18 entries are just a label and `myaccount` is the lone `{ pinnable: false, alwaysOpenAsWindow: true }`.
- `SupportedWorkspaceApp` is derived from the map's keys; `PinnableWorkspaceApp` (renamed from `WorkspaceAppsPinnedApp` — it describes apps that can be pinned, not currently pinned ones) is derived by a mapped type filtering out `pinnable: false` entries (so `myaccount` stays excluded at the type level); `pinnableWorkspaceApps` (renamed from `workspaceAppsPinnedApps`; key → label, used by the titlebar launcher and settings) is derived at runtime from the same map. The tersely-inferred map stays module-private; the exported `workspaceApps` is the same object re-typed as `Record<SupportedWorkspaceApp, WorkspaceAppDefinition>` so flag reads type as `boolean | undefined` and read falsy where omitted.
- `workspaceAppsAlwaysOpenAsWindow` is gone — `handleWindowOpen` reads the `alwaysOpenAsWindow` flag directly.
- Call sites updated: the URL regexp and title fallback in `workspace-app.ts`, and the excluded-apps labels/dropdown in the settings page, now read from `workspaceApps`.

`getWorkspaceAppUrl`, the window renderer's `workspaceApp` search-param cast, and `WorkspaceAppIcon`'s prop are widened from the pinnable type to `SupportedWorkspaceApp` — the URL scheme covers every supported app, and a `myaccount` window genuinely receives `workspaceApp=myaccount`, so the pinnable cast there was inaccurate (no visible change: the icon has no `myaccount` glyph and renders nothing for it, as before). Other consumers of the derived exports (config types, titlebar launcher, settings) are untouched.

## Verification

- `bun types:ci` passes; no references to the removed exports remain.
- No behavior change intended; not runtime-tested in this environment (no display).

🤖 Generated with [Claude Code](https://claude.com/claude-code)




