### PR TITLE
add gmail to workspace app definitions

### DIFF
--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -1,4 +1,9 @@
-import { GMAIL_TAB_ID, type SupportedWorkspaceApp, type TabState } from "@meru/shared/types";
+import {
+  GMAIL_TAB_ID,
+  type SupportedWorkspaceApp,
+  type TabState,
+  workspaceApps,
+} from "@meru/shared/types";
 import type { WebContentsView } from "electron";
 import { accounts } from "./accounts";
 import type { Gmail } from "./gmail";
@@ -22,8 +27,8 @@ export class Tabs {
     this.tabs = [
       {
         id: GMAIL_TAB_ID,
-        app: undefined,
-        title: "Gmail",
+        app: "gmail",
+        title: workspaceApps.gmail.label,
         get view() {
           return gmail.view;
         },

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { APP_TITLEBAR_HEIGHT, GOOGLE_ACCOUNTS_URL } from "@meru/shared/constants";
-import { GMAIL_URL } from "@meru/shared/gmail";
+import { getWorkspaceAppUrl } from "@meru/shared/google";
 import type { AccountConfig } from "@meru/shared/schemas";
 import { type SupportedWorkspaceApp, workspaceApps } from "@meru/shared/types";
 import { clamp } from "@meru/shared/utils";
@@ -48,12 +48,25 @@ const GOOGLE_CHAT_ATTACHMENT_URL_REGEXP = /chat\.google\.com\/u\/\d\/api\/get_at
 
 const GOOGLE_PDF_VIEWER_URL_REGEXP = /googleusercontent\.com\/viewer\/secure\/pdf/;
 
+const workspaceAppsBySubdomain = new Map<string, SupportedWorkspaceApp>(
+  (Object.keys(workspaceApps) as SupportedWorkspaceApp[]).map((workspaceApp) => [
+    new URL(getWorkspaceAppUrl(workspaceApp)).hostname.replace(".google.com", ""),
+    workspaceApp,
+  ]),
+);
+
 const SUPPORTED_WORKSPACE_APPS_URL_REGEXP = new RegExp(
-  `(${Object.keys(workspaceApps).join("|")})(?:\\.usercontent)?\\.google\\.com`,
+  `(${Array.from(workspaceAppsBySubdomain.keys()).join("|")})(?:\\.usercontent)?\\.google\\.com`,
 );
 
 function getWorkspaceAppFromUrl(url: string) {
-  return url.match(SUPPORTED_WORKSPACE_APPS_URL_REGEXP)?.[1] as SupportedWorkspaceApp | undefined;
+  const workspaceAppSubdomain = url.match(SUPPORTED_WORKSPACE_APPS_URL_REGEXP)?.[1];
+
+  if (!workspaceAppSubdomain) {
+    return undefined;
+  }
+
+  return workspaceAppsBySubdomain.get(workspaceAppSubdomain);
 }
 
 type WorkspaceAppOptions = {
@@ -182,18 +195,6 @@ export class WorkspaceApp {
       };
     }
 
-    if (url.startsWith(GMAIL_URL) && disposition !== "background-tab") {
-      const account = accounts.getAccount(accountId);
-
-      account.instance.gmail.navigateToHash(url);
-
-      accounts.selectAccount(accountId);
-
-      main.show();
-
-      return { action: "deny" };
-    }
-
     if (url.startsWith(`${GOOGLE_ACCOUNTS_URL}/AddSession`)) {
       main.navigate("/settings/accounts");
 
@@ -212,9 +213,27 @@ export class WorkspaceApp {
 
     const matchedSupportedWorkspaceApp = getWorkspaceAppFromUrl(url);
 
+    if (
+      matchedSupportedWorkspaceApp &&
+      workspaceApps[matchedSupportedWorkspaceApp].singleInstance &&
+      url.startsWith(getWorkspaceAppUrl(matchedSupportedWorkspaceApp)) &&
+      disposition !== "background-tab"
+    ) {
+      const account = accounts.getAccount(accountId);
+
+      account.instance.gmail.navigateToHash(url);
+
+      accounts.selectAccount(accountId);
+
+      main.show();
+
+      return { action: "deny" };
+    }
+
     const isWorkspaceAppEnabledToOpenInApp =
       licenseKey.isValid &&
       matchedSupportedWorkspaceApp &&
+      !workspaceApps[matchedSupportedWorkspaceApp].singleInstance &&
       config.get("workspaceApps.openInApp") &&
       !config.get("workspaceApps.openInAppExcludedApps").includes(matchedSupportedWorkspaceApp);
 

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -8,10 +8,6 @@ import { GlobeIcon, XIcon } from "lucide-react";
 import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
 
 function TabIcon({ tab }: { tab: TabState }) {
-  if (tab.id === GMAIL_TAB_ID) {
-    return <WorkspaceAppIcon app="gmail" className="size-4" />;
-  }
-
   if (tab.app && tab.app !== "myaccount") {
     return <WorkspaceAppIcon app={tab.app} className="size-4" />;
   }
@@ -43,39 +39,23 @@ export function AppTabStrip() {
       className={cn("flex flex-col border-r", isWide ? "gap-1 p-2" : "items-center gap-2 py-2")}
       style={{ width: tabStripWidth, minWidth: tabStripWidth }}
     >
-      {selectedAccountTabs.tabs.map((tab) => {
-        if (tab.id === GMAIL_TAB_ID) {
-          return (
-            <Button
-              key={tab.id}
-              variant={tab.active ? "secondary" : "ghost"}
-              size={isWide ? "sm" : "icon"}
-              className={isWide ? "w-full justify-start" : undefined}
-              title={tab.title}
-              onClick={() => {
-                ipc.main.send("tabs.selectTab", selectedAccount.config.id, tab.id);
-              }}
-            >
-              <TabIcon tab={tab} />
-              {isWide && <span className="truncate">{tab.title}</span>}
-            </Button>
-          );
-        }
-
-        return (
-          <div key={tab.id} className="group relative">
-            <Button
-              variant={tab.active ? "secondary" : "ghost"}
-              size={isWide ? "sm" : "icon"}
-              className={isWide ? "w-full justify-start pr-7" : undefined}
-              title={tab.title}
-              onClick={() => {
-                ipc.main.send("tabs.selectTab", selectedAccount.config.id, tab.id);
-              }}
-            >
-              <TabIcon tab={tab} />
-              {isWide && <span className="truncate">{tab.title}</span>}
-            </Button>
+      {selectedAccountTabs.tabs.map((tab) => (
+        <div key={tab.id} className="group relative">
+          <Button
+            variant={tab.active ? "secondary" : "ghost"}
+            size={isWide ? "sm" : "icon"}
+            className={
+              isWide ? cn("w-full justify-start", tab.id !== GMAIL_TAB_ID && "pr-7") : undefined
+            }
+            title={tab.title}
+            onClick={() => {
+              ipc.main.send("tabs.selectTab", selectedAccount.config.id, tab.id);
+            }}
+          >
+            <TabIcon tab={tab} />
+            {isWide && <span className="truncate">{tab.title}</span>}
+          </Button>
+          {tab.id !== GMAIL_TAB_ID && (
             <Button
               variant="secondary"
               size="icon"
@@ -92,9 +72,9 @@ export function AppTabStrip() {
             >
               <XIcon className="size-3" />
             </Button>
-          </div>
-        );
-      })}
+          )}
+        </div>
+      ))}
     </div>
   );
 }

--- a/packages/renderer-main/routes/settings/workspace-apps.tsx
+++ b/packages/renderer-main/routes/settings/workspace-apps.tsx
@@ -151,8 +151,9 @@ export function WorkspaceAppsSettings() {
                     }
                   />
                   <DropdownMenuContent align="end">
-                    {(Object.entries(workspaceApps) as Entries<typeof workspaceApps>).map(
-                      ([app, { label }]) => (
+                    {(Object.entries(workspaceApps) as Entries<typeof workspaceApps>)
+                      .filter(([, { singleInstance }]) => !singleInstance)
+                      .map(([app, { label }]) => (
                         <DropdownMenuCheckboxItem
                           key={app}
                           checked={config["workspaceApps.openInAppExcludedApps"].includes(app)}
@@ -169,8 +170,7 @@ export function WorkspaceAppsSettings() {
                         >
                           {label}
                         </DropdownMenuCheckboxItem>
-                      ),
-                    )}
+                      ))}
                   </DropdownMenuContent>
                 </DropdownMenu>
               </Field>

--- a/packages/shared/google.ts
+++ b/packages/shared/google.ts
@@ -1,7 +1,7 @@
-import type { SupportedWorkspaceApp } from "./types";
+import { type SupportedWorkspaceApp, workspaceApps } from "./types";
 
 export function getWorkspaceAppUrl(app: SupportedWorkspaceApp) {
-  return `https://${app}.google.com`;
+  return workspaceApps[app].url ?? `https://${app}.google.com`;
 }
 
 export function getGoogleDomainFaviconUrl(domain: string, size: number) {

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -1,7 +1,7 @@
 import type { LoginItemSettings } from "electron";
 import type { accountColorsMap } from "./accounts";
 import { APP_TAB_STRIP_NARROW_WIDTH, APP_TAB_STRIP_WIDE_WIDTH } from "./constants";
-import type { GMAIL_ACTION_CODE_MAP } from "./gmail";
+import { type GMAIL_ACTION_CODE_MAP, GMAIL_URL } from "./gmail";
 import type {
   AccountConfig,
   AccountConfigInput,
@@ -36,8 +36,10 @@ export type NotificationTime = {
 
 type WorkspaceAppDefinition = {
   label: string;
+  url?: string;
   pinnable?: boolean;
   alwaysOpenAsWindow?: boolean;
+  singleInstance?: boolean;
 };
 
 const workspaceAppDefinitions = {
@@ -49,6 +51,7 @@ const workspaceAppDefinitions = {
   drive: { label: "Drive" },
   forms: { label: "Forms" },
   gemini: { label: "Gemini" },
+  gmail: { label: "Gmail", url: GMAIL_URL, pinnable: false, singleInstance: true },
   groups: { label: "Groups" },
   keep: { label: "Keep" },
   meet: { label: "Meet" },

--- a/packages/ui/components/workspace-app-icon.tsx
+++ b/packages/ui/components/workspace-app-icon.tsx
@@ -4,7 +4,7 @@ import type { ComponentProps } from "react";
 export function WorkspaceAppIcon({
   app,
   ...props
-}: { app: SupportedWorkspaceApp | "gmail" } & ComponentProps<"svg">) {
+}: { app: SupportedWorkspaceApp } & ComponentProps<"svg">) {
   switch (app) {
     case "calendar": {
       return (


### PR DESCRIPTION
## Problem

Gmail is conceptually a workspace app — the permanent one — but it lived entirely outside the `workspaceApps` definitions map (#630): the tab modeled it as `app: undefined` with a hardcoded label and icon special-cases, and `WorkspaceApp.handleWindowOpen` had a dedicated `GMAIL_URL` branch instead of going through the generic matching.

## Changes

- `WorkspaceAppDefinition` gains `url?: string` (default stays `https://<key>.google.com`) and `singleInstance?: boolean`. New entry: `gmail: { label: "Gmail", url: GMAIL_URL, pinnable: false, singleInstance: true }`.
- URL→app matching is now subdomain-based, derived from each definition's URL (`mail.google.com` → `"gmail"`); `getWorkspaceAppUrl` honors the `url` override.
- The dedicated `GMAIL_URL` branch in `handleWindowOpen` is replaced by generic single-instance routing: a matched `singleInstance` app whose URL starts with the app's URL activates the account's existing Gmail tab and navigates it (identical behavior — the `startsWith` check preserves the old scoping to `/mail/u/0`, so other-profile Gmail URLs keep opening externally). The open-in-app gate excludes `singleInstance` apps, so Gmail can never become an extra tab or window through it.
- Compose and popped-out email windows are untouched: Gmail's own window-open handler still routes those URL patterns to windows before the generic path. They now get `app: "gmail"`, so their window chrome shows the Gmail icon and falls back to the "Gmail" label.
- The Gmail tab is a real map citizen: `TabState.app` is `"gmail"`, its label comes from the map, and the strip's Gmail special-cases collapse — one row shape for all tabs, with the close button and the wide-mode padding keyed on `GMAIL_TAB_ID` (identity/uncloseability stay independent of `singleInstance`).
- `WorkspaceAppIcon`'s prop simplifies from `SupportedWorkspaceApp | "gmail"` to `SupportedWorkspaceApp`.
- The excluded-apps settings dropdown filters out `singleInstance` apps — excluding Gmail there would be meaningless.

## Behavior deltas (intentional, minor)

- Gmail links with a background-tab disposition (Cmd/Ctrl+click) now pass `skipTrustedHostCheck` when opening externally (matched as a known Google app; previously unmatched).
- Compose/pop-out windows show the Gmail icon and label fallback in their titlebar instead of nothing.

## Verification

- `bun types:ci` passes.
- Not runtime-tested in this environment (no display). Manual script: click a Gmail message link from a Docs tab → routes to the Gmail tab; compose and pop-out email still open as windows with Gmail icon; Cmd/Ctrl+click a Gmail link → opens in browser; excluded-apps dropdown no longer lists Gmail; tab strip shows the Gmail tab unchanged (icon, no close button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)