### PR TITLE
add tab loading state and identify workspace app ipc by id

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -411,6 +411,14 @@ export class Gmail {
       this.store.setState({ messageId: parseGmailMessageId(new URL(url).hash) });
     });
 
+    this.view.webContents.on("did-start-loading", () => {
+      accounts.sendTabsChangedToRenderer();
+    });
+
+    this.view.webContents.on("did-stop-loading", () => {
+      accounts.sendTabsChangedToRenderer();
+    });
+
     openViewDevToolsInDev(this.view);
 
     return this.view.webContents.loadURL(this.url);

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -232,6 +232,10 @@ export class Gmail {
     this._view = view;
   }
 
+  get isLoading() {
+    return this._view ? this._view.webContents.isLoading() : false;
+  }
+
   viewStore = createStore(
     subscribeWithSelector<{
       navigationHistory: {

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -186,32 +186,32 @@ class Ipc {
       selectedAccount.instance.gmail.search(searchQuery);
     });
 
-    ipc.main.handle("workspaceApp.getLoadingState", (event) => {
-      return WorkspaceApp.fromWebContents(event.sender).isLoading;
+    ipc.main.handle("workspaceApp.getLoadingState", (_event, workspaceAppId) => {
+      return WorkspaceApp.fromId(workspaceAppId).isLoading;
     });
 
-    ipc.main.on("workspaceApp.goBack", (event) => {
-      WorkspaceApp.fromWebContents(event.sender).goBack();
+    ipc.main.on("workspaceApp.goBack", (_event, workspaceAppId) => {
+      WorkspaceApp.fromId(workspaceAppId).goBack();
     });
 
-    ipc.main.on("workspaceApp.goForward", (event) => {
-      WorkspaceApp.fromWebContents(event.sender).goForward();
+    ipc.main.on("workspaceApp.goForward", (_event, workspaceAppId) => {
+      WorkspaceApp.fromId(workspaceAppId).goForward();
     });
 
-    ipc.main.on("workspaceApp.reload", (event) => {
-      WorkspaceApp.fromWebContents(event.sender).reload();
+    ipc.main.on("workspaceApp.reload", (_event, workspaceAppId) => {
+      WorkspaceApp.fromId(workspaceAppId).reload();
     });
 
-    ipc.main.on("workspaceApp.stop", (event) => {
-      WorkspaceApp.fromWebContents(event.sender).stop();
+    ipc.main.on("workspaceApp.stop", (_event, workspaceAppId) => {
+      WorkspaceApp.fromId(workspaceAppId).stop();
     });
 
-    ipc.main.on("workspaceApp.copyUrl", (event) => {
-      WorkspaceApp.fromWebContents(event.sender).copyUrl();
+    ipc.main.on("workspaceApp.copyUrl", (_event, workspaceAppId) => {
+      WorkspaceApp.fromId(workspaceAppId).copyUrl();
     });
 
-    ipc.main.on("workspaceApp.openInBrowser", (event) => {
-      WorkspaceApp.fromWebContents(event.sender).openInBrowser();
+    ipc.main.on("workspaceApp.openInBrowser", (_event, workspaceAppId) => {
+      WorkspaceApp.fromId(workspaceAppId).openInBrowser();
     });
 
     ipc.main.on("tabs.selectTab", (_event, accountId, tabId) => {

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -14,6 +14,7 @@ export type Tab = {
   id: string;
   app: SupportedWorkspaceApp | undefined;
   title: string;
+  isLoading: boolean;
   view: WebContentsView;
   updateViewBounds: () => void;
 };
@@ -29,6 +30,9 @@ export class Tabs {
         id: GMAIL_TAB_ID,
         app: "gmail",
         title: workspaceApps.gmail.label,
+        get isLoading() {
+          return gmail.view.webContents.isLoading();
+        },
         get view() {
           return gmail.view;
         },
@@ -100,6 +104,7 @@ export class Tabs {
       id: tab.id,
       app: tab.app,
       title: tab.title,
+      loading: tab.isLoading,
       active: tab.id === this.activeTabId,
     }));
   }

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -31,7 +31,7 @@ export class Tabs {
         app: "gmail",
         title: workspaceApps.gmail.label,
         get isLoading() {
-          return gmail.view.webContents.isLoading();
+          return gmail.isLoading;
         },
         get view() {
           return gmail.view;

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -585,6 +585,8 @@ export class WorkspaceApp {
 
   broadcastLoadingState = () => {
     if (!this._window) {
+      accounts.sendTabsChangedToRenderer();
+
       return;
     }
 

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -80,11 +80,11 @@ type WorkspaceAppOptions = {
 export class WorkspaceApp {
   private static instances = new Map<string, WorkspaceApp>();
 
-  static fromWebContents(webContents: WebContents) {
-    const instance = WorkspaceApp.tryFromWebContents(webContents);
+  static fromId(workspaceAppId: string) {
+    const instance = WorkspaceApp.instances.get(workspaceAppId);
 
     if (!instance) {
-      throw new Error(`No WorkspaceApp instance for webContents ${webContents.id}`);
+      throw new Error(`No WorkspaceApp instance for id ${workspaceAppId}`);
     }
 
     return instance;
@@ -404,6 +404,8 @@ export class WorkspaceApp {
     const searchParams = new URLSearchParams();
 
     searchParams.set("accountId", this.accountId);
+
+    searchParams.set("workspaceAppId", this.id);
 
     if (this.app) {
       searchParams.set("workspaceApp", this.app);

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -4,10 +4,14 @@ import { GMAIL_TAB_ID, getTabStripWidth, type TabState } from "@meru/shared/type
 import { Button } from "@meru/ui/components/button";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { cn } from "@meru/ui/lib/utils";
-import { GlobeIcon, XIcon } from "lucide-react";
+import { GlobeIcon, LoaderCircleIcon, XIcon } from "lucide-react";
 import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
 
 function TabIcon({ tab }: { tab: TabState }) {
+  if (tab.loading) {
+    return <LoaderCircleIcon className="size-4 animate-spin" />;
+  }
+
   if (tab.app && tab.app !== "myaccount") {
     return <WorkspaceAppIcon app={tab.app} className="size-4" />;
   }

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -4,14 +4,10 @@ import { GMAIL_TAB_ID, getTabStripWidth, type TabState } from "@meru/shared/type
 import { Button } from "@meru/ui/components/button";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { cn } from "@meru/ui/lib/utils";
-import { GlobeIcon, LoaderCircleIcon, XIcon } from "lucide-react";
+import { GlobeIcon, XIcon } from "lucide-react";
 import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
 
 function TabIcon({ tab }: { tab: TabState }) {
-  if (tab.loading) {
-    return <LoaderCircleIcon className="size-4 animate-spin" />;
-  }
-
   if (tab.app && tab.app !== "myaccount") {
     return <WorkspaceAppIcon app={tab.app} className="size-4" />;
   }

--- a/packages/renderer-workspace-app/index.tsx
+++ b/packages/renderer-workspace-app/index.tsx
@@ -47,7 +47,7 @@ function RecentDownloadHistoryButton() {
   );
 }
 
-function ReloadButton() {
+function ReloadButton({ workspaceAppId }: { workspaceAppId: string }) {
   const [loading, setLoading] = useState(false);
   const [hovered, setHovered] = useState(false);
 
@@ -56,10 +56,10 @@ function ReloadButton() {
       setLoading(isLoading);
     });
 
-    ipc.main.invoke("workspaceApp.getLoadingState").then(setLoading);
+    ipc.main.invoke("workspaceApp.getLoadingState", workspaceAppId).then(setLoading);
 
     return unsubscribe;
-  }, []);
+  }, [workspaceAppId]);
 
   return (
     <TitlebarIconButton
@@ -67,7 +67,7 @@ function ReloadButton() {
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       onClick={() => {
-        ipc.main.send(loading ? "workspaceApp.stop" : "workspaceApp.reload");
+        ipc.main.send(loading ? "workspaceApp.stop" : "workspaceApp.reload", workspaceAppId);
       }}
     >
       {loading ? (
@@ -83,14 +83,14 @@ function ReloadButton() {
   );
 }
 
-function CopyUrlButton() {
+function CopyUrlButton({ workspaceAppId }: { workspaceAppId: string }) {
   const { copied, markCopied } = useCopied();
 
   return (
     <TitlebarIconButton
       title="Copy URL"
       onClick={() => {
-        ipc.main.send("workspaceApp.copyUrl");
+        ipc.main.send("workspaceApp.copyUrl", workspaceAppId);
         markCopied();
       }}
     >
@@ -99,7 +99,7 @@ function CopyUrlButton() {
   );
 }
 
-function NavigationButtons() {
+function NavigationButtons({ workspaceAppId }: { workspaceAppId: string }) {
   const [navigationState, setNavigationState] = useState<{
     canGoBack: boolean;
     canGoForward: boolean;
@@ -117,7 +117,7 @@ function NavigationButtons() {
         title="Back"
         disabled={!navigationState?.canGoBack}
         onClick={() => {
-          ipc.main.send("workspaceApp.goBack");
+          ipc.main.send("workspaceApp.goBack", workspaceAppId);
         }}
       >
         <ArrowLeftIcon />
@@ -126,7 +126,7 @@ function NavigationButtons() {
         title="Forward"
         disabled={!navigationState?.canGoForward}
         onClick={() => {
-          ipc.main.send("workspaceApp.goForward");
+          ipc.main.send("workspaceApp.goForward", workspaceAppId);
         }}
       >
         <ArrowRightIcon />
@@ -194,12 +194,18 @@ function App() {
 
   const workspaceApp = searchParams.get("workspaceApp") as SupportedWorkspaceApp | null;
 
+  const workspaceAppId = searchParams.get("workspaceAppId");
+
+  if (!workspaceAppId) {
+    return;
+  }
+
   return (
     <Titlebar>
       <TitlebarLeft>
         <TitlebarButtonGroup>
-          <NavigationButtons />
-          <ReloadButton />
+          <NavigationButtons workspaceAppId={workspaceAppId} />
+          <ReloadButton workspaceAppId={workspaceAppId} />
         </TitlebarButtonGroup>
         {config && config.accounts.length > 1 && account && (
           <AccountBadge label={account.label} color={account.color} />
@@ -213,11 +219,11 @@ function App() {
         <FindInPageControls />
         <TitlebarButtonGroup>
           <RecentDownloadHistoryButton />
-          <CopyUrlButton />
+          <CopyUrlButton workspaceAppId={workspaceAppId} />
           <TitlebarIconButton
             title="Open in Browser"
             onClick={() => {
-              ipc.main.send("workspaceApp.openInBrowser");
+              ipc.main.send("workspaceApp.openInBrowser", workspaceAppId);
             }}
           >
             <ExternalLinkIcon />

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -89,6 +89,7 @@ export type TabState = {
   id: string;
   app: SupportedWorkspaceApp | undefined;
   title: string;
+  loading: boolean;
   active: boolean;
 };
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -232,12 +232,12 @@ export type IpcMainEvents =
       "gmail.setOutOfOffice": [outOfOffice: boolean];
       "gmail.search": [searchQuery: string];
       "gmail.openUserStyles": [openIn: "editor" | "folder"];
-      "workspaceApp.goBack": [];
-      "workspaceApp.goForward": [];
-      "workspaceApp.reload": [];
-      "workspaceApp.stop": [];
-      "workspaceApp.copyUrl": [];
-      "workspaceApp.openInBrowser": [];
+      "workspaceApp.goBack": [workspaceAppId: string];
+      "workspaceApp.goForward": [workspaceAppId: string];
+      "workspaceApp.reload": [workspaceAppId: string];
+      "workspaceApp.stop": [workspaceAppId: string];
+      "workspaceApp.copyUrl": [workspaceAppId: string];
+      "workspaceApp.openInBrowser": [workspaceAppId: string];
       "gmail.navigateTo": [hashLocation: GmailHashLocation];
       "gmail.closeComposeWindow": [];
       "gmail.undoMessageSent": [browserWindowId: number];
@@ -284,7 +284,7 @@ export type IpcMainEvents =
       "app.setAsDefaultMailtoClient": () => void;
       "about.getInfo": () => { version: string; os: string; deviceId: string };
       "about.exportLogs": () => { canceled: boolean };
-      "workspaceApp.getLoadingState": () => boolean;
+      "workspaceApp.getLoadingState": (workspaceAppId: string) => boolean;
     };
 
 export type IpcRendererEvent = {


### PR DESCRIPTION
## Problem

Phase 2 of the workspace-apps-as-tabs roadmap, two related gaps:

1. Nothing in the main window carries per-tab loading state yet — needed for an upcoming titlebar reload button (next to the navigation history buttons, like the workspace-app window's ReloadButton) that doubles as loading indicator and stop control.
2. The `workspaceApp.*` IPC channels (`goBack`, `goForward`, `reload`, `stop`, `copyUrl`, `openInBrowser`, `getLoadingState`) resolve their target via `WorkspaceApp.fromWebContents(event.sender)` — sender identity only works for windowed instances with their own renderer, and is a dead end for embedded tabs (whose chrome is the shared main renderer) and for the upcoming menu integration.

## Changes

**Tab loading state** (plumbing only — a spinner in the tab icons was tried and removed again; the state will be consumed by the upcoming reload button):

- `TabState` gains `loading`; the `Tab` shape gains `isLoading` (satisfied by `WorkspaceApp`'s existing getter; the Gmail tab reads its view's live state via a null-safe `Gmail.isLoading` getter — `serialize()` can run during startup before the Gmail views exist, so reading `gmail.view` directly threw "View has not been created yet").
- Embedded instances and the Gmail views broadcast `tabs.changed` on `did-start-loading`/`did-stop-loading` — same pattern titles already use.

**Id-parameterized IPC** (second commit):

- All seven `workspaceApp.*` channels take an explicit `workspaceAppId`; handlers resolve via a new `WorkspaceApp.fromId` (a map lookup — instances are already keyed by uuid). The throwing `fromWebContents` is gone; `tryFromWebContents` remains for genuinely sender-based cases (find-in-page, menu, screen-share).
- Windowed instances pass their id to the renderer via a `workspaceAppId` search param; the window chrome threads it through its buttons. The chrome renders nothing without the param (cannot happen in practice).

No behavior change intended.

## Verification

- `bun types:ci` passes.
- Not runtime-tested here (no display). Manual script: in a workspace-app window, back/forward/reload/stop/copy-URL/open-in-browser all still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


