### PR TITLE
unify navigation controls across renderers with reload button

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -824,6 +824,8 @@ export class Gmail {
   subscribeToStore() {
     this.viewStore.subscribe(() => {
       accounts.sendAccountsChangedToRenderer();
+
+      accounts.sendTabsChangedToRenderer();
     });
 
     if (this.getIsUnreadCountEnabled()) {

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -33,6 +33,14 @@ import { createNewEmailNotification } from "./notifications";
 import { MAILTO_PROTOCOL } from "./protocol";
 import { appUpdater } from "./updater";
 
+function getNavigationWebContents(workspaceAppId?: string) {
+  if (workspaceAppId) {
+    return WorkspaceApp.fromId(workspaceAppId).view.webContents;
+  }
+
+  return accounts.getSelectedAccount().instance.tabs.activeTab.view.webContents;
+}
+
 class Ipc {
   main = new IpcListener<IpcMainEvents>();
 
@@ -91,12 +99,24 @@ class Ipc {
       accounts.updateAccount(updatedAccount);
     });
 
-    this.main.on("gmail.moveNavigationHistory", (_event, action) => {
-      accounts
-        .getSelectedAccount()
-        .instance.gmail.view.webContents.navigationHistory[
-          action === "back" ? "goBack" : "goForward"
-        ]();
+    this.main.on("workspaceApp.goBack", (_event, workspaceAppId) => {
+      getNavigationWebContents(workspaceAppId).navigationHistory.goBack();
+    });
+
+    this.main.on("workspaceApp.goForward", (_event, workspaceAppId) => {
+      getNavigationWebContents(workspaceAppId).navigationHistory.goForward();
+    });
+
+    this.main.on("workspaceApp.reload", (_event, workspaceAppId) => {
+      getNavigationWebContents(workspaceAppId).reload();
+    });
+
+    this.main.on("workspaceApp.stop", (_event, workspaceAppId) => {
+      getNavigationWebContents(workspaceAppId).stop();
+    });
+
+    this.main.handle("workspaceApp.getLoadingState", (_event, workspaceAppId) => {
+      return getNavigationWebContents(workspaceAppId).isLoading();
     });
 
     this.main.on("gmail.setOutOfOffice", (event, outOfOffice) => {
@@ -184,26 +204,6 @@ class Ipc {
       const selectedAccount = accounts.getSelectedAccount();
 
       selectedAccount.instance.gmail.search(searchQuery);
-    });
-
-    ipc.main.handle("workspaceApp.getLoadingState", (_event, workspaceAppId) => {
-      return WorkspaceApp.fromId(workspaceAppId).isLoading;
-    });
-
-    ipc.main.on("workspaceApp.goBack", (_event, workspaceAppId) => {
-      WorkspaceApp.fromId(workspaceAppId).goBack();
-    });
-
-    ipc.main.on("workspaceApp.goForward", (_event, workspaceAppId) => {
-      WorkspaceApp.fromId(workspaceAppId).goForward();
-    });
-
-    ipc.main.on("workspaceApp.reload", (_event, workspaceAppId) => {
-      WorkspaceApp.fromId(workspaceAppId).reload();
-    });
-
-    ipc.main.on("workspaceApp.stop", (_event, workspaceAppId) => {
-      WorkspaceApp.fromId(workspaceAppId).stop();
     });
 
     ipc.main.on("workspaceApp.copyUrl", (_event, workspaceAppId) => {

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -15,6 +15,7 @@ export type Tab = {
   app: SupportedWorkspaceApp | undefined;
   title: string;
   isLoading: boolean;
+  navigationHistory: { canGoBack: boolean; canGoForward: boolean };
   view: WebContentsView;
   updateViewBounds: () => void;
 };
@@ -32,6 +33,9 @@ export class Tabs {
         title: workspaceApps.gmail.label,
         get isLoading() {
           return gmail.isLoading;
+        },
+        get navigationHistory() {
+          return gmail.viewStore.getState().navigationHistory;
         },
         get view() {
           return gmail.view;
@@ -105,6 +109,7 @@ export class Tabs {
       app: tab.app,
       title: tab.title,
       loading: tab.isLoading,
+      navigationHistory: tab.navigationHistory,
       active: tab.id === this.activeTabId,
     }));
   }

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -545,15 +545,25 @@ export class WorkspaceApp {
     WorkspaceApp.handleRedirect(event, url, this.view.webContents);
   };
 
+  get navigationHistory() {
+    return {
+      canGoBack: this.view.webContents.navigationHistory.canGoBack(),
+      canGoForward: this.view.webContents.navigationHistory.canGoForward(),
+    };
+  }
+
   broadcastNavigationState = () => {
     if (!this._window) {
+      accounts.sendTabsChangedToRenderer();
+
       return;
     }
 
-    ipc.renderer.send(this.chromeWebContents, "workspaceApp.navigationStateChanged", {
-      canGoBack: this.view.webContents.navigationHistory.canGoBack(),
-      canGoForward: this.view.webContents.navigationHistory.canGoForward(),
-    });
+    ipc.renderer.send(
+      this.chromeWebContents,
+      "workspaceApp.navigationStateChanged",
+      this.navigationHistory,
+    );
   };
 
   private pageTitle = "";

--- a/packages/renderer-main/components/app-titlebar.tsx
+++ b/packages/renderer-main/components/app-titlebar.tsx
@@ -305,7 +305,7 @@ export function AppTitlebar() {
               size="icon-sm"
               className="draggable-none"
               onClick={() => {
-                ipc.main.send("gmail.moveNavigationHistory", "back");
+                ipc.main.send("workspaceApp.goBack");
               }}
               disabled={
                 matchUnifiedInboxRoute || !selectedAccount?.gmail.navigationHistory.canGoBack
@@ -319,7 +319,7 @@ export function AppTitlebar() {
               size="icon-sm"
               className="draggable-none"
               onClick={() => {
-                ipc.main.send("gmail.moveNavigationHistory", "forward");
+                ipc.main.send("workspaceApp.goForward");
               }}
               disabled={
                 matchUnifiedInboxRoute || !selectedAccount?.gmail.navigationHistory.canGoForward

--- a/packages/renderer-main/components/app-titlebar.tsx
+++ b/packages/renderer-main/components/app-titlebar.tsx
@@ -11,12 +11,11 @@ import {
   TitlebarButtonGroup,
   TitlebarIconButton,
   TitlebarLeft,
+  TitlebarNavigationControls,
 } from "@meru/ui/components/titlebar";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { cn } from "@meru/ui/lib/utils";
 import {
-  ArrowLeftIcon,
-  ArrowRightIcon,
   BriefcaseIcon,
   CircleAlertIcon,
   CircleXIcon,
@@ -36,6 +35,7 @@ import {
   useAppUpdaterStore,
   useFindInPageStore,
   useSettingsStore,
+  useTabsStore,
   useTrialStore,
 } from "../lib/stores";
 
@@ -180,6 +180,12 @@ export function AppTitlebar() {
 
   const selectedAccount = accounts.find((account) => account.config.selected);
 
+  const accountsTabs = useTabsStore((state) => state.accountsTabs);
+
+  const activeTab = accountsTabs
+    .find((accountTabs) => accountTabs.accountId === selectedAccount?.config.id)
+    ?.tabs.find((tab) => tab.active);
+
   const [matchUnifiedInboxRoute] = useRoute("/unified-inbox");
 
   const appUpdateVersion = useAppUpdaterStore((state) => state.version);
@@ -300,34 +306,24 @@ export function AppTitlebar() {
       <>
         <TitlebarLeft>
           <TitlebarButtonGroup>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              className="draggable-none"
-              onClick={() => {
+            <TitlebarNavigationControls
+              canGoBack={Boolean(activeTab?.navigationHistory.canGoBack)}
+              canGoForward={Boolean(activeTab?.navigationHistory.canGoForward)}
+              isLoading={Boolean(activeTab?.loading)}
+              disabled={matchUnifiedInboxRoute}
+              onGoBack={() => {
                 ipc.main.send("workspaceApp.goBack");
               }}
-              disabled={
-                matchUnifiedInboxRoute || !selectedAccount?.gmail.navigationHistory.canGoBack
-              }
-              title="Go Back"
-            >
-              <ArrowLeftIcon />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              className="draggable-none"
-              onClick={() => {
+              onGoForward={() => {
                 ipc.main.send("workspaceApp.goForward");
               }}
-              disabled={
-                matchUnifiedInboxRoute || !selectedAccount?.gmail.navigationHistory.canGoForward
-              }
-              title="Go Forward"
-            >
-              <ArrowRightIcon />
-            </Button>
+              onReload={() => {
+                ipc.main.send("workspaceApp.reload");
+              }}
+              onStop={() => {
+                ipc.main.send("workspaceApp.stop");
+              }}
+            />
             {isLicenseKeyValid && config["unifiedInbox.enabled"] && accounts.length > 1 && (
               <Button
                 variant={matchUnifiedInboxRoute ? "secondary" : "ghost"}

--- a/packages/renderer-workspace-app/index.tsx
+++ b/packages/renderer-workspace-app/index.tsx
@@ -10,21 +10,12 @@ import {
   TitlebarButtonGroup,
   TitlebarIconButton,
   TitlebarLeft,
+  TitlebarNavigationControls,
   TitlebarPageTitle,
   TitlebarRight,
 } from "@meru/ui/components/titlebar";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
-import {
-  ArrowLeftIcon,
-  ArrowRightIcon,
-  CheckIcon,
-  DownloadIcon,
-  ExternalLinkIcon,
-  LinkIcon,
-  LoaderCircleIcon,
-  RotateCwIcon,
-  XIcon,
-} from "lucide-react";
+import { CheckIcon, DownloadIcon, ExternalLinkIcon, LinkIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "wouter";
 
@@ -47,39 +38,47 @@ function RecentDownloadHistoryButton() {
   );
 }
 
-function ReloadButton({ workspaceAppId }: { workspaceAppId: string }) {
-  const [loading, setLoading] = useState(false);
-  const [hovered, setHovered] = useState(false);
+function NavigationControls({ workspaceAppId }: { workspaceAppId: string }) {
+  const [navigationState, setNavigationState] = useState({
+    canGoBack: false,
+    canGoForward: false,
+  });
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    const unsubscribe = ipc.renderer.on("workspaceApp.loadingStateChanged", (_event, isLoading) => {
-      setLoading(isLoading);
+    return ipc.renderer.on("workspaceApp.navigationStateChanged", (_event, state) => {
+      setNavigationState(state);
+    });
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = ipc.renderer.on("workspaceApp.loadingStateChanged", (_event, loading) => {
+      setIsLoading(loading);
     });
 
-    ipc.main.invoke("workspaceApp.getLoadingState", workspaceAppId).then(setLoading);
+    ipc.main.invoke("workspaceApp.getLoadingState", workspaceAppId).then(setIsLoading);
 
     return unsubscribe;
   }, [workspaceAppId]);
 
   return (
-    <TitlebarIconButton
-      title={loading ? "Stop" : "Reload"}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      onClick={() => {
-        ipc.main.send(loading ? "workspaceApp.stop" : "workspaceApp.reload", workspaceAppId);
+    <TitlebarNavigationControls
+      canGoBack={navigationState.canGoBack}
+      canGoForward={navigationState.canGoForward}
+      isLoading={isLoading}
+      onGoBack={() => {
+        ipc.main.send("workspaceApp.goBack", workspaceAppId);
       }}
-    >
-      {loading ? (
-        hovered ? (
-          <XIcon />
-        ) : (
-          <LoaderCircleIcon className="animate-spin" />
-        )
-      ) : (
-        <RotateCwIcon />
-      )}
-    </TitlebarIconButton>
+      onGoForward={() => {
+        ipc.main.send("workspaceApp.goForward", workspaceAppId);
+      }}
+      onReload={() => {
+        ipc.main.send("workspaceApp.reload", workspaceAppId);
+      }}
+      onStop={() => {
+        ipc.main.send("workspaceApp.stop", workspaceAppId);
+      }}
+    />
   );
 }
 
@@ -96,42 +95,6 @@ function CopyUrlButton({ workspaceAppId }: { workspaceAppId: string }) {
     >
       {copied ? <CheckIcon /> : <LinkIcon />}
     </TitlebarIconButton>
-  );
-}
-
-function NavigationButtons({ workspaceAppId }: { workspaceAppId: string }) {
-  const [navigationState, setNavigationState] = useState<{
-    canGoBack: boolean;
-    canGoForward: boolean;
-  }>();
-
-  useEffect(() => {
-    return ipc.renderer.on("workspaceApp.navigationStateChanged", (_event, state) => {
-      setNavigationState(state);
-    });
-  }, []);
-
-  return (
-    <>
-      <TitlebarIconButton
-        title="Back"
-        disabled={!navigationState?.canGoBack}
-        onClick={() => {
-          ipc.main.send("workspaceApp.goBack", workspaceAppId);
-        }}
-      >
-        <ArrowLeftIcon />
-      </TitlebarIconButton>
-      <TitlebarIconButton
-        title="Forward"
-        disabled={!navigationState?.canGoForward}
-        onClick={() => {
-          ipc.main.send("workspaceApp.goForward", workspaceAppId);
-        }}
-      >
-        <ArrowRightIcon />
-      </TitlebarIconButton>
-    </>
   );
 }
 
@@ -204,8 +167,7 @@ function App() {
     <Titlebar>
       <TitlebarLeft>
         <TitlebarButtonGroup>
-          <NavigationButtons workspaceAppId={workspaceAppId} />
-          <ReloadButton workspaceAppId={workspaceAppId} />
+          <NavigationControls workspaceAppId={workspaceAppId} />
         </TitlebarButtonGroup>
         {config && config.accounts.length > 1 && account && (
           <AccountBadge label={account.label} color={account.color} />

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -90,6 +90,7 @@ export type TabState = {
   app: SupportedWorkspaceApp | undefined;
   title: string;
   loading: boolean;
+  navigationHistory: { canGoBack: boolean; canGoForward: boolean };
   active: boolean;
 };
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -228,15 +228,14 @@ export type IpcMainEvents =
       "accounts.removeAccount": [accountId: AccountConfig["id"]];
       "accounts.updateAccount": [account: AccountConfig];
       "settings.toggleIsOpen": [open?: boolean];
-      "gmail.moveNavigationHistory": [move: "back" | "forward"];
+      "workspaceApp.goBack": [workspaceAppId?: string];
+      "workspaceApp.goForward": [workspaceAppId?: string];
+      "workspaceApp.reload": [workspaceAppId?: string];
+      "workspaceApp.stop": [workspaceAppId?: string];
       "gmail.unreadCountChanged": [unreadCountString: string];
       "gmail.setOutOfOffice": [outOfOffice: boolean];
       "gmail.search": [searchQuery: string];
       "gmail.openUserStyles": [openIn: "editor" | "folder"];
-      "workspaceApp.goBack": [workspaceAppId: string];
-      "workspaceApp.goForward": [workspaceAppId: string];
-      "workspaceApp.reload": [workspaceAppId: string];
-      "workspaceApp.stop": [workspaceAppId: string];
       "workspaceApp.copyUrl": [workspaceAppId: string];
       "workspaceApp.openInBrowser": [workspaceAppId: string];
       "gmail.navigateTo": [hashLocation: GmailHashLocation];
@@ -285,7 +284,7 @@ export type IpcMainEvents =
       "app.setAsDefaultMailtoClient": () => void;
       "about.getInfo": () => { version: string; os: string; deviceId: string };
       "about.exportLogs": () => { canceled: boolean };
-      "workspaceApp.getLoadingState": (workspaceAppId: string) => boolean;
+      "workspaceApp.getLoadingState": (workspaceAppId?: string) => boolean;
     };
 
 export type IpcRendererEvent = {

--- a/packages/ui/components/titlebar.tsx
+++ b/packages/ui/components/titlebar.tsx
@@ -1,5 +1,6 @@
 import { APP_TITLEBAR_HEIGHT } from "@meru/shared/constants";
-import type { ComponentProps, ReactNode } from "react";
+import { ArrowLeftIcon, ArrowRightIcon, LoaderCircleIcon, RotateCwIcon, XIcon } from "lucide-react";
+import { type ComponentProps, type ReactNode, useState } from "react";
 import { cn } from "../lib/utils";
 import { Button } from "./button";
 
@@ -45,5 +46,59 @@ export function TitlebarPageTitle({ children }: { children: string }) {
 export function TitlebarIconButton({ className, ...props }: ComponentProps<typeof Button>) {
   return (
     <Button variant="ghost" size="icon-sm" className={cn("draggable-none", className)} {...props} />
+  );
+}
+
+export function TitlebarNavigationControls({
+  canGoBack,
+  canGoForward,
+  isLoading,
+  disabled,
+  onGoBack,
+  onGoForward,
+  onReload,
+  onStop,
+}: {
+  canGoBack: boolean;
+  canGoForward: boolean;
+  isLoading: boolean;
+  disabled?: boolean;
+  onGoBack: () => void;
+  onGoForward: () => void;
+  onReload: () => void;
+  onStop: () => void;
+}) {
+  const [isReloadHovered, setIsReloadHovered] = useState(false);
+
+  return (
+    <>
+      <TitlebarIconButton title="Back" disabled={disabled || !canGoBack} onClick={onGoBack}>
+        <ArrowLeftIcon />
+      </TitlebarIconButton>
+      <TitlebarIconButton
+        title="Forward"
+        disabled={disabled || !canGoForward}
+        onClick={onGoForward}
+      >
+        <ArrowRightIcon />
+      </TitlebarIconButton>
+      <TitlebarIconButton
+        title={isLoading ? "Stop" : "Reload"}
+        disabled={disabled}
+        onMouseEnter={() => setIsReloadHovered(true)}
+        onMouseLeave={() => setIsReloadHovered(false)}
+        onClick={isLoading ? onStop : onReload}
+      >
+        {isLoading ? (
+          isReloadHovered ? (
+            <XIcon />
+          ) : (
+            <LoaderCircleIcon className="animate-spin" />
+          )
+        ) : (
+          <RotateCwIcon />
+        )}
+      </TitlebarIconButton>
+    </>
   );
 }


### PR DESCRIPTION
## Problem

The main titlebar's back/forward buttons and the workspace-app window's back/forward/reload buttons were separate implementations with separate IPC: `gmail.moveNavigationHistory` (Gmail view only) vs `workspaceApp.goBack/goForward/reload/stop` (window instances only). The main window also lacked a reload control, and its navigation buttons only ever targeted the Gmail view — wrong once a workspace tab is active.

## Changes

Three commits:

1. **`add navigation history to tab state`** — `TabState`/`Tab` gain `navigationHistory` (`canGoBack`/`canGoForward`); embedded instances broadcast `tabs.changed` on navigation changes (same pattern as titles/loading), the Gmail tab reads its `viewStore`, and the gmail `viewStore` subscription now also re-broadcasts tab state.
2. **`unify workspace app navigation ipc with optional target id`** — one channel per action for both renderers: `workspaceApp.goBack/goForward/reload/stop` and the `workspaceApp.getLoadingState` invoke take an optional `workspaceAppId`; without it the main process targets the selected account's **active tab** (Gmail or workspace app). `gmail.moveNavigationHistory` is removed. Handlers act on the resolved `webContents` directly.
3. **`extract shared titlebar navigation controls with reload button`** — new `TitlebarNavigationControls` in `@meru/ui` (back/forward/reload-stop with spinner + hover-to-stop, following the `FindInPage` pattern: dumb component, renderers wire state and IPC). The workspace-app window replaces its two components with it; the main titlebar adopts it wired to the active tab's `TabState` — gaining the reload/stop/loading-indicator button, and back/forward that now follow the active tab instead of always Gmail. Styling is unchanged (`TitlebarIconButton` matches the previous buttons exactly); on the unified-inbox route the controls are disabled as before.

## Verification

- `bun types:ci` passes.
- Not runtime-tested here (no display). Manual script: main titlebar — back/forward follow the active tab (Gmail and workspace tabs), reload button spins while loading and stops on click, disabled on unified inbox; workspace-app window — back/forward/reload/stop unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)