### PR TITLE
derive gmail navigation history from web contents

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -236,18 +236,21 @@ export class Gmail {
     return this._view ? this._view.webContents.isLoading() : false;
   }
 
+  get navigationHistory() {
+    if (!this._view) {
+      return { canGoBack: false, canGoForward: false };
+    }
+
+    return {
+      canGoBack: this._view.webContents.navigationHistory.canGoBack(),
+      canGoForward: this._view.webContents.navigationHistory.canGoForward(),
+    };
+  }
+
   viewStore = createStore(
     subscribeWithSelector<{
-      navigationHistory: {
-        canGoBack: boolean;
-        canGoForward: boolean;
-      };
       attentionRequired: boolean;
     }>(() => ({
-      navigationHistory: {
-        canGoBack: false,
-        canGoForward: false,
-      },
       attentionRequired: false,
     })),
   );
@@ -452,23 +455,14 @@ export class Gmail {
 
       if (window === this.view) {
         this.viewStore.setState({
-          navigationHistory: {
-            canGoBack: this.view.webContents.navigationHistory.canGoBack(),
-            canGoForward: this.view.webContents.navigationHistory.canGoForward(),
-          },
           attentionRequired: !url.startsWith(this.baseUrl),
         });
       }
     });
 
     if (window === this.view) {
-      window.webContents.on("did-navigate-in-page", (_event: Electron.Event) => {
-        this.viewStore.setState({
-          navigationHistory: {
-            canGoBack: this.view.webContents.navigationHistory.canGoBack(),
-            canGoForward: this.view.webContents.navigationHistory.canGoForward(),
-          },
-        });
+      window.webContents.on("did-navigate-in-page", () => {
+        accounts.sendTabsChangedToRenderer();
       });
     }
 

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -35,7 +35,7 @@ export class Tabs {
           return gmail.isLoading;
         },
         get navigationHistory() {
-          return gmail.viewStore.getState().navigationHistory;
+          return gmail.navigationHistory;
         },
         get view() {
           return gmail.view;

--- a/packages/shared/gmail.ts
+++ b/packages/shared/gmail.ts
@@ -52,10 +52,6 @@ export interface GmailInboxMessage {
 }
 
 export type GmailState = {
-  navigationHistory: {
-    canGoBack: boolean;
-    canGoForward: boolean;
-  };
   unreadCount: number | null;
   unreadInbox: GmailInboxMessage[];
   outOfOffice: boolean;


### PR DESCRIPTION
## Problem

First step of converging Gmail onto the `WorkspaceApp` architecture. Gmail maintained `navigationHistory` as event-updated `viewStore` state (written on `did-navigate`/`did-navigate-in-page`), while `WorkspaceApp` derives the same information live from `webContents.navigationHistory` via a getter — duplicated, more complex, and inconsistent between the two.

## Changes

- `Gmail` gains `get navigationHistory()` reading `webContents.navigationHistory` live, matching `WorkspaceApp`'s getter (null-safe before the view exists, like `Gmail.isLoading`, since tab serialization can run during startup).
- `viewStore` shrinks to `{ attentionRequired }`; the navigation handler no longer copies navigation state into it. `did-navigate` still updates `attentionRequired` (whose subscription re-broadcasts account and tab state); `did-navigate-in-page` now just re-broadcasts tab state directly.
- The Gmail tab adapter reads the getter; `GmailState` (the `accounts.changed` payload) drops `navigationHistory` — the renderer's only consumer has read it from `TabState` since #633.

## Verification

- `bun types:ci` passes.
- Not runtime-tested here (no display). Manual: main-titlebar back/forward still enable/disable correctly while navigating within Gmail (including in-page hash navigation) and after account switches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)