### PR TITLE
converge gmail state and view wiring on workspace app patterns

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,15 @@
 
 Follow-up work that should be picked up in a **new session** — items unrelated enough to their originating feature that they shouldn't ride along with it.
 
+## Gmail/WorkspaceApp convergence backlog
+
+Later steps of converging `Gmail` onto the `WorkspaceApp` architecture (the near-term steps — live getters, store dedupe, shared view-event wiring, Gmail tab title — are being done as part of the feature work):
+
+- **Shared `createView` recipe** — both classes build a `WebContentsView` with session+preload, add it as a child view, wire context menu, zoom limits, find-in-page broadcasts, window-open handler, devtools, and `loadURL`. Extract once into `packages/app/lib/web-contents.ts`.
+- **Zoom unification** — `WorkspaceApp` has `zoomIn/zoomOut/resetZoom` with clamping; Gmail zoom lives in the `gmail.zoomFactor` config plus menu branches. One API over the active tab's webContents should serve both (also needed by the menu rework phase).
+- **`Account.windows` diet** — the `Set<BrowserWindow | WebContentsView>` predates the tabs collection; embedded views are tracked twice. Making it windowed-only simplifies the `instanceof BrowserWindow` filters in the display-media handler and `gmail.closeComposeWindow`.
+- **Lazy view creation (needs discussion)** — every null-safe Gmail getter exists because `Gmail` instances are constructed in `accounts.init()` before the main window exists, while `WorkspaceApp` creates its view in the constructor. `Gmail extends WorkspaceApp` only becomes clean if Gmail instance/view creation moves after `main.init()` — an ordering change that would retire the `_view`-throwing-getter pattern entirely. Discuss before attempting.
+
 ## Workspace App context-menu entries
 
 Add "Copy Link" and "Open in Default Browser" entries to the right-click context menu for non-Gmail-view windows — extend `setupWindowContextMenu` in `packages/app/context-menu.ts`, guarded with `window !== accounts.getSelectedAccount().instance.gmail.view`. Gives immediate discoverability even for users who don't end up using the toolbar UI.

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -361,10 +361,7 @@ class Accounts {
       "accounts.changed",
       this.getAccounts().map((account) => ({
         config: account.config,
-        gmail: {
-          ...account.instance.gmail.store.getState(),
-          ...account.instance.gmail.viewStore.getState(),
-        },
+        gmail: account.instance.gmail.store.getState(),
       })),
     );
   }

--- a/packages/app/context-menu.ts
+++ b/packages/app/context-menu.ts
@@ -26,7 +26,7 @@ export function setupWindowContextMenu(window: BrowserWindow | WebContentsView) 
         parameters.pageURL === selectedAccount.instance.gmail.view.webContents.getURL()
       ) {
         const userEmail = selectedAccount.instance.gmail.userEmail;
-        const messageId = selectedAccount.instance.gmail.store.getState().messageId;
+        const messageId = selectedAccount.instance.gmail.messageId;
 
         if (userEmail && messageId) {
           const meruMessageUrl = createMeruMessageUrl(userEmail, messageId);

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -247,6 +247,16 @@ export class Gmail {
     };
   }
 
+  get messageId() {
+    const gmailUrl = this._view?.webContents.getURL();
+
+    if (!gmailUrl) {
+      return null;
+    }
+
+    return parseGmailMessageId(new URL(gmailUrl).hash);
+  }
+
   viewStore = createStore(
     subscribeWithSelector<{
       attentionRequired: boolean;
@@ -266,12 +276,10 @@ export class Gmail {
       unreadCount: number;
       unreadInbox: GmailInboxMessage[];
       outOfOffice: boolean;
-      messageId: string | null;
     }>(() => ({
       unreadCount: 0,
       unreadInbox: [],
       outOfOffice: false,
-      messageId: null,
     })),
   );
 
@@ -408,10 +416,6 @@ export class Gmail {
       }
 
       this.view.webContents.insertCSS(meruCSS);
-    });
-
-    this.view.webContents.on("did-navigate-in-page", (_event, url) => {
-      this.store.setState({ messageId: parseGmailMessageId(new URL(url).hash) });
     });
 
     this.view.webContents.on("did-start-loading", () => {

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -44,6 +44,7 @@ import {
   createNotification,
   isWithinNotificationTimes,
 } from "@/notifications";
+import { registerTabBroadcasts } from "@/tabs";
 import { appTray } from "@/tray";
 import { WorkspaceApp } from "@/workspace-app";
 import gmailCSS from "./gmail.css";
@@ -412,13 +413,7 @@ export class Gmail {
       this.view.webContents.insertCSS(meruCSS);
     });
 
-    this.view.webContents.on("did-start-loading", () => {
-      accounts.sendTabsChangedToRenderer();
-    });
-
-    this.view.webContents.on("did-stop-loading", () => {
-      accounts.sendTabsChangedToRenderer();
-    });
+    registerTabBroadcasts(this.view);
 
     openViewDevToolsInDev(this.view);
 
@@ -457,12 +452,6 @@ export class Gmail {
         });
       }
     });
-
-    if (window === this.view) {
-      window.webContents.on("did-navigate-in-page", () => {
-        accounts.sendTabsChangedToRenderer();
-      });
-    }
 
     window.webContents.on("will-redirect", (event, url) => {
       if (url.startsWith("https://workspace.google.com/u/0/marketplace/appfinder")) {

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -257,14 +257,6 @@ export class Gmail {
     return parseGmailMessageId(new URL(gmailUrl).hash);
   }
 
-  viewStore = createStore(
-    subscribeWithSelector<{
-      attentionRequired: boolean;
-    }>(() => ({
-      attentionRequired: false,
-    })),
-  );
-
   userEmail: string | null = null;
 
   unreadCountEnabled = true;
@@ -276,10 +268,12 @@ export class Gmail {
       unreadCount: number;
       unreadInbox: GmailInboxMessage[];
       outOfOffice: boolean;
+      attentionRequired: boolean;
     }>(() => ({
       unreadCount: 0,
       unreadInbox: [],
       outOfOffice: false,
+      attentionRequired: false,
     })),
   );
 
@@ -458,7 +452,7 @@ export class Gmail {
       WorkspaceApp.handleNavigate(url);
 
       if (window === this.view) {
-        this.viewStore.setState({
+        this.store.setState({
           attentionRequired: !url.startsWith(this.baseUrl),
         });
       }
@@ -820,11 +814,14 @@ export class Gmail {
   }
 
   subscribeToStore() {
-    this.viewStore.subscribe(() => {
-      accounts.sendAccountsChangedToRenderer();
+    this.store.subscribe(
+      (state) => state.attentionRequired,
+      () => {
+        accounts.sendAccountsChangedToRenderer();
 
-      accounts.sendTabsChangedToRenderer();
-    });
+        accounts.sendTabsChangedToRenderer();
+      },
+    );
 
     if (this.getIsUnreadCountEnabled()) {
       const dockUnreadBadge = config.get("dock.unreadBadge");

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -854,17 +854,7 @@ export class Gmail {
 
           appTray.updateUnreadStatus(totalUnreadCount);
 
-          ipc.renderer.send(
-            main.window.webContents,
-            "accounts.changed",
-            accounts.getAccounts().map((account) => ({
-              config: account.config,
-              gmail: {
-                ...account.instance.gmail.store.getState(),
-                ...account.instance.gmail.viewStore.getState(),
-              },
-            })),
-          );
+          accounts.sendAccountsChangedToRenderer();
         },
       );
     }

--- a/packages/app/main.ts
+++ b/packages/app/main.ts
@@ -40,10 +40,7 @@ class Main {
       JSON.stringify(
         accounts.getAccounts().map((account) => ({
           config: account.config,
-          gmail: {
-            ...account.instance.gmail.store.getState(),
-            ...account.instance.gmail.viewStore.getState(),
-          },
+          gmail: account.instance.gmail.store.getState(),
         })),
       ),
     );

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -73,16 +73,21 @@ export class AppMenu {
 
     const selectedAccount = accounts.getSelectedAccount();
 
-    this._selectedAccountUnsubscribeFns.add(
-      selectedAccount.instance.gmail.store.subscribe(
-        (state) => state.messageId,
-        () => {
-          this.menu = this.createMenu();
+    const gmailWebContents = selectedAccount.instance.gmail.view.webContents;
 
-          Menu.setApplicationMenu(this.menu);
-        },
-      ),
-    );
+    const rebuildMenu = () => {
+      this.menu = this.createMenu();
+
+      Menu.setApplicationMenu(this.menu);
+    };
+
+    gmailWebContents.on("did-navigate-in-page", rebuildMenu);
+
+    this._selectedAccountUnsubscribeFns.add(() => {
+      if (!gmailWebContents.isDestroyed()) {
+        gmailWebContents.removeListener("did-navigate-in-page", rebuildMenu);
+      }
+    });
   }
 
   createMenu() {
@@ -149,7 +154,7 @@ export class AppMenu {
     const selectedAccount = accounts.getSelectedAccount();
 
     const userEmail = selectedAccount.instance.gmail.userEmail;
-    const messageId = selectedAccount.instance.gmail.store.getState().messageId;
+    const messageId = selectedAccount.instance.gmail.messageId;
 
     const copyOrShareMessageLink =
       userEmail && messageId && createMeruMessageUrl(userEmail, messageId);

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -10,6 +10,18 @@ import type { Gmail } from "./gmail";
 import { main } from "./main";
 import { WorkspaceApp } from "./workspace-app";
 
+export function registerTabBroadcasts(view: WebContentsView) {
+  const broadcastTabsChanged = () => {
+    accounts.sendTabsChangedToRenderer();
+  };
+
+  view.webContents.on("did-navigate", broadcastTabsChanged);
+  view.webContents.on("did-navigate-in-page", broadcastTabsChanged);
+  view.webContents.on("page-title-updated", broadcastTabsChanged);
+  view.webContents.on("did-start-loading", broadcastTabsChanged);
+  view.webContents.on("did-stop-loading", broadcastTabsChanged);
+}
+
 export type Tab = {
   id: string;
   app: SupportedWorkspaceApp | undefined;

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -35,6 +35,7 @@ import {
 import { licenseKey } from "./license-key";
 import { main } from "./main";
 import { appState } from "./state";
+import { registerTabBroadcasts } from "./tabs";
 import { openExternalUrl } from "./url";
 
 export const MIN_ZOOM_FACTOR = 0.1;
@@ -469,7 +470,7 @@ export class WorkspaceApp {
 
   close() {
     if (!this.viewDestroyed) {
-      this.unregisterViewListeners();
+      this.view.webContents.removeAllListeners();
 
       this.view.webContents.close();
     }
@@ -518,23 +519,18 @@ export class WorkspaceApp {
   }
 
   private registerViewListeners() {
-    this.view.webContents.on("did-navigate", this.broadcastNavigationState);
     this.view.webContents.on("did-navigate", this.handlePasskeyChallenge);
-    this.view.webContents.on("did-navigate-in-page", this.broadcastNavigationState);
-    this.view.webContents.on("page-title-updated", this.handlePageTitleUpdated);
-    this.view.webContents.on("did-start-loading", this.broadcastLoadingState);
-    this.view.webContents.on("did-stop-loading", this.broadcastLoadingState);
     this.view.webContents.on("will-redirect", this.handleGoogleRedirect);
-  }
+    this.view.webContents.on("page-title-updated", this.handlePageTitleUpdated);
 
-  private unregisterViewListeners() {
-    this.view.webContents.removeListener("did-navigate", this.broadcastNavigationState);
-    this.view.webContents.removeListener("did-navigate", this.handlePasskeyChallenge);
-    this.view.webContents.removeListener("did-navigate-in-page", this.broadcastNavigationState);
-    this.view.webContents.removeListener("page-title-updated", this.handlePageTitleUpdated);
-    this.view.webContents.removeListener("did-start-loading", this.broadcastLoadingState);
-    this.view.webContents.removeListener("did-stop-loading", this.broadcastLoadingState);
-    this.view.webContents.removeListener("will-redirect", this.handleGoogleRedirect);
+    if (this._window) {
+      this.view.webContents.on("did-navigate", this.broadcastNavigationState);
+      this.view.webContents.on("did-navigate-in-page", this.broadcastNavigationState);
+      this.view.webContents.on("did-start-loading", this.broadcastLoadingState);
+      this.view.webContents.on("did-stop-loading", this.broadcastLoadingState);
+    } else {
+      registerTabBroadcasts(this.view);
+    }
   }
 
   private handlePasskeyChallenge = (_event: Electron.Event, url: string) => {
@@ -553,12 +549,6 @@ export class WorkspaceApp {
   }
 
   broadcastNavigationState = () => {
-    if (!this._window) {
-      accounts.sendTabsChangedToRenderer();
-
-      return;
-    }
-
     ipc.renderer.send(
       this.chromeWebContents,
       "workspaceApp.navigationStateChanged",
@@ -576,8 +566,6 @@ export class WorkspaceApp {
     this.pageTitle = explicitSet ? pageTitle : "";
 
     if (!this._window) {
-      accounts.sendTabsChangedToRenderer();
-
       return;
     }
 
@@ -596,12 +584,6 @@ export class WorkspaceApp {
   };
 
   broadcastLoadingState = () => {
-    if (!this._window) {
-      accounts.sendTabsChangedToRenderer();
-
-      return;
-    }
-
     ipc.renderer.send(
       this.chromeWebContents,
       "workspaceApp.loadingStateChanged",


### PR DESCRIPTION
## Problem

Next steps of converging `Gmail` onto the `WorkspaceApp` architecture (after #634): derived state was still maintained by hand in stores, one broadcast payload was hand-built twice, and the tab-state broadcast wiring existed in two ad-hoc variants.

## Changes

Five commits:

1. **`add gmail workspace app convergence backlog to todo`** — the deferred convergence items (shared `createView` recipe, zoom unification, `Account.windows` diet, and the lazy-view-creation prerequisite for `Gmail extends WorkspaceApp`, marked needs-discussion) recorded in `TODO.md` for future sessions.
2. **`derive gmail message id from web contents url`** — `store.messageId` (written on `did-navigate-in-page`) becomes a live `get messageId()` parsing the view URL's hash. The app-menu rebuild trigger moves from the store subscription to the view's `did-navigate-in-page` event; the menu and context-menu read the getter.
3. **`reuse accounts changed broadcast in gmail unread subscription`** — the unread-count subscription hand-built the `accounts.changed` payload inline, duplicating `Accounts.sendAccountsChangedToRenderer()`; it now calls it.
4. **`merge gmail view store into store`** — after #634, `viewStore` held only `attentionRequired`; it's folded into `store` (subscription via selector), and the three payload composition sites drop the second spread.
5. **`share tab broadcast wiring between gmail and workspace apps`** — new `registerTabBroadcasts(view)` in `tabs.ts` wires navigate/in-page-navigate/title/loading events to `tabs.changed`. The Gmail view and embedded `WorkspaceApp` instances both use it; `WorkspaceApp`'s broadcast methods lose their embedded branches (they're now registered only for windowed instances, whose chrome events they serve), and the hand-maintained `unregisterViewListeners` mirror is replaced by `removeAllListeners()` on close — the same teardown idiom `Gmail.destroy()` already uses.

Behavior notes: the app menu now rebuilds on every Gmail in-page navigation instead of only when the message id actually changed (rebuilds are cheap and already happen on window focus); Gmail title/navigation events now also refresh tab state (small payload, harmless).

## Verification

- `bun types:ci` passes.
- Not runtime-tested here (no display). Manual: Message menu section enables/disables when opening/closing an email (menu + right-click "Copy Message Link"); unread badge and attention indicator still update; tab strip/titlebar reload state still fresh for Gmail and workspace tabs; closing a tab or workspace window leaks no broadcasts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)