### PR TITLE
use gmail page title as gmail tab title

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -13,6 +13,7 @@ import {
   parseGmailMessageId,
 } from "@meru/shared/gmail";
 import { ms } from "@meru/shared/ms";
+import { workspaceApps } from "@meru/shared/types";
 import { wait } from "@meru/shared/utils";
 import {
   app,
@@ -248,6 +249,12 @@ export class Gmail {
     };
   }
 
+  private pageTitle = "";
+
+  get title() {
+    return this.pageTitle || workspaceApps.gmail.label;
+  }
+
   get messageId() {
     const gmailUrl = this._view?.webContents.getURL();
 
@@ -411,6 +418,10 @@ export class Gmail {
       }
 
       this.view.webContents.insertCSS(meruCSS);
+    });
+
+    this.view.webContents.on("page-title-updated", (_event, pageTitle, explicitSet) => {
+      this.pageTitle = explicitSet ? pageTitle : "";
     });
 
     registerTabBroadcasts(this.view);

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -1,9 +1,4 @@
-import {
-  GMAIL_TAB_ID,
-  type SupportedWorkspaceApp,
-  type TabState,
-  workspaceApps,
-} from "@meru/shared/types";
+import { GMAIL_TAB_ID, type SupportedWorkspaceApp, type TabState } from "@meru/shared/types";
 import type { WebContentsView } from "electron";
 import { accounts } from "./accounts";
 import type { Gmail } from "./gmail";
@@ -42,7 +37,9 @@ export class Tabs {
       {
         id: GMAIL_TAB_ID,
         app: "gmail",
-        title: workspaceApps.gmail.label,
+        get title() {
+          return gmail.title;
+        },
         get isLoading() {
           return gmail.isLoading;
         },


### PR DESCRIPTION
## Problem

The Gmail tab's title was the static "Gmail" label, while workspace-app tabs show their live page title — inconsistent, and the Gmail page title carries useful signal (folder, unread count, account).

## Changes

- `Gmail` tracks `pageTitle` from `page-title-updated` with the `explicitSet` flag (so a synthesized URL-as-title never leaks) and exposes `get title()` falling back to the "Gmail" label from the definitions map — the exact pattern `WorkspaceApp` uses.
- The listener registers before `registerTabBroadcasts`, so the title is updated before the broadcast serializes tab state.
- The Gmail tab adapter delegates its `title` to the getter — in the wide strip the Gmail tab now shows e.g. "Inbox (3) - tim@… - Gmail" live; narrow mode is unaffected (tooltip only).

## Verification

- `bun types:ci` passes.
- Not runtime-tested here (no display). Manual: Gmail tab title/tooltip updates while navigating folders and as unread counts change; falls back to "Gmail" before the page loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)