### PR TITLE
always open workspace apps in a new tab or window

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -336,6 +336,9 @@ export const config = new Store<Config>({
         // @ts-expect-error
         store.delete(previousKey);
       }
+
+      // @ts-expect-error: `workspaceApps.openAppsInNewWindow` was removed
+      store.delete("workspaceApps.openAppsInNewWindow");
     },
   },
 });

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -91,7 +91,6 @@ export const config = new Store<Config>({
     "trial.expired": false,
     "workspaceApps.openInApp": true,
     "workspaceApps.openInAppExcludedApps": [],
-    "workspaceApps.openAppsInNewWindow": false,
     "workspaceApps.pinnedApps": [],
     "workspaceApps.showAccountColor": true,
     "workspaceApps.showAccountLabel": true,

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -105,29 +105,6 @@ export class WorkspaceApp {
       .map((instance) => instance.window);
   }
 
-  static reuseWindowByHostname(accountId: AccountConfig["id"], url: string) {
-    const urlHostname = new URL(url).hostname;
-
-    const reusableInstance = Array.from(WorkspaceApp.instances.values())
-      .reverse()
-      .find(
-        (instance) =>
-          instance._window &&
-          instance.accountId === accountId &&
-          new URL(instance.view.webContents.getURL()).hostname === urlHostname,
-      );
-
-    if (!reusableInstance) {
-      return false;
-    }
-
-    reusableInstance.view.webContents.loadURL(url);
-
-    reusableInstance.window.focus();
-
-    return true;
-  }
-
   static handleNavigate(url: string) {
     if (!url.startsWith(`${GOOGLE_ACCOUNTS_URL}/v3/signin/challenge/pk/presend`)) {
       return;
@@ -248,13 +225,6 @@ export class WorkspaceApp {
           url,
         });
 
-        return { action: "deny" };
-      }
-
-      if (
-        !config.get("workspaceApps.openAppsInNewWindow") &&
-        WorkspaceApp.reuseWindowByHostname(accountId, url)
-      ) {
         return { action: "deny" };
       }
 

--- a/packages/renderer-main/routes/settings/workspace-apps.tsx
+++ b/packages/renderer-main/routes/settings/workspace-apps.tsx
@@ -123,12 +123,6 @@ export function WorkspaceAppsSettings() {
           />
           {config["workspaceApps.openInApp"] && (
             <>
-              <ConfigSwitchField
-                label="Always Open in New Window"
-                description="Always open Workspace Apps in a new window instead of reusing the same window if it is already open."
-                configKey="workspaceApps.openAppsInNewWindow"
-                licenseKeyRequired
-              />
               <Field>
                 <FieldContent>
                   <FieldLabel className="flex items-center gap-2">

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -202,7 +202,6 @@ export type Config = {
   "trial.expired": boolean;
   "workspaceApps.openInApp": boolean;
   "workspaceApps.openInAppExcludedApps": SupportedWorkspaceApp[];
-  "workspaceApps.openAppsInNewWindow": boolean;
   "workspaceApps.pinnedApps": PinnableWorkspaceApp[];
   "workspaceApps.showAccountColor": boolean;
   "workspaceApps.showAccountLabel": boolean;


### PR DESCRIPTION
## Problem

Preparation for the tabs-by-default flip: `handleWindowOpen` carried window-reuse decision logic — `reuseWindowByHostname` plus the `workspaceApps.openAppsInNewWindow` setting choosing between reusing an existing same-hostname window and opening a new one. Browsers don't do this: every open request yields a fresh tab or window. With tabs as the upcoming default, per-hostname window reuse has no future role.

## Changes

- `WorkspaceApp.reuseWindowByHostname` is deleted; a foreground open always creates a new window (Cmd/Ctrl+click keeps creating a new background tab). The upcoming `workspaceApps.openBehavior` config (follow-up PR, default `tab`) plugs into this now-single decision point.
- The `workspaceApps.openAppsInNewWindow` config key, its default, and the "Always Open in New Window" settings switch are removed — the pending `>3.57.0` migration (which runs with the next release) additionally deletes the stale key from existing stores — right after its rename loop, which would otherwise resurrect it from `googleApps.*`. No value mapping: everyone starts on the new default.

## Verification

- `bun types:ci` passes.
- Not runtime-tested here (no display). Manual: plain-clicking the same Docs link twice opens two windows (previously reused one); settings no longer show the switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
