### PR TITLE
open workspace apps as tabs by default

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -91,6 +91,7 @@ export const config = new Store<Config>({
     "trial.expired": false,
     "workspaceApps.openInApp": true,
     "workspaceApps.openInAppExcludedApps": [],
+    "workspaceApps.openBehavior": "tab",
     "workspaceApps.pinnedApps": [],
     "workspaceApps.showAccountColor": true,
     "workspaceApps.showAccountLabel": true,

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -216,23 +216,36 @@ export class WorkspaceApp {
       !config.get("workspaceApps.openInAppExcludedApps").includes(matchedSupportedWorkspaceApp);
 
     if (isWorkspaceAppEnabledToOpenInApp) {
-      if (
-        disposition === "background-tab" &&
-        !workspaceApps[matchedSupportedWorkspaceApp].alwaysOpenAsWindow
-      ) {
+      const openBehavior =
+        workspaceApps[matchedSupportedWorkspaceApp].alwaysOpenAsWindow ||
+        disposition === "new-window"
+          ? "newWindow"
+          : disposition === "background-tab"
+            ? "backgroundTab"
+            : config.get("workspaceApps.openBehavior");
+
+      if (openBehavior === "newWindow") {
         new WorkspaceApp({
           accountId,
           url,
+          asWindow: true,
         });
 
         return { action: "deny" };
       }
 
-      new WorkspaceApp({
+      const workspaceApp = new WorkspaceApp({
         accountId,
         url,
-        asWindow: true,
       });
+
+      if (openBehavior === "tab") {
+        accounts.getAccount(accountId).instance.tabs.activateTab(workspaceApp.id);
+
+        accounts.selectAccount(accountId);
+
+        main.show();
+      }
 
       return { action: "deny" };
     }

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -2,7 +2,11 @@ import { randomUUID } from "node:crypto";
 import { APP_TITLEBAR_HEIGHT, GOOGLE_ACCOUNTS_URL } from "@meru/shared/constants";
 import { getWorkspaceAppUrl } from "@meru/shared/google";
 import type { AccountConfig } from "@meru/shared/schemas";
-import { type SupportedWorkspaceApp, workspaceApps } from "@meru/shared/types";
+import {
+  type SupportedWorkspaceApp,
+  type WorkspaceAppOpenBehavior,
+  workspaceApps,
+} from "@meru/shared/types";
 import { clamp } from "@meru/shared/utils";
 import {
   app,
@@ -216,7 +220,7 @@ export class WorkspaceApp {
       !config.get("workspaceApps.openInAppExcludedApps").includes(matchedSupportedWorkspaceApp);
 
     if (isWorkspaceAppEnabledToOpenInApp) {
-      const openBehavior =
+      const openBehavior: WorkspaceAppOpenBehavior =
         workspaceApps[matchedSupportedWorkspaceApp].alwaysOpenAsWindow ||
         disposition === "new-window"
           ? "newWindow"

--- a/packages/renderer-main/components/config-select-field.tsx
+++ b/packages/renderer-main/components/config-select-field.tsx
@@ -8,6 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@meru/ui/components/select";
+import type { ReactNode } from "react";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { restartRequiredToast } from "@/lib/toast";
 import { LicenseKeyRequiredFieldBadge } from "./license-key-required-field-badge";
@@ -24,7 +25,7 @@ export function ConfigSelectField({
 }: {
   configKey: keyof Config;
   label: string;
-  description: string;
+  description: ReactNode;
   items: { value: string; label: string }[];
   placeholder: string;
   licenseKeyRequired?: boolean;

--- a/packages/renderer-main/routes/settings/workspace-apps.tsx
+++ b/packages/renderer-main/routes/settings/workspace-apps.tsx
@@ -27,6 +27,7 @@ import {
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { ChevronDownIcon, GripVerticalIcon, PlusIcon, XIcon } from "lucide-react";
 import type { Entries } from "type-fest";
+import { ConfigSelectField } from "@/components/config-select-field";
 import { ConfigSwitchField } from "@/components/config-switch-field";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { LicenseKeyRequiredFieldBadge } from "@/components/license-key-required-field-badge";
@@ -123,6 +124,18 @@ export function WorkspaceAppsSettings() {
           />
           {config["workspaceApps.openInApp"] && (
             <>
+              <ConfigSelectField
+                label="Open Behavior"
+                description="How Workspace Apps open: as a tab in the main window, in a new window, or as a background tab."
+                configKey="workspaceApps.openBehavior"
+                placeholder="Select behavior"
+                licenseKeyRequired
+                items={[
+                  { value: "tab", label: "Tab" },
+                  { value: "newWindow", label: "New Window" },
+                  { value: "backgroundTab", label: "Background Tab" },
+                ]}
+              />
               <Field>
                 <FieldContent>
                   <FieldLabel className="flex items-center gap-2">

--- a/packages/renderer-main/routes/settings/workspace-apps.tsx
+++ b/packages/renderer-main/routes/settings/workspace-apps.tsx
@@ -2,6 +2,7 @@ import { move } from "@dnd-kit/helpers";
 import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { useConfig, useConfigMutation } from "@meru/shared/renderer/react-query";
+import { platform } from "@meru/shared/renderer/utils";
 import {
   type PinnableWorkspaceApp,
   pinnableWorkspaceApps,
@@ -127,7 +128,7 @@ export function WorkspaceAppsSettings() {
             <>
               <ConfigSelectField
                 label="Open Behavior"
-                description="How Workspace Apps open: as a tab in the main window (default), in a new window, or as a background tab. Hold Cmd/Ctrl to always open as a background tab or Shift to always open in a new window."
+                description={`How Workspace Apps open: as a tab in the main window (default), in a new window, or as a background tab. Hold ${platform.isMacOS ? "Cmd" : "Ctrl"} to always open as a background tab or Shift to always open in a new window.`}
                 configKey="workspaceApps.openBehavior"
                 placeholder="Select behavior"
                 licenseKeyRequired

--- a/packages/renderer-main/routes/settings/workspace-apps.tsx
+++ b/packages/renderer-main/routes/settings/workspace-apps.tsx
@@ -26,6 +26,7 @@ import {
   FieldLabel,
   FieldSeparator,
 } from "@meru/ui/components/field";
+import { Kbd } from "@meru/ui/components/kbd";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { ChevronDownIcon, GripVerticalIcon, PlusIcon, XIcon } from "lucide-react";
 import type { Entries } from "type-fest";
@@ -128,7 +129,14 @@ export function WorkspaceAppsSettings() {
             <>
               <ConfigSelectField
                 label="Open Behavior"
-                description={`How Workspace Apps open: as a tab in the main window (default), in a new window, or as a background tab. Hold ${platform.isMacOS ? "Cmd" : "Ctrl"} to always open as a background tab or Shift to always open in a new window.`}
+                description={
+                  <>
+                    How Workspace Apps open: as a tab in the main window (default), in a new window,
+                    or as a background tab. Hold <Kbd>{platform.isMacOS ? "Cmd" : "Ctrl"}</Kbd> to
+                    always open as a background tab or <Kbd>Shift</Kbd> to always open in a new
+                    window.
+                  </>
+                }
                 configKey="workspaceApps.openBehavior"
                 placeholder="Select behavior"
                 licenseKeyRequired

--- a/packages/renderer-main/routes/settings/workspace-apps.tsx
+++ b/packages/renderer-main/routes/settings/workspace-apps.tsx
@@ -6,6 +6,7 @@ import {
   type PinnableWorkspaceApp,
   pinnableWorkspaceApps,
   type SupportedWorkspaceApp,
+  workspaceAppOpenBehaviors,
   workspaceApps,
 } from "@meru/shared/types";
 import { Button } from "@meru/ui/components/button";
@@ -130,11 +131,10 @@ export function WorkspaceAppsSettings() {
                 configKey="workspaceApps.openBehavior"
                 placeholder="Select behavior"
                 licenseKeyRequired
-                items={[
-                  { value: "tab", label: "Tab" },
-                  { value: "newWindow", label: "New Window" },
-                  { value: "backgroundTab", label: "Background Tab" },
-                ]}
+                items={Object.entries(workspaceAppOpenBehaviors).map(([value, label]) => ({
+                  value,
+                  label,
+                }))}
               />
               <Field>
                 <FieldContent>

--- a/packages/renderer-main/routes/settings/workspace-apps.tsx
+++ b/packages/renderer-main/routes/settings/workspace-apps.tsx
@@ -127,7 +127,7 @@ export function WorkspaceAppsSettings() {
             <>
               <ConfigSelectField
                 label="Open Behavior"
-                description="How Workspace Apps open: as a tab in the main window, in a new window, or as a background tab."
+                description="How Workspace Apps open: as a tab in the main window (default), in a new window, or as a background tab. Hold Cmd/Ctrl to always open as a background tab or Shift to always open in a new window."
                 configKey="workspaceApps.openBehavior"
                 placeholder="Select behavior"
                 licenseKeyRequired

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -83,6 +83,14 @@ export const pinnableWorkspaceApps = Object.fromEntries(
 
 export type WorkspaceAppOpenDisposition = "foreground-tab" | "background-tab" | "new-window";
 
+export const workspaceAppOpenBehaviors = {
+  tab: "Tab",
+  newWindow: "New Window",
+  backgroundTab: "Background Tab",
+} as const;
+
+export type WorkspaceAppOpenBehavior = keyof typeof workspaceAppOpenBehaviors;
+
 export const GMAIL_TAB_ID = "gmail";
 
 export type TabState = {
@@ -202,7 +210,7 @@ export type Config = {
   "trial.expired": boolean;
   "workspaceApps.openInApp": boolean;
   "workspaceApps.openInAppExcludedApps": SupportedWorkspaceApp[];
-  "workspaceApps.openBehavior": "tab" | "newWindow" | "backgroundTab";
+  "workspaceApps.openBehavior": WorkspaceAppOpenBehavior;
   "workspaceApps.pinnedApps": PinnableWorkspaceApp[];
   "workspaceApps.showAccountColor": boolean;
   "workspaceApps.showAccountLabel": boolean;

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -202,6 +202,7 @@ export type Config = {
   "trial.expired": boolean;
   "workspaceApps.openInApp": boolean;
   "workspaceApps.openInAppExcludedApps": SupportedWorkspaceApp[];
+  "workspaceApps.openBehavior": "tab" | "newWindow" | "backgroundTab";
   "workspaceApps.pinnedApps": PinnableWorkspaceApp[];
   "workspaceApps.showAccountColor": boolean;
   "workspaceApps.showAccountLabel": boolean;


### PR DESCRIPTION
## Problem

The final step of the tabs-by-default flip (phase 3 of the workspace-apps-as-tabs roadmap, building on #637): plain-clicking a workspace-app link still opened a window, and there was no way to configure the default open behavior.

## Changes

- New config `workspaceApps.openBehavior`, backed by a `workspaceAppOpenBehaviors` key→label map as the single source of truth: the `WorkspaceAppOpenBehavior` union derives from its keys (`"tab"` default | `"newWindow"` | `"backgroundTab"`) and the settings select items derive from its entries, default first by key order. No migration — tabs are the new default experience for everyone.
- `handleWindowOpen` resolves the effective behavior at the single decision point #637 left behind: modifier dispositions override per-open (Shift+click / `new-window` → window, Cmd/Ctrl+click / `background-tab` → background tab), `alwaysOpenAsWindow` apps (`myaccount`) force a window, and everything else follows the config. `"tab"` opens a foreground tab: the embedded instance is created, activated, the owning account selected, and the main window shown — so a link clicked in a workspace-app window lands you on the new tab in the main window.
- Settings: a "Open Behavior" `ConfigSelectField` (default `"tab"` listed first) in the Open-in-App section, replacing the removed switch.

**This flips the default**: with a valid license and `workspaceApps.openInApp` on, plain-clicking a Docs link (or a pinned titlebar app) now opens a tab in the main window instead of a window.

## Verification

- `bun types:ci` passes.
- Not runtime-tested here (no display). Manual: plain click a workspace link → foreground tab, activated, strip appears; Cmd/Ctrl+click → background tab; Shift+click → window; pinned titlebar app plain click → foreground tab; `myaccount` → always window; setting to "New Window"/"Background Tab" changes the plain-click behavior; free tier unchanged (external browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
