### PR TITLE
document kbd component for keyboard keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ This installs dependencies and runs postinstall scripts (including the lefthook 
 - Components in `packages/ui` follow shadcn conventions. Many are compound components with named sub-components (e.g. `Item` → `ItemContent`, `ItemActions`, `ItemTitle`, `ItemDescription`). Always read the component file before use to find available sub-components and use them instead of plain `<div>` wrappers.
 - Never repeat shared classes across the branches of a conditional `className`. Hoist them and merge with the `cn` helper (`@meru/ui/lib/utils`): `cn("absolute hidden", isWide ? "size-5" : "size-4")`.
 - Consider the platform when showing platform-specific information (modifier keys, OS names): branch on the existing `platform` helper — `@meru/shared/renderer/utils` in renderers, `@electron-toolkit/utils` in the main process — e.g. `platform.isMacOS ? "Cmd" : "Ctrl"`.
+- Render keyboard keys in user-facing text with the `Kbd` component (`@meru/ui/components/kbd`), not as plain text: `Hold <Kbd>Shift</Kbd> to …`.
 
 ## React State
 


### PR DESCRIPTION
## Problem

Keyboard keys in user-facing text (like the modifier shortcuts in the workspace-apps Open Behavior description) should render as key chips, not plain text — the `Kbd` component exists for this but wasn't documented.

## Changes

Adds a guideline to CLAUDE.md's UI Components section, next to the platform-copy guideline from #639: render keyboard keys in user-facing text with the `Kbd` component (`@meru/ui/components/kbd`) instead of plain text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)