### PR TITLE
target active tab in menu actions

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -153,6 +153,18 @@ export class AppMenu {
 
     const selectedAccount = accounts.getSelectedAccount();
 
+    const getActiveViewWebContents = () => {
+      if (focusedWindow && focusedWindow !== main.window) {
+        const workspaceApp = WorkspaceApp.tryFromWebContents(focusedWindow.webContents);
+
+        if (workspaceApp) {
+          return workspaceApp.view.webContents;
+        }
+      }
+
+      return selectedAccount.instance.tabs.activeTab.view.webContents;
+    };
+
     const userEmail = selectedAccount.instance.gmail.userEmail;
     const messageId = selectedAccount.instance.gmail.messageId;
 
@@ -396,26 +408,14 @@ export class AppMenu {
             label: "Reload",
             accelerator: "CommandOrControl+R",
             click: () => {
-              if (focusedWindow && focusedWindow !== main.window) {
-                WorkspaceApp.tryFromWebContents(focusedWindow.webContents)?.reload();
-
-                return;
-              }
-
-              selectedAccount.instance.gmail.view.webContents.reload();
+              getActiveViewWebContents().reload();
             },
           },
           {
             label: "Hard Reload",
             accelerator: "CommandOrControl+Shift+R",
-            click: async () => {
-              if (focusedWindow && focusedWindow !== main.window) {
-                WorkspaceApp.tryFromWebContents(focusedWindow.webContents)?.hardReload();
-
-                return;
-              }
-
-              selectedAccount.instance.gmail.view.webContents.reloadIgnoringCache();
+            click: () => {
+              getActiveViewWebContents().reloadIgnoringCache();
             },
           },
           {
@@ -439,7 +439,7 @@ export class AppMenu {
 
               main.window.webContents.openDevTools({ mode: "detach" });
 
-              selectedAccount.instance.gmail.view.webContents.openDevTools();
+              selectedAccount.instance.tabs.activeTab.view.webContents.openDevTools();
             },
           },
         ],
@@ -451,26 +451,14 @@ export class AppMenu {
             label: "Back",
             accelerator: platform.isMacOS ? "Command+[" : "Alt+Left",
             click: () => {
-              if (focusedWindow && focusedWindow !== main.window) {
-                WorkspaceApp.tryFromWebContents(focusedWindow.webContents)?.goBack();
-
-                return;
-              }
-
-              selectedAccount.instance.gmail.view.webContents.navigationHistory.goBack();
+              getActiveViewWebContents().navigationHistory.goBack();
             },
           },
           {
             label: "Forward",
             accelerator: platform.isMacOS ? "Command+]" : "Alt+Right",
             click: () => {
-              if (focusedWindow && focusedWindow !== main.window) {
-                WorkspaceApp.tryFromWebContents(focusedWindow.webContents)?.goForward();
-
-                return;
-              }
-
-              selectedAccount.instance.gmail.view.webContents.navigationHistory.goForward();
+              getActiveViewWebContents().navigationHistory.goForward();
             },
           },
         ],


### PR DESCRIPTION
## Problem

The View and History menu actions (Reload, Hard Reload, Developer Tools, Back, Forward) dispatched on the focused window: a workspace-app *window* was handled, but with an embedded tab active the focused window is the main window, so all of these targeted the Gmail view while the user was looking at a workspace tab.

## Changes

- New `getActiveViewWebContents()` in the menu builder: the focused workspace-app window's view if there is one, otherwise the selected account's **active tab** (Gmail or embedded workspace app). Reload, Hard Reload, Back, and Forward collapse onto it — each click handler is now a single line.
- Developer Tools keeps its windowed branch (it also opens the window chrome's devtools) but the main-window path now opens the active tab's devtools instead of always Gmail's.
- Zoom actions are deliberately untouched (Gmail zoom is config-backed and applied across accounts; unifying zoom with tabs needs its own discussion). Find already targets the active tab via the renderer's find-in-page. The Message section stays Gmail-specific by design.
- Minor behavior note: with a non-workspace secondary window focused (e.g. the screen-share picker), these actions previously did nothing; they now act on the active tab.

## Verification

- `bun types:ci` passes.
- Not runtime-tested here (no display). Manual: with a Docs tab active, Cmd+R reloads the tab (not Gmail), Cmd+[/] navigate the tab, DevTools opens for the tab; with the Gmail tab active all behave as before; in a workspace-app window they act on that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)