### PR TITLE
close tabs with middle click

### DIFF
--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -51,6 +51,11 @@ export function AppTabStrip() {
             onClick={() => {
               ipc.main.send("tabs.selectTab", selectedAccount.config.id, tab.id);
             }}
+            onAuxClick={(event) => {
+              if (event.button === 1 && tab.id !== GMAIL_TAB_ID) {
+                ipc.main.send("tabs.closeTab", selectedAccount.config.id, tab.id);
+              }
+            }}
           >
             <TabIcon tab={tab} />
             {isWide && <span className="truncate">{tab.title}</span>}


### PR DESCRIPTION
## Problem

Tabs could only be closed via the hover close button. Browsers universally also close tabs on middle-click; keyboard closing stays deliberately unassigned since Cmd/Ctrl+W remains close-window in Meru.

## Changes

Middle-click (`onAuxClick` with `button === 1`) on a tab in the strip closes it, in both narrow and wide modes. The Gmail tab is excluded — it is permanent.

## Verification

- `bun types:ci` passes.
- Not runtime-tested here (no display). Manual: middle-click a workspace tab → closes; middle-click the Gmail tab → nothing; hover close button unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)