### PR TITLE
add tab switching shortcuts

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -464,6 +464,37 @@ export class AppMenu {
         ],
       },
       {
+        label: "Tabs",
+        submenu: [
+          {
+            label: "Select Next Tab",
+            accelerator: platform.isMacOS ? "Command+Option+Down" : "Ctrl+PageDown",
+            click: () => {
+              accounts.getSelectedAccount().instance.tabs.activateNextTab();
+
+              appState.setIsSettingsOpen(false);
+
+              accounts.refreshSelectedAccountView();
+
+              main.show();
+            },
+          },
+          {
+            label: "Select Previous Tab",
+            accelerator: platform.isMacOS ? "Command+Option+Up" : "Ctrl+PageUp",
+            click: () => {
+              accounts.getSelectedAccount().instance.tabs.activatePreviousTab();
+
+              appState.setIsSettingsOpen(false);
+
+              accounts.refreshSelectedAccountView();
+
+              main.show();
+            },
+          },
+        ],
+      },
+      {
         label: "Accounts",
         submenu: [
           ...allAccounts.map((account, index) => ({

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -165,6 +165,26 @@ export class AppMenu {
       return selectedAccount.instance.tabs.activeTab.view.webContents;
     };
 
+    const selectNextTab = () => {
+      accounts.getSelectedAccount().instance.tabs.activateNextTab();
+
+      appState.setIsSettingsOpen(false);
+
+      accounts.refreshSelectedAccountView();
+
+      main.show();
+    };
+
+    const selectPreviousTab = () => {
+      accounts.getSelectedAccount().instance.tabs.activatePreviousTab();
+
+      appState.setIsSettingsOpen(false);
+
+      accounts.refreshSelectedAccountView();
+
+      main.show();
+    };
+
     const userEmail = selectedAccount.instance.gmail.userEmail;
     const messageId = selectedAccount.instance.gmail.messageId;
 
@@ -468,29 +488,27 @@ export class AppMenu {
         submenu: [
           {
             label: "Select Next Tab",
+            accelerator: "Ctrl+Tab",
+            click: selectNextTab,
+          },
+          {
+            label: "Select Next Tab (hidden shortcut 1)",
             accelerator: platform.isMacOS ? "Command+Option+Down" : "Ctrl+PageDown",
-            click: () => {
-              accounts.getSelectedAccount().instance.tabs.activateNextTab();
-
-              appState.setIsSettingsOpen(false);
-
-              accounts.refreshSelectedAccountView();
-
-              main.show();
-            },
+            visible: is.dev,
+            acceleratorWorksWhenHidden: true,
+            click: selectNextTab,
           },
           {
             label: "Select Previous Tab",
+            accelerator: "Ctrl+Shift+Tab",
+            click: selectPreviousTab,
+          },
+          {
+            label: "Select Previous Tab (hidden shortcut 1)",
             accelerator: platform.isMacOS ? "Command+Option+Up" : "Ctrl+PageUp",
-            click: () => {
-              accounts.getSelectedAccount().instance.tabs.activatePreviousTab();
-
-              appState.setIsSettingsOpen(false);
-
-              accounts.refreshSelectedAccountView();
-
-              main.show();
-            },
+            visible: is.dev,
+            acceleratorWorksWhenHidden: true,
+            click: selectPreviousTab,
           },
         ],
       },
@@ -513,7 +531,7 @@ export class AppMenu {
           },
           {
             label: "Select Next Account",
-            accelerator: "Ctrl+Tab",
+            accelerator: platform.isMacOS ? "Command+Shift+]" : undefined,
             click: () => {
               accounts.selectNextAccount();
 
@@ -524,19 +542,6 @@ export class AppMenu {
           },
           {
             label: "Select Next Account (hidden shortcut 1)",
-            accelerator: "Command+Shift+]",
-            visible: is.dev,
-            acceleratorWorksWhenHidden: true,
-            click: () => {
-              accounts.selectNextAccount();
-
-              appState.setIsSettingsOpen(false);
-
-              main.show();
-            },
-          },
-          {
-            label: "Select Next Account (hidden shortcut 2)",
             accelerator: "Command+Option+Right",
             visible: is.dev,
             acceleratorWorksWhenHidden: true,
@@ -550,7 +555,7 @@ export class AppMenu {
           },
           {
             label: "Select Previous Account",
-            accelerator: "Ctrl+Shift+Tab",
+            accelerator: platform.isMacOS ? "Command+Shift+[" : undefined,
             click: () => {
               accounts.selectPreviousAccount();
 
@@ -561,19 +566,6 @@ export class AppMenu {
           },
           {
             label: "Select Previous Account (hidden shortcut 1)",
-            accelerator: "Command+Shift+[",
-            visible: is.dev,
-            acceleratorWorksWhenHidden: true,
-            click: () => {
-              accounts.selectPreviousAccount();
-
-              appState.setIsSettingsOpen(false);
-
-              main.show();
-            },
-          },
-          {
-            label: "Select Previous Account (hidden shortcut 2)",
             accelerator: "Command+Option+Left",
             visible: is.dev,
             acceleratorWorksWhenHidden: true,

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -96,6 +96,26 @@ export class Tabs {
     this.broadcastTabsChanged();
   }
 
+  activateNextTab() {
+    const activeTabIndex = this.tabs.findIndex((tab) => tab.id === this.activeTabId);
+
+    const nextTab = this.tabs.at(activeTabIndex === this.tabs.length - 1 ? 0 : activeTabIndex + 1);
+
+    if (nextTab) {
+      this.activateTab(nextTab.id);
+    }
+  }
+
+  activatePreviousTab() {
+    const activeTabIndex = this.tabs.findIndex((tab) => tab.id === this.activeTabId);
+
+    const previousTab = this.tabs.at(activeTabIndex === 0 ? -1 : activeTabIndex - 1);
+
+    if (previousTab) {
+      this.activateTab(previousTab.id);
+    }
+  }
+
   closeTab(tabId: string) {
     const closableTab = this.getTab(tabId);
 


### PR DESCRIPTION
## Problem

Tabs could only be switched with the mouse. All browser tab-switching conventions on macOS (Ctrl+Tab, Cmd+Shift+[/], Cmd+Option+←/→, Cmd+1..N) are already bound to account switching in Meru.

## Changes

- New "Tabs" application menu between History and Accounts with "Select Next Tab" / "Select Previous Tab".
- Primary accelerators: `Ctrl+Tab`/`Ctrl+Shift+Tab` — the pair every browser uses for tab switching on all platforms — **rebound from account switching**. Hidden-but-active extras (same pattern the accounts menu uses): `Cmd+Option+Down/Up` on macOS (Arc's vertical-tabs convention) and `Ctrl+PageDown/PageUp` elsewhere (Chrome's convention; the `Ctrl+Alt+↑/↓` analog is typically intercepted by the desktop environment).
- Accounts keep `Cmd/Ctrl/Alt+1..N` everywhere; on macOS the previously hidden `Cmd+Shift+]`/`[` are promoted to the visible next/previous-account accelerators, with `Cmd+Option+→/←` remaining hidden. Known gap: Windows/Linux no longer have a sequential account-cycling shortcut (direct select via `Ctrl/Alt+1..N` remains).
- `Tabs.activateNextTab()`/`activatePreviousTab()` cycle through the selected account's tabs with wrap-around, mirroring the account-switching methods; the menu handlers close settings, raise the tab, and show the main window like the account items do. With only the Gmail tab open they're a no-op.

## Verification

- `bun types:ci` passes.
- Not runtime-tested here (no display). Manual: with several tabs open, Ctrl+Tab/Ctrl+Shift+Tab cycle tabs including wrap-around and update the strip's active state; Cmd+Shift+]/[ still cycle accounts on macOS; Cmd/Ctrl/Alt+1..N account selection unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
