### PR TITLE
add pinned tabs with url persistence

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -246,6 +246,9 @@ class Accounts {
         unifiedInbox: accountDetails.gmail.unifiedInbox,
         delegatedAccountId: null,
       },
+      workspaceApps: {
+        pinnedTabs: [],
+      },
     };
 
     const instance = new Account(createdAccount);
@@ -342,6 +345,30 @@ class Accounts {
         }
       }
     }
+  }
+
+  savePinnedTabs() {
+    if (appState.isQuittingApp) {
+      return;
+    }
+
+    config.set(
+      "accounts",
+      this.getAccountConfigs().map((accountConfig) => {
+        const instance = this.instances.get(accountConfig.id);
+
+        if (!instance) {
+          return accountConfig;
+        }
+
+        return {
+          ...accountConfig,
+          workspaceApps: {
+            pinnedTabs: instance.tabs.serializePinnedTabs(),
+          },
+        };
+      }),
+    );
   }
 
   sendTabsChangedToRenderer() {

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -27,6 +27,9 @@ export const config = new Store<Config>({
           delegatedAccountId: null,
           unifiedInbox: true,
         },
+        workspaceApps: {
+          pinnedTabs: [],
+        },
       },
     ],
     "accounts.unreadBadge": true,
@@ -340,6 +343,18 @@ export const config = new Store<Config>({
 
       // @ts-expect-error: `workspaceApps.openAppsInNewWindow` was removed
       store.delete("workspaceApps.openAppsInNewWindow");
+
+      const accounts = store.get("accounts");
+
+      if (Array.isArray(accounts)) {
+        for (const account of accounts) {
+          if (typeof account.workspaceApps === "undefined") {
+            account.workspaceApps = { pinnedTabs: [] };
+          }
+        }
+
+        store.set("accounts", accounts);
+      }
     },
   },
 });

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -185,6 +185,8 @@ async function init() {
     if (!appState.isQuittingApp) {
       main.saveWindowState();
 
+      accounts.savePinnedTabs();
+
       appState.isQuittingApp = true;
     }
   });

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -236,6 +236,45 @@ class Ipc {
       }
     });
 
+    ipc.main.on("tabs.showTabContextMenu", (_event, accountId, tabId) => {
+      const account = accounts.getAccount(accountId);
+
+      const tab = account.instance.tabs.getTab(tabId);
+
+      if (!(tab instanceof WorkspaceApp)) {
+        return;
+      }
+
+      Menu.buildFromTemplate([
+        tab.pinned
+          ? {
+              label: "Unpin Tab",
+              click: () => {
+                account.instance.tabs.unpinTab(tabId);
+              },
+            }
+          : {
+              label: "Pin Tab",
+              click: () => {
+                account.instance.tabs.pinTab(tabId);
+              },
+            },
+        {
+          type: "separator",
+        },
+        {
+          label: "Close Tab",
+          click: () => {
+            account.instance.tabs.closeTab(tabId);
+
+            if (account.config.selected) {
+              accounts.refreshSelectedAccountView();
+            }
+          },
+        },
+      ]).popup();
+    });
+
     ipc.main.handle("config.getConfig", () => config.store);
 
     ipc.main.handle(

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -1,3 +1,4 @@
+import type { PinnedTab } from "@meru/shared/schemas";
 import { GMAIL_TAB_ID, type SupportedWorkspaceApp, type TabState } from "@meru/shared/types";
 import type { WebContentsView } from "electron";
 import { accounts } from "./accounts";
@@ -21,6 +22,7 @@ export type Tab = {
   id: string;
   app: SupportedWorkspaceApp | undefined;
   title: string;
+  pinned: boolean;
   isLoading: boolean;
   navigationHistory: { canGoBack: boolean; canGoForward: boolean };
   view: WebContentsView;
@@ -37,6 +39,7 @@ export class Tabs {
       {
         id: GMAIL_TAB_ID,
         app: "gmail",
+        pinned: false,
         get title() {
           return gmail.title;
         },
@@ -81,6 +84,8 @@ export class Tabs {
   }
 
   removeTab(tabId: string) {
+    const removedTab = this.getTab(tabId);
+
     this.tabs = this.tabs.filter((tab) => tab.id !== tabId);
 
     if (this.activeTabId === tabId) {
@@ -88,6 +93,10 @@ export class Tabs {
     }
 
     this.broadcastTabsChanged();
+
+    if (removedTab?.pinned) {
+      accounts.savePinnedTabs();
+    }
   }
 
   activateTab(tabId: string) {
@@ -124,6 +133,58 @@ export class Tabs {
     }
   }
 
+  pinTab(tabId: string) {
+    const pinnableTab = this.getTab(tabId);
+
+    if (!(pinnableTab instanceof WorkspaceApp)) {
+      return;
+    }
+
+    pinnableTab.pinned = true;
+
+    this.reorderTabs();
+
+    this.broadcastTabsChanged();
+
+    accounts.savePinnedTabs();
+  }
+
+  unpinTab(tabId: string) {
+    const unpinnableTab = this.getTab(tabId);
+
+    if (!(unpinnableTab instanceof WorkspaceApp)) {
+      return;
+    }
+
+    unpinnableTab.pinned = false;
+
+    this.reorderTabs();
+
+    this.broadcastTabsChanged();
+
+    accounts.savePinnedTabs();
+  }
+
+  private reorderTabs() {
+    this.tabs = [
+      ...this.tabs.filter((tab) => tab.id === GMAIL_TAB_ID),
+      ...this.tabs.filter((tab) => tab.id !== GMAIL_TAB_ID && tab.pinned),
+      ...this.tabs.filter((tab) => tab.id !== GMAIL_TAB_ID && !tab.pinned),
+    ];
+  }
+
+  serializePinnedTabs(): PinnedTab[] {
+    const pinnedTabs: PinnedTab[] = [];
+
+    for (const tab of this.tabs) {
+      if (tab instanceof WorkspaceApp && tab.pinned && tab.app) {
+        pinnedTabs.push({ app: tab.app, url: tab.view.webContents.getURL() });
+      }
+    }
+
+    return pinnedTabs;
+  }
+
   closeAll() {
     for (const tab of this.tabs.slice()) {
       if (tab instanceof WorkspaceApp) {
@@ -137,6 +198,7 @@ export class Tabs {
       id: tab.id,
       app: tab.app,
       title: tab.title,
+      pinned: tab.pinned,
       loading: tab.isLoading,
       navigationHistory: tab.navigationHistory,
       active: tab.id === this.activeTabId,

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -323,6 +323,8 @@ export class WorkspaceApp {
 
   view: WebContentsView;
 
+  pinned = false;
+
   private powerSaveBlockerId: number | undefined;
 
   private viewDestroyed = false;

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -45,22 +45,29 @@ export function AppTabStrip() {
             variant={tab.active ? "secondary" : "ghost"}
             size={isWide ? "sm" : "icon"}
             className={
-              isWide ? cn("w-full justify-start", tab.id !== GMAIL_TAB_ID && "pr-7") : undefined
+              isWide
+                ? cn("w-full justify-start", tab.id !== GMAIL_TAB_ID && !tab.pinned && "pr-7")
+                : undefined
             }
             title={tab.title}
             onClick={() => {
               ipc.main.send("tabs.selectTab", selectedAccount.config.id, tab.id);
             }}
             onAuxClick={(event) => {
-              if (event.button === 1 && tab.id !== GMAIL_TAB_ID) {
+              if (event.button === 1 && tab.id !== GMAIL_TAB_ID && !tab.pinned) {
                 ipc.main.send("tabs.closeTab", selectedAccount.config.id, tab.id);
               }
+            }}
+            onContextMenu={(event) => {
+              event.preventDefault();
+
+              ipc.main.send("tabs.showTabContextMenu", selectedAccount.config.id, tab.id);
             }}
           >
             <TabIcon tab={tab} />
             {isWide && <span className="truncate">{tab.title}</span>}
           </Button>
-          {tab.id !== GMAIL_TAB_ID && (
+          {tab.id !== GMAIL_TAB_ID && !tab.pinned && (
             <Button
               variant="secondary"
               size="icon"

--- a/packages/shared/schemas.ts
+++ b/packages/shared/schemas.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { isValidCssColorInput } from "./color";
 import type { GmailState } from "./gmail";
+import { type SupportedWorkspaceApp, workspaceApps } from "./types";
 
 export const accountColors = [
   "orange",
@@ -20,6 +21,15 @@ export const accountColors = [
   "pink",
 ] as const;
 
+export const pinnedTabSchema = z.object({
+  app: z.custom<SupportedWorkspaceApp>(
+    (value) => typeof value === "string" && value in workspaceApps,
+  ),
+  url: z.string(),
+});
+
+export type PinnedTab = z.infer<typeof pinnedTabSchema>;
+
 export const accountConfigSchema = z.object({
   id: z.string(),
   label: z.string(),
@@ -30,6 +40,9 @@ export const accountConfigSchema = z.object({
     unreadBadge: z.boolean(),
     delegatedAccountId: z.string().nullable(),
     unifiedInbox: z.boolean(),
+  }),
+  workspaceApps: z.object({
+    pinnedTabs: z.array(pinnedTabSchema),
   }),
 });
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -97,6 +97,7 @@ export type TabState = {
   id: string;
   app: SupportedWorkspaceApp | undefined;
   title: string;
+  pinned: boolean;
   loading: boolean;
   navigationHistory: { canGoBack: boolean; canGoForward: boolean };
   active: boolean;
@@ -266,6 +267,7 @@ export type IpcMainEvents =
       ];
       "tabs.selectTab": [accountId: AccountConfig["id"], tabId: string];
       "tabs.closeTab": [accountId: AccountConfig["id"], tabId: string];
+      "tabs.showTabContextMenu": [accountId: AccountConfig["id"], tabId: string];
       "doNotDisturb.toggle": [];
       "doNotDisturb.showOptions": [];
       "downloads.toggleRecentDownloadHistoryPopup": [];


### PR DESCRIPTION
## Problem

Phase 5 (first half) of the workspace-apps-as-tabs roadmap: tabs should be pinnable like in Chrome, and a pinned tab should persist its last URL so a future startup restore (follow-up PR) can reopen it where it left off.

## Changes

- `AccountConfig` gains `workspaceApps.pinnedTabs: { app, url }[]` (`pinnedTabSchema`, app validated against the definitions map). Seeded via the pending `>3.57.0` migration plus the two account-creation sites — no value migration needed.
- `WorkspaceApp.pinned` flag, carried into `Tab`/`TabState`. `Tabs.pinTab`/`unpinTab` reorder the list to Gmail → pinned → regular (relative order preserved) and snapshot the pinned state.
- Persistence is a snapshot of live pinned tabs (`Tabs.serializePinnedTabs` → `Accounts.savePinnedTabs`), written on pin, unpin, pinned-tab close, and **on `before-quit`** — the quit-time write refreshes each pinned tab's current URL. `savePinnedTabs` is guarded by `isQuittingApp` so teardown-driven tab removal after `before-quit` can't wipe the saved state.
- Tab context menu (native `Menu.popup` via new `tabs.showTabContextMenu` IPC): Pin/Unpin Tab and Close Tab. Right-clicking the Gmail tab shows nothing (permanent).
- Strip: pinned tabs lose the hover close button and middle-click close, Chrome-style — closing a pinned tab goes through the context menu (which also removes it from the persisted list).

Deferred to the follow-up PR: restoring pinned tabs on startup as dormant entries (icon only, `WebContentsView` created on first activation). Until then the persisted list is written but not yet read.

## Verification

- `bun types:ci` passes.
- Not runtime-tested here (no display). Manual: right-click a tab → Pin — it moves under Gmail, loses the close affordances; unpin restores them; pin state and current URL land in `config.dev.json` on pin and on quit; middle-click a pinned tab does nothing; Gmail tab has no context menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)