### PR TITLE
restore pinned tabs on startup

### DIFF
--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -49,7 +49,9 @@ export class Account {
       delegatedAccountId: accountConfig.gmail.delegatedAccountId,
     });
 
-    this.tabs = new Tabs(this.gmail);
+    this.tabs = new Tabs(accountConfig.id, this.gmail);
+
+    this.tabs.restorePinnedTabs(accountConfig.workspaceApps.pinnedTabs);
   }
 
   setSpellCheckerLanguages() {

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -92,7 +92,7 @@ class Accounts {
   updateAllViewBounds() {
     for (const account of this.instances.values()) {
       for (const tab of account.tabs.tabs) {
-        tab.updateViewBounds();
+        tab.updateViewBounds?.();
       }
     }
   }
@@ -100,10 +100,14 @@ class Accounts {
   refreshSelectedAccountView() {
     const activeTab = this.getSelectedAccount().instance.tabs.activeTab;
 
+    if (!activeTab.view) {
+      return;
+    }
+
     main.window.contentView.removeChildView(activeTab.view);
     main.window.contentView.addChildView(activeTab.view);
 
-    activeTab.updateViewBounds();
+    activeTab.updateViewBounds?.();
 
     if (!appState.isSettingsOpen) {
       activeTab.view.webContents.focus();
@@ -312,7 +316,7 @@ class Accounts {
   hide() {
     for (const account of this.instances.values()) {
       for (const tab of account.tabs.tabs) {
-        tab.view.setVisible(false);
+        tab.view?.setVisible(false);
       }
     }
   }
@@ -320,7 +324,7 @@ class Accounts {
   show() {
     for (const account of this.instances.values()) {
       for (const tab of account.tabs.tabs) {
-        tab.view.setVisible(true);
+        tab.view?.setVisible(true);
       }
     }
   }

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -72,7 +72,7 @@ class Accounts {
     }
 
     for (const account of accounts) {
-      account.instance.tabs.materializeLoadOnLaunchTabs();
+      account.instance.tabs.loadLaunchTabs();
     }
 
     main.window.on("resize", () => {

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -72,7 +72,7 @@ class Accounts {
     }
 
     for (const account of accounts) {
-      account.instance.tabs.loadLaunchTabs();
+      account.instance.tabs.materializeLoadOnLaunchTabs();
     }
 
     main.window.on("resize", () => {

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -71,6 +71,10 @@ class Accounts {
       account.instance.gmail.view.webContents.setBackgroundThrottling(true);
     }
 
+    for (const account of accounts) {
+      account.instance.tabs.loadLaunchTabs();
+    }
+
     main.window.on("resize", () => {
       this.updateAllViewBounds();
     });

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -24,6 +24,7 @@ import { licenseKey } from "@/license-key";
 import { main } from "@/main";
 import { appMenu } from "@/menu";
 import { appState } from "@/state";
+import { DormantTab } from "@/tabs";
 import { WorkspaceApp } from "@/workspace-app";
 import { DoNotDisturb, doNotDisturb } from "./do-not-disturb";
 import { downloads } from "./downloads";
@@ -38,7 +39,10 @@ function getNavigationWebContents(workspaceAppId?: string) {
     return WorkspaceApp.fromId(workspaceAppId).view.webContents;
   }
 
-  return accounts.getSelectedAccount().instance.tabs.activeTab.view.webContents;
+  const selectedAccount = accounts.getSelectedAccount();
+
+  return (selectedAccount.instance.tabs.activeTab.view ?? selectedAccount.instance.gmail.view)
+    .webContents;
 }
 
 class Ipc {
@@ -152,10 +156,9 @@ class Ipc {
     });
 
     this.main.on("findInPage", (event, text, options) => {
-      const targetWebContents = (
-        WorkspaceApp.tryFromWebContents(event.sender) ??
-        accounts.getSelectedAccount().instance.tabs.activeTab
-      ).view.webContents;
+      const targetWebContents =
+        WorkspaceApp.tryFromWebContents(event.sender)?.view.webContents ??
+        getNavigationWebContents();
 
       if (!text) {
         targetWebContents.stopFindInPage("clearSelection");
@@ -241,7 +244,7 @@ class Ipc {
 
       const tab = account.instance.tabs.getTab(tabId);
 
-      if (!(tab instanceof WorkspaceApp)) {
+      if (!(tab instanceof WorkspaceApp) && !(tab instanceof DormantTab)) {
         return;
       }
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -262,6 +262,20 @@ class Ipc {
                 account.instance.tabs.pinTab(tabId);
               },
             },
+        ...(tab.pinned
+          ? [
+              {
+                label: "Load on Launch",
+                type: "checkbox" as const,
+                checked: tab.loadOnLaunch,
+                click: () => {
+                  tab.loadOnLaunch = !tab.loadOnLaunch;
+
+                  accounts.savePinnedTabs();
+                },
+              },
+            ]
+          : []),
         {
           type: "separator",
         },

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -162,7 +162,8 @@ export class AppMenu {
         }
       }
 
-      return selectedAccount.instance.tabs.activeTab.view.webContents;
+      return (selectedAccount.instance.tabs.activeTab.view ?? selectedAccount.instance.gmail.view)
+        .webContents;
     };
 
     const selectNextTab = () => {
@@ -459,7 +460,7 @@ export class AppMenu {
 
               main.window.webContents.openDevTools({ mode: "detach" });
 
-              selectedAccount.instance.tabs.activeTab.view.webContents.openDevTools();
+              getActiveViewWebContents().openDevTools();
             },
           },
         ],

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -72,8 +72,6 @@ export class Tabs {
 
   activeTabId: string = GMAIL_TAB_ID;
 
-  private suppressBroadcasts = false;
-
   constructor(accountId: string, gmail: Gmail) {
     this.accountId = accountId;
 
@@ -119,10 +117,17 @@ export class Tabs {
     return this.tabs.find((tab) => tab.id === tabId);
   }
 
-  addTab(workspaceApp: WorkspaceApp) {
+  openTab(url: string) {
+    const workspaceApp = new WorkspaceApp({
+      accountId: this.accountId,
+      url,
+    });
+
     this.tabs.push(workspaceApp);
 
     this.broadcastTabsChanged();
+
+    return workspaceApp;
   }
 
   removeTab(tabId: string) {
@@ -158,25 +163,17 @@ export class Tabs {
   }
 
   private materializeDormantTab(dormantTab: DormantTab) {
-    this.suppressBroadcasts = true;
+    const workspaceApp = new WorkspaceApp({
+      accountId: this.accountId,
+      url: dormantTab.url,
+      pinned: true,
+      loadOnLaunch: dormantTab.loadOnLaunch,
+      app: dormantTab.app,
+    });
 
-    try {
-      const workspaceApp = new WorkspaceApp({
-        accountId: this.accountId,
-        url: dormantTab.url,
-        pinned: true,
-        loadOnLaunch: dormantTab.loadOnLaunch,
-        app: dormantTab.app,
-      });
+    this.tabs.splice(this.tabs.indexOf(dormantTab), 1, workspaceApp);
 
-      this.tabs = this.tabs.filter((tab) => tab !== workspaceApp);
-
-      this.tabs.splice(this.tabs.indexOf(dormantTab), 1, workspaceApp);
-
-      return workspaceApp;
-    } finally {
-      this.suppressBroadcasts = false;
-    }
+    return workspaceApp;
   }
 
   loadLaunchTabs() {
@@ -321,7 +318,7 @@ export class Tabs {
   }
 
   private broadcastTabsChanged() {
-    if (this.suppressBroadcasts || main.window.isDestroyed()) {
+    if (main.window.isDestroyed()) {
       return;
     }
 

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -72,6 +72,8 @@ export class Tabs {
 
   activeTabId: string = GMAIL_TAB_ID;
 
+  private suppressBroadcasts = false;
+
   constructor(accountId: string, gmail: Gmail) {
     this.accountId = accountId;
 
@@ -156,19 +158,25 @@ export class Tabs {
   }
 
   private materializeDormantTab(dormantTab: DormantTab) {
-    const workspaceApp = new WorkspaceApp({
-      accountId: this.accountId,
-      url: dormantTab.url,
-      pinned: true,
-      loadOnLaunch: dormantTab.loadOnLaunch,
-      app: dormantTab.app,
-    });
+    this.suppressBroadcasts = true;
 
-    this.tabs = this.tabs.filter((tab) => tab !== workspaceApp);
+    try {
+      const workspaceApp = new WorkspaceApp({
+        accountId: this.accountId,
+        url: dormantTab.url,
+        pinned: true,
+        loadOnLaunch: dormantTab.loadOnLaunch,
+        app: dormantTab.app,
+      });
 
-    this.tabs.splice(this.tabs.indexOf(dormantTab), 1, workspaceApp);
+      this.tabs = this.tabs.filter((tab) => tab !== workspaceApp);
 
-    return workspaceApp;
+      this.tabs.splice(this.tabs.indexOf(dormantTab), 1, workspaceApp);
+
+      return workspaceApp;
+    } finally {
+      this.suppressBroadcasts = false;
+    }
   }
 
   loadLaunchTabs() {
@@ -177,6 +185,8 @@ export class Tabs {
         this.materializeDormantTab(tab);
       }
     }
+
+    this.broadcastTabsChanged();
   }
 
   restorePinnedTabs(pinnedTabs: PinnedTab[]) {
@@ -311,7 +321,7 @@ export class Tabs {
   }
 
   private broadcastTabsChanged() {
-    if (main.window.isDestroyed()) {
+    if (this.suppressBroadcasts || main.window.isDestroyed()) {
       return;
     }
 

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -49,13 +49,16 @@ export class DormantTab {
 
   navigationHistory = { canGoBack: false, canGoForward: false };
 
-  constructor(app: SupportedWorkspaceApp, url: string) {
-    this.app = app;
-    this.url = url;
+  private pageTitle: string;
+
+  constructor(pinnedTab: PinnedTab) {
+    this.app = pinnedTab.app;
+    this.url = pinnedTab.url;
+    this.pageTitle = pinnedTab.title;
   }
 
   get title() {
-    return workspaceApps[this.app].label;
+    return this.pageTitle || workspaceApps[this.app].label;
   }
 }
 
@@ -162,7 +165,7 @@ export class Tabs {
 
   restorePinnedTabs(pinnedTabs: PinnedTab[]) {
     for (const pinnedTab of pinnedTabs) {
-      this.tabs.push(new DormantTab(pinnedTab.app, pinnedTab.url));
+      this.tabs.push(new DormantTab(pinnedTab));
     }
   }
 
@@ -254,9 +257,10 @@ export class Tabs {
         pinnedTabs.push({
           app: tab.app,
           url: tab.view.webContents.getURL() || getWorkspaceAppUrl(tab.app),
+          title: tab.title,
         });
       } else if (tab instanceof DormantTab) {
-        pinnedTabs.push({ app: tab.app, url: tab.url });
+        pinnedTabs.push({ app: tab.app, url: tab.url, title: tab.title });
       }
     }
 

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -303,6 +303,7 @@ export class Tabs {
       app: tab.app,
       title: tab.title,
       pinned: tab.pinned,
+      dormant: tab instanceof DormantTab,
       loading: tab.isLoading,
       navigationHistory: tab.navigationHistory,
       active: tab.id === this.activeTabId,

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -171,7 +171,7 @@ export class Tabs {
     return workspaceApp;
   }
 
-  loadLaunchTabs() {
+  materializeLoadOnLaunchTabs() {
     for (const tab of this.tabs.slice()) {
       if (tab instanceof DormantTab && tab.loadOnLaunch) {
         this.materializeDormantTab(tab);

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -1,5 +1,12 @@
+import { randomUUID } from "node:crypto";
+import { getWorkspaceAppUrl } from "@meru/shared/google";
 import type { PinnedTab } from "@meru/shared/schemas";
-import { GMAIL_TAB_ID, type SupportedWorkspaceApp, type TabState } from "@meru/shared/types";
+import {
+  GMAIL_TAB_ID,
+  type SupportedWorkspaceApp,
+  type TabState,
+  workspaceApps,
+} from "@meru/shared/types";
 import type { WebContentsView } from "electron";
 import { accounts } from "./accounts";
 import type { Gmail } from "./gmail";
@@ -25,16 +32,43 @@ export type Tab = {
   pinned: boolean;
   isLoading: boolean;
   navigationHistory: { canGoBack: boolean; canGoForward: boolean };
-  view: WebContentsView;
-  updateViewBounds: () => void;
+  view?: WebContentsView;
+  updateViewBounds?: () => void;
 };
 
+export class DormantTab {
+  id = randomUUID();
+
+  app: SupportedWorkspaceApp;
+
+  url: string;
+
+  pinned = true;
+
+  isLoading = false;
+
+  navigationHistory = { canGoBack: false, canGoForward: false };
+
+  constructor(app: SupportedWorkspaceApp, url: string) {
+    this.app = app;
+    this.url = url;
+  }
+
+  get title() {
+    return workspaceApps[this.app].label;
+  }
+}
+
 export class Tabs {
+  private accountId: string;
+
   tabs: Tab[];
 
   activeTabId: string = GMAIL_TAB_ID;
 
-  constructor(gmail: Gmail) {
+  constructor(accountId: string, gmail: Gmail) {
+    this.accountId = accountId;
+
     this.tabs = [
       {
         id: GMAIL_TAB_ID,
@@ -100,9 +134,35 @@ export class Tabs {
   }
 
   activateTab(tabId: string) {
+    const activatedTab = this.getTab(tabId);
+
+    if (activatedTab instanceof DormantTab) {
+      const workspaceApp = new WorkspaceApp({
+        accountId: this.accountId,
+        url: activatedTab.url,
+        pinned: true,
+      });
+
+      this.tabs = this.tabs.filter((tab) => tab !== workspaceApp);
+
+      this.tabs.splice(this.tabs.indexOf(activatedTab), 1, workspaceApp);
+
+      this.activeTabId = workspaceApp.id;
+
+      this.broadcastTabsChanged();
+
+      return;
+    }
+
     this.activeTabId = tabId;
 
     this.broadcastTabsChanged();
+  }
+
+  restorePinnedTabs(pinnedTabs: PinnedTab[]) {
+    for (const pinnedTab of pinnedTabs) {
+      this.tabs.push(new DormantTab(pinnedTab.app, pinnedTab.url));
+    }
   }
 
   activateNextTab() {
@@ -130,6 +190,12 @@ export class Tabs {
 
     if (closableTab instanceof WorkspaceApp) {
       closableTab.close();
+
+      return;
+    }
+
+    if (closableTab instanceof DormantTab) {
+      this.removeTab(tabId);
     }
   }
 
@@ -151,6 +217,12 @@ export class Tabs {
 
   unpinTab(tabId: string) {
     const unpinnableTab = this.getTab(tabId);
+
+    if (unpinnableTab instanceof DormantTab) {
+      this.removeTab(tabId);
+
+      return;
+    }
 
     if (!(unpinnableTab instanceof WorkspaceApp)) {
       return;
@@ -178,7 +250,12 @@ export class Tabs {
 
     for (const tab of this.tabs) {
       if (tab instanceof WorkspaceApp && tab.pinned && tab.app) {
-        pinnedTabs.push({ app: tab.app, url: tab.view.webContents.getURL() });
+        pinnedTabs.push({
+          app: tab.app,
+          url: tab.view.webContents.getURL() || getWorkspaceAppUrl(tab.app),
+        });
+      } else if (tab instanceof DormantTab) {
+        pinnedTabs.push({ app: tab.app, url: tab.url });
       }
     }
 

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -49,12 +49,15 @@ export class DormantTab {
 
   navigationHistory = { canGoBack: false, canGoForward: false };
 
+  loadOnLaunch: boolean;
+
   private pageTitle: string;
 
   constructor(pinnedTab: PinnedTab) {
     this.app = pinnedTab.app;
     this.url = pinnedTab.url;
     this.pageTitle = pinnedTab.title;
+    this.loadOnLaunch = Boolean(pinnedTab.loadOnLaunch);
   }
 
   get title() {
@@ -140,18 +143,7 @@ export class Tabs {
     const activatedTab = this.getTab(tabId);
 
     if (activatedTab instanceof DormantTab) {
-      const workspaceApp = new WorkspaceApp({
-        accountId: this.accountId,
-        url: activatedTab.url,
-        pinned: true,
-        app: activatedTab.app,
-      });
-
-      this.tabs = this.tabs.filter((tab) => tab !== workspaceApp);
-
-      this.tabs.splice(this.tabs.indexOf(activatedTab), 1, workspaceApp);
-
-      this.activeTabId = workspaceApp.id;
+      this.activeTabId = this.materializeDormantTab(activatedTab).id;
 
       this.broadcastTabsChanged();
 
@@ -161,6 +153,30 @@ export class Tabs {
     this.activeTabId = tabId;
 
     this.broadcastTabsChanged();
+  }
+
+  private materializeDormantTab(dormantTab: DormantTab) {
+    const workspaceApp = new WorkspaceApp({
+      accountId: this.accountId,
+      url: dormantTab.url,
+      pinned: true,
+      loadOnLaunch: dormantTab.loadOnLaunch,
+      app: dormantTab.app,
+    });
+
+    this.tabs = this.tabs.filter((tab) => tab !== workspaceApp);
+
+    this.tabs.splice(this.tabs.indexOf(dormantTab), 1, workspaceApp);
+
+    return workspaceApp;
+  }
+
+  loadLaunchTabs() {
+    for (const tab of this.tabs.slice()) {
+      if (tab instanceof DormantTab && tab.loadOnLaunch) {
+        this.materializeDormantTab(tab);
+      }
+    }
   }
 
   restorePinnedTabs(pinnedTabs: PinnedTab[]) {
@@ -258,9 +274,15 @@ export class Tabs {
           app: tab.app,
           url: tab.view.webContents.getURL() || getWorkspaceAppUrl(tab.app),
           title: tab.title,
+          loadOnLaunch: tab.loadOnLaunch,
         });
       } else if (tab instanceof DormantTab) {
-        pinnedTabs.push({ app: tab.app, url: tab.url, title: tab.title });
+        pinnedTabs.push({
+          app: tab.app,
+          url: tab.url,
+          title: tab.title,
+          loadOnLaunch: tab.loadOnLaunch,
+        });
       }
     }
 

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -141,6 +141,7 @@ export class Tabs {
         accountId: this.accountId,
         url: activatedTab.url,
         pinned: true,
+        app: activatedTab.app,
       });
 
       this.tabs = this.tabs.filter((tab) => tab !== workspaceApp);

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -171,7 +171,7 @@ export class Tabs {
     return workspaceApp;
   }
 
-  materializeLoadOnLaunchTabs() {
+  loadLaunchTabs() {
     for (const tab of this.tabs.slice()) {
       if (tab instanceof DormantTab && tab.loadOnLaunch) {
         this.materializeDormantTab(tab);

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -80,6 +80,7 @@ type WorkspaceAppOptions = {
   window?: BrowserWindowConstructorOptions;
   view?: WebContentsViewConstructorOptions;
   asWindow?: boolean;
+  pinned?: boolean;
 };
 
 export class WorkspaceApp {
@@ -329,9 +330,10 @@ export class WorkspaceApp {
 
   private viewDestroyed = false;
 
-  constructor({ accountId, url, window, view, asWindow }: WorkspaceAppOptions) {
+  constructor({ accountId, url, window, view, asWindow, pinned }: WorkspaceAppOptions) {
     this.accountId = accountId;
     this.app = getWorkspaceAppFromUrl(url);
+    this.pinned = Boolean(pinned);
 
     if (asWindow) {
       this._window = this.createBrowserWindow(window);

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -81,6 +81,7 @@ type WorkspaceAppOptions = {
   view?: WebContentsViewConstructorOptions;
   asWindow?: boolean;
   pinned?: boolean;
+  app?: SupportedWorkspaceApp;
 };
 
 export class WorkspaceApp {
@@ -330,9 +331,9 @@ export class WorkspaceApp {
 
   private viewDestroyed = false;
 
-  constructor({ accountId, url, window, view, asWindow, pinned }: WorkspaceAppOptions) {
+  constructor({ accountId, url, window, view, asWindow, pinned, app }: WorkspaceAppOptions) {
     this.accountId = accountId;
-    this.app = getWorkspaceAppFromUrl(url);
+    this.app = app ?? getWorkspaceAppFromUrl(url);
     this.pinned = Boolean(pinned);
 
     if (asWindow) {

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -241,13 +241,12 @@ export class WorkspaceApp {
         return { action: "deny" };
       }
 
-      const workspaceApp = new WorkspaceApp({
-        accountId,
-        url,
-      });
+      const account = accounts.getAccount(accountId);
+
+      const workspaceApp = account.instance.tabs.openTab(url);
 
       if (openBehavior === "tab") {
-        accounts.getAccount(accountId).instance.tabs.activateTab(workspaceApp.id);
+        account.instance.tabs.activateTab(workspaceApp.id);
 
         accounts.selectAccount(accountId);
 
@@ -390,8 +389,6 @@ export class WorkspaceApp {
       if (appState.isSettingsOpen) {
         this.view.setVisible(false);
       }
-
-      this.account.instance.tabs.addTab(this);
     }
 
     this.setupApp();

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -81,6 +81,7 @@ type WorkspaceAppOptions = {
   view?: WebContentsViewConstructorOptions;
   asWindow?: boolean;
   pinned?: boolean;
+  loadOnLaunch?: boolean;
   app?: SupportedWorkspaceApp;
 };
 
@@ -327,14 +328,26 @@ export class WorkspaceApp {
 
   pinned = false;
 
+  loadOnLaunch = false;
+
   private powerSaveBlockerId: number | undefined;
 
   private viewDestroyed = false;
 
-  constructor({ accountId, url, window, view, asWindow, pinned, app }: WorkspaceAppOptions) {
+  constructor({
+    accountId,
+    url,
+    window,
+    view,
+    asWindow,
+    pinned,
+    loadOnLaunch,
+    app,
+  }: WorkspaceAppOptions) {
     this.accountId = accountId;
     this.app = app ?? getWorkspaceAppFromUrl(url);
     this.pinned = Boolean(pinned);
+    this.loadOnLaunch = Boolean(loadOnLaunch);
 
     if (asWindow) {
       this._window = this.createBrowserWindow(window);

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -4,7 +4,7 @@ import { GMAIL_TAB_ID, getTabStripWidth, type TabState } from "@meru/shared/type
 import { Button } from "@meru/ui/components/button";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { cn } from "@meru/ui/lib/utils";
-import { CircleDashedIcon, GlobeIcon, XIcon } from "lucide-react";
+import { GlobeIcon, XIcon } from "lucide-react";
 import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
 
 function TabIcon({ tab }: { tab: TabState }) {
@@ -44,14 +44,11 @@ export function AppTabStrip() {
           <Button
             variant={tab.active ? "secondary" : "ghost"}
             size={isWide ? "sm" : "icon"}
-            className={
-              isWide
-                ? cn(
-                    "w-full justify-start",
-                    ((tab.id !== GMAIL_TAB_ID && !tab.pinned) || tab.dormant) && "pr-7",
-                  )
-                : undefined
-            }
+            className={cn(
+              tab.dormant && "opacity-50",
+              isWide && "w-full justify-start",
+              isWide && tab.id !== GMAIL_TAB_ID && !tab.pinned && "pr-7",
+            )}
             title={tab.title}
             onClick={() => {
               ipc.main.send("tabs.selectTab", selectedAccount.config.id, tab.id);
@@ -70,14 +67,6 @@ export function AppTabStrip() {
             <TabIcon tab={tab} />
             {isWide && <span className="truncate">{tab.title}</span>}
           </Button>
-          {tab.dormant && (
-            <CircleDashedIcon
-              className={cn(
-                "absolute text-muted-foreground",
-                isWide ? "top-1/2 right-2 size-3.5 -translate-y-1/2" : "-top-1 -right-1 size-3.5",
-              )}
-            />
-          )}
           {tab.id !== GMAIL_TAB_ID && !tab.pinned && (
             <Button
               variant="secondary"

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -4,7 +4,7 @@ import { GMAIL_TAB_ID, getTabStripWidth, type TabState } from "@meru/shared/type
 import { Button } from "@meru/ui/components/button";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { cn } from "@meru/ui/lib/utils";
-import { GlobeIcon, XIcon } from "lucide-react";
+import { CircleDashedIcon, GlobeIcon, XIcon } from "lucide-react";
 import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
 
 function TabIcon({ tab }: { tab: TabState }) {
@@ -46,7 +46,10 @@ export function AppTabStrip() {
             size={isWide ? "sm" : "icon"}
             className={
               isWide
-                ? cn("w-full justify-start", tab.id !== GMAIL_TAB_ID && !tab.pinned && "pr-7")
+                ? cn(
+                    "w-full justify-start",
+                    ((tab.id !== GMAIL_TAB_ID && !tab.pinned) || tab.dormant) && "pr-7",
+                  )
                 : undefined
             }
             title={tab.title}
@@ -67,6 +70,14 @@ export function AppTabStrip() {
             <TabIcon tab={tab} />
             {isWide && <span className="truncate">{tab.title}</span>}
           </Button>
+          {tab.dormant && (
+            <CircleDashedIcon
+              className={cn(
+                "absolute text-muted-foreground",
+                isWide ? "top-1/2 right-2 size-3.5 -translate-y-1/2" : "-top-1 -right-1 size-3.5",
+              )}
+            />
+          )}
           {tab.id !== GMAIL_TAB_ID && !tab.pinned && (
             <Button
               variant="secondary"

--- a/packages/shared/schemas.ts
+++ b/packages/shared/schemas.ts
@@ -27,6 +27,7 @@ export const pinnedTabSchema = z.object({
   ),
   url: z.string(),
   title: z.string(),
+  loadOnLaunch: z.boolean(),
 });
 
 export type PinnedTab = z.infer<typeof pinnedTabSchema>;

--- a/packages/shared/schemas.ts
+++ b/packages/shared/schemas.ts
@@ -26,6 +26,7 @@ export const pinnedTabSchema = z.object({
     (value) => typeof value === "string" && value in workspaceApps,
   ),
   url: z.string(),
+  title: z.string(),
 });
 
 export type PinnedTab = z.infer<typeof pinnedTabSchema>;

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -98,6 +98,7 @@ export type TabState = {
   app: SupportedWorkspaceApp | undefined;
   title: string;
   pinned: boolean;
+  dormant: boolean;
   loading: boolean;
   navigationHistory: { canGoBack: boolean; canGoForward: boolean };
   active: boolean;


### PR DESCRIPTION
## Problem

Second half of phase 5 (building on #644): the persisted pinned tabs (`workspaceApps.pinnedTabs` with each tab's last URL) were written but never read — a restart lost the pinned tabs.

## Changes

- New `DormantTab` in `tabs.ts`: a view-less pinned tab entry (id, app, stored url, label as title). On startup each account's persisted pinned tabs are restored as dormant entries after the Gmail tab — icon and label in the strip, but no `WebContentsView` and no resource cost.
- **Lazy materialization**: activating a dormant tab (click, Ctrl+Tab cycling) constructs the embedded `WorkspaceApp` with the stored URL and `pinned: true`, replacing the dormant entry *in place* so the pinned order is preserved; the tab becomes fully live from that moment.
- The `Tab` shape's `view`/`updateViewBounds` become optional: `hide`/`show`/bounds iteration skip view-less entries, `refreshSelectedAccountView` guards, and the active-view resolutions in the menu and IPC fall back to the Gmail view (a dormant tab can never actually be active — activation materializes first — so the fallbacks are type-safety, not reachable behavior).
- Dormant tabs participate in `serializePinnedTabs` with their stored URL (an unopened pinned tab survives further restarts unchanged), get the same context menu (Unpin/Close both discard the entry), and a live pinned tab with a not-yet-loaded view now persists its app URL as fallback instead of an empty string.
- `Tabs` regained its `accountId` (needed to construct the materialized instance).
- Roundtrip hardening: materialization passes the stored `app` into the `WorkspaceApp` constructor (`app ?? getWorkspaceAppFromUrl(url)`) instead of re-deriving it from the URL — a pinned tab whose last URL was an off-app page (auth interstitial, usercontent viewer) previously materialized with `app: undefined` and would then silently drop from persistence on the next quit.

Follow-up commits on review feedback:

- **Page titles persist**: `pinnedTabs` entries carry `title`; dormant tabs show the last page title (falling back to the app label) instead of just the label.
- **Load on Launch**: per-pinned-tab checkbox in the tab context menu (default off, persisted as `loadOnLaunch`). Enabled tabs are materialized eagerly during `createViews()` right after the Gmail views, so they load with the app instead of on first click.
- **Dormant indicator**: unloaded pinned tabs are dimmed (`opacity-50`), the convention Edge sleeping tabs and Vivaldi hibernated tabs use — an earlier badge-icon approach was tried and replaced. `TabState` gains a `dormant` flag.
- The stored `app` stays authoritative on materialization (not re-derived from the URL): the persisted URL can be an off-app page at quit time, and inferring from it would degrade and eventually drop the pin.

**Materialization flicker fix**: activating a dormant tab briefly flashed the strip wide with a phantom duplicate tab — the `WorkspaceApp` constructor self-registered into the tabs collection mid-materialization, exposing an inconsistent intermediate list. Fixed by ownership inversion rather than broadcast suppression (a flag was tried and replaced — it silently drops legitimate notifications): the constructor no longer inserts itself; `Tabs.openTab(url)` constructs and inserts atomically (the only ergonomic path, so call sites cannot forget), and materialization splices the new instance directly into the dormant slot — no intermediate state exists even in principle.

## Verification

- `bun types:ci` passes.
- Not runtime-tested here (no display). Manual: pin a Docs tab, navigate somewhere in it, quit, relaunch → the tab appears pinned under Gmail with its last page title and the dashed dormant indicator; clicking it loads the last URL and the indicator disappears; enable Load on Launch via right-click, relaunch → the tab is live immediately; restart without ever clicking it → still there; unpin or close a dormant tab → gone and removed from config; strip width/duplicate detection counts dormant tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



