### PR TITLE
rename pinned apps to bookmarked apps

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -95,7 +95,7 @@ export const config = new Store<Config>({
     "workspaceApps.openInApp": true,
     "workspaceApps.openInAppExcludedApps": [],
     "workspaceApps.openBehavior": "tab",
-    "workspaceApps.pinnedApps": [],
+    "workspaceApps.bookmarkedApps": [],
     "workspaceApps.showAccountColor": true,
     "workspaceApps.showAccountLabel": true,
     "verificationCodes.autoCopy": false,
@@ -322,7 +322,7 @@ export const config = new Store<Config>({
         ["googleApps.openInApp", "workspaceApps.openInApp"],
         ["googleApps.openInAppExcludedApps", "workspaceApps.openInAppExcludedApps"],
         ["googleApps.openAppsInNewWindow", "workspaceApps.openAppsInNewWindow"],
-        ["googleApps.pinnedApps", "workspaceApps.pinnedApps"],
+        ["googleApps.pinnedApps", "workspaceApps.bookmarkedApps"],
         ["googleApps.showAccountColor", "workspaceApps.showAccountColor"],
         ["googleApps.showAccountLabel", "workspaceApps.showAccountLabel"],
         ["notifications.allowFromGoogleApps", "notifications.allowFromWorkspaceApps"],
@@ -343,6 +343,17 @@ export const config = new Store<Config>({
 
       // @ts-expect-error: `workspaceApps.openAppsInNewWindow` was removed
       store.delete("workspaceApps.openAppsInNewWindow");
+
+      // @ts-expect-error: `workspaceApps.pinnedApps` is now 'workspaceApps.bookmarkedApps'
+      const pinnedApps = store.get("workspaceApps.pinnedApps");
+
+      if (typeof pinnedApps !== "undefined") {
+        // @ts-expect-error
+        store.set("workspaceApps.bookmarkedApps", pinnedApps);
+
+        // @ts-expect-error
+        store.delete("workspaceApps.pinnedApps");
+      }
 
       const accounts = store.get("accounts");
 

--- a/packages/renderer-main/components/app-titlebar.tsx
+++ b/packages/renderer-main/components/app-titlebar.tsx
@@ -2,7 +2,7 @@ import { accountColorsMap } from "@meru/shared/accounts";
 import { WEBSITE_URL } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
 import { useConfig } from "@meru/shared/renderer/react-query";
-import { pinnableWorkspaceApps } from "@meru/shared/types";
+import { bookmarkableWorkspaceApps } from "@meru/shared/types";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import { FindInPage as UiFindInPage } from "@meru/ui/components/find-in-page";
@@ -141,18 +141,18 @@ function DoNotDisturb() {
   );
 }
 
-function PinnedWorkspaceApps() {
+function BookmarkedWorkspaceApps() {
   const { config } = useConfig();
 
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
-  if (!config || !isLicenseKeyValid || config["workspaceApps.pinnedApps"].length === 0) {
+  if (!config || !isLicenseKeyValid || config["workspaceApps.bookmarkedApps"].length === 0) {
     return;
   }
 
   return (
     <div className="flex gap-2 border-r pr-2 not-first:border-l not-first:pl-2">
-      {config["workspaceApps.pinnedApps"].map((app) => (
+      {config["workspaceApps.bookmarkedApps"].map((app) => (
         <TitlebarIconButton
           key={app}
           onClick={(event) => {
@@ -166,7 +166,7 @@ function PinnedWorkspaceApps() {
                   : "foreground-tab",
             );
           }}
-          title={pinnableWorkspaceApps[app]}
+          title={bookmarkableWorkspaceApps[app]}
         >
           <WorkspaceAppIcon app={app} />
         </TitlebarIconButton>
@@ -378,7 +378,7 @@ export function AppTitlebar() {
           <div className="flex gap-2">
             <Trial />
             <FindInPage />
-            <PinnedWorkspaceApps />
+            <BookmarkedWorkspaceApps />
             <RecentDownloadHistoryButton />
             <DoNotDisturb />
           </div>

--- a/packages/renderer-main/routes/settings/workspace-apps.tsx
+++ b/packages/renderer-main/routes/settings/workspace-apps.tsx
@@ -4,8 +4,8 @@ import { useSortable } from "@dnd-kit/react/sortable";
 import { useConfig, useConfigMutation } from "@meru/shared/renderer/react-query";
 import { platform } from "@meru/shared/renderer/utils";
 import {
-  type PinnableWorkspaceApp,
-  pinnableWorkspaceApps,
+  type BookmarkableWorkspaceApp,
+  bookmarkableWorkspaceApps,
   type SupportedWorkspaceApp,
   workspaceAppOpenBehaviors,
   workspaceApps,
@@ -37,15 +37,15 @@ import { LicenseKeyRequiredFieldBadge } from "@/components/license-key-required-
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 
-function SortablePinnedAppItem({
+function SortableBookmarkedAppItem({
   app,
   index,
-  onUnpin,
+  onRemove,
   disabled,
 }: {
-  app: PinnableWorkspaceApp;
+  app: BookmarkableWorkspaceApp;
   index: number;
-  onUnpin: () => void;
+  onRemove: () => void;
   disabled: boolean;
 }) {
   const { ref, handleRef, isDragging } = useSortable({ id: app, index, disabled });
@@ -58,18 +58,18 @@ function SortablePinnedAppItem({
         size="xs"
         className="cursor-grab touch-none"
         disabled={disabled}
-        aria-label={`Drag ${pinnableWorkspaceApps[app]} to reorder`}
+        aria-label={`Drag ${bookmarkableWorkspaceApps[app]} to reorder`}
       >
         <GripVerticalIcon />
         <WorkspaceAppIcon app={app} className="size-3.5" />
-        {pinnableWorkspaceApps[app]}
+        {bookmarkableWorkspaceApps[app]}
       </Button>
       <Button
         variant="outline"
         size="icon-xs"
-        onClick={onUnpin}
+        onClick={onRemove}
         disabled={disabled}
-        aria-label={`Unpin ${pinnableWorkspaceApps[app]}`}
+        aria-label={`Remove ${bookmarkableWorkspaceApps[app]} bookmark`}
       >
         <XIcon />
       </Button>
@@ -88,11 +88,11 @@ export function WorkspaceAppsSettings() {
     return;
   }
 
-  const pinnedApps = config["workspaceApps.pinnedApps"];
+  const bookmarkedApps = config["workspaceApps.bookmarkedApps"];
 
-  const availableApps = (Object.keys(pinnableWorkspaceApps) as PinnableWorkspaceApp[]).filter(
-    (app) => !pinnedApps.includes(app),
-  );
+  const availableApps = (
+    Object.keys(bookmarkableWorkspaceApps) as BookmarkableWorkspaceApp[]
+  ).filter((app) => !bookmarkedApps.includes(app));
 
   const excludedApps = config["workspaceApps.openInAppExcludedApps"];
 
@@ -209,19 +209,19 @@ export function WorkspaceAppsSettings() {
           <Field>
             <FieldContent>
               <FieldLabel className="flex items-center gap-2">
-                Pinned Apps
+                Bookmarked Apps
                 {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
               </FieldLabel>
               <FieldDescription>
-                Pin Workspace Apps to the titlebar and drag to reorder.
+                Bookmark Workspace Apps to the titlebar and drag to reorder.
               </FieldDescription>
             </FieldContent>
             <div className="flex flex-col gap-4">
               <div className="flex flex-col gap-2">
-                <div className="text-xs font-medium text-muted-foreground">Pinned</div>
-                {pinnedApps.length === 0 ? (
+                <div className="text-xs font-medium text-muted-foreground">Bookmarked</div>
+                {bookmarkedApps.length === 0 ? (
                   <p className="rounded-lg border border-dashed px-3 py-4 text-center text-sm text-muted-foreground">
-                    No pinned apps. Add apps from Available below.
+                    No bookmarked apps. Add apps from Available below.
                   </p>
                 ) : (
                   <DragDropProvider
@@ -231,19 +231,19 @@ export function WorkspaceAppsSettings() {
                       }
 
                       configMutation.mutate({
-                        "workspaceApps.pinnedApps": move(pinnedApps, event),
+                        "workspaceApps.bookmarkedApps": move(bookmarkedApps, event),
                       });
                     }}
                   >
                     <div className="flex flex-row flex-wrap gap-2">
-                      {pinnedApps.map((app, index) => (
-                        <SortablePinnedAppItem
+                      {bookmarkedApps.map((app, index) => (
+                        <SortableBookmarkedAppItem
                           key={app}
                           app={app}
                           index={index}
-                          onUnpin={() => {
+                          onRemove={() => {
                             configMutation.mutate({
-                              "workspaceApps.pinnedApps": pinnedApps.filter(
+                              "workspaceApps.bookmarkedApps": bookmarkedApps.filter(
                                 (value) => value !== app,
                               ),
                             });
@@ -266,14 +266,14 @@ export function WorkspaceAppsSettings() {
                         size="xs"
                         onClick={() => {
                           configMutation.mutate({
-                            "workspaceApps.pinnedApps": [...pinnedApps, app],
+                            "workspaceApps.bookmarkedApps": [...bookmarkedApps, app],
                           });
                         }}
                         disabled={!isLicenseKeyValid}
-                        aria-label={`Pin ${pinnableWorkspaceApps[app]}`}
+                        aria-label={`Bookmark ${bookmarkableWorkspaceApps[app]}`}
                       >
                         <WorkspaceAppIcon app={app} className="size-3.5" />
-                        {pinnableWorkspaceApps[app]}
+                        {bookmarkableWorkspaceApps[app]}
                         <PlusIcon />
                       </Button>
                     ))}

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -37,7 +37,7 @@ export type NotificationTime = {
 type WorkspaceAppDefinition = {
   label: string;
   url?: string;
-  pinnable?: boolean;
+  bookmarkable?: boolean;
   alwaysOpenAsWindow?: boolean;
   singleInstance?: boolean;
 };
@@ -51,11 +51,11 @@ const workspaceAppDefinitions = {
   drive: { label: "Drive" },
   forms: { label: "Forms" },
   gemini: { label: "Gemini" },
-  gmail: { label: "Gmail", url: GMAIL_URL, pinnable: false, singleInstance: true },
+  gmail: { label: "Gmail", url: GMAIL_URL, bookmarkable: false, singleInstance: true },
   groups: { label: "Groups" },
   keep: { label: "Keep" },
   meet: { label: "Meet" },
-  myaccount: { label: "My Account", pinnable: false, alwaysOpenAsWindow: true },
+  myaccount: { label: "My Account", bookmarkable: false, alwaysOpenAsWindow: true },
   notebooklm: { label: "NotebookLM" },
   sheets: { label: "Sheets" },
   sites: { label: "Sites" },
@@ -66,8 +66,10 @@ const workspaceAppDefinitions = {
 
 export type SupportedWorkspaceApp = keyof typeof workspaceAppDefinitions;
 
-export type PinnableWorkspaceApp = {
-  [App in SupportedWorkspaceApp]: (typeof workspaceAppDefinitions)[App] extends { pinnable: false }
+export type BookmarkableWorkspaceApp = {
+  [App in SupportedWorkspaceApp]: (typeof workspaceAppDefinitions)[App] extends {
+    bookmarkable: false;
+  }
     ? never
     : App;
 }[SupportedWorkspaceApp];
@@ -75,11 +77,11 @@ export type PinnableWorkspaceApp = {
 export const workspaceApps: Record<SupportedWorkspaceApp, WorkspaceAppDefinition> =
   workspaceAppDefinitions;
 
-export const pinnableWorkspaceApps = Object.fromEntries(
+export const bookmarkableWorkspaceApps = Object.fromEntries(
   Object.entries(workspaceApps)
-    .filter(([, workspaceAppDefinition]) => workspaceAppDefinition.pinnable !== false)
+    .filter(([, workspaceAppDefinition]) => workspaceAppDefinition.bookmarkable !== false)
     .map(([workspaceApp, workspaceAppDefinition]) => [workspaceApp, workspaceAppDefinition.label]),
-) as Record<PinnableWorkspaceApp, string>;
+) as Record<BookmarkableWorkspaceApp, string>;
 
 export type WorkspaceAppOpenDisposition = "foreground-tab" | "background-tab" | "new-window";
 
@@ -213,7 +215,7 @@ export type Config = {
   "workspaceApps.openInApp": boolean;
   "workspaceApps.openInAppExcludedApps": SupportedWorkspaceApp[];
   "workspaceApps.openBehavior": WorkspaceAppOpenBehavior;
-  "workspaceApps.pinnedApps": PinnableWorkspaceApp[];
+  "workspaceApps.bookmarkedApps": BookmarkableWorkspaceApp[];
   "workspaceApps.showAccountColor": boolean;
   "workspaceApps.showAccountLabel": boolean;
   "verificationCodes.autoCopy": boolean;
@@ -263,7 +265,7 @@ export type IpcMainEvents =
       "theme.setTheme": [theme: "system" | "light" | "dark"];
       "notifications.showTestNotification": [];
       "workspaceApps.openApp": [
-        app: PinnableWorkspaceApp,
+        app: BookmarkableWorkspaceApp,
         disposition?: WorkspaceAppOpenDisposition,
       ];
       "tabs.selectTab": [accountId: AccountConfig["id"], tabId: string];


### PR DESCRIPTION
## Problem

With pinned tabs shipped (#644/#645), "pinned" meant two different things: pinned *tabs* (persistent tabs in the strip) and the titlebar launcher's pinned/pinnable *apps*. The launcher domain moves to bookmark terminology so "pinned" refers exclusively to tabs.

## Changes

- Definitions map: the `pinnable` capability flag → `bookmarkable`; derived `PinnableWorkspaceApp` → `BookmarkableWorkspaceApp`, `pinnableWorkspaceApps` → `bookmarkableWorkspaceApps`.
- Config: `workspaceApps.pinnedApps` → `workspaceApps.bookmarkedApps`. Value-carrying migration in the pending `>3.57.0` entry: the `googleApps.pinnedApps` rename tuple now targets `bookmarkedApps` directly (for users upgrading from the released 3.57.0), and a second hop moves any existing `workspaceApps.pinnedApps` (unreleased installs created after the googleApps rename) — the hop runs after the tuple loop so a more recent value wins.
- UI follows: titlebar `PinnedWorkspaceApps` → `BookmarkedWorkspaceApps`; settings section "Pinned Apps" → "Bookmarked Apps" (`SortableBookmarkedAppItem`, `onRemove`, bookmark-phrased aria labels and empty state).
- Untouched by design: everything `pinnedTabs`/`pinned`-flag related (that *is* tab pinning), and `workspaceApps.openApp` behavior.

## Verification

- `bun types:ci` passes; no stale `Pinnable`/`pinnedApps` references remain outside the migration.
- Not runtime-tested here (no display). Manual: settings show "Bookmarked Apps" with existing entries carried over; titlebar launcher unchanged; tab pinning unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)