### PR TITLE
open bookmarked apps from a new tab menu in the tab strip

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -44,9 +44,7 @@ class Accounts {
     });
 
     config.onDidChange("workspaceApps.bookmarkedApps", () => {
-      for (const account of accounts.instances.values()) {
-        account.tabs.syncBookmarkTabs();
-      }
+      accounts.updateAllViewBounds();
     });
   }
 
@@ -96,7 +94,10 @@ class Accounts {
   }
 
   getTabStripWidth() {
-    return getTabStripWidth(this.getSelectedAccount().instance.tabs.serialize());
+    return getTabStripWidth(
+      this.getSelectedAccount().instance.tabs.serialize(),
+      config.get("workspaceApps.bookmarkedApps").length > 0,
+    );
   }
 
   updateAllViewBounds() {

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -42,6 +42,12 @@ class Accounts {
         account.gmail.applyLabelColors();
       }
     });
+
+    config.onDidChange("workspaceApps.bookmarkedApps", () => {
+      for (const account of accounts.instances.values()) {
+        account.tabs.syncBookmarkTabs();
+      }
+    });
   }
 
   async createViews() {

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 import { IpcEmitter, IpcListener } from "@electron-toolkit/typed-ipc/main";
 import { MAX_RECENT_DOWNLOAD_HISTORY_ITEMS } from "@meru/shared/constants";
-import { getWorkspaceAppUrl } from "@meru/shared/google";
 import type { IpcMainEvents, IpcRendererEvent } from "@meru/shared/types";
 import {
   app,
@@ -386,19 +385,6 @@ class Ipc {
         title: "Tim from Meru",
         subtitle: "Your Test Notification Request",
         body: "This is a test notification to show how notifications will appear.",
-      });
-    });
-
-    ipc.main.on("workspaceApps.openApp", (_event, app, disposition) => {
-      const selectedAccount = accounts.getSelectedAccount();
-
-      WorkspaceApp.handleWindowOpen({
-        accountId: selectedAccount.config.id,
-        details: {
-          url: getWorkspaceAppUrl(app),
-          disposition: disposition ?? "foreground-tab",
-        },
-        webContents: selectedAccount.instance.gmail.view.webContents,
       });
     });
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { IpcEmitter, IpcListener } from "@electron-toolkit/typed-ipc/main";
 import { MAX_RECENT_DOWNLOAD_HISTORY_ITEMS } from "@meru/shared/constants";
+import { getWorkspaceAppUrl } from "@meru/shared/google";
 import type { IpcMainEvents, IpcRendererEvent } from "@meru/shared/types";
 import {
   app,
@@ -386,6 +387,20 @@ class Ipc {
         subtitle: "Your Test Notification Request",
         body: "This is a test notification to show how notifications will appear.",
       });
+    });
+
+    ipc.main.on("workspaceApps.openApp", (_event, app) => {
+      if (!licenseKey.isValid) {
+        return;
+      }
+
+      const selectedAccount = accounts.getSelectedAccount();
+
+      const workspaceApp = selectedAccount.instance.tabs.openTab(getWorkspaceAppUrl(app));
+
+      selectedAccount.instance.tabs.activateTab(workspaceApp.id);
+
+      accounts.refreshSelectedAccountView();
     });
 
     ipc.main.on("doNotDisturb.toggle", () => {

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { getWorkspaceAppUrl } from "@meru/shared/google";
 import type { PinnedTab } from "@meru/shared/schemas";
 import {
+  type BookmarkableWorkspaceApp,
   GMAIL_TAB_ID,
   type SupportedWorkspaceApp,
   type TabState,
@@ -9,6 +10,7 @@ import {
 } from "@meru/shared/types";
 import type { WebContentsView } from "electron";
 import { accounts } from "./accounts";
+import { config } from "./config";
 import type { Gmail } from "./gmail";
 import { main } from "./main";
 import { WorkspaceApp } from "./workspace-app";
@@ -35,6 +37,26 @@ export type Tab = {
   view?: WebContentsView;
   updateViewBounds?: () => void;
 };
+
+export class BookmarkTab {
+  id = randomUUID();
+
+  app: BookmarkableWorkspaceApp;
+
+  pinned = false;
+
+  isLoading = false;
+
+  navigationHistory = { canGoBack: false, canGoForward: false };
+
+  constructor(app: BookmarkableWorkspaceApp) {
+    this.app = app;
+  }
+
+  get title() {
+    return workspaceApps[this.app].label;
+  }
+}
 
 export class DormantTab {
   id = randomUUID();
@@ -70,10 +92,16 @@ export class Tabs {
 
   tabs: Tab[];
 
+  private bookmarkTabs: BookmarkTab[];
+
   activeTabId: string = GMAIL_TAB_ID;
 
   constructor(accountId: string, gmail: Gmail) {
     this.accountId = accountId;
+
+    this.bookmarkTabs = config
+      .get("workspaceApps.bookmarkedApps")
+      .map((bookmarkedApp) => new BookmarkTab(bookmarkedApp));
 
     this.tabs = [
       {
@@ -113,8 +141,29 @@ export class Tabs {
     return activeTab;
   }
 
-  getTab(tabId: string) {
-    return this.tabs.find((tab) => tab.id === tabId);
+  getTab(tabId: string): Tab | undefined {
+    return (
+      this.tabs.find((tab) => tab.id === tabId) ??
+      this.bookmarkTabs.find((bookmarkTab) => bookmarkTab.id === tabId)
+    );
+  }
+
+  private get visibleBookmarkTabs() {
+    return this.bookmarkTabs.filter(
+      (bookmarkTab) => !this.tabs.some((tab) => tab.app === bookmarkTab.app),
+    );
+  }
+
+  syncBookmarkTabs() {
+    this.bookmarkTabs = config
+      .get("workspaceApps.bookmarkedApps")
+      .map(
+        (bookmarkedApp) =>
+          this.bookmarkTabs.find((bookmarkTab) => bookmarkTab.app === bookmarkedApp) ??
+          new BookmarkTab(bookmarkedApp),
+      );
+
+    this.broadcastTabsChanged();
   }
 
   openTab(url: string) {
@@ -157,9 +206,37 @@ export class Tabs {
       return;
     }
 
+    if (activatedTab instanceof BookmarkTab) {
+      this.activeTabId = this.materializeBookmarkTab(activatedTab).id;
+
+      this.broadcastTabsChanged();
+
+      return;
+    }
+
     this.activeTabId = tabId;
 
     this.broadcastTabsChanged();
+  }
+
+  private materializeBookmarkTab(bookmarkTab: BookmarkTab) {
+    const workspaceApp = new WorkspaceApp({
+      accountId: this.accountId,
+      url: getWorkspaceAppUrl(bookmarkTab.app),
+      app: bookmarkTab.app,
+    });
+
+    const firstUnpinnedTabIndex = this.tabs.findIndex(
+      (tab) => tab.id !== GMAIL_TAB_ID && !tab.pinned,
+    );
+
+    this.tabs.splice(
+      firstUnpinnedTabIndex === -1 ? this.tabs.length : firstUnpinnedTabIndex,
+      0,
+      workspaceApp,
+    );
+
+    return workspaceApp;
   }
 
   private materializeDormantTab(dormantTab: DormantTab) {
@@ -305,12 +382,13 @@ export class Tabs {
   }
 
   serialize(): TabState[] {
-    return this.tabs.map((tab) => ({
+    return [...this.tabs, ...this.visibleBookmarkTabs].map((tab) => ({
       id: tab.id,
       app: tab.app,
       title: tab.title,
       pinned: tab.pinned,
-      dormant: tab instanceof DormantTab,
+      dormant: tab instanceof DormantTab || tab instanceof BookmarkTab,
+      bookmark: tab instanceof BookmarkTab,
       loading: tab.isLoading,
       navigationHistory: tab.navigationHistory,
       active: tab.id === this.activeTabId,

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 import { getWorkspaceAppUrl } from "@meru/shared/google";
 import type { PinnedTab } from "@meru/shared/schemas";
 import {
-  type BookmarkableWorkspaceApp,
   GMAIL_TAB_ID,
   type SupportedWorkspaceApp,
   type TabState,
@@ -10,7 +9,6 @@ import {
 } from "@meru/shared/types";
 import type { WebContentsView } from "electron";
 import { accounts } from "./accounts";
-import { config } from "./config";
 import type { Gmail } from "./gmail";
 import { main } from "./main";
 import { WorkspaceApp } from "./workspace-app";
@@ -37,26 +35,6 @@ export type Tab = {
   view?: WebContentsView;
   updateViewBounds?: () => void;
 };
-
-export class BookmarkTab {
-  id = randomUUID();
-
-  app: BookmarkableWorkspaceApp;
-
-  pinned = false;
-
-  isLoading = false;
-
-  navigationHistory = { canGoBack: false, canGoForward: false };
-
-  constructor(app: BookmarkableWorkspaceApp) {
-    this.app = app;
-  }
-
-  get title() {
-    return workspaceApps[this.app].label;
-  }
-}
 
 export class DormantTab {
   id = randomUUID();
@@ -92,16 +70,10 @@ export class Tabs {
 
   tabs: Tab[];
 
-  private bookmarkTabs: BookmarkTab[];
-
   activeTabId: string = GMAIL_TAB_ID;
 
   constructor(accountId: string, gmail: Gmail) {
     this.accountId = accountId;
-
-    this.bookmarkTabs = config
-      .get("workspaceApps.bookmarkedApps")
-      .map((bookmarkedApp) => new BookmarkTab(bookmarkedApp));
 
     this.tabs = [
       {
@@ -141,29 +113,8 @@ export class Tabs {
     return activeTab;
   }
 
-  getTab(tabId: string): Tab | undefined {
-    return (
-      this.tabs.find((tab) => tab.id === tabId) ??
-      this.bookmarkTabs.find((bookmarkTab) => bookmarkTab.id === tabId)
-    );
-  }
-
-  private get visibleBookmarkTabs() {
-    return this.bookmarkTabs.filter(
-      (bookmarkTab) => !this.tabs.some((tab) => tab.app === bookmarkTab.app),
-    );
-  }
-
-  syncBookmarkTabs() {
-    this.bookmarkTabs = config
-      .get("workspaceApps.bookmarkedApps")
-      .map(
-        (bookmarkedApp) =>
-          this.bookmarkTabs.find((bookmarkTab) => bookmarkTab.app === bookmarkedApp) ??
-          new BookmarkTab(bookmarkedApp),
-      );
-
-    this.broadcastTabsChanged();
+  getTab(tabId: string) {
+    return this.tabs.find((tab) => tab.id === tabId);
   }
 
   openTab(url: string) {
@@ -206,37 +157,9 @@ export class Tabs {
       return;
     }
 
-    if (activatedTab instanceof BookmarkTab) {
-      this.activeTabId = this.materializeBookmarkTab(activatedTab).id;
-
-      this.broadcastTabsChanged();
-
-      return;
-    }
-
     this.activeTabId = tabId;
 
     this.broadcastTabsChanged();
-  }
-
-  private materializeBookmarkTab(bookmarkTab: BookmarkTab) {
-    const workspaceApp = new WorkspaceApp({
-      accountId: this.accountId,
-      url: getWorkspaceAppUrl(bookmarkTab.app),
-      app: bookmarkTab.app,
-    });
-
-    const firstUnpinnedTabIndex = this.tabs.findIndex(
-      (tab) => tab.id !== GMAIL_TAB_ID && !tab.pinned,
-    );
-
-    this.tabs.splice(
-      firstUnpinnedTabIndex === -1 ? this.tabs.length : firstUnpinnedTabIndex,
-      0,
-      workspaceApp,
-    );
-
-    return workspaceApp;
   }
 
   private materializeDormantTab(dormantTab: DormantTab) {
@@ -382,13 +305,12 @@ export class Tabs {
   }
 
   serialize(): TabState[] {
-    return [...this.tabs, ...this.visibleBookmarkTabs].map((tab) => ({
+    return this.tabs.map((tab) => ({
       id: tab.id,
       app: tab.app,
       title: tab.title,
       pinned: tab.pinned,
-      dormant: tab instanceof DormantTab || tab instanceof BookmarkTab,
-      bookmark: tab instanceof BookmarkTab,
+      dormant: tab instanceof DormantTab,
       loading: tab.isLoading,
       navigationHistory: tab.navigationHistory,
       active: tab.id === this.activeTabId,

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -116,7 +116,11 @@ function NewTabButton({ isWide }: { isWide: boolean }) {
             )
           }
         />
-        <DropdownMenuContent side="top" align="start" className={isWide ? undefined : "min-w-0"}>
+        <DropdownMenuContent
+          side="top"
+          align="start"
+          className={cn("space-y-1", !isWide && "min-w-0")}
+        >
           {config["workspaceApps.bookmarkedApps"].map((app) => (
             <DropdownMenuItem
               key={app}

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -104,16 +104,14 @@ function NewTabButton({ isWide }: { isWide: boolean }) {
       <DropdownMenu>
         <DropdownMenuTrigger
           render={
-            isWide ? (
-              <Button variant="ghost" size="sm" className="w-full justify-start">
-                <PlusIcon />
-                New Tab
-              </Button>
-            ) : (
-              <Button variant="ghost" size="icon" title="New Tab">
-                <PlusIcon />
-              </Button>
-            )
+            <Button
+              variant="ghost"
+              size={isWide ? "sm" : "icon"}
+              className={cn("opacity-50 hover:opacity-100", isWide && "w-full")}
+              title="New Tab"
+            >
+              <PlusIcon />
+            </Button>
           }
         />
         <DropdownMenuContent

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -1,11 +1,24 @@
 import { APP_TAB_STRIP_WIDE_WIDTH } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
+import { useConfig } from "@meru/shared/renderer/react-query";
 import type { AccountConfig } from "@meru/shared/schemas";
-import { GMAIL_TAB_ID, getTabStripWidth, type TabState } from "@meru/shared/types";
+import {
+  bookmarkableWorkspaceApps,
+  GMAIL_TAB_ID,
+  getTabStripWidth,
+  type TabState,
+} from "@meru/shared/types";
 import { Button } from "@meru/ui/components/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@meru/ui/components/dropdown-menu";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { cn } from "@meru/ui/lib/utils";
-import { GlobeIcon, XIcon } from "lucide-react";
+import { GlobeIcon, PlusIcon, XIcon } from "lucide-react";
+import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
 
 function TabIcon({ tab }: { tab: TabState }) {
@@ -25,7 +38,7 @@ function StripTab({
   accountId: AccountConfig["id"];
   isWide: boolean;
 }) {
-  const isCloseable = !tab.bookmark && tab.id !== GMAIL_TAB_ID && !tab.pinned;
+  const isCloseable = tab.id !== GMAIL_TAB_ID && !tab.pinned;
 
   return (
     <div className="group relative">
@@ -77,10 +90,56 @@ function StripTab({
   );
 }
 
+function NewTabButton({ isWide }: { isWide: boolean }) {
+  const { config } = useConfig();
+
+  const isLicenseKeyValid = useIsLicenseKeyValid();
+
+  if (!config || !isLicenseKeyValid || config["workspaceApps.bookmarkedApps"].length === 0) {
+    return;
+  }
+
+  return (
+    <div className={cn("mt-auto", isWide && "w-full")}>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            isWide ? (
+              <Button variant="ghost" size="sm" className="w-full justify-start">
+                <PlusIcon />
+                New Tab
+              </Button>
+            ) : (
+              <Button variant="ghost" size="icon" title="New Tab">
+                <PlusIcon />
+              </Button>
+            )
+          }
+        />
+        <DropdownMenuContent side="right" align="end">
+          {config["workspaceApps.bookmarkedApps"].map((app) => (
+            <DropdownMenuItem
+              key={app}
+              onClick={() => {
+                ipc.main.send("workspaceApps.openApp", app);
+              }}
+            >
+              <WorkspaceAppIcon app={app} className="size-4" />
+              {bookmarkableWorkspaceApps[app]}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
 export function AppTabStrip() {
   const accounts = useAccountsStore((state) => state.accounts);
   const accountsTabs = useTabsStore((state) => state.accountsTabs);
   const isSettingsOpen = useSettingsStore((state) => state.isOpen);
+
+  const { config } = useConfig();
 
   const selectedAccount = accounts.find((account) => account.config.selected);
 
@@ -88,7 +147,12 @@ export function AppTabStrip() {
     (accountTabs) => accountTabs.accountId === selectedAccount?.config.id,
   );
 
-  const tabStripWidth = selectedAccountTabs ? getTabStripWidth(selectedAccountTabs.tabs) : 0;
+  const tabStripWidth = selectedAccountTabs
+    ? getTabStripWidth(
+        selectedAccountTabs.tabs,
+        (config?.["workspaceApps.bookmarkedApps"].length ?? 0) > 0,
+      )
+    : 0;
 
   if (isSettingsOpen || !selectedAccount || !selectedAccountTabs || tabStripWidth === 0) {
     return;
@@ -96,30 +160,15 @@ export function AppTabStrip() {
 
   const isWide = tabStripWidth === APP_TAB_STRIP_WIDE_WIDTH;
 
-  const openTabs = selectedAccountTabs.tabs.filter((tab) => !tab.bookmark);
-
-  const bookmarkTabs = selectedAccountTabs.tabs.filter((tab) => tab.bookmark);
-
   return (
     <div
       className={cn("flex flex-col border-r", isWide ? "gap-1 p-2" : "items-center gap-2 py-2")}
       style={{ width: tabStripWidth, minWidth: tabStripWidth }}
     >
-      {openTabs.map((tab) => (
+      {selectedAccountTabs.tabs.map((tab) => (
         <StripTab key={tab.id} tab={tab} accountId={selectedAccount.config.id} isWide={isWide} />
       ))}
-      {bookmarkTabs.length > 0 && (
-        <div className={cn("mt-auto flex flex-col", isWide ? "gap-1" : "items-center gap-2")}>
-          {bookmarkTabs.map((tab) => (
-            <StripTab
-              key={tab.id}
-              tab={tab}
-              accountId={selectedAccount.config.id}
-              isWide={isWide}
-            />
-          ))}
-        </div>
-      )}
+      <NewTabButton isWide={isWide} />
     </div>
   );
 }

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -116,16 +116,18 @@ function NewTabButton({ isWide }: { isWide: boolean }) {
             )
           }
         />
-        <DropdownMenuContent side="right" align="end">
+        <DropdownMenuContent side="top" align="start" className={isWide ? undefined : "min-w-0"}>
           {config["workspaceApps.bookmarkedApps"].map((app) => (
             <DropdownMenuItem
               key={app}
+              className={isWide ? undefined : "justify-center"}
+              title={bookmarkableWorkspaceApps[app]}
               onClick={() => {
                 ipc.main.send("workspaceApps.openApp", app);
               }}
             >
               <WorkspaceAppIcon app={app} className="size-4" />
-              {bookmarkableWorkspaceApps[app]}
+              {isWide && bookmarkableWorkspaceApps[app]}
             </DropdownMenuItem>
           ))}
         </DropdownMenuContent>

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -18,6 +18,7 @@ import {
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { cn } from "@meru/ui/lib/utils";
 import { GlobeIcon, PlusIcon, XIcon } from "lucide-react";
+import { useEffect, useState } from "react";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
 
@@ -95,13 +96,31 @@ function NewTabButton({ isWide }: { isWide: boolean }) {
 
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleWindowBlur = () => {
+      setIsOpen(false);
+    };
+
+    window.addEventListener("blur", handleWindowBlur);
+
+    return () => {
+      window.removeEventListener("blur", handleWindowBlur);
+    };
+  }, [isOpen]);
+
   if (!config || !isLicenseKeyValid || config["workspaceApps.bookmarkedApps"].length === 0) {
     return;
   }
 
   return (
     <div className={isWide ? "w-full" : undefined}>
-      <DropdownMenu>
+      <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
         <DropdownMenuTrigger
           render={
             <Button

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -100,7 +100,7 @@ function NewTabButton({ isWide }: { isWide: boolean }) {
   }
 
   return (
-    <div className={cn("mt-auto", isWide && "w-full")}>
+    <div className={isWide ? "w-full" : undefined}>
       <DropdownMenu>
         <DropdownMenuTrigger
           render={
@@ -115,7 +115,7 @@ function NewTabButton({ isWide }: { isWide: boolean }) {
           }
         />
         <DropdownMenuContent
-          side="top"
+          side="bottom"
           align="start"
           className={cn("space-y-1", !isWide && "min-w-0")}
         >

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -1,5 +1,6 @@
 import { APP_TAB_STRIP_WIDE_WIDTH } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
+import type { AccountConfig } from "@meru/shared/schemas";
 import { GMAIL_TAB_ID, getTabStripWidth, type TabState } from "@meru/shared/types";
 import { Button } from "@meru/ui/components/button";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
@@ -13,6 +14,67 @@ function TabIcon({ tab }: { tab: TabState }) {
   }
 
   return <GlobeIcon />;
+}
+
+function StripTab({
+  tab,
+  accountId,
+  isWide,
+}: {
+  tab: TabState;
+  accountId: AccountConfig["id"];
+  isWide: boolean;
+}) {
+  const isCloseable = !tab.bookmark && tab.id !== GMAIL_TAB_ID && !tab.pinned;
+
+  return (
+    <div className="group relative">
+      <Button
+        variant={tab.active ? "secondary" : "ghost"}
+        size={isWide ? "sm" : "icon"}
+        className={cn(
+          tab.dormant && "opacity-50",
+          isWide && "w-full justify-start",
+          isWide && isCloseable && "pr-7",
+        )}
+        title={tab.title}
+        onClick={() => {
+          ipc.main.send("tabs.selectTab", accountId, tab.id);
+        }}
+        onAuxClick={(event) => {
+          if (event.button === 1 && isCloseable) {
+            ipc.main.send("tabs.closeTab", accountId, tab.id);
+          }
+        }}
+        onContextMenu={(event) => {
+          event.preventDefault();
+
+          ipc.main.send("tabs.showTabContextMenu", accountId, tab.id);
+        }}
+      >
+        <TabIcon tab={tab} />
+        {isWide && <span className="truncate">{tab.title}</span>}
+      </Button>
+      {isCloseable && (
+        <Button
+          variant="secondary"
+          size="icon"
+          className={cn(
+            "absolute hidden group-hover:flex",
+            isWide
+              ? "top-1/2 right-1 size-5 -translate-y-1/2"
+              : "-top-1 -right-1 size-4 rounded-full",
+          )}
+          title="Close Tab"
+          onClick={() => {
+            ipc.main.send("tabs.closeTab", accountId, tab.id);
+          }}
+        >
+          <XIcon className="size-3" />
+        </Button>
+      )}
+    </div>
+  );
 }
 
 export function AppTabStrip() {
@@ -34,59 +96,30 @@ export function AppTabStrip() {
 
   const isWide = tabStripWidth === APP_TAB_STRIP_WIDE_WIDTH;
 
+  const openTabs = selectedAccountTabs.tabs.filter((tab) => !tab.bookmark);
+
+  const bookmarkTabs = selectedAccountTabs.tabs.filter((tab) => tab.bookmark);
+
   return (
     <div
       className={cn("flex flex-col border-r", isWide ? "gap-1 p-2" : "items-center gap-2 py-2")}
       style={{ width: tabStripWidth, minWidth: tabStripWidth }}
     >
-      {selectedAccountTabs.tabs.map((tab) => (
-        <div key={tab.id} className="group relative">
-          <Button
-            variant={tab.active ? "secondary" : "ghost"}
-            size={isWide ? "sm" : "icon"}
-            className={cn(
-              tab.dormant && "opacity-50",
-              isWide && "w-full justify-start",
-              isWide && tab.id !== GMAIL_TAB_ID && !tab.pinned && "pr-7",
-            )}
-            title={tab.title}
-            onClick={() => {
-              ipc.main.send("tabs.selectTab", selectedAccount.config.id, tab.id);
-            }}
-            onAuxClick={(event) => {
-              if (event.button === 1 && tab.id !== GMAIL_TAB_ID && !tab.pinned) {
-                ipc.main.send("tabs.closeTab", selectedAccount.config.id, tab.id);
-              }
-            }}
-            onContextMenu={(event) => {
-              event.preventDefault();
-
-              ipc.main.send("tabs.showTabContextMenu", selectedAccount.config.id, tab.id);
-            }}
-          >
-            <TabIcon tab={tab} />
-            {isWide && <span className="truncate">{tab.title}</span>}
-          </Button>
-          {tab.id !== GMAIL_TAB_ID && !tab.pinned && (
-            <Button
-              variant="secondary"
-              size="icon"
-              className={cn(
-                "absolute hidden group-hover:flex",
-                isWide
-                  ? "top-1/2 right-1 size-5 -translate-y-1/2"
-                  : "-top-1 -right-1 size-4 rounded-full",
-              )}
-              title="Close Tab"
-              onClick={() => {
-                ipc.main.send("tabs.closeTab", selectedAccount.config.id, tab.id);
-              }}
-            >
-              <XIcon className="size-3" />
-            </Button>
-          )}
-        </div>
+      {openTabs.map((tab) => (
+        <StripTab key={tab.id} tab={tab} accountId={selectedAccount.config.id} isWide={isWide} />
       ))}
+      {bookmarkTabs.length > 0 && (
+        <div className={cn("mt-auto flex flex-col", isWide ? "gap-1" : "items-center gap-2")}>
+          {bookmarkTabs.map((tab) => (
+            <StripTab
+              key={tab.id}
+              tab={tab}
+              accountId={selectedAccount.config.id}
+              isWide={isWide}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/renderer-main/components/app-titlebar.tsx
+++ b/packages/renderer-main/components/app-titlebar.tsx
@@ -2,7 +2,6 @@ import { accountColorsMap } from "@meru/shared/accounts";
 import { WEBSITE_URL } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
 import { useConfig } from "@meru/shared/renderer/react-query";
-import { bookmarkableWorkspaceApps } from "@meru/shared/types";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import { FindInPage as UiFindInPage } from "@meru/ui/components/find-in-page";
@@ -13,7 +12,6 @@ import {
   TitlebarLeft,
   TitlebarNavigationControls,
 } from "@meru/ui/components/titlebar";
-import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { cn } from "@meru/ui/lib/utils";
 import {
   BriefcaseIcon,
@@ -138,40 +136,6 @@ function DoNotDisturb() {
         })}
       />
     </TitlebarIconButton>
-  );
-}
-
-function BookmarkedWorkspaceApps() {
-  const { config } = useConfig();
-
-  const isLicenseKeyValid = useIsLicenseKeyValid();
-
-  if (!config || !isLicenseKeyValid || config["workspaceApps.bookmarkedApps"].length === 0) {
-    return;
-  }
-
-  return (
-    <div className="flex gap-2 border-r pr-2 not-first:border-l not-first:pl-2">
-      {config["workspaceApps.bookmarkedApps"].map((app) => (
-        <TitlebarIconButton
-          key={app}
-          onClick={(event) => {
-            ipc.main.send(
-              "workspaceApps.openApp",
-              app,
-              event.metaKey || event.ctrlKey
-                ? "background-tab"
-                : event.shiftKey
-                  ? "new-window"
-                  : "foreground-tab",
-            );
-          }}
-          title={bookmarkableWorkspaceApps[app]}
-        >
-          <WorkspaceAppIcon app={app} />
-        </TitlebarIconButton>
-      ))}
-    </div>
   );
 }
 
@@ -378,7 +342,6 @@ export function AppTitlebar() {
           <div className="flex gap-2">
             <Trial />
             <FindInPage />
-            <BookmarkedWorkspaceApps />
             <RecentDownloadHistoryButton />
             <DoNotDisturb />
           </div>

--- a/packages/renderer-main/routes/settings/workspace-apps.tsx
+++ b/packages/renderer-main/routes/settings/workspace-apps.tsx
@@ -213,7 +213,8 @@ export function WorkspaceAppsSettings() {
                 {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
               </FieldLabel>
               <FieldDescription>
-                Bookmark Workspace Apps to the titlebar and drag to reorder.
+                Bookmark Workspace Apps to show them at the bottom of the tab strip and drag to
+                reorder.
               </FieldDescription>
             </FieldContent>
             <div className="flex flex-col gap-4">

--- a/packages/renderer-main/routes/settings/workspace-apps.tsx
+++ b/packages/renderer-main/routes/settings/workspace-apps.tsx
@@ -213,7 +213,7 @@ export function WorkspaceAppsSettings() {
                 {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
               </FieldLabel>
               <FieldDescription>
-                Bookmark Workspace Apps to show them at the bottom of the tab strip and drag to
+                Bookmark Workspace Apps to open them from the tab strip's New Tab menu and drag to
                 reorder.
               </FieldDescription>
             </FieldContent>

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -99,7 +99,6 @@ export type TabState = {
   title: string;
   pinned: boolean;
   dormant: boolean;
-  bookmark: boolean;
   loading: boolean;
   navigationHistory: { canGoBack: boolean; canGoForward: boolean };
   active: boolean;
@@ -110,8 +109,8 @@ export type AccountTabsState = {
   tabs: TabState[];
 };
 
-export function getTabStripWidth(tabs: Pick<TabState, "app">[]) {
-  if (tabs.length <= 1) {
+export function getTabStripWidth(tabs: Pick<TabState, "app">[], hasBookmarkedApps: boolean) {
+  if (tabs.length <= 1 && !hasBookmarkedApps) {
     return 0;
   }
 
@@ -266,6 +265,7 @@ export type IpcMainEvents =
       "tabs.selectTab": [accountId: AccountConfig["id"], tabId: string];
       "tabs.closeTab": [accountId: AccountConfig["id"], tabId: string];
       "tabs.showTabContextMenu": [accountId: AccountConfig["id"], tabId: string];
+      "workspaceApps.openApp": [app: BookmarkableWorkspaceApp];
       "doNotDisturb.toggle": [];
       "doNotDisturb.showOptions": [];
       "downloads.toggleRecentDownloadHistoryPopup": [];

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -83,8 +83,6 @@ export const bookmarkableWorkspaceApps = Object.fromEntries(
     .map(([workspaceApp, workspaceAppDefinition]) => [workspaceApp, workspaceAppDefinition.label]),
 ) as Record<BookmarkableWorkspaceApp, string>;
 
-export type WorkspaceAppOpenDisposition = "foreground-tab" | "background-tab" | "new-window";
-
 export const workspaceAppOpenBehaviors = {
   tab: "Tab",
   newWindow: "New Window",
@@ -101,6 +99,7 @@ export type TabState = {
   title: string;
   pinned: boolean;
   dormant: boolean;
+  bookmark: boolean;
   loading: boolean;
   navigationHistory: { canGoBack: boolean; canGoForward: boolean };
   active: boolean;
@@ -264,10 +263,6 @@ export type IpcMainEvents =
       "app.relaunch": [];
       "theme.setTheme": [theme: "system" | "light" | "dark"];
       "notifications.showTestNotification": [];
-      "workspaceApps.openApp": [
-        app: BookmarkableWorkspaceApp,
-        disposition?: WorkspaceAppOpenDisposition,
-      ];
       "tabs.selectTab": [accountId: AccountConfig["id"], tabId: string];
       "tabs.closeTab": [accountId: AccountConfig["id"], tabId: string];
       "tabs.showTabContextMenu": [accountId: AccountConfig["id"], tabId: string];


### PR DESCRIPTION
## Problem

Phase 6 of the workspace-apps-as-tabs roadmap: the titlebar launcher duplicated the tab strip — the same app icons in two places. The launcher moves into the strip as a "+" New Tab menu.

(The first commit implemented an earlier design — always-visible bookmark rows with single-slot semantics — which was replaced in review by the follow-up commit; the squash result is the menu design described here.)

## Changes

- **"+" New Tab button** at the bottom of the strip (`mt-auto`; icon-only in narrow mode, a "New Tab" row in wide mode), opening a dropdown of the user's bookmarked apps (icon + label, config order). Picking one **always opens a foreground tab**: created via `Tabs.openTab`, activated, and the view raised — an explicit launch intent, deliberately bypassing the `openBehavior` config that governs link opens. License-gated like the old launcher (renderer hides the button, main guards the handler).
- The strip is **visible whenever bookmarked apps exist** (`getTabStripWidth` gains a `hasBookmarkedApps` parameter; bounds recompute when the config changes) — otherwise deleting the titlebar launcher would leave no way to open the first tab.
- The `workspaceApps.openApp` IPC is reduced to `[app]` (no disposition — the menu has no modifier semantics).
- **Titlebar launcher removed**: `BookmarkedWorkspaceApps` component deleted; the orphaned `WorkspaceAppOpenDisposition` type removed. Settings description now points at the New Tab menu.
- The strip's tab row markup is extracted into a `StripTab` component.

Deferred to a follow-up PR: second-instance gestures (Cmd/Ctrl+click on a strip tab → new background tab of that app; context-menu "New <App> Tab").

## Verification

- `bun types:ci` passes.
- Not runtime-tested here (no display). Manual: with bookmarked apps configured, the strip is always visible with a "+" at the bottom; picking an app opens a focused foreground tab; the menu follows settings changes live; without bookmarks (or license) the "+" is absent and the strip reverts to tab-dependent visibility; the titlebar shows no launcher buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)