### PR TITLE
document web contents view overlay constraint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,7 @@ This installs dependencies and runs postinstall scripts (including the lefthook 
 - Never repeat shared classes across the branches of a conditional `className`. Hoist them and merge with the `cn` helper (`@meru/ui/lib/utils`): `cn("absolute hidden", isWide ? "size-5" : "size-4")`.
 - Consider the platform when showing platform-specific information (modifier keys, OS names): branch on the existing `platform` helper — `@meru/shared/renderer/utils` in renderers, `@electron-toolkit/utils` in the main process — e.g. `platform.isMacOS ? "Cmd" : "Ctrl"`.
 - Render keyboard keys in user-facing text with the `Kbd` component (`@meru/ui/components/kbd`), not as plain text: `Hold <Kbd>Shift</Kbd> to …`.
+- Child `WebContentsView`s always paint above the main window's HTML, so renderer-drawn overlays (dropdowns, tooltips, dialogs) get covered wherever a view sits. Keep overlays inside the regions the renderer owns (titlebar, tab strip) — e.g. tab strip menus open with `side="top"` at anchor width. For overlays over view content, use a native `Menu.popup` or a dedicated `WebContentsView` (see the recent-downloads popup).
 
 ## React State
 


### PR DESCRIPTION
## Problem

Child `WebContentsView`s always paint above the main window's HTML — a structural Electron constraint that is invisible in the code and resurfaced in #647, where the tab strip's New Tab dropdown was covered by the workspace-app view until repositioned to open upward within the strip column.

## Changes

Adds a guideline to CLAUDE.md's UI Components section: renderer-drawn overlays must stay inside the regions the renderer owns (titlebar, tab strip); for overlays over view content, use a native `Menu.popup` or a dedicated `WebContentsView` (the recent-downloads popup is the existing example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)