### PR TITLE
split shared types into domain files

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { platform } from "@electron-toolkit/utils";
 import type { AccountConfig } from "@meru/shared/schemas";
-import { getTabStripWidth } from "@meru/shared/types";
+import { getTabStripWidth } from "@meru/shared/tabs";
 import { Account } from "./account";
 import { config } from "./config";
 import { ipc } from "./ipc";

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -13,8 +13,8 @@ import {
   parseGmailMessageId,
 } from "@meru/shared/gmail";
 import { ms } from "@meru/shared/ms";
-import { workspaceApps } from "@meru/shared/types";
 import { wait } from "@meru/shared/utils";
+import { workspaceApps } from "@meru/shared/workspace-apps";
 import {
   app,
   BrowserWindow,

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -1,12 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { getWorkspaceAppUrl } from "@meru/shared/google";
 import type { PinnedTab } from "@meru/shared/schemas";
-import {
-  GMAIL_TAB_ID,
-  type SupportedWorkspaceApp,
-  type TabState,
-  workspaceApps,
-} from "@meru/shared/types";
+import { GMAIL_TAB_ID, type TabState } from "@meru/shared/tabs";
+import { type SupportedWorkspaceApp, workspaceApps } from "@meru/shared/workspace-apps";
 import type { WebContentsView } from "electron";
 import { accounts } from "./accounts";
 import type { Gmail } from "./gmail";

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -2,12 +2,12 @@ import { randomUUID } from "node:crypto";
 import { APP_TITLEBAR_HEIGHT, GOOGLE_ACCOUNTS_URL } from "@meru/shared/constants";
 import { getWorkspaceAppUrl } from "@meru/shared/google";
 import type { AccountConfig } from "@meru/shared/schemas";
+import { clamp } from "@meru/shared/utils";
 import {
   type SupportedWorkspaceApp,
   type WorkspaceAppOpenBehavior,
   workspaceApps,
-} from "@meru/shared/types";
-import { clamp } from "@meru/shared/utils";
+} from "@meru/shared/workspace-apps";
 import {
   app,
   BrowserWindow,

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -2,12 +2,8 @@ import { APP_TAB_STRIP_WIDE_WIDTH } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
 import { useConfig } from "@meru/shared/renderer/react-query";
 import type { AccountConfig } from "@meru/shared/schemas";
-import {
-  bookmarkableWorkspaceApps,
-  GMAIL_TAB_ID,
-  getTabStripWidth,
-  type TabState,
-} from "@meru/shared/types";
+import { GMAIL_TAB_ID, getTabStripWidth, type TabState } from "@meru/shared/tabs";
+import { bookmarkableWorkspaceApps } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import {
   DropdownMenu,

--- a/packages/renderer-main/lib/stores.ts
+++ b/packages/renderer-main/lib/stores.ts
@@ -2,7 +2,7 @@ import { ipc } from "@meru/shared/renderer/ipc";
 import { getConfig } from "@meru/shared/renderer/react-query";
 import { accountsSearchParam, trialDaysLeftSearchParam } from "@meru/shared/renderer/search-params";
 import type { AccountInstances } from "@meru/shared/schemas";
-import type { AccountTabsState } from "@meru/shared/types";
+import type { AccountTabsState } from "@meru/shared/tabs";
 import { toast } from "sonner";
 import { navigate } from "wouter/use-hash-location";
 import { create } from "zustand";

--- a/packages/renderer-main/routes/settings/workspace-apps.tsx
+++ b/packages/renderer-main/routes/settings/workspace-apps.tsx
@@ -9,7 +9,7 @@ import {
   type SupportedWorkspaceApp,
   workspaceAppOpenBehaviors,
   workspaceApps,
-} from "@meru/shared/types";
+} from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import { ButtonGroup } from "@meru/ui/components/button-group";
 import {

--- a/packages/renderer-workspace-app/index.tsx
+++ b/packages/renderer-workspace-app/index.tsx
@@ -2,7 +2,7 @@ import { useCopied } from "@meru/shared/renderer/hooks";
 import { ipc } from "@meru/shared/renderer/ipc";
 import { renderApp } from "@meru/shared/renderer/react";
 import { useConfig } from "@meru/shared/renderer/react-query";
-import type { SupportedWorkspaceApp } from "@meru/shared/types";
+import type { SupportedWorkspaceApp } from "@meru/shared/workspace-apps";
 import { AccountBadge } from "@meru/ui/components/account-badge";
 import { FindInPage } from "@meru/ui/components/find-in-page";
 import {

--- a/packages/shared/google.ts
+++ b/packages/shared/google.ts
@@ -1,4 +1,4 @@
-import { type SupportedWorkspaceApp, workspaceApps } from "./types";
+import { type SupportedWorkspaceApp, workspaceApps } from "./workspace-apps";
 
 export function getWorkspaceAppUrl(app: SupportedWorkspaceApp) {
   return workspaceApps[app].url ?? `https://${app}.google.com`;

--- a/packages/shared/schemas.ts
+++ b/packages/shared/schemas.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { isValidCssColorInput } from "./color";
 import type { GmailState } from "./gmail";
-import { type SupportedWorkspaceApp, workspaceApps } from "./types";
+import { type SupportedWorkspaceApp, workspaceApps } from "./workspace-apps";
 
 export const accountColors = [
   "orange",

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -1,0 +1,41 @@
+import { APP_TAB_STRIP_NARROW_WIDTH, APP_TAB_STRIP_WIDE_WIDTH } from "./constants";
+import type { AccountConfig } from "./schemas";
+import type { SupportedWorkspaceApp } from "./workspace-apps";
+
+export const GMAIL_TAB_ID = "gmail";
+
+export type TabState = {
+  id: string;
+  app: SupportedWorkspaceApp | undefined;
+  title: string;
+  pinned: boolean;
+  dormant: boolean;
+  loading: boolean;
+  navigationHistory: { canGoBack: boolean; canGoForward: boolean };
+  active: boolean;
+};
+
+export type AccountTabsState = {
+  accountId: AccountConfig["id"];
+  tabs: TabState[];
+};
+
+export function getTabStripWidth(tabs: Pick<TabState, "app">[], hasBookmarkedApps: boolean) {
+  if (tabs.length <= 1 && !hasBookmarkedApps) {
+    return 0;
+  }
+
+  const workspaceAppTabCounts = new Map<SupportedWorkspaceApp, number>();
+
+  for (const tab of tabs) {
+    if (tab.app) {
+      workspaceAppTabCounts.set(tab.app, (workspaceAppTabCounts.get(tab.app) ?? 0) + 1);
+    }
+  }
+
+  const hasWorkspaceAppWithMultipleTabs = Array.from(workspaceAppTabCounts.values()).some(
+    (workspaceAppTabCount) => workspaceAppTabCount > 1,
+  );
+
+  return hasWorkspaceAppWithMultipleTabs ? APP_TAB_STRIP_WIDE_WIDTH : APP_TAB_STRIP_NARROW_WIDTH;
+}

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -1,7 +1,6 @@
 import type { LoginItemSettings } from "electron";
 import type { accountColorsMap } from "./accounts";
-import { APP_TAB_STRIP_NARROW_WIDTH, APP_TAB_STRIP_WIDE_WIDTH } from "./constants";
-import { type GMAIL_ACTION_CODE_MAP, GMAIL_URL } from "./gmail";
+import type { GMAIL_ACTION_CODE_MAP } from "./gmail";
 import type {
   AccountConfig,
   AccountConfigInput,
@@ -10,6 +9,12 @@ import type {
   GmailLabelColors,
   GmailSavedSearches,
 } from "./schemas";
+import type { AccountTabsState } from "./tabs";
+import type {
+  BookmarkableWorkspaceApp,
+  SupportedWorkspaceApp,
+  WorkspaceAppOpenBehavior,
+} from "./workspace-apps";
 
 export type DesktopSource = { id: string; name: string; thumbnail: string };
 
@@ -33,101 +38,6 @@ export type NotificationTime = {
   end: string; // "HH:mm" 24-hour
   days?: number[]; // 0=Sun,1=Mon,...,6=Sat; undefined/empty = all days
 };
-
-type WorkspaceAppDefinition = {
-  label: string;
-  url?: string;
-  bookmarkable?: boolean;
-  alwaysOpenAsWindow?: boolean;
-  singleInstance?: boolean;
-};
-
-const workspaceAppDefinitions = {
-  calendar: { label: "Calendar" },
-  chat: { label: "Chat" },
-  classroom: { label: "Classroom" },
-  contacts: { label: "Contacts" },
-  docs: { label: "Docs" },
-  drive: { label: "Drive" },
-  forms: { label: "Forms" },
-  gemini: { label: "Gemini" },
-  gmail: { label: "Gmail", url: GMAIL_URL, bookmarkable: false, singleInstance: true },
-  groups: { label: "Groups" },
-  keep: { label: "Keep" },
-  meet: { label: "Meet" },
-  myaccount: { label: "My Account", bookmarkable: false, alwaysOpenAsWindow: true },
-  notebooklm: { label: "NotebookLM" },
-  sheets: { label: "Sheets" },
-  sites: { label: "Sites" },
-  slides: { label: "Slides" },
-  tasks: { label: "Tasks" },
-  voice: { label: "Voice" },
-} as const satisfies Record<string, WorkspaceAppDefinition>;
-
-export type SupportedWorkspaceApp = keyof typeof workspaceAppDefinitions;
-
-export type BookmarkableWorkspaceApp = {
-  [App in SupportedWorkspaceApp]: (typeof workspaceAppDefinitions)[App] extends {
-    bookmarkable: false;
-  }
-    ? never
-    : App;
-}[SupportedWorkspaceApp];
-
-export const workspaceApps: Record<SupportedWorkspaceApp, WorkspaceAppDefinition> =
-  workspaceAppDefinitions;
-
-export const bookmarkableWorkspaceApps = Object.fromEntries(
-  Object.entries(workspaceApps)
-    .filter(([, workspaceAppDefinition]) => workspaceAppDefinition.bookmarkable !== false)
-    .map(([workspaceApp, workspaceAppDefinition]) => [workspaceApp, workspaceAppDefinition.label]),
-) as Record<BookmarkableWorkspaceApp, string>;
-
-export const workspaceAppOpenBehaviors = {
-  tab: "Tab",
-  newWindow: "New Window",
-  backgroundTab: "Background Tab",
-} as const;
-
-export type WorkspaceAppOpenBehavior = keyof typeof workspaceAppOpenBehaviors;
-
-export const GMAIL_TAB_ID = "gmail";
-
-export type TabState = {
-  id: string;
-  app: SupportedWorkspaceApp | undefined;
-  title: string;
-  pinned: boolean;
-  dormant: boolean;
-  loading: boolean;
-  navigationHistory: { canGoBack: boolean; canGoForward: boolean };
-  active: boolean;
-};
-
-export type AccountTabsState = {
-  accountId: AccountConfig["id"];
-  tabs: TabState[];
-};
-
-export function getTabStripWidth(tabs: Pick<TabState, "app">[], hasBookmarkedApps: boolean) {
-  if (tabs.length <= 1 && !hasBookmarkedApps) {
-    return 0;
-  }
-
-  const workspaceAppTabCounts = new Map<SupportedWorkspaceApp, number>();
-
-  for (const tab of tabs) {
-    if (tab.app) {
-      workspaceAppTabCounts.set(tab.app, (workspaceAppTabCounts.get(tab.app) ?? 0) + 1);
-    }
-  }
-
-  const hasWorkspaceAppWithMultipleTabs = Array.from(workspaceAppTabCounts.values()).some(
-    (workspaceAppTabCount) => workspaceAppTabCount > 1,
-  );
-
-  return hasWorkspaceAppWithMultipleTabs ? APP_TAB_STRIP_WIDE_WIDTH : APP_TAB_STRIP_NARROW_WIDTH;
-}
 
 type GmailHashLocation =
   | "inbox"

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -1,0 +1,58 @@
+import { GMAIL_URL } from "./gmail";
+
+type WorkspaceAppDefinition = {
+  label: string;
+  url?: string;
+  bookmarkable?: boolean;
+  alwaysOpenAsWindow?: boolean;
+  singleInstance?: boolean;
+};
+
+const workspaceAppDefinitions = {
+  calendar: { label: "Calendar" },
+  chat: { label: "Chat" },
+  classroom: { label: "Classroom" },
+  contacts: { label: "Contacts" },
+  docs: { label: "Docs" },
+  drive: { label: "Drive" },
+  forms: { label: "Forms" },
+  gemini: { label: "Gemini" },
+  gmail: { label: "Gmail", url: GMAIL_URL, bookmarkable: false, singleInstance: true },
+  groups: { label: "Groups" },
+  keep: { label: "Keep" },
+  meet: { label: "Meet" },
+  myaccount: { label: "My Account", bookmarkable: false, alwaysOpenAsWindow: true },
+  notebooklm: { label: "NotebookLM" },
+  sheets: { label: "Sheets" },
+  sites: { label: "Sites" },
+  slides: { label: "Slides" },
+  tasks: { label: "Tasks" },
+  voice: { label: "Voice" },
+} as const satisfies Record<string, WorkspaceAppDefinition>;
+
+export type SupportedWorkspaceApp = keyof typeof workspaceAppDefinitions;
+
+export type BookmarkableWorkspaceApp = {
+  [App in SupportedWorkspaceApp]: (typeof workspaceAppDefinitions)[App] extends {
+    bookmarkable: false;
+  }
+    ? never
+    : App;
+}[SupportedWorkspaceApp];
+
+export const workspaceApps: Record<SupportedWorkspaceApp, WorkspaceAppDefinition> =
+  workspaceAppDefinitions;
+
+export const bookmarkableWorkspaceApps = Object.fromEntries(
+  Object.entries(workspaceApps)
+    .filter(([, workspaceAppDefinition]) => workspaceAppDefinition.bookmarkable !== false)
+    .map(([workspaceApp, workspaceAppDefinition]) => [workspaceApp, workspaceAppDefinition.label]),
+) as Record<BookmarkableWorkspaceApp, string>;
+
+export const workspaceAppOpenBehaviors = {
+  tab: "Tab",
+  newWindow: "New Window",
+  backgroundTab: "Background Tab",
+} as const;
+
+export type WorkspaceAppOpenBehavior = keyof typeof workspaceAppOpenBehaviors;

--- a/packages/ui/components/workspace-app-icon.tsx
+++ b/packages/ui/components/workspace-app-icon.tsx
@@ -1,4 +1,4 @@
-import type { SupportedWorkspaceApp } from "@meru/shared/types";
+import type { SupportedWorkspaceApp } from "@meru/shared/workspace-apps";
 import type { ComponentProps } from "react";
 
 export function WorkspaceAppIcon({


### PR DESCRIPTION
## Problem

`packages/shared/types.ts` had drifted from a type file into a grab-bag: Config/IPC types plus the workspace-app definitions map and derived values, the tab-state types, and the `getTabStripWidth` layout function.

## Changes

Pure refactor, import-path updates only, moved code byte-identical:

- New `packages/shared/workspace-apps.ts`: the definitions map (`workspaceApps`, private `WorkspaceAppDefinition`/`workspaceAppDefinitions`), `SupportedWorkspaceApp`, `BookmarkableWorkspaceApp`, `bookmarkableWorkspaceApps`, `workspaceAppOpenBehaviors`/`WorkspaceAppOpenBehavior`.
- New `packages/shared/tabs.ts`: `GMAIL_TAB_ID`, `TabState`, `AccountTabsState`, `getTabStripWidth`.
- `types.ts` keeps the Config/IPC surface and imports the moved symbols it references; no re-exports, so consumers import from the new domain files (13 files updated across app/renderer-main/renderer-workspace-app/ui/shared).

## Verification

- `bun types:ci` passes; every remaining `@meru/shared/types` import pulls only symbols still living there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)