### PR TITLE
open another tab of an app via modifier click and context menu

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -5,6 +5,7 @@ import { IpcEmitter, IpcListener } from "@electron-toolkit/typed-ipc/main";
 import { MAX_RECENT_DOWNLOAD_HISTORY_ITEMS } from "@meru/shared/constants";
 import { getWorkspaceAppUrl } from "@meru/shared/google";
 import type { IpcMainEvents, IpcRendererEvent } from "@meru/shared/types";
+import { workspaceApps } from "@meru/shared/workspace-apps";
 import {
   app,
   BrowserWindow,
@@ -248,7 +249,30 @@ class Ipc {
         return;
       }
 
+      const tabApp = tab.app;
+
       Menu.buildFromTemplate([
+        ...(tabApp &&
+        !workspaceApps[tabApp].singleInstance &&
+        !workspaceApps[tabApp].alwaysOpenAsWindow
+          ? [
+              {
+                label: `New ${workspaceApps[tabApp].label} Tab`,
+                click: () => {
+                  const workspaceApp = account.instance.tabs.openTab(getWorkspaceAppUrl(tabApp));
+
+                  account.instance.tabs.activateTab(workspaceApp.id);
+
+                  if (account.config.selected) {
+                    accounts.refreshSelectedAccountView();
+                  }
+                },
+              },
+              {
+                type: "separator" as const,
+              },
+            ]
+          : []),
         tab.pinned
           ? {
               label: "Unpin Tab",
@@ -389,7 +413,7 @@ class Ipc {
       });
     });
 
-    ipc.main.on("workspaceApps.openApp", (_event, app) => {
+    ipc.main.on("workspaceApps.openApp", (_event, app, options) => {
       if (!licenseKey.isValid) {
         return;
       }
@@ -397,6 +421,10 @@ class Ipc {
       const selectedAccount = accounts.getSelectedAccount();
 
       const workspaceApp = selectedAccount.instance.tabs.openTab(getWorkspaceAppUrl(app));
+
+      if (options?.background) {
+        return;
+      }
 
       selectedAccount.instance.tabs.activateTab(workspaceApp.id);
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -268,11 +268,29 @@ class Ipc {
                   }
                 },
               },
-              {
-                type: "separator" as const,
-              },
             ]
           : []),
+        {
+          label: "Duplicate Tab",
+          click: () => {
+            const currentTabUrl =
+              tab instanceof WorkspaceApp ? tab.view.webContents.getURL() : tab.url;
+
+            const duplicatedTabUrl =
+              !currentTabUrl && tabApp ? getWorkspaceAppUrl(tabApp) : currentTabUrl;
+
+            const workspaceApp = account.instance.tabs.openTab(duplicatedTabUrl);
+
+            account.instance.tabs.activateTab(workspaceApp.id);
+
+            if (account.config.selected) {
+              accounts.refreshSelectedAccountView();
+            }
+          },
+        },
+        {
+          type: "separator",
+        },
         tab.pinned
           ? {
               label: "Unpin Tab",

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -413,16 +413,26 @@ class Ipc {
       });
     });
 
-    ipc.main.on("workspaceApps.openApp", (_event, app, options) => {
+    ipc.main.on("workspaceApps.openApp", (_event, app, openBehavior = "tab") => {
       if (!licenseKey.isValid) {
         return;
       }
 
       const selectedAccount = accounts.getSelectedAccount();
 
+      if (openBehavior === "newWindow") {
+        new WorkspaceApp({
+          accountId: selectedAccount.config.id,
+          url: getWorkspaceAppUrl(app),
+          asWindow: true,
+        });
+
+        return;
+      }
+
       const workspaceApp = selectedAccount.instance.tabs.openTab(getWorkspaceAppUrl(app));
 
-      if (options?.background) {
+      if (openBehavior === "backgroundTab") {
         return;
       }
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { IpcEmitter, IpcListener } from "@electron-toolkit/typed-ipc/main";
 import { MAX_RECENT_DOWNLOAD_HISTORY_ITEMS } from "@meru/shared/constants";
 import { getWorkspaceAppUrl } from "@meru/shared/google";
+import { GMAIL_TAB_ID } from "@meru/shared/tabs";
 import type { IpcMainEvents, IpcRendererEvent } from "@meru/shared/types";
 import { workspaceApps } from "@meru/shared/workspace-apps";
 import {
@@ -251,6 +252,19 @@ class Ipc {
 
       const tabApp = tab.app;
 
+      const hasOtherClosableTabs = account.instance.tabs.tabs.some(
+        (accountTab) =>
+          accountTab.id !== tabId && accountTab.id !== GMAIL_TAB_ID && !accountTab.pinned,
+      );
+
+      const contextTabIndex = account.instance.tabs.tabs.findIndex(
+        (accountTab) => accountTab.id === tabId,
+      );
+
+      const hasClosableTabsBelow = account.instance.tabs.tabs
+        .slice(contextTabIndex + 1)
+        .some((accountTab) => !accountTab.pinned);
+
       Menu.buildFromTemplate([
         ...(tabApp &&
         !workspaceApps[tabApp].singleInstance &&
@@ -325,6 +339,28 @@ class Ipc {
           label: "Close Tab",
           click: () => {
             account.instance.tabs.closeTab(tabId);
+
+            if (account.config.selected) {
+              accounts.refreshSelectedAccountView();
+            }
+          },
+        },
+        {
+          label: "Close Other Tabs",
+          enabled: hasOtherClosableTabs,
+          click: () => {
+            account.instance.tabs.closeOtherTabs(tabId);
+
+            if (account.config.selected) {
+              accounts.refreshSelectedAccountView();
+            }
+          },
+        },
+        {
+          label: "Close Tabs Below",
+          enabled: hasClosableTabsBelow,
+          click: () => {
+            account.instance.tabs.closeTabsBelow(tabId);
 
             if (account.config.selected) {
               accounts.refreshSelectedAccountView();

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -222,6 +222,36 @@ export class Tabs {
     }
   }
 
+  closeOtherTabs(keptTabId: string) {
+    const previousActiveTabId = this.activeTabId;
+
+    for (const tab of this.tabs.slice()) {
+      if (tab.id !== keptTabId && tab.id !== GMAIL_TAB_ID && !tab.pinned) {
+        this.closeTab(tab.id);
+      }
+    }
+
+    if (this.activeTabId !== previousActiveTabId) {
+      this.activateTab(keptTabId);
+    }
+  }
+
+  closeTabsBelow(tabId: string) {
+    const previousActiveTabId = this.activeTabId;
+
+    const tabIndex = this.tabs.findIndex((tab) => tab.id === tabId);
+
+    for (const tab of this.tabs.slice(tabIndex + 1)) {
+      if (!tab.pinned) {
+        this.closeTab(tab.id);
+      }
+    }
+
+    if (this.activeTabId !== previousActiveTabId) {
+      this.activateTab(tabId);
+    }
+  }
+
   pinTab(tabId: string) {
     const pinnableTab = this.getTab(tabId);
 

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -53,12 +53,10 @@ function StripTab({
         )}
         title={tab.title}
         onClick={(event) => {
-          if (
-            canOpenSecondInstance &&
-            tab.app &&
-            (platform.isMacOS ? event.metaKey : event.ctrlKey)
-          ) {
-            ipc.main.send("workspaceApps.openApp", tab.app, { background: true });
+          const isCommandOrControlClick = platform.isMacOS ? event.metaKey : event.ctrlKey;
+
+          if (canOpenSecondInstance && tab.app && isCommandOrControlClick) {
+            ipc.main.send("workspaceApps.openApp", tab.app, { background: !event.shiftKey });
 
             return;
           }
@@ -153,8 +151,10 @@ function NewTabButton({ isWide }: { isWide: boolean }) {
               key={app}
               className={isWide ? undefined : "justify-center"}
               title={bookmarkableWorkspaceApps[app]}
-              onClick={() => {
-                ipc.main.send("workspaceApps.openApp", app);
+              onClick={(event) => {
+                ipc.main.send("workspaceApps.openApp", app, {
+                  background: (platform.isMacOS ? event.metaKey : event.ctrlKey) && !event.shiftKey,
+                });
               }}
             >
               <WorkspaceAppIcon app={app} className="size-4" />

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -15,9 +15,19 @@ import {
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { cn } from "@meru/ui/lib/utils";
 import { GlobeIcon, PlusIcon, XIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { type MouseEvent, useEffect, useState } from "react";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
+
+function getModifierOpenBehavior(event: MouseEvent) {
+  if (platform.isMacOS ? event.metaKey : event.ctrlKey) {
+    return event.shiftKey ? "tab" : "backgroundTab";
+  }
+
+  if (event.shiftKey) {
+    return "newWindow";
+  }
+}
 
 function TabIcon({ tab }: { tab: TabState }) {
   if (tab.app && tab.app !== "myaccount") {
@@ -53,10 +63,10 @@ function StripTab({
         )}
         title={tab.title}
         onClick={(event) => {
-          const isCommandOrControlClick = platform.isMacOS ? event.metaKey : event.ctrlKey;
+          const modifierOpenBehavior = getModifierOpenBehavior(event);
 
-          if (canOpenSecondInstance && tab.app && isCommandOrControlClick) {
-            ipc.main.send("workspaceApps.openApp", tab.app, { background: !event.shiftKey });
+          if (canOpenSecondInstance && tab.app && modifierOpenBehavior) {
+            ipc.main.send("workspaceApps.openApp", tab.app, modifierOpenBehavior);
 
             return;
           }
@@ -152,9 +162,7 @@ function NewTabButton({ isWide }: { isWide: boolean }) {
               className={isWide ? undefined : "justify-center"}
               title={bookmarkableWorkspaceApps[app]}
               onClick={(event) => {
-                ipc.main.send("workspaceApps.openApp", app, {
-                  background: (platform.isMacOS ? event.metaKey : event.ctrlKey) && !event.shiftKey,
-                });
+                ipc.main.send("workspaceApps.openApp", app, getModifierOpenBehavior(event));
               }}
             >
               <WorkspaceAppIcon app={app} className="size-4" />

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -164,6 +164,13 @@ function NewTabButton({ isWide }: { isWide: boolean }) {
               onClick={(event) => {
                 ipc.main.send("workspaceApps.openApp", app, getModifierOpenBehavior(event));
               }}
+              onAuxClick={(event) => {
+                if (event.button === 1) {
+                  ipc.main.send("workspaceApps.openApp", app, "backgroundTab");
+
+                  setIsOpen(false);
+                }
+              }}
             >
               <WorkspaceAppIcon app={app} className="size-4" />
               {isWide && bookmarkableWorkspaceApps[app]}

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -1,9 +1,10 @@
 import { APP_TAB_STRIP_WIDE_WIDTH } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
 import { useConfig } from "@meru/shared/renderer/react-query";
+import { platform } from "@meru/shared/renderer/utils";
 import type { AccountConfig } from "@meru/shared/schemas";
 import { GMAIL_TAB_ID, getTabStripWidth, type TabState } from "@meru/shared/tabs";
-import { bookmarkableWorkspaceApps } from "@meru/shared/workspace-apps";
+import { bookmarkableWorkspaceApps, workspaceApps } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import {
   DropdownMenu,
@@ -37,6 +38,9 @@ function StripTab({
 }) {
   const isCloseable = tab.id !== GMAIL_TAB_ID && !tab.pinned;
 
+  const canOpenSecondInstance =
+    tab.app && !workspaceApps[tab.app].singleInstance && !workspaceApps[tab.app].alwaysOpenAsWindow;
+
   return (
     <div className="group relative">
       <Button
@@ -48,7 +52,17 @@ function StripTab({
           isWide && isCloseable && "pr-7",
         )}
         title={tab.title}
-        onClick={() => {
+        onClick={(event) => {
+          if (
+            canOpenSecondInstance &&
+            tab.app &&
+            (platform.isMacOS ? event.metaKey : event.ctrlKey)
+          ) {
+            ipc.main.send("workspaceApps.openApp", tab.app, { background: true });
+
+            return;
+          }
+
           ipc.main.send("tabs.selectTab", accountId, tab.id);
         }}
         onAuxClick={(event) => {

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -175,7 +175,7 @@ export type IpcMainEvents =
       "tabs.selectTab": [accountId: AccountConfig["id"], tabId: string];
       "tabs.closeTab": [accountId: AccountConfig["id"], tabId: string];
       "tabs.showTabContextMenu": [accountId: AccountConfig["id"], tabId: string];
-      "workspaceApps.openApp": [app: BookmarkableWorkspaceApp];
+      "workspaceApps.openApp": [app: SupportedWorkspaceApp, options?: { background?: boolean }];
       "doNotDisturb.toggle": [];
       "doNotDisturb.showOptions": [];
       "downloads.toggleRecentDownloadHistoryPopup": [];

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -175,7 +175,10 @@ export type IpcMainEvents =
       "tabs.selectTab": [accountId: AccountConfig["id"], tabId: string];
       "tabs.closeTab": [accountId: AccountConfig["id"], tabId: string];
       "tabs.showTabContextMenu": [accountId: AccountConfig["id"], tabId: string];
-      "workspaceApps.openApp": [app: SupportedWorkspaceApp, options?: { background?: boolean }];
+      "workspaceApps.openApp": [
+        app: SupportedWorkspaceApp,
+        openBehavior?: WorkspaceAppOpenBehavior,
+      ];
       "doNotDisturb.toggle": [];
       "doNotDisturb.showOptions": [];
       "downloads.toggleRecentDownloadHistoryPopup": [];


### PR DESCRIPTION
The tab strip so far only supported one tab per app gesture-wise: clicking a tab selects it, and the "+" menu opens bookmarked apps in the foreground. This adds the second-instance gestures planned as the follow-up to #647, adopting Chrome's modifier conventions, plus the Chrome tab-management context menu items.

## Changes

- **Modifier clicks on a strip tab** open a new instance of that tab's app at its root URL instead of selecting the tab, following Chrome:
  - Cmd/Ctrl+click → new **background** tab
  - Shift+Cmd/Ctrl+click → new **foreground** tab
  - Shift+click → new **window**
- **The same modifiers work on "+" New Tab menu items** (plain click stays foreground, as before), and **middle-click** on a menu item opens a background tab, like Chrome bookmarks.
- **Tab context menu** gains, in Chrome order:
  - **"New <App> Tab"** (first entry) → new foreground tab of that app at its root URL
  - **"Duplicate Tab"** → new foreground tab at the tab's *current* URL (works for dormant pinned tabs too, using their saved URL)
  - **"Close Other Tabs"** and **"Close Tabs Below"** → both spare Gmail and pinned tabs, are disabled when there's nothing to close, and if the active tab was among the closed ones, the context-menu tab is activated (Chrome behavior) instead of falling back to Gmail
- The modifier gestures and "New <App> Tab" are excluded for apps marked `singleInstance` (Gmail) or `alwaysOpenAsWindow` (My Account); a modifier click on those falls through to a plain tab select.
- Plumbing: the existing `workspaceApps.openApp` IPC event is widened from `[app: BookmarkableWorkspaceApp]` to `[app: SupportedWorkspaceApp, openBehavior?: WorkspaceAppOpenBehavior]` (defaulting to `"tab"`), reusing the existing behavior union rather than adding a parallel event. The renderer maps click modifiers to a behavior in one shared helper (`getModifierOpenBehavior`). New background views need no z-order raise because embedded views attach at the bottom of the z-order (`addChildView(view, 0)`), same as the existing `handleWindowOpen` background-tab path; `"newWindow"` constructs a windowed `WorkspaceApp` exactly like `handleWindowOpen`'s `newWindow` branch.

## Notes for review

- New tabs/windows from the modifier gestures open at the app's root URL (`getWorkspaceAppUrl`) — "new tab of this app"; "Duplicate Tab" is the current-URL variant.
- These gestures deliberately bypass the `workspaceApps.openBehavior` config — the modifier expresses the exact intent, and a plain "+"-menu click keeps its established foreground behavior.
- "Close Tabs Below" doesn't need a Gmail guard because `reorderTabs` keeps Gmail at index 0, so it can never be below the context tab; if tab ordering ever changes this needs the same `GMAIL_TAB_ID` check "Close Other Tabs" has.
- License gating is unchanged: the `workspaceApps.openApp` handler keeps its `licenseKey.isValid` early return. The context menu items are not separately gated since workspace tabs can only exist on licensed accounts.
- Verified with `bun types:ci`; not manually tested in the running app.

## Test plan

Licensed account with at least one bookmarked app; Cmd on macOS, Ctrl elsewhere.

1. Open a Docs tab from the "+" menu, then **Cmd+click the Docs tab** in the strip → a second Docs tab appears without stealing focus (the strip switches to the wide layout since Docs now has two tabs).
2. **Shift+Cmd+click** a tab → a new tab of that app opens *and becomes active*.
3. **Shift+click** a tab → the app opens in a separate window; the strip is unchanged.
4. In the **"+" menu**: plain click → foreground tab (unchanged); Cmd+click → background tab; Shift+click → new window; **middle-click** → background tab and the menu closes.
5. Modifier-click the **Gmail tab** → it is just selected; no second Gmail instance anywhere.
6. Right-click an app tab → **"New <App> Tab"** is the first item and opens a foreground tab at the app's root URL.
7. Navigate inside a tab (e.g. open a document), right-click → **"Duplicate Tab"** → new foreground tab at that same URL, not the app root. On a dimmed dormant pinned tab, it opens the saved URL.
8. With several tabs open (one pinned): **"Close Other Tabs"** keeps the clicked tab, Gmail, and pinned tabs; if the previously active tab was closed, the clicked tab becomes active.
9. **"Close Tabs Below"** closes only unpinned tabs below the clicked one, and both close items are greyed out when there is nothing they would close.
10. Free tier: modifier clicks and the context-menu open items do nothing (no tabs are created).

🤖 Generated with [Claude Code](https://claude.com/claude-code)