### PR TITLE
reopen the last closed tab with a keyboard shortcut

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -376,7 +376,6 @@ class Ipc {
       Menu.buildFromTemplate([
         {
           label: "Reopen Closed Tab",
-          accelerator: "CommandOrControl+Shift+T",
           enabled: account.instance.tabs.hasRecentlyClosedTabs,
           click: () => {
             if (account.instance.tabs.reopenClosedTab() && account.config.selected) {

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -370,6 +370,23 @@ class Ipc {
       ]).popup();
     });
 
+    ipc.main.on("tabs.showTabStripContextMenu", (_event, accountId) => {
+      const account = accounts.getAccount(accountId);
+
+      Menu.buildFromTemplate([
+        {
+          label: "Reopen Closed Tab",
+          accelerator: "CommandOrControl+Shift+T",
+          enabled: account.instance.tabs.hasRecentlyClosedTabs,
+          click: () => {
+            if (account.instance.tabs.reopenClosedTab() && account.config.selected) {
+              accounts.refreshSelectedAccountView();
+            }
+          },
+        },
+      ]).popup();
+    });
+
     ipc.main.handle("config.getConfig", () => config.store);
 
     ipc.main.handle(

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -511,6 +511,18 @@ export class AppMenu {
             acceleratorWorksWhenHidden: true,
             click: selectPreviousTab,
           },
+          {
+            type: "separator",
+          },
+          {
+            label: "Reopen Closed Tab",
+            accelerator: "CommandOrControl+Shift+T",
+            click: () => {
+              if (accounts.getSelectedAccount().instance.tabs.reopenClosedTab()) {
+                accounts.refreshSelectedAccountView();
+              }
+            },
+          },
         ],
       },
       {

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -259,6 +259,10 @@ export class Tabs {
     return workspaceApp;
   }
 
+  get hasRecentlyClosedTabs() {
+    return this.recentlyClosedTabUrls.length > 0;
+  }
+
   closeOtherTabs(keptTabId: string) {
     const previousActiveTabId = this.activeTabId;
 

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -9,6 +9,8 @@ import type { Gmail } from "./gmail";
 import { main } from "./main";
 import { WorkspaceApp } from "./workspace-app";
 
+const MAX_RECENTLY_CLOSED_TAB_URLS = 20;
+
 export function registerTabBroadcasts(view: WebContentsView) {
   const broadcastTabsChanged = () => {
     accounts.sendTabsChangedToRenderer();
@@ -67,6 +69,8 @@ export class Tabs {
   tabs: Tab[];
 
   activeTabId: string = GMAIL_TAB_ID;
+
+  private recentlyClosedTabUrls: string[] = [];
 
   constructor(accountId: string, gmail: Gmail) {
     this.accountId = accountId;
@@ -212,14 +216,47 @@ export class Tabs {
     const closableTab = this.getTab(tabId);
 
     if (closableTab instanceof WorkspaceApp) {
+      this.recordRecentlyClosedTab(
+        closableTab.view.webContents.getURL() ||
+          (closableTab.app ? getWorkspaceAppUrl(closableTab.app) : ""),
+      );
+
       closableTab.close();
 
       return;
     }
 
     if (closableTab instanceof DormantTab) {
+      this.recordRecentlyClosedTab(closableTab.url);
+
       this.removeTab(tabId);
     }
+  }
+
+  private recordRecentlyClosedTab(closedTabUrl: string) {
+    if (!closedTabUrl) {
+      return;
+    }
+
+    this.recentlyClosedTabUrls.push(closedTabUrl);
+
+    if (this.recentlyClosedTabUrls.length > MAX_RECENTLY_CLOSED_TAB_URLS) {
+      this.recentlyClosedTabUrls.shift();
+    }
+  }
+
+  reopenClosedTab() {
+    const reopenedTabUrl = this.recentlyClosedTabUrls.pop();
+
+    if (!reopenedTabUrl) {
+      return;
+    }
+
+    const workspaceApp = this.openTab(reopenedTabUrl);
+
+    this.activateTab(workspaceApp.id);
+
+    return workspaceApp;
   }
 
   closeOtherTabs(keptTabId: string) {

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -212,6 +212,15 @@ export function AppTabStrip() {
     <div
       className={cn("flex flex-col border-r", isWide ? "gap-1 p-2" : "items-center gap-2 py-2")}
       style={{ width: tabStripWidth, minWidth: tabStripWidth }}
+      onContextMenu={(event) => {
+        if (event.defaultPrevented) {
+          return;
+        }
+
+        event.preventDefault();
+
+        ipc.main.send("tabs.showTabStripContextMenu", selectedAccount.config.id);
+      }}
     >
       {selectedAccountTabs.tabs.map((tab) => (
         <StripTab key={tab.id} tab={tab} accountId={selectedAccount.config.id} isWide={isWide} />

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -175,6 +175,7 @@ export type IpcMainEvents =
       "tabs.selectTab": [accountId: AccountConfig["id"], tabId: string];
       "tabs.closeTab": [accountId: AccountConfig["id"], tabId: string];
       "tabs.showTabContextMenu": [accountId: AccountConfig["id"], tabId: string];
+      "tabs.showTabStripContextMenu": [accountId: AccountConfig["id"]];
       "workspaceApps.openApp": [
         app: SupportedWorkspaceApp,
         openBehavior?: WorkspaceAppOpenBehavior,


### PR DESCRIPTION
Adds Chrome's reopen-closed-tab muscle memory: **Cmd/Ctrl+Shift+T** reopens the most recently closed workspace-app tab of the selected account, via a new "Reopen Closed Tab" item in the Tabs menu — and the same action from a **context menu on the tab strip's empty space**, like Chrome's tab-strip menu.

## Changes

- Each `Tabs` instance keeps a session-only `recentlyClosedTabUrls` stack (capped at 20). `closeTab` records the tab's current URL before closing — this covers the close button, middle-click, the context menu's Close Tab / Close Other Tabs / Close Tabs Below, and dormant pinned tabs (their saved URL).
- Deliberately **not** recorded: `closeAll` (account removal / quit) and the unpin-a-dormant-tab removal path — those aren't user "close tab" actions.
- `reopenClosedTab()` pops the stack, opens the URL as a foreground tab, and activates it; the menu item is a no-op when the stack is empty.
- **Right-clicking empty strip space** opens a menu with "Reopen Closed Tab" (greyed out when nothing was closed this session), via a new `tabs.showTabStripContextMenu` IPC event. A `defaultPrevented` guard keeps tab right-clicks (which open the per-tab menu) from also triggering the strip menu.

## Notes for review

- Session-only by design — the stack doesn't survive a restart (Chrome persists; can be added later if missed).
- Reopening a closed *pinned* tab restores its URL but not its pinned state or Load on Launch flag — it comes back as a regular tab.
- The accelerator lives in the Tabs menu next to Select Next/Previous Tab and follows their pattern (no `main.show()`).
- Verified with `bun types:ci`; not manually tested in the running app.

## Test plan

Licensed account; Cmd on macOS, Ctrl elsewhere.

1. Open an app tab, navigate somewhere inside it, close it (hover X) → **Cmd+Shift+T** brings it back as the active tab at the navigated URL, not the app root.
2. Close three tabs in sequence, press Cmd+Shift+T three times → they reopen in reverse order (most recently closed first).
3. Use **Close Other Tabs** on a strip tab, then press Cmd+Shift+T repeatedly → each swept-away tab comes back.
4. Close a *pinned* tab via its context menu, reopen it → it returns at its URL but as a regular unpinned tab (pin and Load on Launch are deliberately not restored).
5. Close a dimmed **dormant** pinned tab, reopen → it comes back live at its saved URL.
6. Check the menu bar: **Tabs → Reopen Closed Tab** sits after a separator below the select items.
7. **Right-click the empty area of the tab strip** (below the "+" button) → a menu shows "Reopen Closed Tab"; picking it reopens the last closed tab. With nothing closed this session, the item is greyed out.
8. Right-click a **tab** in the strip → only the per-tab menu opens, never the strip menu on top of it.
9. Per-account isolation: close a tab in account A, switch to account B, press Cmd+Shift+T → nothing happens in B; switch back to A and it reopens there.
10. Fresh start: relaunch the app and press Cmd+Shift+T → no-op (the stack is session-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

