### PR TITLE
add stacked pull requests guideline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,7 @@ This installs dependencies and runs postinstall scripts (including the lefthook 
 - The description should cover the problem being solved, the changes made, and anything a reviewer needs in order to judge them — including deliberate omissions, known risks, and what has not been verified.
 - End every description with a **Test plan** section: a numbered list of concrete steps to walk through in the running app to verify the work. Write each step as a user action with its expected outcome, and cover the changed behavior's edge cases (gated states, empty states, platform differences), not just the happy path. Keep it in sync with the branch like the rest of the description.
 - Check the state of a pull request before acting on it rather than assuming it is unchanged. `gh pr list` only shows open pull requests, so one disappearing from the list means it was merged or closed.
+- When new work depends on a pull request that is still open, don't wait for it to merge and don't base the work on `main` — branch off the open pull request's branch, open the new pull request with that branch as its base, and link the chain into a GitHub stack with `gh stack link <bottom> ... <top>` (bottom to top; PR numbers or branch names). GitHub then shows the stack on each pull request and retargets bases as parts merge; merge a whole chain atomically with `gh stack merge` instead of merging its pull requests one by one.
 
 ## Release Notes
 


### PR DESCRIPTION
Dependent work has so far been stacked ad hoc (base-branch PRs with a manual "merge X first" note, e.g. the original #651 description). This documents the GitHub-native workflow in CLAUDE.md's Pull Requests section: branch off the open parent PR, base the new PR on it, link the chain with `gh stack link` (bottom to top), and merge chains atomically with `gh stack merge`.

(Originally stacked on #652, which merged while this was being opened — now a plain PR against main.)

## Test plan

1. Read the new bullet at the end of the Pull Requests section — it should cover the full lifecycle: when to stack, how to base the branch and PR, `gh stack link` argument order, and `gh stack merge`.
2. Open #650 or #651 on GitHub — both show their stack in the PR header (linked via `gh stack link 650 651`), serving as the reference example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)