### PR TITLE
add reload, copy link and open in default browser to the tab context menu

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -287,7 +287,7 @@ class Ipc {
             ]
           : []),
         {
-          label: "Reload Tab",
+          label: "Reload",
           enabled: tab instanceof WorkspaceApp,
           click: () => {
             if (tab instanceof WorkspaceApp) {

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -296,7 +296,7 @@ class Ipc {
           },
         },
         {
-          label: "Duplicate Tab",
+          label: "Duplicate",
           click: () => {
             const currentTabUrl =
               tab instanceof WorkspaceApp ? tab.view.webContents.getURL() : tab.url;

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -345,13 +345,13 @@ class Ipc {
         },
         tab.pinned
           ? {
-              label: "Unpin Tab",
+              label: "Unpin",
               click: () => {
                 account.instance.tabs.unpinTab(tabId);
               },
             }
           : {
-              label: "Pin Tab",
+              label: "Pin",
               click: () => {
                 account.instance.tabs.pinTab(tabId);
               },
@@ -374,7 +374,7 @@ class Ipc {
           type: "separator",
         },
         {
-          label: "Close Tab",
+          label: "Close",
           click: () => {
             account.instance.tabs.closeTab(tabId);
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -329,7 +329,7 @@ class Ipc {
           },
         },
         {
-          label: "Open in Browser",
+          label: "Open in Default Browser",
           click: () => {
             if (tab instanceof WorkspaceApp) {
               tab.openInBrowser();

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -317,7 +317,7 @@ class Ipc {
           type: "separator",
         },
         {
-          label: "Copy URL",
+          label: "Copy Link",
           click: () => {
             if (tab instanceof WorkspaceApp) {
               tab.copyUrl();

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -287,6 +287,15 @@ class Ipc {
             ]
           : []),
         {
+          label: "Reload Tab",
+          enabled: tab instanceof WorkspaceApp,
+          click: () => {
+            if (tab instanceof WorkspaceApp) {
+              tab.reload();
+            }
+          },
+        },
+        {
           label: "Duplicate Tab",
           click: () => {
             const currentTabUrl =

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -10,6 +10,7 @@ import { workspaceApps } from "@meru/shared/workspace-apps";
 import {
   app,
   BrowserWindow,
+  clipboard,
   desktopCapturer,
   dialog,
   Menu,
@@ -35,6 +36,7 @@ import { log } from "./lib/log";
 import { createNewEmailNotification } from "./notifications";
 import { MAILTO_PROTOCOL } from "./protocol";
 import { appUpdater } from "./updater";
+import { openExternalUrl } from "./url";
 
 function getNavigationWebContents(workspaceAppId?: string) {
   if (workspaceAppId) {
@@ -300,6 +302,33 @@ class Ipc {
             if (account.config.selected) {
               accounts.refreshSelectedAccountView();
             }
+          },
+        },
+        {
+          type: "separator",
+        },
+        {
+          label: "Copy URL",
+          click: () => {
+            if (tab instanceof WorkspaceApp) {
+              tab.copyUrl();
+
+              return;
+            }
+
+            clipboard.writeText(tab.url);
+          },
+        },
+        {
+          label: "Open in Browser",
+          click: () => {
+            if (tab instanceof WorkspaceApp) {
+              tab.openInBrowser();
+
+              return;
+            }
+
+            openExternalUrl(tab.url, { skipTrustedHostCheck: true });
           },
         },
         {

--- a/packages/renderer-workspace-app/index.tsx
+++ b/packages/renderer-workspace-app/index.tsx
@@ -183,7 +183,7 @@ function App() {
           <RecentDownloadHistoryButton />
           <CopyUrlButton workspaceAppId={workspaceAppId} />
           <TitlebarIconButton
-            title="Open in Browser"
+            title="Open in Default Browser"
             onClick={() => {
               ipc.main.send("workspaceApp.openInBrowser", workspaceAppId);
             }}

--- a/packages/renderer-workspace-app/index.tsx
+++ b/packages/renderer-workspace-app/index.tsx
@@ -87,7 +87,7 @@ function CopyUrlButton({ workspaceAppId }: { workspaceAppId: string }) {
 
   return (
     <TitlebarIconButton
-      title="Copy URL"
+      title="Copy Link"
       onClick={() => {
         ipc.main.send("workspaceApp.copyUrl", workspaceAppId);
         markCopied();


### PR DESCRIPTION
Workspace apps opened as windows offer copying the page link and Open in Browser in their titlebar, but the same apps opened as embedded tabs had no equivalent — and no way to reload from the tab itself. This adds all three to the tab context menu, and settles the wording as **"Copy Link"** across both surfaces (Google's own Workspace apps use "Copy link" in their Share UIs, so it matches what users of these apps see daily; the windowed titlebar button is renamed in the same commit).

## Changes

- **"Copy Link"** and **"Open in Default Browser"**, in their own group after Duplicate. Live tabs reuse the existing `WorkspaceApp.copyUrl()` / `openInBrowser()` methods; dormant pinned tabs mirror them against their saved URL (including the `skipTrustedHostCheck: true` flag, since workspace-app URLs are inherently trusted).
- **"Reload"** (Chrome's tab-menu wording), placed before Duplicate, calling the existing `WorkspaceApp.reload()`; greyed out for dormant tabs, which have no view to reload.
- The workspace-app window titlebar buttons are renamed "Copy URL" → "Copy Link" and "Open in Browser" → "Open in Default Browser" to match (label only — the `workspaceApp.copyUrl` IPC name and `copyUrl()` method are unchanged).

Resulting menu order: [New <App> Tab], Reload, Duplicate | Copy Link, Open in Default Browser | Pin/Unpin, [Load on Launch] | Close, Close Other Tabs, Close Tabs Below.

## Notes for review

- No IPC surface changes; the rename is user-facing text only.
- The page-content right-click menu ("Copy Link"/"Open in Default Browser" from TODO.md) is deliberately not part of this — different surface, separate change.
- Verified with `bun types:ci`; not manually tested in the running app.

## Test plan

1. Open a workspace app tab and navigate somewhere inside it (e.g. open a document). Right-click the tab → the menu shows Reload and Duplicate, then Copy Link and Open in Default Browser in their own group.
2. **Copy Link** → paste somewhere: it's the tab's current URL (the document), not the app root.
3. **Open in Default Browser** → the default browser opens that same URL.
4. **Reload** → the tab reloads (spinner in the titlebar navigation controls while loading).
5. On a dimmed **dormant** pinned tab: Reload is greyed out; Copy Link and Open in Default Browser act on its saved URL.
6. Gmail tab: right-click still shows no menu (unchanged).
7. Open a workspace app **as a window** → the titlebar's copy button tooltips now read "Copy Link" and "Open in Default Browser".

🤖 Generated with [Claude Code](https://claude.com/claude-code)




