### PR TITLE
strip google from app names in tab titles

### DIFF
--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -11,18 +11,10 @@ import { WorkspaceApp } from "./workspace-app";
 
 const MAX_RECENTLY_CLOSED_TAB_URLS = 20;
 
-function stripWorkspaceAppPageTitle(pageTitle: string, app: SupportedWorkspaceApp) {
+function stripGoogleFromPageTitle(pageTitle: string, app: SupportedWorkspaceApp) {
   const appLabel = workspaceApps[app].label;
 
-  if (pageTitle === appLabel || pageTitle === `Google ${appLabel}`) {
-    return pageTitle;
-  }
-
-  const strippedPageTitle = pageTitle
-    .replace(new RegExp(` - (Google )?${appLabel}$`), "")
-    .replace(new RegExp(`^Google ${appLabel} - `), "");
-
-  return strippedPageTitle || pageTitle;
+  return pageTitle.replace(`Google ${appLabel}`, appLabel);
 }
 
 export function registerTabBroadcasts(view: WebContentsView) {
@@ -389,7 +381,7 @@ export class Tabs {
     return this.tabs.map((tab) => ({
       id: tab.id,
       app: tab.app,
-      title: tab.app ? stripWorkspaceAppPageTitle(tab.title, tab.app) : tab.title,
+      title: tab.app ? stripGoogleFromPageTitle(tab.title, tab.app) : tab.title,
       pinned: tab.pinned,
       dormant: tab instanceof DormantTab,
       loading: tab.isLoading,

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -11,6 +11,20 @@ import { WorkspaceApp } from "./workspace-app";
 
 const MAX_RECENTLY_CLOSED_TAB_URLS = 20;
 
+function stripWorkspaceAppPageTitle(pageTitle: string, app: SupportedWorkspaceApp) {
+  const appLabel = workspaceApps[app].label;
+
+  if (pageTitle === appLabel || pageTitle === `Google ${appLabel}`) {
+    return pageTitle;
+  }
+
+  const strippedPageTitle = pageTitle
+    .replace(new RegExp(` - (Google )?${appLabel}$`), "")
+    .replace(new RegExp(`^Google ${appLabel} - `), "");
+
+  return strippedPageTitle || pageTitle;
+}
+
 export function registerTabBroadcasts(view: WebContentsView) {
   const broadcastTabsChanged = () => {
     accounts.sendTabsChangedToRenderer();
@@ -375,7 +389,7 @@ export class Tabs {
     return this.tabs.map((tab) => ({
       id: tab.id,
       app: tab.app,
-      title: tab.title,
+      title: tab.app ? stripWorkspaceAppPageTitle(tab.title, tab.app) : tab.title,
       pinned: tab.pinned,
       dormant: tab instanceof DormantTab,
       loading: tab.isLoading,


### PR DESCRIPTION
Google page titles carry verbose app names — "Quarterly Notes - Google Docs", "Google Calendar - August 2026", or just "Google Docs" on unnamed documents. This shortens them in the tab strip by dropping the "Google " prefix from the app name wherever "Google <App>" appears, keeping the app name itself.

## Changes

- New `stripGoogleFromPageTitle` helper in `packages/app/tabs.ts`: a plain string replace of `Google <Label>` → `<Label>`, using the app's label from the `workspaceApps` map. No regex, no positional anchors, no empty-result edge case (the label always remains).
- Applied only in `Tabs.serialize()`, and only for tabs with a known app — the single point feeding the strip (labels and hover tooltips).

Examples: "Quarterly Notes - Google Docs" → "Quarterly Notes - Docs" · "Google Docs" → "Docs" · "Google Calendar - August 2026" → "Calendar - August 2026" · Gmail titles are unchanged (they end in " - Gmail", no "Google " prefix).

(The first iteration stripped the whole " - Google <App>" suffix, which left bare "Google Docs" titles untouched — replaced after review.)

## Notes for review

- Deliberately **not** touched: the `title` getters, the windowed titlebar's page title, and `serializePinnedTabs` — persisted pinned titles stay raw and get stripped fresh at render time, so the config file shows the full title while the strip shows the short one.
- Only the first "Google <Label>" occurrence is replaced (plain string replace) — fine in practice, a title repeating it is pathological.
- Verified with `bun types:ci`; not manually tested in the running app.

## Test plan

1. Open a Docs document as a tab with the wide strip active → the tab shows "<Document name> - Docs" (hover tooltip matches).
2. Open a fresh unnamed document or the Docs home page (title just "Google Docs") → the tab shows "Docs".
3. Open Calendar as a tab → "Calendar - August 2026" (or the current view) without "Google ".
4. The Gmail tab keeps its full title (e.g. "Inbox - tim@example.com - Gmail") — no "Google " prefix to strip.
5. Pin a Docs tab and check the config file (`workspaceApps.pinnedTabs`) → the persisted title still contains "Google Docs" while the strip shows the short form.
6. A workspace-app **window**'s titlebar still shows the full page title (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)