### PR TITLE
add a divider between pinned and unpinned tabs

### DIFF
--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -12,10 +12,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@meru/ui/components/dropdown-menu";
+import { Separator } from "@meru/ui/components/separator";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { cn } from "@meru/ui/lib/utils";
 import { GlobeIcon, PlusIcon, XIcon } from "lucide-react";
-import { type MouseEvent, useEffect, useState } from "react";
+import { Fragment, type MouseEvent, useEffect, useState } from "react";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
 
@@ -208,6 +209,12 @@ export function AppTabStrip() {
 
   const isWide = tabStripWidth === APP_TAB_STRIP_WIDE_WIDTH;
 
+  const hasPinnedTabs = selectedAccountTabs.tabs.some((tab) => tab.pinned);
+
+  const firstUnpinnedTabId = selectedAccountTabs.tabs.find(
+    (tab) => !tab.pinned && tab.id !== GMAIL_TAB_ID,
+  )?.id;
+
   return (
     <div
       className={cn("flex flex-col border-r", isWide ? "gap-1 p-2" : "items-center gap-2 py-2")}
@@ -223,7 +230,12 @@ export function AppTabStrip() {
       }}
     >
       {selectedAccountTabs.tabs.map((tab) => (
-        <StripTab key={tab.id} tab={tab} accountId={selectedAccount.config.id} isWide={isWide} />
+        <Fragment key={tab.id}>
+          {hasPinnedTabs && tab.id === firstUnpinnedTabId && (
+            <Separator className={isWide ? undefined : "data-horizontal:w-8"} />
+          )}
+          <StripTab tab={tab} accountId={selectedAccount.config.id} isWide={isWide} />
+        </Fragment>
       ))}
       <NewTabButton isWide={isWide} />
     </div>


### PR DESCRIPTION
Pinned and regular tabs currently run together in the strip. This adds a Chrome-style divider between the two sections.

## Changes

- `AppTabStrip` renders a `Separator` (existing `@meru/ui` component) before the first unpinned non-Gmail tab, only when the strip has at least one pinned tab **and** at least one unpinned tab. No pinned tabs → no divider (Gmail sits directly above regular tabs, unchanged); only pinned tabs → no divider.
- Narrow (icon rail) layout uses a 32px divider matching the icon-button width (`data-horizontal:w-8`, prefixed to override the component's own `data-horizontal:w-full` via `twMerge`); wide layout keeps the full-row width.

## Notes for review

- Renderer-only; the boundary is computed from the already-ordered tab list (`Tabs.reorderTabs` guarantees Gmail → pinned → unpinned).
- Verified with `bun types:ci`; not visually verified in the running app — the narrow-mode divider width is the thing to eyeball.

## Test plan

1. Pin one tab while another unpinned tab is open → a divider appears between the pinned and unpinned sections, in both the narrow rail and the wide strip (open a second tab of the same app to force wide mode).
2. In the narrow rail, the divider is a short centered line (icon-width), not a full-bleed line; in the wide strip it spans the row.
3. Unpin the tab (or close all unpinned tabs) → the divider disappears.
4. With no pinned tabs at all, the strip looks exactly as before — no divider under Gmail.
5. Restart with a pinned tab and an unpinned tab restored → divider present above the freshly restored unpinned section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)