### PR TITLE
show pinned tabs as an icon grid in the wide tab strip

### DIFF
--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -234,7 +234,7 @@ export function AppTabStrip() {
     (tab) => tab.id !== GMAIL_TAB_ID && !tab.pinned,
   );
 
-  const shouldRenderSeparator = unpinnedTabs.length > 0 && (isWide || hasPinnedTabs);
+  const shouldRenderSeparator = !isWide && hasPinnedTabs && unpinnedTabs.length > 0;
 
   return (
     <div
@@ -253,7 +253,7 @@ export function AppTabStrip() {
       {isWide ? (
         <div
           className={cn(
-            "grid w-full gap-1",
+            "grid w-full gap-2",
             getPinnedSectionGridColumnsClassName(pinnedSectionTabs.length),
           )}
         >
@@ -276,9 +276,7 @@ export function AppTabStrip() {
           />
         ))
       )}
-      {shouldRenderSeparator && (
-        <Separator className={isWide ? undefined : "data-horizontal:w-8"} />
-      )}
+      {shouldRenderSeparator && <Separator className="data-horizontal:w-8" />}
       {unpinnedTabs.map((tab) => (
         <StripTab
           key={tab.id}

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -253,7 +253,7 @@ export function AppTabStrip() {
       {isWide ? (
         <div
           className={cn(
-            "grid w-full gap-2",
+            "mb-2 grid w-full gap-2",
             getPinnedSectionGridColumnsClassName(pinnedSectionTabs.length),
           )}
         >

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -16,7 +16,7 @@ import { Separator } from "@meru/ui/components/separator";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { cn } from "@meru/ui/lib/utils";
 import { GlobeIcon, PlusIcon, XIcon } from "lucide-react";
-import { Fragment, type MouseEvent, useEffect, useState } from "react";
+import { type MouseEvent, useEffect, useState } from "react";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
 
@@ -41,13 +41,15 @@ function TabIcon({ tab }: { tab: TabState }) {
 function StripTab({
   tab,
   accountId,
-  isWide,
+  presentation,
 }: {
   tab: TabState;
   accountId: AccountConfig["id"];
-  isWide: boolean;
+  presentation: "wideRow" | "narrowIcon" | "gridIcon";
 }) {
   const isCloseable = tab.id !== GMAIL_TAB_ID && !tab.pinned;
+
+  const isWideRow = presentation === "wideRow";
 
   const canOpenSecondInstance =
     tab.app && !workspaceApps[tab.app].singleInstance && !workspaceApps[tab.app].alwaysOpenAsWindow;
@@ -56,11 +58,12 @@ function StripTab({
     <div className="group relative">
       <Button
         variant={tab.active ? "secondary" : "ghost"}
-        size={isWide ? "sm" : "icon"}
+        size={isWideRow ? "sm" : "icon"}
         className={cn(
           tab.dormant && "opacity-50",
-          isWide && "w-full justify-start",
-          isWide && isCloseable && "pr-7",
+          isWideRow && "w-full justify-start",
+          isWideRow && isCloseable && "pr-7",
+          presentation === "gridIcon" && "w-full",
         )}
         title={tab.title}
         onClick={(event) => {
@@ -86,7 +89,7 @@ function StripTab({
         }}
       >
         <TabIcon tab={tab} />
-        {isWide && <span className="truncate">{tab.title}</span>}
+        {isWideRow && <span className="truncate">{tab.title}</span>}
       </Button>
       {isCloseable && (
         <Button
@@ -94,7 +97,7 @@ function StripTab({
           size="icon"
           className={cn(
             "absolute hidden group-hover:flex",
-            isWide
+            isWideRow
               ? "top-1/2 right-1 size-5 -translate-y-1/2"
               : "-top-1 -right-1 size-4 rounded-full",
           )}
@@ -183,6 +186,18 @@ function NewTabButton({ isWide }: { isWide: boolean }) {
   );
 }
 
+function getPinnedSectionGridColumnsClassName(pinnedSectionTabsCount: number) {
+  if (pinnedSectionTabsCount === 1) {
+    return "grid-cols-1";
+  }
+
+  if (pinnedSectionTabsCount % 2 === 0) {
+    return "grid-cols-2";
+  }
+
+  return "grid-cols-3";
+}
+
 export function AppTabStrip() {
   const accounts = useAccountsStore((state) => state.accounts);
   const accountsTabs = useTabsStore((state) => state.accountsTabs);
@@ -211,9 +226,15 @@ export function AppTabStrip() {
 
   const hasPinnedTabs = selectedAccountTabs.tabs.some((tab) => tab.pinned);
 
-  const firstUnpinnedTabId = selectedAccountTabs.tabs.find(
-    (tab) => !tab.pinned && tab.id !== GMAIL_TAB_ID,
-  )?.id;
+  const pinnedSectionTabs = selectedAccountTabs.tabs.filter(
+    (tab) => tab.id === GMAIL_TAB_ID || tab.pinned,
+  );
+
+  const unpinnedTabs = selectedAccountTabs.tabs.filter(
+    (tab) => tab.id !== GMAIL_TAB_ID && !tab.pinned,
+  );
+
+  const shouldRenderSeparator = unpinnedTabs.length > 0 && (isWide || hasPinnedTabs);
 
   return (
     <div
@@ -229,13 +250,42 @@ export function AppTabStrip() {
         ipc.main.send("tabs.showTabStripContextMenu", selectedAccount.config.id);
       }}
     >
-      {selectedAccountTabs.tabs.map((tab) => (
-        <Fragment key={tab.id}>
-          {hasPinnedTabs && tab.id === firstUnpinnedTabId && (
-            <Separator className={isWide ? undefined : "data-horizontal:w-8"} />
+      {isWide ? (
+        <div
+          className={cn(
+            "grid w-full gap-1",
+            getPinnedSectionGridColumnsClassName(pinnedSectionTabs.length),
           )}
-          <StripTab tab={tab} accountId={selectedAccount.config.id} isWide={isWide} />
-        </Fragment>
+        >
+          {pinnedSectionTabs.map((tab) => (
+            <StripTab
+              key={tab.id}
+              tab={tab}
+              accountId={selectedAccount.config.id}
+              presentation="gridIcon"
+            />
+          ))}
+        </div>
+      ) : (
+        pinnedSectionTabs.map((tab) => (
+          <StripTab
+            key={tab.id}
+            tab={tab}
+            accountId={selectedAccount.config.id}
+            presentation="narrowIcon"
+          />
+        ))
+      )}
+      {shouldRenderSeparator && (
+        <Separator className={isWide ? undefined : "data-horizontal:w-8"} />
+      )}
+      {unpinnedTabs.map((tab) => (
+        <StripTab
+          key={tab.id}
+          tab={tab}
+          accountId={selectedAccount.config.id}
+          presentation={isWide ? "wideRow" : "narrowIcon"}
+        />
       ))}
       <NewTabButton isWide={isWide} />
     </div>

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -249,9 +249,7 @@ export function AppTabStrip() {
               accountId={selectedAccount.config.id}
               presentation="gridIcon"
               className={cn(
-                pinnedSectionTabs.length % 2 === 1 &&
-                  pinnedSectionTabIndex === pinnedSectionTabs.length - 1 &&
-                  "col-span-2",
+                pinnedSectionTabs.length % 2 === 1 && pinnedSectionTabIndex === 0 && "col-span-2",
               )}
             />
           ))}

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -42,10 +42,12 @@ function StripTab({
   tab,
   accountId,
   presentation,
+  className,
 }: {
   tab: TabState;
   accountId: AccountConfig["id"];
   presentation: "wideRow" | "narrowIcon" | "gridIcon";
+  className?: string;
 }) {
   const isCloseable = tab.id !== GMAIL_TAB_ID && !tab.pinned;
 
@@ -55,7 +57,7 @@ function StripTab({
     tab.app && !workspaceApps[tab.app].singleInstance && !workspaceApps[tab.app].alwaysOpenAsWindow;
 
   return (
-    <div className="group relative">
+    <div className={cn("group relative", className)}>
       <Button
         variant={tab.active ? "secondary" : presentation === "gridIcon" ? "outline" : "ghost"}
         size={isWideRow ? "sm" : "icon"}
@@ -186,18 +188,6 @@ function NewTabButton({ isWide }: { isWide: boolean }) {
   );
 }
 
-function getPinnedSectionGridColumnsClassName(pinnedSectionTabsCount: number) {
-  if (pinnedSectionTabsCount === 1) {
-    return "grid-cols-1";
-  }
-
-  if (pinnedSectionTabsCount % 2 === 0) {
-    return "grid-cols-2";
-  }
-
-  return "grid-cols-3";
-}
-
 export function AppTabStrip() {
   const accounts = useAccountsStore((state) => state.accounts);
   const accountsTabs = useTabsStore((state) => state.accountsTabs);
@@ -251,18 +241,18 @@ export function AppTabStrip() {
       }}
     >
       {isWide ? (
-        <div
-          className={cn(
-            "mb-1 grid w-full gap-2",
-            getPinnedSectionGridColumnsClassName(pinnedSectionTabs.length),
-          )}
-        >
-          {pinnedSectionTabs.map((tab) => (
+        <div className="mb-1 grid w-full grid-cols-2 gap-2">
+          {pinnedSectionTabs.map((tab, pinnedSectionTabIndex) => (
             <StripTab
               key={tab.id}
               tab={tab}
               accountId={selectedAccount.config.id}
               presentation="gridIcon"
+              className={cn(
+                pinnedSectionTabs.length % 2 === 1 &&
+                  pinnedSectionTabIndex === pinnedSectionTabs.length - 1 &&
+                  "col-span-2",
+              )}
             />
           ))}
         </div>

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -253,7 +253,7 @@ export function AppTabStrip() {
       {isWide ? (
         <div
           className={cn(
-            "mb-2 grid w-full gap-2",
+            "mb-1 grid w-full gap-2",
             getPinnedSectionGridColumnsClassName(pinnedSectionTabs.length),
           )}
         >

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -57,7 +57,7 @@ function StripTab({
   return (
     <div className="group relative">
       <Button
-        variant={tab.active ? "secondary" : "ghost"}
+        variant={tab.active ? "secondary" : presentation === "gridIcon" ? "outline" : "ghost"}
         size={isWideRow ? "sm" : "icon"}
         className={cn(
           tab.dormant && "opacity-50",

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -20,7 +20,10 @@ export type AccountTabsState = {
   tabs: TabState[];
 };
 
-export function getTabStripWidth(tabs: Pick<TabState, "app">[], hasBookmarkedApps: boolean) {
+export function getTabStripWidth(
+  tabs: Pick<TabState, "app" | "pinned">[],
+  hasBookmarkedApps: boolean,
+) {
   if (tabs.length <= 1 && !hasBookmarkedApps) {
     return 0;
   }
@@ -28,7 +31,7 @@ export function getTabStripWidth(tabs: Pick<TabState, "app">[], hasBookmarkedApp
   const workspaceAppTabCounts = new Map<SupportedWorkspaceApp, number>();
 
   for (const tab of tabs) {
-    if (tab.app) {
+    if (tab.app && !tab.pinned) {
       workspaceAppTabCounts.set(tab.app, (workspaceAppTabCounts.get(tab.app) ?? 0) + 1);
     }
   }


### PR DESCRIPTION
In the wide strip, pinned tabs currently occupy a full row each, showing page titles that matter least for pinned entries (they're recognized by icon). This reworks the pinned section — the Gmail tab plus all pinned tabs — into an Arc-style grid of icon-only outline buttons.

## Changes

- **Wide layout**: the pinned section renders as a CSS grid of icon buttons at the top of the strip — always 2 columns; an odd count makes Gmail (always first) the full-width button at the top with the pairs below, so a lone Gmail is a single full-width button with the centered icon (Arc's lone-favorite look). Unpinned tabs keep their full rows with titles below.
- **Divider**: removed in wide mode — the grid itself visually separates the sections; the narrow rail keeps the #657 divider exactly as before. The grid gap matches the strip's edge padding (`gap-2` vs `p-2`).
- **Narrow layout**: unchanged.
- **Wide trigger**: `getTabStripWidth` now counts only non-pinned tabs when checking for a duplicated app — pinned tabs live in the titleless grid, so duplicates among them (previously forcing the 224px layout) keep the strip narrow. Wide mode is reserved for duplicated *normal* tabs, where titles disambiguate.
- Refactor: `StripTab`'s `isWide` boolean became a `presentation: "wideRow" | "narrowIcon" | "gridIcon"` prop — the grid variant is the narrow icon stretched to its cell (`w-full`), and all click/modifier/context-menu handlers, tooltips, and active/dormant styling are shared, not duplicated.

## Notes for review

- Grid buttons never need the hover close overlay: Gmail and pinned tabs are already non-closeable in the strip.
- Verified with `bun types:ci`; **not visually verified** — the button proportions at 2/3 columns inside the 224px strip are the thing to eyeball, plus the lone-Gmail centered look.
- Follow-up memo remains open: possibly test a constant 3-per-row variant instead of the even→2 rule.

## Test plan

Wide strip active (open a second tab of some app), at least one pinned tab.

1. With Gmail + 1 pinned tab (even count) → the two icons sit side by side; with Gmail + 2 pinned (odd) → Gmail full-width on top, the pair below.
2. Unpin everything → Gmail alone shows as a single full-width button with the icon centered.
3. Pinned icons: hover shows the page-title tooltip; inactive icons show the outline (bordered tile) style, the active tab shows the secondary background; a dormant restored tab is dimmed; right-click opens the tab context menu; Cmd/Ctrl+click still opens a background tab of the app.
4. No divider in the wide strip — the spacing between the grid and the unpinned rows separates the sections; the icon spacing inside the grid matches the strip's edge padding.
5. Pin two tabs of the same app with no duplicated normal tabs → the strip stays narrow (before this PR it went wide); open a second normal tab of some app → it goes wide.
6. Switch to the narrow rail (only single tabs per app, or a Gmail-only account with bookmarks) → everything looks exactly as before this PR.
7. Unpinned tabs below the grid still show icon + truncated title rows with hover close buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




