### PR TITLE
fix screen sharing in embedded Meet tabs

### DIFF
--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -16,6 +16,7 @@ import { config } from "./config";
 import { Gmail } from "./gmail";
 import { createBrowserWindow, getPreloadPath, loadRenderer } from "./lib/window";
 import { licenseKey } from "./license-key";
+import { main } from "./main";
 import { Tabs } from "./tabs";
 import { WorkspaceApp } from "./workspace-app";
 
@@ -97,19 +98,31 @@ export class Account {
   private registerSessionDisplayMediaRequestHandler() {
     this.session.setDisplayMediaRequestHandler(
       async (_request, callback) => {
-        const googleMeetWindow = Array.from(this.windows).find(
-          (window): window is BrowserWindow => {
-            if (!(window instanceof BrowserWindow)) {
-              return false;
+        let googleMeetParentWindow: BrowserWindow | undefined;
+
+        for (const workspaceAppWindowOrView of this.windows) {
+          if (workspaceAppWindowOrView instanceof BrowserWindow) {
+            const workspaceApp = WorkspaceApp.tryFromWebContents(
+              workspaceAppWindowOrView.webContents,
+            );
+
+            if (workspaceApp?.view.webContents.getURL().startsWith(GOOGLE_MEET_URL)) {
+              googleMeetParentWindow = workspaceAppWindowOrView;
+
+              break;
             }
 
-            const workspaceApp = WorkspaceApp.tryFromWebContents(window.webContents);
+            continue;
+          }
 
-            return workspaceApp?.view.webContents.getURL().startsWith(GOOGLE_MEET_URL) ?? false;
-          },
-        );
+          if (workspaceAppWindowOrView.webContents.getURL().startsWith(GOOGLE_MEET_URL)) {
+            googleMeetParentWindow = main.window;
 
-        if (!googleMeetWindow) {
+            break;
+          }
+        }
+
+        if (!googleMeetParentWindow) {
           callback({});
 
           return;
@@ -117,7 +130,7 @@ export class Account {
 
         const desktopSourcesWindow = createBrowserWindow({
           title: "Choose what to share",
-          parent: googleMeetWindow,
+          parent: googleMeetParentWindow,
           width: 576,
           height: 512,
           resizable: false,


### PR DESCRIPTION
## Problem

`registerSessionDisplayMediaRequestHandler` in `packages/app/account.ts` locates the Meet instance by filtering `Account.windows` with `instanceof BrowserWindow`. An embedded Meet **tab** is a bare `WebContentsView` in that set, so it never matches — the handler falls through to `callback({})` and screen sharing is silently denied in embedded Meet.

## Changes

- The handler now resolves a `googleMeetParentWindow` by walking `Account.windows` for both shapes: a windowed Meet instance (resolved via `WorkspaceApp.tryFromWebContents`, picker parented to that window, as before) and an embedded Meet view (URL checked directly on the view's webContents, picker parented to `main.window`).
- If neither exists, the request is still denied via `callback({})` as before.

Only `WorkspaceApp` instances populate `Account.windows` (windowed instances add their `BrowserWindow`, embedded tabs add their `WebContentsView`), so a `WebContentsView` entry is always a workspace-app view and its URL can be checked directly.

## Notes for review

- The upcoming `Account.windows` diet refactor (convergence backlog in `TODO.md`) would simplify this handler further; this PR is the minimal bug fix.
- Verified with `bun types:ci`; not exercised in a live Meet call.

## Test plan

1. With a valid license, open Google Meet as an embedded tab, join a meeting, and click Present now → a "Choose what to share" picker window opens centered on the main window; picking a source starts the share.
2. Cancel/close the picker without choosing → Meet reports the share as cancelled, no crash.
3. Open Meet in its own window instead and present → picker still opens parented to the Meet window and sharing works (regression check).
4. With "Use system picker" enabled in settings (macOS), the system picker path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)