### PR TITLE
add move to new window to the tab context menu

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -8,6 +8,7 @@ import { ipc } from "./ipc";
 import { licenseKey } from "./license-key";
 import { main } from "./main";
 import { appState } from "./state";
+import { isWindowedTab } from "./tabs";
 
 class Accounts {
   instances: Map<string, Account> = new Map();
@@ -325,17 +326,21 @@ class Accounts {
   }
 
   hide() {
-    for (const account of this.instances.values()) {
-      for (const tab of account.tabs.tabs) {
-        tab.view?.setVisible(false);
-      }
-    }
+    this.setEmbeddedViewsVisible(false);
   }
 
   show() {
+    this.setEmbeddedViewsVisible(true);
+  }
+
+  private setEmbeddedViewsVisible(visible: boolean) {
     for (const account of this.instances.values()) {
       for (const tab of account.tabs.tabs) {
-        tab.view?.setVisible(true);
+        if (isWindowedTab(tab)) {
+          continue;
+        }
+
+        tab.view?.setVisible(visible);
       }
     }
   }

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -394,7 +394,7 @@ export class Gmail {
 
     this.registerNavigationHandler(this.view);
 
-    broadcastFoundInPageResults(this.view, main.window.webContents);
+    broadcastFoundInPageResults(this.view, () => main.window.webContents);
 
     this.registerWindowOpenHandler(this.view);
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -224,7 +224,13 @@ class Ipc {
     ipc.main.on("tabs.selectTab", (_event, accountId, tabId) => {
       const account = accounts.getAccount(accountId);
 
+      const selectedTab = account.instance.tabs.getTab(tabId);
+
       account.instance.tabs.activateTab(tabId);
+
+      if (selectedTab instanceof WorkspaceApp && selectedTab.hasWindow) {
+        return;
+      }
 
       if (account.config.selected) {
         accounts.refreshSelectedAccountView();
@@ -315,7 +321,7 @@ class Ipc {
         },
         {
           label: "Move to New Window",
-          enabled: tab instanceof WorkspaceApp,
+          enabled: tab instanceof WorkspaceApp && !tab.hasWindow,
           click: () => {
             if (tab instanceof WorkspaceApp) {
               tab.detachToWindow();

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -314,6 +314,19 @@ class Ipc {
           },
         },
         {
+          label: "Move to New Window",
+          enabled: tab instanceof WorkspaceApp,
+          click: () => {
+            if (tab instanceof WorkspaceApp) {
+              tab.detachToWindow();
+            }
+
+            if (account.config.selected) {
+              accounts.refreshSelectedAccountView();
+            }
+          },
+        },
+        {
           type: "separator",
         },
         {

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -228,7 +228,7 @@ class Ipc {
 
       account.instance.tabs.activateTab(tabId);
 
-      if (selectedTab instanceof WorkspaceApp && selectedTab.hasWindow) {
+      if (selectedTab instanceof WorkspaceApp && selectedTab.isWindowed) {
         return;
       }
 
@@ -321,7 +321,7 @@ class Ipc {
         },
         {
           label: "Move to New Window",
-          enabled: tab instanceof WorkspaceApp && !tab.hasWindow,
+          enabled: tab instanceof WorkspaceApp && !tab.isWindowed,
           click: () => {
             if (tab instanceof WorkspaceApp) {
               tab.detachToWindow();

--- a/packages/app/lib/web-contents.ts
+++ b/packages/app/lib/web-contents.ts
@@ -14,9 +14,12 @@ export function openViewDevToolsInDev(view: WebContentsView) {
   }
 }
 
-export function broadcastFoundInPageResults(view: WebContentsView, target: WebContents) {
+export function broadcastFoundInPageResults(
+  view: WebContentsView,
+  getTargetWebContents: () => WebContents,
+) {
   view.webContents.on("found-in-page", (_event, result) => {
-    ipc.renderer.send(target, "findInPage.result", {
+    ipc.renderer.send(getTargetWebContents(), "findInPage.result", {
       activeMatch: result.activeMatchOrdinal,
       totalMatches: result.matches,
     });

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -27,6 +27,14 @@ export function registerTabBroadcasts(view: WebContentsView) {
   view.webContents.on("page-title-updated", broadcastTabsChanged);
   view.webContents.on("did-start-loading", broadcastTabsChanged);
   view.webContents.on("did-stop-loading", broadcastTabsChanged);
+
+  return () => {
+    view.webContents.off("did-navigate", broadcastTabsChanged);
+    view.webContents.off("did-navigate-in-page", broadcastTabsChanged);
+    view.webContents.off("page-title-updated", broadcastTabsChanged);
+    view.webContents.off("did-start-loading", broadcastTabsChanged);
+    view.webContents.off("did-stop-loading", broadcastTabsChanged);
+  };
 }
 
 export type Tab = {

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -29,7 +29,7 @@ export function registerTabBroadcasts(view: WebContentsView) {
 }
 
 export function isWindowedTab(tab: Tab) {
-  return tab instanceof WorkspaceApp && tab.hasWindow;
+  return tab instanceof WorkspaceApp && tab.isWindowed;
 }
 
 export type Tab = {
@@ -158,7 +158,7 @@ export class Tabs {
   activateTab(tabId: string) {
     const activatedTab = this.getTab(tabId);
 
-    if (activatedTab instanceof WorkspaceApp && activatedTab.hasWindow) {
+    if (activatedTab instanceof WorkspaceApp && activatedTab.isWindowed) {
       activatedTab.focusWindow();
 
       return;

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -208,19 +208,21 @@ export class Tabs {
   }
 
   activateNextTab() {
-    this.activateAdjacentTab(1);
+    this.activateAdjacentTab("next");
   }
 
   activatePreviousTab() {
-    this.activateAdjacentTab(-1);
+    this.activateAdjacentTab("previous");
   }
 
-  private activateAdjacentTab(direction: 1 | -1) {
+  private activateAdjacentTab(direction: "next" | "previous") {
     const cyclableTabs = this.tabs.filter((tab) => !isWindowedTab(tab));
 
     const activeTabIndex = cyclableTabs.findIndex((tab) => tab.id === this.activeTabId);
 
-    const adjacentTab = cyclableTabs.at((activeTabIndex + direction) % cyclableTabs.length);
+    const indexOffset = direction === "next" ? 1 : -1;
+
+    const adjacentTab = cyclableTabs.at((activeTabIndex + indexOffset) % cyclableTabs.length);
 
     if (adjacentTab) {
       this.activateTab(adjacentTab.id);

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { getWorkspaceAppUrl } from "@meru/shared/google";
 import type { PinnedTab } from "@meru/shared/schemas";
 import { GMAIL_TAB_ID, type TabState } from "@meru/shared/tabs";
 import { type SupportedWorkspaceApp, workspaceApps } from "@meru/shared/workspace-apps";
@@ -27,14 +26,10 @@ export function registerTabBroadcasts(view: WebContentsView) {
   view.webContents.on("page-title-updated", broadcastTabsChanged);
   view.webContents.on("did-start-loading", broadcastTabsChanged);
   view.webContents.on("did-stop-loading", broadcastTabsChanged);
+}
 
-  return () => {
-    view.webContents.off("did-navigate", broadcastTabsChanged);
-    view.webContents.off("did-navigate-in-page", broadcastTabsChanged);
-    view.webContents.off("page-title-updated", broadcastTabsChanged);
-    view.webContents.off("did-start-loading", broadcastTabsChanged);
-    view.webContents.off("did-stop-loading", broadcastTabsChanged);
-  };
+export function isWindowedTab(tab: Tab) {
+  return tab instanceof WorkspaceApp && tab.hasWindow;
 }
 
 export type Tab = {
@@ -163,6 +158,12 @@ export class Tabs {
   activateTab(tabId: string) {
     const activatedTab = this.getTab(tabId);
 
+    if (activatedTab instanceof WorkspaceApp && activatedTab.hasWindow) {
+      activatedTab.focusWindow();
+
+      return;
+    }
+
     if (activatedTab instanceof DormantTab) {
       this.activeTabId = this.materializeDormantTab(activatedTab).id;
 
@@ -207,33 +208,38 @@ export class Tabs {
   }
 
   activateNextTab() {
-    const activeTabIndex = this.tabs.findIndex((tab) => tab.id === this.activeTabId);
-
-    const nextTab = this.tabs.at(activeTabIndex === this.tabs.length - 1 ? 0 : activeTabIndex + 1);
-
-    if (nextTab) {
-      this.activateTab(nextTab.id);
-    }
+    this.activateAdjacentTab(1);
   }
 
   activatePreviousTab() {
-    const activeTabIndex = this.tabs.findIndex((tab) => tab.id === this.activeTabId);
+    this.activateAdjacentTab(-1);
+  }
 
-    const previousTab = this.tabs.at(activeTabIndex === 0 ? -1 : activeTabIndex - 1);
+  private activateAdjacentTab(direction: 1 | -1) {
+    const cyclableTabs = this.tabs.filter((tab) => !isWindowedTab(tab));
 
-    if (previousTab) {
-      this.activateTab(previousTab.id);
+    const activeTabIndex = cyclableTabs.findIndex((tab) => tab.id === this.activeTabId);
+
+    const adjacentTab = cyclableTabs.at((activeTabIndex + direction) % cyclableTabs.length);
+
+    if (adjacentTab) {
+      this.activateTab(adjacentTab.id);
     }
+  }
+
+  deactivateTab(tabId: string) {
+    if (this.activeTabId === tabId) {
+      this.activeTabId = GMAIL_TAB_ID;
+    }
+
+    this.broadcastTabsChanged();
   }
 
   closeTab(tabId: string) {
     const closableTab = this.getTab(tabId);
 
     if (closableTab instanceof WorkspaceApp) {
-      this.recordRecentlyClosedTab(
-        closableTab.view.webContents.getURL() ||
-          (closableTab.app ? getWorkspaceAppUrl(closableTab.app) : ""),
-      );
+      this.recordRecentlyClosedTab(closableTab.url);
 
       closableTab.close();
 
@@ -245,6 +251,35 @@ export class Tabs {
 
       this.removeTab(tabId);
     }
+  }
+
+  handleWindowedTabClosed(windowedTab: WorkspaceApp) {
+    if (!this.tabs.includes(windowedTab)) {
+      return;
+    }
+
+    if (windowedTab.pinned && windowedTab.app) {
+      this.tabs.splice(
+        this.tabs.indexOf(windowedTab),
+        1,
+        new DormantTab({
+          app: windowedTab.app,
+          url: windowedTab.url,
+          title: windowedTab.title,
+          loadOnLaunch: windowedTab.loadOnLaunch,
+        }),
+      );
+
+      this.broadcastTabsChanged();
+
+      accounts.savePinnedTabs();
+
+      return;
+    }
+
+    this.recordRecentlyClosedTab(windowedTab.url);
+
+    this.removeTab(windowedTab.id);
   }
 
   private recordRecentlyClosedTab(closedTabUrl: string) {
@@ -360,7 +395,7 @@ export class Tabs {
       if (tab instanceof WorkspaceApp && tab.pinned && tab.app) {
         pinnedTabs.push({
           app: tab.app,
-          url: tab.view.webContents.getURL() || getWorkspaceAppUrl(tab.app),
+          url: tab.url,
           title: tab.title,
           loadOnLaunch: tab.loadOnLaunch,
         });
@@ -392,6 +427,7 @@ export class Tabs {
       title: tab.app ? stripGoogleFromPageTitle(tab.title, tab.app) : tab.title,
       pinned: tab.pinned,
       dormant: tab instanceof DormantTab,
+      windowed: isWindowedTab(tab),
       loading: tab.isLoading,
       navigationHistory: tab.navigationHistory,
       active: tab.id === this.activeTabId,

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -333,6 +333,8 @@ export class WorkspaceApp {
 
   private viewDestroyed = false;
 
+  private unregisterTabBroadcasts: (() => void) | undefined;
+
   constructor({
     accountId,
     url,
@@ -374,15 +376,7 @@ export class WorkspaceApp {
     WorkspaceApp.instances.set(this.id, this);
 
     if (this._window) {
-      this.window.on("resize", this.updateViewBounds);
-      this.window.on("close", this.handleClose);
-      this.window.on("focus", () => {
-        WorkspaceApp.instances.delete(this.id);
-
-        WorkspaceApp.instances.set(this.id, this);
-      });
-
-      this.account.instance.windows.add(this.window);
+      this.registerWindowListeners();
     } else {
       this.account.instance.windows.add(this.view);
 
@@ -449,7 +443,7 @@ export class WorkspaceApp {
 
     applyViewZoomLimits(view);
 
-    broadcastFoundInPageResults(view, this.chromeWebContents);
+    broadcastFoundInPageResults(view, () => this.chromeWebContents);
 
     this.setWindowOpenHandler(view);
 
@@ -526,13 +520,64 @@ export class WorkspaceApp {
     this.view.webContents.on("page-title-updated", this.handlePageTitleUpdated);
 
     if (this._window) {
-      this.view.webContents.on("did-navigate", this.broadcastNavigationState);
-      this.view.webContents.on("did-navigate-in-page", this.broadcastNavigationState);
-      this.view.webContents.on("did-start-loading", this.broadcastLoadingState);
-      this.view.webContents.on("did-stop-loading", this.broadcastLoadingState);
+      this.registerWindowedViewListeners();
     } else {
-      registerTabBroadcasts(this.view);
+      this.unregisterTabBroadcasts = registerTabBroadcasts(this.view);
     }
+  }
+
+  private registerWindowedViewListeners() {
+    this.view.webContents.on("did-navigate", this.broadcastNavigationState);
+    this.view.webContents.on("did-navigate-in-page", this.broadcastNavigationState);
+    this.view.webContents.on("did-start-loading", this.broadcastLoadingState);
+    this.view.webContents.on("did-stop-loading", this.broadcastLoadingState);
+  }
+
+  private registerWindowListeners() {
+    this.window.on("resize", this.updateViewBounds);
+    this.window.on("close", this.handleClose);
+    this.window.on("focus", () => {
+      WorkspaceApp.instances.delete(this.id);
+
+      WorkspaceApp.instances.set(this.id, this);
+    });
+
+    this.account.instance.windows.add(this.window);
+  }
+
+  detachToWindow() {
+    this.account.instance.tabs.removeTab(this.id);
+
+    this.pinned = false;
+    this.loadOnLaunch = false;
+
+    main.window.contentView.removeChildView(this.view);
+
+    this.account.instance.windows.delete(this.view);
+
+    this.unregisterTabBroadcasts?.();
+
+    this.unregisterTabBroadcasts = undefined;
+
+    this._window = this.createBrowserWindow();
+
+    this.window.contentView.addChildView(this.view);
+
+    this.view.setVisible(true);
+
+    this.registerWindowedViewListeners();
+    this.registerWindowListeners();
+
+    this.updateViewBounds();
+    this.updateWindowTitle();
+
+    this.window.webContents.once("did-finish-load", () => {
+      this.broadcastNavigationState();
+
+      this.broadcastLoadingState();
+
+      ipc.renderer.send(this.chromeWebContents, "workspaceApp.pageTitleChanged", this.title);
+    });
   }
 
   private handlePasskeyChallenge = (_event: Electron.Event, url: string) => {
@@ -573,6 +618,10 @@ export class WorkspaceApp {
 
     ipc.renderer.send(this.chromeWebContents, "workspaceApp.pageTitleChanged", this.title);
 
+    this.updateWindowTitle();
+  };
+
+  private updateWindowTitle() {
     if (!this.title) {
       this.window.setTitle(app.name);
 
@@ -583,7 +632,7 @@ export class WorkspaceApp {
       config.get("accounts").length > 1 ? `[${this.account.config.label}] ` : "";
 
     this.window.setTitle(`${accountLabelPrefix}${this.title} - ${app.name}`);
-  };
+  }
 
   broadcastLoadingState = () => {
     ipc.renderer.send(

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -319,6 +319,10 @@ export class WorkspaceApp {
     return this._window;
   }
 
+  get hasWindow() {
+    return Boolean(this._window);
+  }
+
   private get chromeWebContents() {
     return this._window ? this._window.webContents : main.window.webContents;
   }
@@ -333,7 +337,7 @@ export class WorkspaceApp {
 
   private viewDestroyed = false;
 
-  private unregisterTabBroadcasts: (() => void) | undefined;
+  private isClosing = false;
 
   constructor({
     accountId,
@@ -465,20 +469,36 @@ export class WorkspaceApp {
   }
 
   close() {
+    if (this.isClosing) {
+      return;
+    }
+
+    this.isClosing = true;
+
+    this.teardown();
+
+    if (this._window && !this._window.isDestroyed()) {
+      this._window.destroy();
+    }
+
+    this.account.instance.tabs.removeTab(this.id);
+  }
+
+  private teardown() {
     if (!this.viewDestroyed) {
       this.view.webContents.removeAllListeners();
 
       this.view.webContents.close();
     }
 
-    if (!this._window) {
+    if (this._window) {
+      this.account.instance.windows.delete(this._window);
+    } else {
       if (!main.window.isDestroyed()) {
         main.window.contentView.removeChildView(this.view);
       }
 
       this.account.instance.windows.delete(this.view);
-
-      this.account.instance.tabs.removeTab(this.id);
     }
 
     this.teardownApp();
@@ -487,9 +507,15 @@ export class WorkspaceApp {
   }
 
   private handleClose = () => {
-    this.close();
+    if (this.isClosing) {
+      return;
+    }
 
-    this.account.instance.windows.delete(this.window);
+    this.isClosing = true;
+
+    this.account.instance.tabs.handleWindowedTabClosed(this);
+
+    this.teardown();
   };
 
   private setupApp() {
@@ -522,7 +548,7 @@ export class WorkspaceApp {
     if (this._window) {
       this.registerWindowedViewListeners();
     } else {
-      this.unregisterTabBroadcasts = registerTabBroadcasts(this.view);
+      registerTabBroadcasts(this.view);
     }
   }
 
@@ -546,18 +572,9 @@ export class WorkspaceApp {
   }
 
   detachToWindow() {
-    this.account.instance.tabs.removeTab(this.id);
-
-    this.pinned = false;
-    this.loadOnLaunch = false;
-
     main.window.contentView.removeChildView(this.view);
 
     this.account.instance.windows.delete(this.view);
-
-    this.unregisterTabBroadcasts?.();
-
-    this.unregisterTabBroadcasts = undefined;
 
     this._window = this.createBrowserWindow();
 
@@ -578,6 +595,14 @@ export class WorkspaceApp {
 
       ipc.renderer.send(this.chromeWebContents, "workspaceApp.pageTitleChanged", this.title);
     });
+
+    this.account.instance.tabs.deactivateTab(this.id);
+  }
+
+  focusWindow() {
+    this.window.show();
+
+    this.window.focus();
   }
 
   private handlePasskeyChallenge = (_event: Electron.Event, url: string) => {
@@ -710,6 +735,10 @@ export class WorkspaceApp {
 
   get isLoading() {
     return this.view.webContents.isLoading();
+  }
+
+  get url() {
+    return this.view.webContents.getURL() || (this.app ? getWorkspaceAppUrl(this.app) : "");
   }
 
   copyUrl() {

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -319,7 +319,7 @@ export class WorkspaceApp {
     return this._window;
   }
 
-  get hasWindow() {
+  get isWindowed() {
     return Boolean(this._window);
   }
 

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -602,7 +602,7 @@ export class WorkspaceApp {
   focusWindow() {
     this.window.show();
 
-    this.window.focus();
+    this.view.webContents.focus();
   }
 
   private handlePasskeyChallenge = (_event: Electron.Event, url: string) => {

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -77,7 +77,8 @@ function StripTab({
         className={cn(
           tab.dormant && "opacity-50",
           isWideRow && "w-full justify-start",
-          isWideRow && isCloseable && "pr-7",
+          isWideRow && isCloseable && (tab.windowed ? "pr-11" : "pr-7"),
+          isWideRow && !isCloseable && tab.windowed && "pr-6",
           presentation === "gridIcon" && "w-full",
         )}
         title={tab.title}
@@ -103,13 +104,20 @@ function StripTab({
           ipc.main.send("tabs.showTabContextMenu", accountId, tab.id);
         }}
       >
-        <div className={cn("relative shrink-0", isWideRow && tab.windowed && "mr-1")}>
-          <TabIcon tab={tab} />
-          {isWideRow && tab.windowed && <WindowedTabBadge className="-right-2 -bottom-2" />}
-        </div>
+        <TabIcon tab={tab} />
         {isWideRow && <span className="truncate">{tab.title}</span>}
       </Button>
-      {!isWideRow && tab.windowed && <WindowedTabBadge className="-right-1 -bottom-1" />}
+      {tab.windowed &&
+        (isWideRow ? (
+          <AppWindowIcon
+            className={cn(
+              "pointer-events-none absolute top-1/2 right-2 size-3 -translate-y-1/2 text-muted-foreground",
+              isCloseable && "group-hover:right-7",
+            )}
+          />
+        ) : (
+          <WindowedTabBadge className="-right-1 -bottom-1" />
+        ))}
       {isCloseable && (
         <Button
           variant="secondary"

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -38,6 +38,19 @@ function TabIcon({ tab }: { tab: TabState }) {
   return <GlobeIcon />;
 }
 
+function WindowedTabBadge({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "absolute flex size-4 items-center justify-center rounded-full bg-secondary text-secondary-foreground",
+        className,
+      )}
+    >
+      <AppWindowIcon className="size-2.5" />
+    </div>
+  );
+}
+
 function StripTab({
   tab,
   accountId,
@@ -90,15 +103,13 @@ function StripTab({
           ipc.main.send("tabs.showTabContextMenu", accountId, tab.id);
         }}
       >
-        <TabIcon tab={tab} />
-        {isWideRow && <span className="truncate">{tab.title}</span>}
-        {isWideRow && tab.windowed && <AppWindowIcon className="size-3" />}
-      </Button>
-      {!isWideRow && tab.windowed && (
-        <div className="absolute -right-1 -bottom-1 flex size-4 items-center justify-center rounded-full bg-secondary text-secondary-foreground">
-          <AppWindowIcon className="size-3" />
+        <div className={cn("relative shrink-0", isWideRow && tab.windowed && "mr-1")}>
+          <TabIcon tab={tab} />
+          {isWideRow && tab.windowed && <WindowedTabBadge className="-right-2 -bottom-2" />}
         </div>
-      )}
+        {isWideRow && <span className="truncate">{tab.title}</span>}
+      </Button>
+      {!isWideRow && tab.windowed && <WindowedTabBadge className="-right-1 -bottom-1" />}
       {isCloseable && (
         <Button
           variant="secondary"

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -77,9 +77,7 @@ function StripTab({
         className={cn(
           tab.dormant && "opacity-50",
           isWideRow && "w-full justify-start",
-          isWideRow && isCloseable && !tab.windowed && "pr-7",
-          isWideRow && tab.windowed && "pr-6",
-          isWideRow && tab.windowed && isCloseable && "group-hover:pr-11",
+          isWideRow && isCloseable && "group-hover:pr-7",
           presentation === "gridIcon" && "w-full",
         )}
         title={tab.title}
@@ -106,19 +104,12 @@ function StripTab({
         }}
       >
         <TabIcon tab={tab} />
-        {isWideRow && <span className="truncate">{tab.title}</span>}
+        {isWideRow && <span className="min-w-0 flex-1 truncate text-left">{tab.title}</span>}
+        {isWideRow && tab.windowed && (
+          <AppWindowIcon className="size-3 shrink-0 text-muted-foreground" />
+        )}
       </Button>
-      {tab.windowed &&
-        (isWideRow ? (
-          <AppWindowIcon
-            className={cn(
-              "pointer-events-none absolute top-1/2 right-2 size-3 -translate-y-1/2 text-muted-foreground",
-              isCloseable && "group-hover:right-7",
-            )}
-          />
-        ) : (
-          <WindowedTabBadge className="-right-1 -bottom-1" />
-        ))}
+      {!isWideRow && tab.windowed && <WindowedTabBadge className="-right-1 -bottom-1" />}
       {isCloseable && (
         <Button
           variant="secondary"

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -15,7 +15,7 @@ import {
 import { Separator } from "@meru/ui/components/separator";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { cn } from "@meru/ui/lib/utils";
-import { GlobeIcon, PlusIcon, XIcon } from "lucide-react";
+import { AppWindowIcon, GlobeIcon, PlusIcon, XIcon } from "lucide-react";
 import { type MouseEvent, useEffect, useState } from "react";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
@@ -92,7 +92,13 @@ function StripTab({
       >
         <TabIcon tab={tab} />
         {isWideRow && <span className="truncate">{tab.title}</span>}
+        {isWideRow && tab.windowed && <AppWindowIcon className="size-3" />}
       </Button>
+      {!isWideRow && tab.windowed && (
+        <div className="absolute -right-1 -bottom-1 flex size-4 items-center justify-center rounded-full bg-secondary text-secondary-foreground">
+          <AppWindowIcon className="size-3" />
+        </div>
+      )}
       {isCloseable && (
         <Button
           variant="secondary"

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -77,8 +77,9 @@ function StripTab({
         className={cn(
           tab.dormant && "opacity-50",
           isWideRow && "w-full justify-start",
-          isWideRow && isCloseable && (tab.windowed ? "pr-11" : "pr-7"),
-          isWideRow && !isCloseable && tab.windowed && "pr-6",
+          isWideRow && isCloseable && !tab.windowed && "pr-7",
+          isWideRow && tab.windowed && "pr-6",
+          isWideRow && tab.windowed && isCloseable && "group-hover:pr-11",
           presentation === "gridIcon" && "w-full",
         )}
         title={tab.title}

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -10,6 +10,7 @@ export type TabState = {
   title: string;
   pinned: boolean;
   dormant: boolean;
+  windowed: boolean;
   loading: boolean;
   navigationHistory: { canGoBack: boolean; canGoForward: boolean };
   active: boolean;


### PR DESCRIPTION
## Problem

First half of the detach/adopt roadmap item: an embedded workspace-app tab can't be moved into its own window without losing page state.

## Changes

Detaching moves the **view**, not the tab's identity: the live `WebContentsView` is re-parented into a freshly created workspace-app window shell (no reload — page state survives), while the tab **stays in the strip** at its position with a window indicator. The strip doubles as the account's roster of open surfaces, so windows are findable without the OS window switcher.

- New "Move to New Window" tab context-menu item after "Duplicate"; disabled for dormant tabs and for tabs already in a window.
- `TabState.windowed` + a persistent window indicator in the strip: a circular corner badge on the tab icon in the narrow/grid presentations; in the wide row, a muted `AppWindowIcon` as an in-flow flex child pinned to the row's right edge by the `flex-1` title. The title truncates against whatever is actually rendered on its right in the current state — space for the hover-only close button is reserved only while hovered, for all closeable rows.
- Clicking a windowed tab raises its window and focuses the page content (the window is only the shell), with an early return so refreshing the main view doesn't steal focus back. Tab cycling (next/previous) skips windowed tabs. A windowed tab is never the strip-active tab; detach yields active to Gmail.
- Pinned tabs stay pinned through detach and keep persisting (`serializePinnedTabs` reads the live view's URL).
- Two distinct close intents:
  - **Closing the tab** (strip ×, middle-click, context-menu Close/Close Other/Close Below): records into recently-closed and tears everything down — for a windowed tab this destroys its window too.
  - **Closing the window** (OS close button): an unpinned tab's entry closes with it (recorded into recently-closed); a **pinned** tab reverts in place to its dormant state — pinned means it can't be lost this way. Guarded against double-teardown via an `isClosing` latch; natively-windowed instances (never in the strip) are unaffected.
- `accounts.hide()/show()` (settings open/close) now only toggle embedded views, so opening settings doesn't blank detached windows.
- Constructor's windowed wiring extracted into shared register methods; window-title setting extracted into `updateWindowTitle`; navigation/loading/title state pushed to the shell renderer once it loads.
- Drive-by fix this surfaced: `broadcastFoundInPageResults` captured its target webContents at view-creation time, so a detached window's find-in-page results would have gone to the main window forever. It now takes a lazy getter; Gmail caller updated with identical behavior.

## Notes for review

- The second commit is a rework after design feedback (the first removed the tab on detach); reading the branch diff as a whole is easiest.
- The reverse direction (window → tab) is the stacked PR on top of this branch.
- A follow-up (tracked in TODO) will list **all** of an account's workspace-app windows in the strip, not just detached ones.
- Verified with `bun types:ci` (including a local test-merge with current main); not exercised in the running app — the test plan below is the runtime verification. Explicitly unverified: runtime focus behavior, indicator badge placement.

## Test plan

1. Open a workspace-app tab (e.g. Docs with text typed into a document), right-click → "Move to New Window" → a window opens with the same page state (no reload), and the tab **stays** in the strip showing a small window badge; Gmail becomes the active tab.
2. Click the windowed tab in the strip → its window comes to the foreground and typing lands in the page (not the shell chrome); the main window's active tab does not change and focus is not stolen back.
3. Detach a **pinned** tab → still pinned, badge shown; restart the app → it is restored as a pinned (dormant) tab.
4. Close the **window** of a pinned detached tab → the strip entry stays, reverting to the dimmed dormant style; clicking it reloads the page as an embedded tab. It does not appear under "Reopen Closed Tab".
5. Close the **window** of an unpinned detached tab → the strip entry disappears and "Reopen Closed Tab" restores it.
6. Close a detached tab from the strip (× / middle-click / context-menu "Close") → its window closes too, and "Reopen Closed Tab" restores it.
7. Ctrl+Tab / Ctrl+Shift+Tab cycling skips windowed tabs.
8. Open Settings while a detached window is showing → the detached window's content stays visible.
9. In the detached window: navigate → back/forward/loading states update; the window title shows the page title (account-label prefix with multiple accounts); find-in-page match counts appear in that window.
10. Right-click a windowed tab in the strip → "Move to New Window" is disabled; Reload / Copy Link / Open in Default Browser / Pin / Unpin operate on the windowed page.
11. Right-click a dormant tab → "Move to New Window" is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



