### PR TITLE
add tab strip width setting

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -46,6 +46,10 @@ class Accounts {
     config.onDidChange("workspaceApps.bookmarkedApps", () => {
       accounts.updateAllViewBounds();
     });
+
+    config.onDidChange("workspaceApps.tabStripWidth", () => {
+      accounts.updateAllViewBounds();
+    });
   }
 
   async createViews() {
@@ -97,6 +101,7 @@ class Accounts {
     return getTabStripWidth(
       this.getSelectedAccount().instance.tabs.serialize(),
       config.get("workspaceApps.bookmarkedApps").length > 0,
+      config.get("workspaceApps.tabStripWidth"),
     );
   }
 

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -95,6 +95,7 @@ export const config = new Store<Config>({
     "workspaceApps.openInApp": true,
     "workspaceApps.openInAppExcludedApps": [],
     "workspaceApps.openBehavior": "tab",
+    "workspaceApps.tabStripWidth": "auto",
     "workspaceApps.bookmarkedApps": [],
     "workspaceApps.showAccountColor": true,
     "workspaceApps.showAccountLabel": true,

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -2,10 +2,6 @@ import { is, platform } from "@electron-toolkit/utils";
 import { GITHUB_REPO_URL, WEBSITE_URL } from "@meru/shared/constants";
 import { clamp } from "@meru/shared/utils";
 import {
-  type WorkspaceAppTabStripWidth,
-  workspaceAppTabStripWidths,
-} from "@meru/shared/workspace-apps";
-import {
   app,
   BrowserWindow,
   clipboard,
@@ -57,12 +53,6 @@ export class AppMenu {
       this.menu = this.createMenu();
 
       this._subscribeToSelectedAccount();
-
-      Menu.setApplicationMenu(this.menu);
-    });
-
-    config.onDidChange("workspaceApps.tabStripWidth", () => {
-      this.menu = this.createMenu();
 
       Menu.setApplicationMenu(this.menu);
     });
@@ -386,19 +376,6 @@ export class AppMenu {
             click: () => {
               main.navigate("/download-history");
             },
-          },
-          {
-            label: "Tab Strip Width",
-            submenu: (Object.keys(workspaceAppTabStripWidths) as WorkspaceAppTabStripWidth[]).map(
-              (tabStripWidth) => ({
-                label: workspaceAppTabStripWidths[tabStripWidth],
-                type: "radio" as const,
-                checked: config.get("workspaceApps.tabStripWidth") === tabStripWidth,
-                click: () => {
-                  config.set("workspaceApps.tabStripWidth", tabStripWidth);
-                },
-              }),
-            ),
           },
           {
             type: "separator",

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -2,6 +2,10 @@ import { is, platform } from "@electron-toolkit/utils";
 import { GITHUB_REPO_URL, WEBSITE_URL } from "@meru/shared/constants";
 import { clamp } from "@meru/shared/utils";
 import {
+  type WorkspaceAppTabStripWidth,
+  workspaceAppTabStripWidths,
+} from "@meru/shared/workspace-apps";
+import {
   app,
   BrowserWindow,
   clipboard,
@@ -53,6 +57,12 @@ export class AppMenu {
       this.menu = this.createMenu();
 
       this._subscribeToSelectedAccount();
+
+      Menu.setApplicationMenu(this.menu);
+    });
+
+    config.onDidChange("workspaceApps.tabStripWidth", () => {
+      this.menu = this.createMenu();
 
       Menu.setApplicationMenu(this.menu);
     });
@@ -376,6 +386,19 @@ export class AppMenu {
             click: () => {
               main.navigate("/download-history");
             },
+          },
+          {
+            label: "Tab Strip Width",
+            submenu: (Object.keys(workspaceAppTabStripWidths) as WorkspaceAppTabStripWidth[]).map(
+              (tabStripWidth) => ({
+                label: workspaceAppTabStripWidths[tabStripWidth],
+                type: "radio" as const,
+                checked: config.get("workspaceApps.tabStripWidth") === tabStripWidth,
+                click: () => {
+                  config.set("workspaceApps.tabStripWidth", tabStripWidth);
+                },
+              }),
+            ),
           },
           {
             type: "separator",

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -205,6 +205,7 @@ export function AppTabStrip() {
     ? getTabStripWidth(
         selectedAccountTabs.tabs,
         (config?.["workspaceApps.bookmarkedApps"].length ?? 0) > 0,
+        config?.["workspaceApps.tabStripWidth"] ?? "auto",
       )
     : 0;
 

--- a/packages/renderer-main/routes/settings/workspace-apps.tsx
+++ b/packages/renderer-main/routes/settings/workspace-apps.tsx
@@ -9,6 +9,7 @@ import {
   type SupportedWorkspaceApp,
   workspaceAppOpenBehaviors,
   workspaceApps,
+  workspaceAppTabStripWidths,
 } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import { ButtonGroup } from "@meru/ui/components/button-group";
@@ -206,6 +207,17 @@ export function WorkspaceAppsSettings() {
             licenseKeyRequired
           />
           <FieldSeparator />
+          <ConfigSelectField
+            label="Tab Strip Width"
+            description="How wide the tab strip is. Auto switches between narrow and wide automatically based on the open tabs."
+            configKey="workspaceApps.tabStripWidth"
+            placeholder="Select width"
+            licenseKeyRequired
+            items={Object.entries(workspaceAppTabStripWidths).map(([value, label]) => ({
+              value,
+              label,
+            }))}
+          />
           <Field>
             <FieldContent>
               <FieldLabel className="flex items-center gap-2">

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -1,6 +1,6 @@
 import { APP_TAB_STRIP_NARROW_WIDTH, APP_TAB_STRIP_WIDE_WIDTH } from "./constants";
 import type { AccountConfig } from "./schemas";
-import type { SupportedWorkspaceApp } from "./workspace-apps";
+import type { SupportedWorkspaceApp, WorkspaceAppTabStripWidth } from "./workspace-apps";
 
 export const GMAIL_TAB_ID = "gmail";
 
@@ -23,9 +23,18 @@ export type AccountTabsState = {
 export function getTabStripWidth(
   tabs: Pick<TabState, "app" | "pinned">[],
   hasBookmarkedApps: boolean,
+  configuredTabStripWidth: WorkspaceAppTabStripWidth,
 ) {
   if (tabs.length <= 1 && !hasBookmarkedApps) {
     return 0;
+  }
+
+  if (configuredTabStripWidth === "narrow") {
+    return APP_TAB_STRIP_NARROW_WIDTH;
+  }
+
+  if (configuredTabStripWidth === "wide") {
+    return APP_TAB_STRIP_WIDE_WIDTH;
   }
 
   const workspaceAppTabCounts = new Map<SupportedWorkspaceApp, number>();

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -14,6 +14,7 @@ import type {
   BookmarkableWorkspaceApp,
   SupportedWorkspaceApp,
   WorkspaceAppOpenBehavior,
+  WorkspaceAppTabStripWidth,
 } from "./workspace-apps";
 
 export type DesktopSource = { id: string; name: string; thumbnail: string };
@@ -123,6 +124,7 @@ export type Config = {
   "workspaceApps.openInApp": boolean;
   "workspaceApps.openInAppExcludedApps": SupportedWorkspaceApp[];
   "workspaceApps.openBehavior": WorkspaceAppOpenBehavior;
+  "workspaceApps.tabStripWidth": WorkspaceAppTabStripWidth;
   "workspaceApps.bookmarkedApps": BookmarkableWorkspaceApp[];
   "workspaceApps.showAccountColor": boolean;
   "workspaceApps.showAccountLabel": boolean;

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -56,3 +56,11 @@ export const workspaceAppOpenBehaviors = {
 } as const;
 
 export type WorkspaceAppOpenBehavior = keyof typeof workspaceAppOpenBehaviors;
+
+export const workspaceAppTabStripWidths = {
+  auto: "Auto",
+  narrow: "Narrow",
+  wide: "Wide",
+} as const;
+
+export type WorkspaceAppTabStripWidth = keyof typeof workspaceAppTabStripWidths;


### PR DESCRIPTION
## Problem

The tab strip picks narrow vs wide automatically (wide once some unpinned workspace app has multiple tabs). There's no way to force a preferred width.

## Changes

- New config key `workspaceApps.tabStripWidth` with union `auto | narrow | wide`, default `auto` (current automatic behavior). Union + labels live in `packages/shared/workspace-apps.ts`, mirroring `workspaceAppOpenBehaviors`.
- The shared `getTabStripWidth` takes the setting as a third parameter. The visibility check (`return 0` when there's a single tab and no bookmarked apps) stays first and untouched — the setting affects width only, never visibility. `narrow` also implies no pinned icon grid, which falls out of the existing `isWide` derivation.
- Both callers (main-process `Accounts.getTabStripWidth`, renderer `AppTabStrip`) pass the config value.
- Settings → Workspace Apps: a "Tab Strip Width" `ConfigSelectField` (Auto first, license-gated like its siblings). This is the only place the setting is changed.
- A manager-level `config.onDidChange` listener in `accounts.ts` resizes the embedded views when the value changes.

A View-menu radio submenu was part of the first commit and removed in the second after review — the settings field is the wanted scope.

## Test plan

1. Settings → Workspace Apps shows "Tab Strip Width" defaulting to Auto; without a valid license the field is gated.
2. Open two tabs of the same app (strip goes wide under Auto), then set Narrow → the strip immediately collapses to the icon column, pinned tabs render as icons with the pinned/unpinned separator, no icon grid.
3. With only one workspace tab open (strip narrow under Auto), set Wide → the strip widens and the pinned section renders as the icon grid.
4. Set back to Auto → automatic switching resumes (open/close a second same-app tab to see it flip).
5. With no workspace tabs and no bookmarked apps, the strip stays hidden regardless of the setting (width config never affects visibility).
6. The View menu contains no width-related entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)