### PR TITLE
align tab close button tooltip with Chrome wording

### DIFF
--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -103,7 +103,7 @@ function StripTab({
               ? "top-1/2 right-1 size-5 -translate-y-1/2"
               : "-top-1 -right-1 size-4 rounded-full",
           )}
-          title="Close Tab"
+          title="Close"
           onClick={() => {
             ipc.main.send("tabs.closeTab", accountId, tab.id);
           }}


### PR DESCRIPTION
## Problem

The Chrome-wording pass (#655) covered the tab context menus only; the tab close button's hover tooltip still said "Close Tab" while the context-menu item says "Close".

## Changes

- `title="Close Tab"` → `title="Close"` on the strip tab close button in `app-tab-strip.tsx`. Nothing else.

## Test plan

1. Hover the × button on an unpinned workspace-app tab (narrow and wide strip) → the tooltip reads "Close".

🤖 Generated with [Claude Code](https://claude.com/claude-code)