### PR TITLE
add copy link and open in default browser to the workspace app context menu

### DIFF
--- a/packages/app/context-menu.ts
+++ b/packages/app/context-menu.ts
@@ -8,6 +8,7 @@ import electronContextMenu from "electron-context-menu";
 import { accounts } from "./accounts";
 import { licenseKey } from "./license-key";
 import { createMeruMessageUrl } from "./protocol";
+import { openExternalUrl } from "./url";
 
 export function setupWindowContextMenu(window: BrowserWindow | WebContentsView) {
   electronContextMenu({
@@ -49,6 +50,28 @@ export function setupWindowContextMenu(window: BrowserWindow | WebContentsView) 
             },
           );
         }
+      }
+
+      if (window !== selectedAccount.instance.gmail.view) {
+        menuItems.push(
+          {
+            label: "Copy Link",
+            click: () => {
+              clipboard.writeText(window.webContents.getURL());
+            },
+          },
+          {
+            label: "Open in Default Browser",
+            click: () => {
+              openExternalUrl(window.webContents.getURL(), {
+                skipTrustedHostCheck: true,
+              });
+            },
+          },
+          {
+            type: "separator",
+          },
+        );
       }
 
       menuItems.push({


### PR DESCRIPTION
## Problem

Page-link actions ("Copy Link", "Open in Default Browser") exist in the tab context menu, but the right-click page context menu inside workspace-app views has no way to grab the current URL — an issue for discoverability, especially for users who never touch the tab strip.

## Changes

- `setupWindowContextMenu` now appends "Copy Link" (copies `webContents.getURL()`) and "Open in Default Browser" (`openExternalUrl` with the trusted-host check skipped), followed by a separator, above "Inspect Element" — for every view except the selected account's main Gmail view.
- Labels match the tab context menu exactly. The entries are not license-gated (the existing license-gated message-link block is untouched).

## Test plan

1. Right-click inside an embedded workspace-app tab (e.g. Docs) → the menu shows "Copy Link" and "Open in Default Browser" above "Inspect Element"; "Copy Link" puts the current page URL on the clipboard, "Open in Default Browser" opens it in the default browser.
2. Right-click inside a workspace-app **window** → same two entries, same behavior.
3. Right-click inside the main Gmail view → the two entries are absent; the existing "Copy Message Link"/share entries (with a license, inside a message) are unchanged.
4. Right-click on an image inside a workspace app → the standard image entries still appear alongside the new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)