### PR TITLE
move copy link and open in browser into a workspace app window titlebar menu

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -213,12 +213,23 @@ class Ipc {
       selectedAccount.instance.gmail.search(searchQuery);
     });
 
-    ipc.main.on("workspaceApp.copyUrl", (_event, workspaceAppId) => {
-      WorkspaceApp.fromId(workspaceAppId).copyUrl();
-    });
+    ipc.main.on("workspaceApp.showMenu", (_event, workspaceAppId) => {
+      const workspaceApp = WorkspaceApp.fromId(workspaceAppId);
 
-    ipc.main.on("workspaceApp.openInBrowser", (_event, workspaceAppId) => {
-      WorkspaceApp.fromId(workspaceAppId).openInBrowser();
+      Menu.buildFromTemplate([
+        {
+          label: "Copy Link",
+          click: () => {
+            workspaceApp.copyUrl();
+          },
+        },
+        {
+          label: "Open in Default Browser",
+          click: () => {
+            workspaceApp.openInBrowser();
+          },
+        },
+      ]).popup();
     });
 
     ipc.main.on("tabs.selectTab", (_event, accountId, tabId) => {

--- a/packages/renderer-workspace-app/index.tsx
+++ b/packages/renderer-workspace-app/index.tsx
@@ -1,4 +1,3 @@
-import { useCopied } from "@meru/shared/renderer/hooks";
 import { ipc } from "@meru/shared/renderer/ipc";
 import { renderApp } from "@meru/shared/renderer/react";
 import { useConfig } from "@meru/shared/renderer/react-query";
@@ -15,7 +14,7 @@ import {
   TitlebarRight,
 } from "@meru/ui/components/titlebar";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
-import { CheckIcon, DownloadIcon, ExternalLinkIcon, LinkIcon } from "lucide-react";
+import { DownloadIcon, EllipsisVerticalIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "wouter";
 
@@ -79,22 +78,6 @@ function NavigationControls({ workspaceAppId }: { workspaceAppId: string }) {
         ipc.main.send("workspaceApp.stop", workspaceAppId);
       }}
     />
-  );
-}
-
-function CopyUrlButton({ workspaceAppId }: { workspaceAppId: string }) {
-  const { copied, markCopied } = useCopied();
-
-  return (
-    <TitlebarIconButton
-      title="Copy Link"
-      onClick={() => {
-        ipc.main.send("workspaceApp.copyUrl", workspaceAppId);
-        markCopied();
-      }}
-    >
-      {copied ? <CheckIcon /> : <LinkIcon />}
-    </TitlebarIconButton>
   );
 }
 
@@ -181,14 +164,13 @@ function App() {
         <FindInPageControls />
         <TitlebarButtonGroup>
           <RecentDownloadHistoryButton />
-          <CopyUrlButton workspaceAppId={workspaceAppId} />
           <TitlebarIconButton
-            title="Open in Default Browser"
+            title="More Options"
             onClick={() => {
-              ipc.main.send("workspaceApp.openInBrowser", workspaceAppId);
+              ipc.main.send("workspaceApp.showMenu", workspaceAppId);
             }}
           >
-            <ExternalLinkIcon />
+            <EllipsisVerticalIcon />
           </TitlebarIconButton>
         </TitlebarButtonGroup>
       </TitlebarRight>

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -158,8 +158,7 @@ export type IpcMainEvents =
       "gmail.setOutOfOffice": [outOfOffice: boolean];
       "gmail.search": [searchQuery: string];
       "gmail.openUserStyles": [openIn: "editor" | "folder"];
-      "workspaceApp.copyUrl": [workspaceAppId: string];
-      "workspaceApp.openInBrowser": [workspaceAppId: string];
+      "workspaceApp.showMenu": [workspaceAppId: string];
       "gmail.navigateTo": [hashLocation: GmailHashLocation];
       "gmail.closeComposeWindow": [];
       "gmail.undoMessageSent": [browserWindowId: number];


### PR DESCRIPTION
## Problem

Workspace app windows had two separate titlebar icon buttons for Copy Link and Open in Default Browser, taking up titlebar space for secondary actions.

## Changes

- Replaced the two buttons with a single ellipsis-vertical "More Options" button in the titlebar.
- Clicking it opens a native `Menu.popup` (built in the main process) with **Copy Link** and **Open in Default Browser** items. A native menu is used instead of a renderer-drawn dropdown because the workspace app's `WebContentsView` paints above the window's HTML, so a renderer dropdown extending below the titlebar would be covered.
- Replaced the `workspaceApp.copyUrl` and `workspaceApp.openInBrowser` IPC channels with a single `workspaceApp.showMenu` channel; the menu items call the existing `WorkspaceApp.copyUrl()`/`openInBrowser()` methods directly.
- Removed the now-unused `CopyUrlButton` component. Its copied-checkmark feedback is dropped — a native menu closes on click, so there is no place to show it. The `useCopied` hook itself stays (still used by `renderer-main`'s copy button).

## Not verified

- Manual testing in the running app (type checks pass).

## Test plan

1. Open a workspace app in its own window (e.g. a Google Docs link with "open as window" behavior).
2. Verify the titlebar shows a single ellipsis-vertical button where the link and external-link buttons used to be, next to the download history button.
3. Click the button — a native context menu appears with "Copy Link" and "Open in Default Browser".
4. Click "Copy Link" and paste somewhere — the clipboard contains the window's current URL.
5. Click "Open in Default Browser" — the current URL opens in the default browser.
6. Navigate within the workspace app, then repeat steps 4–5 — both actions use the new URL, not the original one.
7. Verify the in-app tab context menu (right-click a tab in the tab strip) still shows working "Copy Link" and "Open in Default Browser" items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)