### PR TITLE
render narrow strip pinned apps as outline buttons

### DIFF
--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -12,7 +12,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@meru/ui/components/dropdown-menu";
-import { Separator } from "@meru/ui/components/separator";
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { cn } from "@meru/ui/lib/utils";
 import { AppWindowIcon, GlobeIcon, PlusIcon, XIcon } from "lucide-react";
@@ -62,7 +61,9 @@ function StripTab({
   presentation: "wideRow" | "narrowIcon" | "gridIcon";
   className?: string;
 }) {
-  const isCloseable = tab.id !== GMAIL_TAB_ID && !tab.pinned;
+  const isPinnedSectionTab = tab.id === GMAIL_TAB_ID || tab.pinned;
+
+  const isCloseable = !isPinnedSectionTab;
 
   const isWideRow = presentation === "wideRow";
 
@@ -72,7 +73,7 @@ function StripTab({
   return (
     <div className={cn("group relative", className)}>
       <Button
-        variant={tab.active ? "secondary" : presentation === "gridIcon" ? "outline" : "ghost"}
+        variant={tab.active ? "secondary" : !isWideRow && isPinnedSectionTab ? "outline" : "ghost"}
         size={isWideRow ? "sm" : "icon"}
         className={cn(
           tab.dormant && "opacity-50",
@@ -232,8 +233,6 @@ export function AppTabStrip() {
 
   const isWide = tabStripWidth === APP_TAB_STRIP_WIDE_WIDTH;
 
-  const hasPinnedTabs = selectedAccountTabs.tabs.some((tab) => tab.pinned);
-
   const pinnedSectionTabs = selectedAccountTabs.tabs.filter(
     (tab) => tab.id === GMAIL_TAB_ID || tab.pinned,
   );
@@ -241,8 +240,6 @@ export function AppTabStrip() {
   const unpinnedTabs = selectedAccountTabs.tabs.filter(
     (tab) => tab.id !== GMAIL_TAB_ID && !tab.pinned,
   );
-
-  const shouldRenderSeparator = !isWide && hasPinnedTabs && unpinnedTabs.length > 0;
 
   return (
     <div
@@ -282,7 +279,6 @@ export function AppTabStrip() {
           />
         ))
       )}
-      {shouldRenderSeparator && <Separator className="data-horizontal:w-8" />}
       {unpinnedTabs.map((tab) => (
         <StripTab
           key={tab.id}


### PR DESCRIPTION
## Problem

The narrow tab strip styles pinned apps like any other tab (ghost buttons) and separates them from unpinned tabs with a divider. The wide strip already renders the pinned section as outline tiles with no divider — the two widths should share the same visual language.

## Changes

- Pinned-section tabs in the narrow strip (the Gmail tab + pinned tabs, matching the wide grid where Gmail is an outline tile) now render as `outline`-variant buttons when not active; the active tab keeps `secondary`, unpinned narrow tabs keep `ghost`.
- The pinned/unpinned `Separator` in the narrow strip is removed, along with the `shouldRenderSeparator`/`hasPinnedTabs` locals and the now-unused import.
- Wired without a new prop or presentation value: `StripTab` derives `isPinnedSectionTab` (`tab.id === GMAIL_TAB_ID || tab.pinned`) — the same predicate the parent uses to build `pinnedSectionTabs` — and `isCloseable` is now its negation (logically identical to before). The variant ternary keys on `!isWideRow && isPinnedSectionTab`; the wide grid only ever renders pinned-section tabs, so its `outline` styling is unchanged.

## Test plan

1. Set tab strip width to Narrow (Settings → workspace apps) with at least one pinned and one unpinned tab open → Gmail and pinned tabs show outline borders, unpinned tabs stay borderless (ghost), and no divider renders between the sections.
2. Click through tabs → the active tab (pinned or not) shows the filled `secondary` style; deactivating returns pinned tabs to outline and unpinned to ghost.
3. Pin an unpinned tab via its context menu → it moves up into the pinned section and gains the outline style; unpin it → outline gone, back below.
4. Switch to Wide → the pinned grid tiles and unpinned rows look exactly as before this change.
5. Narrow strip with no unpinned tabs (only Gmail + pinned) and with no pinned tabs at all → renders correctly with no stray gaps.
6. Hover a dormant pinned tab → reduced opacity still applies; hover close button still only appears on unpinned tabs.
