### PR TITLE
fade out overflowing tab titles instead of truncating

### DIFF
--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -104,7 +104,11 @@ function StripTab({
         }}
       >
         <TabIcon tab={tab} />
-        {isWideRow && <span className="min-w-0 flex-1 truncate text-left">{tab.title}</span>}
+        {isWideRow && (
+          <span className="min-w-0 flex-1 overflow-hidden mask-r-from-[calc(100%-1.5rem)] text-left whitespace-nowrap">
+            {tab.title}
+          </span>
+        )}
         {isWideRow && tab.windowed && (
           <AppWindowIcon className="size-3 shrink-0 text-muted-foreground" />
         )}


### PR DESCRIPTION
## Problem

Overflowing tab titles in the wide strip cut off with an ellipsis. A right-edge fade reads cleaner and shows slightly more of the title.

## Changes

The wide-row title span swaps `truncate` for its `overflow-hidden` + `whitespace-nowrap` parts plus Tailwind 4's built-in mask utility: `mask-r-from-[calc(100%-1.5rem)]`, which compiles to `mask-image: linear-gradient(to right, black calc(100% - 1.5rem), transparent 100%)` — fully opaque until a fixed 1.5rem fade zone at the right edge.

- A mask fades the glyphs themselves to transparent, so it works over every button background (ghost, active `secondary`, hover) in both themes with no background-color coupling — unlike a gradient overlay.
- `calc(100% - 1.5rem)` over a bare percentage keeps the fade zone a fixed width instead of scaling with tab width.
- The layout is untouched: the span stays a `min-w-0 flex-1` child, so the fade zone tracks whatever is actually rendered to its right (windowed indicator, hover close-button padding). Short titles end before the fade zone and render fully opaque.
- Wide strip only — narrow and grid presentations show no titles.

The emitted CSS was verified by compiling the class through the Tailwind CLI; the running app has not been visually checked.

## Test plan

1. Wide strip with a long-titled tab (e.g. a Doc with a long name) → the title fades out at the right edge instead of ending in "…".
2. Short-titled tab → title renders fully opaque, no visible fade.
3. Hover a closeable long-titled tab → the close button appears, the title reflows to the narrower space, and the fade sits at the new right edge.
4. Detach a long-titled tab → the window indicator appears and the fade sits just left of it.
5. Check an active (secondary background) and a hovered tab in both light and dark theme → the fade blends into every background with no hard edge or color mismatch.
6. Narrow strip and pinned grid → unchanged (no titles rendered).
