### PR TITLE
fade in the tab close button

### DIFF
--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -116,7 +116,7 @@ function StripTab({
           variant="secondary"
           size="icon"
           className={cn(
-            "absolute hidden group-hover:flex",
+            "absolute opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
             isWideRow
               ? "top-1/2 right-1 size-5 -translate-y-1/2"
               : "-top-1 -right-1 size-4 rounded-full",


### PR DESCRIPTION
## Problem

The tab strip's close button pops in abruptly on hover (`hidden` → `group-hover:flex`). It should fade in.

## Changes

The close button's reveal switches to opacity: `opacity-0 group-hover:opacity-100`. The `Button` base classes already include `transition-all` (and `inline-flex`, so dropping `hidden` leaves layout unchanged), so no extra transition utility is needed — the fade comes for free.

Also adds `focus-visible:opacity-100`: unlike `hidden`, an opacity-0 element is keyboard-focusable, and without this a focused close button would be invisible.

Both presentations (wide row and narrow icon) share the one `cn` call, so both fade. The wide row's `group-hover:pr-7` title padding shift is untouched (and already animates via the same `transition-all`).

## Test plan

1. Wide strip: hover an unpinned tab → the close button fades in smoothly instead of popping; move the pointer away → it fades out.
2. Narrow strip: same fade on the corner close badge of an unpinned tab.
3. Click the close button mid-fade → the tab closes normally.
4. Keyboard-tab to a close button without hovering → it becomes visible while focused.
5. Pinned tabs and the Gmail tab → still no close button at all.
