### PR TITLE
strip google prefix from page titles in workspace app

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,16 +2,11 @@
 
 Follow-up work that should be picked up in a **new session** — items unrelated enough to their originating feature that they shouldn't ride along with it.
 
-## Workspace apps tabs — remaining roadmap (handoff, 2026-08-04)
+## Workspace apps tabs — remaining roadmap (handoff, 2026-08-04, updated 2026-08-05)
 
-The planning notes for this feature lived in machine-local files; this section is the complete, self-contained handoff. All planned workspace-apps-tabs work through PR #658 is merged: embedded tabs with pinned-tab persistence and restore, bookmarked apps in the "+" New Tab menu, Chrome modifier gestures (#650), reopen closed tab (#651), tab context-menu polish with Chrome wording (#655), "Google " prefix stripped from tab titles (#656), pinned/unpinned divider in the narrow strip (#657), and the Arc-style pinned icon grid in the wide strip (#658). Remaining work, in recommended order:
+The planning notes for this feature lived in machine-local files; this section is the complete, self-contained handoff. All planned workspace-apps-tabs work through PR #668 is merged: embedded tabs with pinned-tab persistence and restore, bookmarked apps in the "+" New Tab menu, Chrome modifier gestures (#650), reopen closed tab (#651), tab context-menu polish with Chrome wording (#655), "Google " prefix stripped from tab titles (#656), pinned/unpinned divider in the narrow strip (#657), the Arc-style pinned icon grid in the wide strip (#658), the Meet screen-share fix for embedded tabs (#659), the tab strip width setting (#662), Chrome-wording close tooltip (#663), page-link actions in the workspace-app context menu (#664) later moved into the window titlebar menu (#666), and detach/adopt tab ↔ window — detached tabs persist in the strip with a window indicator, "Move to Tab" lives in the titlebar menu (#660, #661), narrow-strip pinned apps as outline buttons without the divider (#667), and fade-out tab titles instead of ellipsis truncation (#668). Remaining work, in recommended order:
 
-### 1. Meet screen-share picker fix (small, an actual bug — do this first)
-
-- Bug: `registerSessionDisplayMediaRequestHandler` in `packages/app/account.ts` locates the Meet instance by filtering `Account.windows` with `instanceof BrowserWindow`. An embedded Meet **tab** never matches, so the handler falls through to `callback({})` and screen sharing is silently denied in embedded Meet.
-- Fix: also match embedded Meet instances and parent the source-picker to `main.window` in that case.
-
-### 2. Drag-and-drop tab reordering (plan agreed, not started)
+### 1. Drag-and-drop tab reordering (plan agreed, not started)
 
 - Use `@dnd-kit/react` following the existing pattern in the bookmarked-apps editor (`packages/renderer-main/routes/settings/workspace-apps.tsx`).
 - `useSortable` per strip tab; the Gmail tab is fixed (not draggable, nothing can drop above it).
@@ -19,26 +14,18 @@ The planning notes for this feature lived in machine-local files; this section i
 - New `tabs.moveTab` IPC → `Tabs.moveTab` in `packages/app/tabs.ts`: splice to the new index, then `reorderTabs()` (enforces Gmail → pinned → unpinned) and `savePinnedTabs()` — pinned order persists for free because `serializePinnedTabs` walks the list in order.
 - Risk to verify first: dnd-kit sorting across the two differently-laid-out containers (pinned grid vs unpinned list) in the wide strip.
 
-### 3. Configurable + toggleable strip width (memo)
-
-- Strip width behavior becomes **configurable and also toggleable**: a config key (proposed union `auto | narrow | wide`, default `auto` = current automatic switching in `getTabStripWidth`) rendered with `ConfigSelectField`, plus a runtime toggle (menu item and/or shortcut) to flip it without opening settings.
-- Config only affects width, never visibility. `narrow` implies no pinned grid (the grid is wide-only).
-
-### 4. Detach/adopt tab ↔ window (plan agreed; two PRs, detach first)
-
-- Core mechanism for both directions: re-parent the **live** `WebContentsView` between `main.window.contentView` and a `BrowserWindow`'s `contentView` — no reload, page state survives.
-- Detach: tab context-menu item "Move to New Window". Unpins the tab if pinned; does not record into the recently-closed stack.
-- Adopt: titlebar button on workspace-app windows moves the view into the main window as a tab, then destroys the window shell — guard the window close handler so it doesn't tear down the re-parented view.
-
-### 5. Needs discussion before implementation (parked)
+### 2. Needs discussion before implementation (parked)
 
 - Resting state when only Gmail is open: without bookmarked apps the strip is hidden (then the only first-tab entry points are links and settings); with bookmarks it shows permanently as lone Gmail tab + "+". Is that the desired resting state? Auto-hide? Does the no-bookmarks state need an entry point?
 - Zoom targeting: menu zoom still drives the `gmail.zoomFactor` config; `WorkspaceApp` has its own `zoomIn/zoomOut/resetZoom`. One API over the active tab is wanted (overlaps the convergence backlog below).
 
-### Wording conventions + minor leftover
+### 3. Strip polish memos (2026-08-05)
 
-- Page-link actions everywhere use exactly "Copy Link" and "Open in Default Browser"; tab context menu mirrors Chrome: "Reload", "Duplicate", "Pin"/"Unpin", "Close", "Close Other Tabs", "Close Tabs Below", "Reopen Closed Tab". Identifiers deliberately keep `copyUrl`-style names.
-- Known leftover: the strip close-button hover tooltip still says "Close Tab" (deliberately left; Chrome-wording pass covered menus only).
+- List **all** of an account's workspace-app windows in the strip with the window indicator, not just detached tabs (decided 2026-08-05 when scoping the persistent-tab rework of the detach PR; needs a design pass for edge cases like PDF-viewer popups and `alwaysOpenAsWindow` apps). Concrete missing case: apps opened directly as a window (Shift+click in the "+" menu) never appear in the strip but should.
+
+### Wording conventions
+
+- Page-link actions everywhere use exactly "Copy Link" and "Open in Default Browser"; tab context menu mirrors Chrome: "Reload", "Duplicate", "Pin"/"Unpin", "Close", "Close Other Tabs", "Close Tabs Below", "Reopen Closed Tab", "Move to New Window"/"Move to Tab". Identifiers deliberately keep `copyUrl`-style names.
 
 ### Process notes for the next session
 

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -14,7 +14,6 @@ import {
 } from "@meru/shared/gmail";
 import { ms } from "@meru/shared/ms";
 import { wait } from "@meru/shared/utils";
-import { workspaceApps } from "@meru/shared/workspace-apps";
 import {
   app,
   BrowserWindow,
@@ -252,7 +251,7 @@ export class Gmail {
   private pageTitle = "";
 
   get title() {
-    return this.pageTitle || workspaceApps.gmail.label;
+    return WorkspaceApp.resolveTitle(this.pageTitle, "gmail");
   }
 
   get messageId() {

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -14,6 +14,7 @@ import {
 } from "@meru/shared/gmail";
 import { ms } from "@meru/shared/ms";
 import { wait } from "@meru/shared/utils";
+import type { SupportedWorkspaceApp } from "@meru/shared/workspace-apps";
 import {
   app,
   BrowserWindow,
@@ -211,6 +212,8 @@ function extractVerificationCode(texts: string[]) {
 export class Gmail {
   accountId: string;
 
+  app: SupportedWorkspaceApp = "gmail";
+
   url: string;
 
   baseUrl: string;
@@ -251,7 +254,7 @@ export class Gmail {
   private pageTitle = "";
 
   get title() {
-    return WorkspaceApp.resolveTitle(this.pageTitle, "gmail");
+    return WorkspaceApp.resolveTitle(this.pageTitle, this.app);
   }
 
   get messageId() {

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 import type { PinnedTab } from "@meru/shared/schemas";
 import { GMAIL_TAB_ID, type TabState } from "@meru/shared/tabs";
-import { type SupportedWorkspaceApp, workspaceApps } from "@meru/shared/workspace-apps";
+import {
+  stripGoogleFromPageTitle,
+  type SupportedWorkspaceApp,
+  workspaceApps,
+} from "@meru/shared/workspace-apps";
 import type { WebContentsView } from "electron";
 import { accounts } from "./accounts";
 import type { Gmail } from "./gmail";
@@ -9,12 +13,6 @@ import { main } from "./main";
 import { WorkspaceApp } from "./workspace-app";
 
 const MAX_RECENTLY_CLOSED_TAB_URLS = 20;
-
-function stripGoogleFromPageTitle(pageTitle: string, app: SupportedWorkspaceApp) {
-  const appLabel = workspaceApps[app].label;
-
-  return pageTitle.replace(`Google ${appLabel}`, appLabel);
-}
 
 export function registerTabBroadcasts(view: WebContentsView) {
   const broadcastTabsChanged = () => {
@@ -68,7 +66,11 @@ export class DormantTab {
   }
 
   get title() {
-    return this.pageTitle || workspaceApps[this.app].label;
+    if (!this.pageTitle) {
+      return workspaceApps[this.app].label;
+    }
+
+    return stripGoogleFromPageTitle(this.pageTitle, this.app);
   }
 }
 
@@ -432,7 +434,7 @@ export class Tabs {
     return this.tabs.map((tab) => ({
       id: tab.id,
       app: tab.app,
-      title: tab.app ? stripGoogleFromPageTitle(tab.title, tab.app) : tab.title,
+      title: tab.title,
       pinned: tab.pinned,
       dormant: tab instanceof DormantTab,
       windowed: isWindowedTab(tab),

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -57,7 +57,7 @@ export class DormantTab {
   constructor(pinnedTab: PinnedTab) {
     this.app = pinnedTab.app;
     this.url = pinnedTab.url;
-    this.title = WorkspaceApp.resolveTitle(pinnedTab.title, pinnedTab.app);
+    this.title = pinnedTab.title;
     this.loadOnLaunch = Boolean(pinnedTab.loadOnLaunch);
   }
 }

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -1,11 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { PinnedTab } from "@meru/shared/schemas";
 import { GMAIL_TAB_ID, type TabState } from "@meru/shared/tabs";
-import {
-  stripGoogleFromPageTitle,
-  type SupportedWorkspaceApp,
-  workspaceApps,
-} from "@meru/shared/workspace-apps";
+import type { SupportedWorkspaceApp } from "@meru/shared/workspace-apps";
 import type { WebContentsView } from "electron";
 import { accounts } from "./accounts";
 import type { Gmail } from "./gmail";
@@ -66,11 +62,7 @@ export class DormantTab {
   }
 
   get title() {
-    if (!this.pageTitle) {
-      return workspaceApps[this.app].label;
-    }
-
-    return stripGoogleFromPageTitle(this.pageTitle, this.app);
+    return WorkspaceApp.resolveTitle(this.pageTitle, this.app);
   }
 }
 

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -52,17 +52,13 @@ export class DormantTab {
 
   loadOnLaunch: boolean;
 
-  private pageTitle: string;
+  title: string;
 
   constructor(pinnedTab: PinnedTab) {
     this.app = pinnedTab.app;
     this.url = pinnedTab.url;
-    this.pageTitle = pinnedTab.title;
+    this.title = WorkspaceApp.resolveTitle(pinnedTab.title, pinnedTab.app);
     this.loadOnLaunch = Boolean(pinnedTab.loadOnLaunch);
-  }
-
-  get title() {
-    return WorkspaceApp.resolveTitle(this.pageTitle, this.app);
   }
 }
 
@@ -81,7 +77,7 @@ export class Tabs {
     this.tabs = [
       {
         id: GMAIL_TAB_ID,
-        app: "gmail",
+        app: gmail.app,
         pinned: false,
         get title() {
           return gmail.title;

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -4,7 +4,6 @@ import { getWorkspaceAppUrl } from "@meru/shared/google";
 import type { AccountConfig } from "@meru/shared/schemas";
 import { clamp } from "@meru/shared/utils";
 import {
-  stripGoogleFromPageTitle,
   type SupportedWorkspaceApp,
   type WorkspaceAppOpenBehavior,
   workspaceApps,
@@ -302,6 +301,20 @@ export class WorkspaceApp {
   private static unregisterMeetShortcuts() {
     globalShortcut.unregister(GOOGLE_MEET_TOGGLE_MICROPHONE_ACCELERATOR);
     globalShortcut.unregister(GOOGLE_MEET_TOGGLE_CAMERA_ACCELERATOR);
+  }
+
+  static resolveTitle(pageTitle: string, app: SupportedWorkspaceApp | undefined) {
+    if (!app) {
+      return pageTitle;
+    }
+
+    const appLabel = workspaceApps[app].label;
+
+    if (!pageTitle) {
+      return appLabel;
+    }
+
+    return pageTitle.replace(`Google ${appLabel}`, appLabel);
   }
 
   accountId: AccountConfig["id"];
@@ -678,15 +691,7 @@ export class WorkspaceApp {
   private pageTitle = "";
 
   get title() {
-    if (!this.app) {
-      return this.pageTitle;
-    }
-
-    if (!this.pageTitle) {
-      return workspaceApps[this.app].label;
-    }
-
-    return stripGoogleFromPageTitle(this.pageTitle, this.app);
+    return WorkspaceApp.resolveTitle(this.pageTitle, this.app);
   }
 
   handlePageTitleUpdated = (_event: Electron.Event, pageTitle: string, explicitSet: boolean) => {

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -4,6 +4,7 @@ import { getWorkspaceAppUrl } from "@meru/shared/google";
 import type { AccountConfig } from "@meru/shared/schemas";
 import { clamp } from "@meru/shared/utils";
 import {
+  stripGoogleFromPageTitle,
   type SupportedWorkspaceApp,
   type WorkspaceAppOpenBehavior,
   workspaceApps,
@@ -677,7 +678,15 @@ export class WorkspaceApp {
   private pageTitle = "";
 
   get title() {
-    return this.pageTitle || (this.app ? workspaceApps[this.app].label : "");
+    if (!this.app) {
+      return this.pageTitle;
+    }
+
+    if (!this.pageTitle) {
+      return workspaceApps[this.app].label;
+    }
+
+    return stripGoogleFromPageTitle(this.pageTitle, this.app);
   }
 
   handlePageTitleUpdated = (_event: Electron.Event, pageTitle: string, explicitSet: boolean) => {

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -43,12 +43,6 @@ export type BookmarkableWorkspaceApp = {
 export const workspaceApps: Record<SupportedWorkspaceApp, WorkspaceAppDefinition> =
   workspaceAppDefinitions;
 
-export function stripGoogleFromPageTitle(pageTitle: string, app: SupportedWorkspaceApp) {
-  const appLabel = workspaceApps[app].label;
-
-  return pageTitle.replace(`Google ${appLabel}`, appLabel);
-}
-
 export const bookmarkableWorkspaceApps = Object.fromEntries(
   Object.entries(workspaceApps)
     .filter(([, workspaceAppDefinition]) => workspaceAppDefinition.bookmarkable !== false)

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -43,6 +43,12 @@ export type BookmarkableWorkspaceApp = {
 export const workspaceApps: Record<SupportedWorkspaceApp, WorkspaceAppDefinition> =
   workspaceAppDefinitions;
 
+export function stripGoogleFromPageTitle(pageTitle: string, app: SupportedWorkspaceApp) {
+  const appLabel = workspaceApps[app].label;
+
+  return pageTitle.replace(`Google ${appLabel}`, appLabel);
+}
+
 export const bookmarkableWorkspaceApps = Object.fromEntries(
   Object.entries(workspaceApps)
     .filter(([, workspaceAppDefinition]) => workspaceAppDefinition.bookmarkable !== false)


### PR DESCRIPTION
Workspace-app **window** titles still showed Google's raw page titles ("Google Chat", "Google Calendar — …"), because the `stripGoogleFromPageTitle` cleanup only ran in `Tabs.serialize` — the path that feeds the tab strip. Anything reading a title outside of that serialization (the native window title via `updateWindowTitle`, the workspace-app titlebar via `workspaceApp.pageTitleChanged`, and persisted pinned-tab titles via `serializePinnedTabs`) got the unstripped title.

Underneath that, the title rule — "the page title if there is one, else the app label, with the `Google ` prefix stripped" — was spelled out in three separate getters, and every read re-derived it.

## Changes

Titles are now resolved once, at the source, and that resolved value is what every consumer reads and what gets saved:

- Replace `stripGoogleFromPageTitle` with `WorkspaceApp.resolveTitle(pageTitle, app)`: `WorkspaceApp` owns the whole rule, label fallback included.
- `WorkspaceApp.title` is the only place a live page title is resolved; `Gmail.title` calls the same helper so the rule is not copied.
- `Tabs.serialize` passes `tab.title` through untouched — `Tabs` no longer formats titles at all, it only reads them.
- `serializePinnedTabs` therefore writes resolved titles to config, and `DormantTab` takes its title straight from what was saved (plain field, no getter, no second resolve). Its other construction site — demoting a closed pinned tab back to dormant — feeds it `windowedTab.title`, already resolved.
- Declare `app` on `Gmail` the way `WorkspaceApp` does, so the `"gmail"` app key is written once instead of being hardcoded in both `Gmail.title` and the Gmail tab entry.

`pageTitle` stays private on `WorkspaceApp` and `Gmail`. Only the resolved `title` is exposed, so no consumer can re-format an already-formatted title — that layering is what caused the bug.

`Gmail` gains the strip pass it never had, which is a no-op today (Google does not emit "Google Gmail" in the page title), but it removes the last copy of the fallback logic. Both getters disappear once the convergence backlog's lazy-view-creation item unblocks `Gmail extends WorkspaceApp`.

Pinned-tab configs written by earlier builds hold raw titles, since the old `serializePinnedTabs` saved the unstripped value — a dormant tab restored from one renders raw until it is materialized and saved again. No migration for that: tabs are unreleased, so there is nothing to upgrade.

Verified with `bun types:ci`. Not verified in a running app — no manual run of the test plan below.

## Test plan

1. Open a Chat tab in the strip (via the "+" menu). The tab title reads "Chat", not "Google Chat" — unchanged from before.
2. Right-click that tab → "Move to New Window". The native window title (title bar / taskbar / window list) reads "Chat - Meru", not "Google Chat - Meru", and the in-app titlebar page title also reads "Chat".
3. With more than one account configured, repeat step 2 and confirm the window title is `[<account label>] Chat - Meru`.
4. Open an app directly as a window (Shift+click an entry in the "+" menu, or a `myaccount`-style always-window app) and confirm its window title is stripped the same way.
5. Navigate inside that window (e.g. Chat → a space, Calendar → a specific day) so a new page title arrives. Both the window title and titlebar page title stay stripped on every update.
6. Move the window back with "Move to Tab" from the titlebar menu; the tab title in the strip is still stripped.
7. Pin a Chat tab, quit and relaunch. The persisted `pinnedTabs` entry holds the resolved title ("Chat"), and the restored dormant tab shows it — no re-resolving on restore.
8. Close a pinned tab that is open in a detached window; it becomes dormant again and keeps its resolved title in the strip and in config.
9. Open a page with no explicit title (a document or PDF that never sets one). The tab and window fall back to the app label, and a workspace app with no recognized app shows an empty title rather than crashing.
10. Confirm the Gmail tab is unaffected: it still shows the current mailbox title (or "Gmail" before the page sets one), keeps its app icon in the strip, and switching accounts still shows the right per-account title.
