### PR TITLE
add drag-and-drop tab reordering to the tab strip

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "meru",
       "devDependencies": {
         "@base-ui/react": "^1.4.0",
+        "@dnd-kit/dom": "^0.5.0",
         "@dnd-kit/helpers": "^0.5.0",
         "@dnd-kit/react": "^0.5.0",
         "@electron-toolkit/preload": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@base-ui/react": "^1.4.0",
+    "@dnd-kit/dom": "^0.5.0",
     "@dnd-kit/helpers": "^0.5.0",
     "@dnd-kit/react": "^0.5.0",
     "@electron-toolkit/preload": "^3.0.2",

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -269,6 +269,12 @@ class Ipc {
       }
     });
 
+    ipc.main.on("tabs.moveTab", (_event, accountId, tabId, targetSectionIndex) => {
+      const account = accounts.getAccount(accountId);
+
+      account.instance.tabs.moveTab(tabId, targetSectionIndex);
+    });
+
     ipc.main.on("tabs.showTabContextMenu", (_event, accountId, tabId) => {
       const account = accounts.getAccount(accountId);
 

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -378,6 +378,49 @@ export class Tabs {
     accounts.savePinnedTabs();
   }
 
+  moveTab(tabId: string, targetSectionIndex: number) {
+    if (tabId === GMAIL_TAB_ID) {
+      return;
+    }
+
+    const movedTab = this.getTab(tabId);
+
+    if (!movedTab) {
+      return;
+    }
+
+    const remainingTabs = this.tabs.filter((tab) => tab.id !== tabId);
+
+    const remainingPinnedSectionTabCount = remainingTabs.filter(
+      (tab) => tab.id === GMAIL_TAB_ID || tab.pinned,
+    ).length;
+
+    const sectionStartIndex = movedTab.pinned ? 0 : remainingPinnedSectionTabCount;
+
+    const sectionTabCount = movedTab.pinned
+      ? remainingPinnedSectionTabCount
+      : remainingTabs.length - remainingPinnedSectionTabCount;
+
+    const minimumSectionIndex = movedTab.pinned ? 1 : 0;
+
+    const clampedSectionIndex = Math.min(
+      Math.max(targetSectionIndex, minimumSectionIndex),
+      sectionTabCount,
+    );
+
+    remainingTabs.splice(sectionStartIndex + clampedSectionIndex, 0, movedTab);
+
+    this.tabs = remainingTabs;
+
+    this.reorderTabs();
+
+    this.broadcastTabsChanged();
+
+    if (movedTab.pinned) {
+      accounts.savePinnedTabs();
+    }
+  }
+
   private reorderTabs() {
     this.tabs = [
       ...this.tabs.filter((tab) => tab.id === GMAIL_TAB_ID),

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -189,7 +189,7 @@ function SortableStripTab({
 }: {
   tab: TabState;
   accountId: AccountConfig["id"];
-  presentation: "wideRow" | "gridIcon";
+  presentation: "wideRow" | "narrowIcon" | "gridIcon";
   sectionIndex: number;
   className?: string;
 }) {
@@ -332,14 +332,14 @@ export function AppTabStrip() {
         ipc.main.send("tabs.showTabStripContextMenu", selectedAccount.config.id);
       }}
     >
-      {isWide ? (
-        <DragDropProvider
-          plugins={tabStripPlugins}
-          sensors={tabStripSensors}
-          onDragEnd={(event) => {
-            moveSectionTab(selectedAccount.config.id, pinnedSectionTabs, event);
-          }}
-        >
+      <DragDropProvider
+        plugins={tabStripPlugins}
+        sensors={tabStripSensors}
+        onDragEnd={(event) => {
+          moveSectionTab(selectedAccount.config.id, pinnedSectionTabs, event);
+        }}
+      >
+        {isWide ? (
           <div className="mb-1 grid w-full grid-cols-2 gap-2">
             {pinnedSectionTabs.map((tab, pinnedSectionTabIndex) => (
               <SortableStripTab
@@ -354,45 +354,35 @@ export function AppTabStrip() {
               />
             ))}
           </div>
-        </DragDropProvider>
-      ) : (
-        pinnedSectionTabs.map((tab) => (
-          <StripTab
-            key={tab.id}
-            tab={tab}
-            accountId={selectedAccount.config.id}
-            presentation="narrowIcon"
-          />
-        ))
-      )}
-      {isWide ? (
-        <DragDropProvider
-          plugins={tabStripPlugins}
-          sensors={tabStripSensors}
-          onDragEnd={(event) => {
-            moveSectionTab(selectedAccount.config.id, unpinnedTabs, event);
-          }}
-        >
-          {unpinnedTabs.map((tab, unpinnedTabIndex) => (
+        ) : (
+          pinnedSectionTabs.map((tab, pinnedSectionTabIndex) => (
             <SortableStripTab
               key={tab.id}
               tab={tab}
               accountId={selectedAccount.config.id}
-              presentation="wideRow"
-              sectionIndex={unpinnedTabIndex}
+              presentation="narrowIcon"
+              sectionIndex={pinnedSectionTabIndex}
             />
-          ))}
-        </DragDropProvider>
-      ) : (
-        unpinnedTabs.map((tab) => (
-          <StripTab
+          ))
+        )}
+      </DragDropProvider>
+      <DragDropProvider
+        plugins={tabStripPlugins}
+        sensors={tabStripSensors}
+        onDragEnd={(event) => {
+          moveSectionTab(selectedAccount.config.id, unpinnedTabs, event);
+        }}
+      >
+        {unpinnedTabs.map((tab, unpinnedTabIndex) => (
+          <SortableStripTab
             key={tab.id}
             tab={tab}
             accountId={selectedAccount.config.id}
-            presentation="narrowIcon"
+            presentation={isWide ? "wideRow" : "narrowIcon"}
+            sectionIndex={unpinnedTabIndex}
           />
-        ))
-      )}
+        ))}
+      </DragDropProvider>
       <NewTabButton isWide={isWide} />
     </div>
   );

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -1,3 +1,7 @@
+import { PointerActivationConstraints } from "@dnd-kit/dom";
+import { move } from "@dnd-kit/helpers";
+import { type DragEndEvent, DragDropProvider, KeyboardSensor, PointerSensor } from "@dnd-kit/react";
+import { useSortable } from "@dnd-kit/react/sortable";
 import { APP_TAB_STRIP_WIDE_WIDTH } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
 import { useConfig } from "@meru/shared/renderer/react-query";
@@ -15,9 +19,44 @@ import {
 import { WorkspaceAppIcon } from "@meru/ui/components/workspace-app-icon";
 import { cn } from "@meru/ui/lib/utils";
 import { AppWindowIcon, GlobeIcon, PlusIcon, XIcon } from "lucide-react";
-import { type MouseEvent, useEffect, useState } from "react";
+import { type MouseEvent, type Ref, useEffect, useState } from "react";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
+
+const tabStripSensors = [
+  PointerSensor.configure({
+    activationConstraints: [new PointerActivationConstraints.Distance({ value: 5 })],
+    preventActivation: (event) =>
+      event.target instanceof Element && event.target.closest("[data-tab-close]") !== null,
+  }),
+  KeyboardSensor,
+];
+
+function moveSectionTab(
+  accountId: AccountConfig["id"],
+  sectionTabs: TabState[],
+  event: DragEndEvent,
+) {
+  if (event.canceled) {
+    return;
+  }
+
+  const sectionTabIds = sectionTabs.map((tab) => tab.id);
+
+  const movedSectionTabIds = move(sectionTabIds, event);
+
+  if (movedSectionTabIds === sectionTabIds) {
+    return;
+  }
+
+  const movedTabId = event.operation.source?.id;
+
+  if (typeof movedTabId !== "string") {
+    return;
+  }
+
+  ipc.main.send("tabs.moveTab", accountId, movedTabId, movedSectionTabIds.indexOf(movedTabId));
+}
 
 function getModifierOpenBehavior(event: MouseEvent) {
   if (platform.isMacOS ? event.metaKey : event.ctrlKey) {
@@ -51,11 +90,13 @@ function WindowedTabBadge({ className }: { className?: string }) {
 }
 
 function StripTab({
+  ref,
   tab,
   accountId,
   presentation,
   className,
 }: {
+  ref?: Ref<HTMLDivElement>;
   tab: TabState;
   accountId: AccountConfig["id"];
   presentation: "wideRow" | "narrowIcon" | "gridIcon";
@@ -71,7 +112,7 @@ function StripTab({
     tab.app && !workspaceApps[tab.app].singleInstance && !workspaceApps[tab.app].alwaysOpenAsWindow;
 
   return (
-    <div className={cn("group relative", className)}>
+    <div ref={ref} className={cn("group relative", className)}>
       <Button
         variant={tab.active ? "secondary" : !isWideRow && isPinnedSectionTab ? "outline" : "ghost"}
         size={isWideRow ? "sm" : "icon"}
@@ -119,6 +160,7 @@ function StripTab({
         <Button
           variant="secondary"
           size="icon"
+          data-tab-close
           className={cn(
             "absolute opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
             isWideRow
@@ -134,6 +176,36 @@ function StripTab({
         </Button>
       )}
     </div>
+  );
+}
+
+function SortableStripTab({
+  tab,
+  accountId,
+  presentation,
+  sectionIndex,
+  className,
+}: {
+  tab: TabState;
+  accountId: AccountConfig["id"];
+  presentation: "wideRow" | "gridIcon";
+  sectionIndex: number;
+  className?: string;
+}) {
+  const { ref, isDragging } = useSortable({
+    id: tab.id,
+    index: sectionIndex,
+    disabled: tab.id === GMAIL_TAB_ID,
+  });
+
+  return (
+    <StripTab
+      ref={ref}
+      tab={tab}
+      accountId={accountId}
+      presentation={presentation}
+      className={cn("touch-none", isDragging && "opacity-50", className)}
+    />
   );
 }
 
@@ -260,19 +332,27 @@ export function AppTabStrip() {
       }}
     >
       {isWide ? (
-        <div className="mb-1 grid w-full grid-cols-2 gap-2">
-          {pinnedSectionTabs.map((tab, pinnedSectionTabIndex) => (
-            <StripTab
-              key={tab.id}
-              tab={tab}
-              accountId={selectedAccount.config.id}
-              presentation="gridIcon"
-              className={cn(
-                pinnedSectionTabs.length % 2 === 1 && pinnedSectionTabIndex === 0 && "col-span-2",
-              )}
-            />
-          ))}
-        </div>
+        <DragDropProvider
+          sensors={tabStripSensors}
+          onDragEnd={(event) => {
+            moveSectionTab(selectedAccount.config.id, pinnedSectionTabs, event);
+          }}
+        >
+          <div className="mb-1 grid w-full grid-cols-2 gap-2">
+            {pinnedSectionTabs.map((tab, pinnedSectionTabIndex) => (
+              <SortableStripTab
+                key={tab.id}
+                tab={tab}
+                accountId={selectedAccount.config.id}
+                presentation="gridIcon"
+                sectionIndex={pinnedSectionTabIndex}
+                className={cn(
+                  pinnedSectionTabs.length % 2 === 1 && pinnedSectionTabIndex === 0 && "col-span-2",
+                )}
+              />
+            ))}
+          </div>
+        </DragDropProvider>
       ) : (
         pinnedSectionTabs.map((tab) => (
           <StripTab
@@ -283,14 +363,33 @@ export function AppTabStrip() {
           />
         ))
       )}
-      {unpinnedTabs.map((tab) => (
-        <StripTab
-          key={tab.id}
-          tab={tab}
-          accountId={selectedAccount.config.id}
-          presentation={isWide ? "wideRow" : "narrowIcon"}
-        />
-      ))}
+      {isWide ? (
+        <DragDropProvider
+          sensors={tabStripSensors}
+          onDragEnd={(event) => {
+            moveSectionTab(selectedAccount.config.id, unpinnedTabs, event);
+          }}
+        >
+          {unpinnedTabs.map((tab, unpinnedTabIndex) => (
+            <SortableStripTab
+              key={tab.id}
+              tab={tab}
+              accountId={selectedAccount.config.id}
+              presentation="wideRow"
+              sectionIndex={unpinnedTabIndex}
+            />
+          ))}
+        </DragDropProvider>
+      ) : (
+        unpinnedTabs.map((tab) => (
+          <StripTab
+            key={tab.id}
+            tab={tab}
+            accountId={selectedAccount.config.id}
+            presentation="narrowIcon"
+          />
+        ))
+      )}
       <NewTabButton isWide={isWide} />
     </div>
   );

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -1,4 +1,4 @@
-import { PointerActivationConstraints } from "@dnd-kit/dom";
+import { Accessibility, defaultPreset, PointerActivationConstraints } from "@dnd-kit/dom";
 import { move } from "@dnd-kit/helpers";
 import { type DragEndEvent, DragDropProvider, PointerSensor } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
@@ -22,6 +22,8 @@ import { AppWindowIcon, GlobeIcon, PlusIcon, XIcon } from "lucide-react";
 import { type MouseEvent, type Ref, useEffect, useState } from "react";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
+
+const tabStripPlugins = defaultPreset.plugins.filter((plugin) => plugin !== Accessibility);
 
 const tabStripSensors = [
   PointerSensor.configure({
@@ -332,6 +334,7 @@ export function AppTabStrip() {
     >
       {isWide ? (
         <DragDropProvider
+          plugins={tabStripPlugins}
           sensors={tabStripSensors}
           onDragEnd={(event) => {
             moveSectionTab(selectedAccount.config.id, pinnedSectionTabs, event);
@@ -364,6 +367,7 @@ export function AppTabStrip() {
       )}
       {isWide ? (
         <DragDropProvider
+          plugins={tabStripPlugins}
           sensors={tabStripSensors}
           onDragEnd={(event) => {
             moveSectionTab(selectedAccount.config.id, unpinnedTabs, event);

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -1,6 +1,6 @@
 import { PointerActivationConstraints } from "@dnd-kit/dom";
 import { move } from "@dnd-kit/helpers";
-import { type DragEndEvent, DragDropProvider, KeyboardSensor, PointerSensor } from "@dnd-kit/react";
+import { type DragEndEvent, DragDropProvider, PointerSensor } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { APP_TAB_STRIP_WIDE_WIDTH } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
@@ -29,7 +29,6 @@ const tabStripSensors = [
     preventActivation: (event) =>
       event.target instanceof Element && event.target.closest("[data-tab-close]") !== null,
   }),
-  KeyboardSensor,
 ];
 
 function moveSectionTab(

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -175,6 +175,7 @@ export type IpcMainEvents =
       "notifications.showTestNotification": [];
       "tabs.selectTab": [accountId: AccountConfig["id"], tabId: string];
       "tabs.closeTab": [accountId: AccountConfig["id"], tabId: string];
+      "tabs.moveTab": [accountId: AccountConfig["id"], tabId: string, targetSectionIndex: number];
       "tabs.showTabContextMenu": [accountId: AccountConfig["id"], tabId: string];
       "tabs.showTabStripContextMenu": [accountId: AccountConfig["id"]];
       "workspaceApps.openApp": [


### PR DESCRIPTION
## Problem

Tabs in the strip can't be reordered — it always renders store order. Reordering should work by drag and drop in both strip widths, but only **within** each section: within the pinned section and within the unpinned list. Dragging never crosses the pinned/unpinned boundary (pinning stays a context-menu action), and the Gmail tab is fixed first. The functionality is deliberately mouse-only.

## Changes

### Renderer (`app-tab-strip.tsx`)

- Two independent `DragDropProvider`s — one per section, each wrapping that section's width-conditional rendering (wide pinned grid or narrow icon list; wide rows or narrow icons for unpinned) — following the existing bookmarked-apps editor pattern (`useSortable` + `move()` in `onDragEnd`). Separate providers share no droppables, so a cross-section drop is structurally impossible: dropping outside the source section reverts. The provider renders no DOM element, so both layouts are unchanged.
- New `SortableStripTab` wraps `StripTab` with `useSortable`; `StripTab` gained an optional `ref` prop (React 19 ref-as-prop) forwarded to its wrapper div. Dragging shows the same `opacity-50` treatment as the settings page.
- The Gmail tab passes `disabled: true` — it can't be dragged, and (verified in the dnd-kit 0.5 source) a disabled sortable is skipped by collision detection while still holding its index, so nothing can land before it and the odd-count `col-span-2` tile stays first.
- The pointer sensor is configured deliberately, because both defaults break this use case (verified against the installed `@dnd-kit` source):
  - Default `preventActivation` blocks any drag whose pointer-down lands on an interactive descendant — which is every tab, since the sortable element is the wrapper div around the `<Button>`. The override only blocks the close button (`data-tab-close`), so a close click can never start a drag.
  - Default activation adds a 200 ms hold-to-drag: a slow press-and-release would start a drag and swallow the click, leaving the tab unselected. Replaced with a distance-only constraint (5 px).
  - The configured sensors array is hoisted to module scope — the provider deep-compares `sensors` by function reference, so an inline array would re-bind sensors every render.
  - The array contains only the pointer sensor: dragging is **mouse-only**. Supplying `sensors` replaces dnd-kit's default preset, so omitting the keyboard sensor fully disables keyboard dragging.
- The strip is app shell, so dnd-kit's `Accessibility` plugin is excluded: `plugins` is the default preset minus `Accessibility` (derived from the exported `defaultPreset`, so future preset additions are picked up automatically). Without it, dnd-kit injects nothing into the wrappers at rest — no `tabindex`/`role`/`aria-*` stamping, no hidden instruction elements. Feedback (drag preview), auto-scroll, and selection prevention are preserved; the optimistic sort preview lives on the sortable itself and is unaffected.
- On drop, the renderer sends `tabs.moveTab` with the tab id and its new section-relative index; no local order state. The optimistic drag preview already shows the final order at drop time, and the store broadcast re-renders that same order, so no flicker is expected (unverified in the running app).
- `@dnd-kit/dom` added as a direct dev dependency (`bun add -d`) — `PointerActivationConstraints`, `defaultPreset`, and `Accessibility` aren't re-exported by `@dnd-kit/react`, and the package was previously only a transitive dependency.

### IPC + main process

- New `tabs.moveTab: [accountId, tabId, targetSectionIndex]` event, handled in `ipc.ts` like the other `tabs.*` events. Both widths send the same section-relative payload.
- `Tabs.moveTab` removes the tab, maps the section-relative index to an absolute index (pinned section starts at 0, unpinned after it), clamps so nothing lands before Gmail (defence-in-depth — the renderer can't produce that), splices, then runs the existing `reorderTabs()` + `broadcastTabsChanged()`, and `savePinnedTabs()` when the moved tab is pinned. Pinned order persists across restarts for free because `serializePinnedTabs` walks the list in order; unpinned tabs aren't persisted (unchanged).

### Known edges / not verified

- In the narrow strip the pinned/unpinned boundary is invisible — every tab is the same icon button in one column. Dragging an icon into the other section snaps back by design, which could read as broken there; flagging for review whether that's acceptable or the narrow strip wants a visual hint.
- Middle-click close and right-click context menu are untouched: the pointer sensor ignores non-primary buttons at the source. dnd-kit suppresses the context menu only during an active drag, which is desired.
- Shared pre-existing caveat with the settings-page pattern: if a drop is released with no collision target after an optimistic sort, the DOM briefly keeps the preview order with no broadcast to reconcile it. In practice the source's own droppable sits under the pointer, so the target is normally non-null.
- Nothing has been verified visually in the running app; the sensor/collision/plugin behavior claims come from reading the installed dnd-kit 0.5 source.

## Test plan

1. Wide strip with ≥3 pinned-section tiles: drag a pinned tile between two others → order updates; restart the app → the new pinned order is restored.
2. Drag a pinned tile onto the Gmail tile → it never lands before Gmail; try to drag the Gmail tile itself → nothing happens.
3. Odd pinned-section count: the first tile keeps its full-width `col-span-2` spot during and after a drag.
4. Drag an unpinned row up/down → order updates; drag a pinned tile over the unpinned list (or an unpinned row over the grid) and release → snaps back, section membership unchanged.
5. Narrow strip: drag icons within the pinned section and within the unpinned section → order updates; drag an icon across the (invisible) section boundary → snaps back. The dragged icon stays centered in the column, and the windowed/close badges ride along with it.
6. Quick click a tab (both widths) → selects, no drag. Press and hold ~1 s without moving, then release → the tab still selects (regression guard for the removed 200 ms hold-to-drag).
7. Press, move a few pixels, release roughly in place → order unchanged and the tab is not selected.
8. Hover a closeable tab and click its close button (wide row and narrow corner badge) → closes, no drag; press the close button and move 20 px → still no drag.
9. Middle-click a tab → closes. Right-click → context menu opens; Pin/Unpin from the menu still moves the tab across sections.
10. Start a drag and press Escape → the tab snaps back, no order change.
11. Inspect a strip tab in devtools → no `tabindex`, `role`, or `aria-*` attributes injected on the wrapper divs.
12. Multi-account: reorder in account A, switch to B and back → each account keeps its own order.
13. Reorder a dormant pinned tab, then click it → it still loads and activates; reorder a tab with the windowed badge → the badge stays on the right tab.
