### PR TITLE
list directly opened workspace app windows in the tab strip

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -397,6 +397,10 @@ class Accounts {
   }
 
   sendTabsChangedToRenderer() {
+    if (main.window.isDestroyed()) {
+      return;
+    }
+
     ipc.renderer.send(
       main.window.webContents,
       "tabs.changed",
@@ -408,6 +412,10 @@ class Accounts {
   }
 
   sendAccountsChangedToRenderer() {
+    if (main.window.isDestroyed()) {
+      return;
+    }
+
     ipc.renderer.send(
       main.window.webContents,
       "accounts.changed",

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -306,9 +306,7 @@ class Ipc {
         .some((accountTab) => !accountTab.pinned);
 
       Menu.buildFromTemplate([
-        ...(tabApp &&
-        !workspaceApps[tabApp].singleInstance &&
-        !workspaceApps[tabApp].alwaysOpenAsWindow
+        ...(tabApp && !workspaceApps[tabApp].singleInstance && !workspaceApps[tabApp].popupOnly
           ? [
               {
                 label: `New ${workspaceApps[tabApp].label} Tab`,

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -216,16 +216,22 @@ class Ipc {
     ipc.main.on("workspaceApp.showMenu", (_event, workspaceAppId) => {
       const workspaceApp = WorkspaceApp.fromId(workspaceAppId);
 
+      const isPopupWindow = !workspaceApp.account.instance.tabs.getTab(workspaceApp.id);
+
       Menu.buildFromTemplate([
-        {
-          label: "Move to Tab",
-          click: () => {
-            workspaceApp.adoptIntoTabs();
-          },
-        },
-        {
-          type: "separator",
-        },
+        ...(isPopupWindow
+          ? []
+          : [
+              {
+                label: "Move to Tab",
+                click: () => {
+                  workspaceApp.adoptIntoTabs();
+                },
+              },
+              {
+                type: "separator" as const,
+              },
+            ]),
         {
           label: "Copy Link",
           click: () => {

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -591,11 +591,7 @@ class Ipc {
       const selectedAccount = accounts.getSelectedAccount();
 
       if (openBehavior === "newWindow") {
-        new WorkspaceApp({
-          accountId: selectedAccount.config.id,
-          url: getWorkspaceAppUrl(app),
-          asWindow: true,
-        });
+        selectedAccount.instance.tabs.openWindowedTab(getWorkspaceAppUrl(app));
 
         return;
       }

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -216,10 +216,8 @@ class Ipc {
     ipc.main.on("workspaceApp.showMenu", (_event, workspaceAppId) => {
       const workspaceApp = WorkspaceApp.fromId(workspaceAppId);
 
-      const isPopupWindow = !workspaceApp.account.instance.tabs.getTab(workspaceApp.id);
-
       Menu.buildFromTemplate([
-        ...(isPopupWindow
+        ...(workspaceApp.isPopup
           ? []
           : [
               {

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -129,6 +129,22 @@ export class Tabs {
     return workspaceApp;
   }
 
+  openWindowedTab(url: string) {
+    const workspaceApp = new WorkspaceApp({
+      accountId: this.accountId,
+      url,
+      asWindow: true,
+    });
+
+    registerTabBroadcasts(workspaceApp.view);
+
+    this.tabs.push(workspaceApp);
+
+    this.broadcastTabsChanged();
+
+    return workspaceApp;
+  }
+
   adoptTab(workspaceApp: WorkspaceApp) {
     this.tabs.push(workspaceApp);
 

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -223,8 +223,13 @@ export class WorkspaceApp {
       !config.get("workspaceApps.openInAppExcludedApps").includes(matchedSupportedWorkspaceApp);
 
     if (isWorkspaceAppEnabledToOpenInApp) {
+      if (workspaceApps[matchedSupportedWorkspaceApp].popupOnly) {
+        new WorkspaceApp({ accountId, url, asWindow: true });
+
+        return { action: "deny" };
+      }
+
       const openBehavior: WorkspaceAppOpenBehavior =
-        workspaceApps[matchedSupportedWorkspaceApp].alwaysOpenAsWindow ||
         disposition === "new-window"
           ? "newWindow"
           : disposition === "background-tab"

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -231,17 +231,13 @@ export class WorkspaceApp {
             ? "backgroundTab"
             : config.get("workspaceApps.openBehavior");
 
+      const account = accounts.getAccount(accountId);
+
       if (openBehavior === "newWindow") {
-        new WorkspaceApp({
-          accountId,
-          url,
-          asWindow: true,
-        });
+        account.instance.tabs.openWindowedTab(url);
 
         return { action: "deny" };
       }
-
-      const account = accounts.getAccount(accountId);
 
       const workspaceApp = account.instance.tabs.openTab(url);
 

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -338,6 +338,10 @@ export class WorkspaceApp {
     return Boolean(this._window);
   }
 
+  get isPopup() {
+    return !this.account.instance.tabs.getTab(this.id);
+  }
+
   private get chromeWebContents() {
     return this._window ? this._window.webContents : main.window.webContents;
   }
@@ -651,12 +655,12 @@ export class WorkspaceApp {
       this.view.setVisible(false);
     }
 
-    if (this.account.instance.tabs.getTab(this.id)) {
-      this.account.instance.tabs.activateTab(this.id);
-    } else {
+    if (this.isPopup) {
       registerTabBroadcasts(this.view);
 
       this.account.instance.tabs.adoptTab(this);
+    } else {
+      this.account.instance.tabs.activateTab(this.id);
     }
 
     accounts.selectAccount(this.accountId);

--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -110,7 +110,7 @@ function StripTab({
   const isWideRow = presentation === "wideRow";
 
   const canOpenSecondInstance =
-    tab.app && !workspaceApps[tab.app].singleInstance && !workspaceApps[tab.app].alwaysOpenAsWindow;
+    tab.app && !workspaceApps[tab.app].singleInstance && !workspaceApps[tab.app].popupOnly;
 
   return (
     <div ref={ref} className={cn("group relative", className)}>

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -4,7 +4,7 @@ type WorkspaceAppDefinition = {
   label: string;
   url?: string;
   bookmarkable?: boolean;
-  alwaysOpenAsWindow?: boolean;
+  popupOnly?: boolean;
   singleInstance?: boolean;
 };
 
@@ -21,7 +21,7 @@ const workspaceAppDefinitions = {
   groups: { label: "Groups" },
   keep: { label: "Keep" },
   meet: { label: "Meet" },
-  myaccount: { label: "My Account", bookmarkable: false, alwaysOpenAsWindow: true },
+  myaccount: { label: "My Account", bookmarkable: false, popupOnly: true },
   notebooklm: { label: "NotebookLM" },
   sheets: { label: "Sheets" },
   sites: { label: "Sites" },


### PR DESCRIPTION
## Problem

Only tabs detached via "Move to New Window" appear in the tab strip with the window indicator. Apps opened *directly* as a window — Shift+click in the "+" menu, the "New Window" open behavior, links opened while that behavior is set — exist with no strip representation at all. Every deliberately opened workspace-app window should appear in its account's strip as a windowed entry. Popups deliberately do not: the PDF viewer, OAuth/login windows, Gmail pop-outs, compose windows, and popup-only apps like My Account.

## Changes

The detach machinery already carried everything a windowed strip entry needs; the missing piece was membership in the tabs collection. So the core change is small:

- New `Tabs.openWindowedTab(url)` — the window-mode sibling of `openTab`: constructs the `WorkspaceApp` with `asWindow: true`, registers the tab broadcasts that keep the strip entry's title/loading state fresh, pushes it into the tabs list (end of the unpinned section, like any new tab), and broadcasts.
- The two places that previously constructed a windowed `WorkspaceApp` directly for deliberate opens — the `newWindow` branch of the window-open handler in `workspace-app.ts` and the `workspaceApps.openApp` IPC handler — now call `openWindowedTab` instead.
- No renderer, shared-types, or detach-path changes. The strip already renders `tab.windowed` generically, and everything downstream comes free because the entry is a real windowed tab: clicking it focuses the window, the context menu's and window titlebar menu's "Move to Tab" adopt it (reusing the entry instead of duplicating), close/middle-click tears the window down, and window-close semantics match detached tabs exactly (`handleWindowedTabClosed`: pinned+app → dormant in place, otherwise removed and recorded for Reopen Closed Tab).

### Popup exclusion (decided design rule)

Windows are popups exactly when they are **not members of their account's tabs collection**. Everything still constructing `new WorkspaceApp({ asWindow: true })` directly — the PDF-viewer branch, Gmail child-window popups, mailto compose windows — plus plain-Electron OAuth windows stays outside the collection, so none get strip entries, and their closing can't perturb the strip.

Two follow-up commits from review harden this:

- **Popup windows no longer offer "Move to Tab"** in their titlebar menu. Popup-ness is a derived getter — `WorkspaceApp.isPopup`, defined as "not a member of the account's tabs collection" — used by both the `workspaceApp.showMenu` handler (drops the item plus its separator, leaving just Copy Link / Open in Default Browser) and `adoptIntoTabs`'s internal branch, so the menu and the method share one definition instead of a stored flag that could drift.
- **`alwaysOpenAsWindow` is renamed to `popupOnly`**, and My Account is reclassified: a popup-only app short-circuits in `handleWindowOpen` to the plain popup constructor before `openBehavior` is even computed, so it never touches the tabs collection — no strip entry, no "Move to Tab". The rename touches the definition type, the `myaccount` entry, `handleWindowOpen`, the tab context menu's "New … Tab" gate, and the strip's `canOpenSecondInstance`; no config or persisted schema referenced the old name.

`adoptIntoTabs`'s non-member branch is now unreachable from any UI path (kept functional as the correct implementation for any future "adopt this popup" caller).

### Crash fix (found testing this PR)

Quitting with an app window open could crash with `TypeError: Object has been destroyed` in `Accounts.sendTabsChangedToRenderer`. Cause: the `registerTabBroadcasts` closure fires on view webContents events (`did-stop-loading`/`did-navigate` during Electron's own teardown) with no destroyed-window guard — unlike `Tabs.broadcastTabsChanged`, which has always been guarded. The race is pre-existing (detached tab windows carry the same listeners), but this PR made it reproducible by registering broadcasts on every deliberately opened window. Fix: `main.window.isDestroyed()` guards in `sendTabsChangedToRenderer` and `sendAccountsChangedToRenderer` (the same dereference, reachable from async Gmail store subscriptions) — guarding the send helpers covers every present and future caller, and is order-independent where unregister-on-teardown would not be.

### Known edges

- Pre-existing hole, flagged not fixed: the config store has no runtime schema validation, so a hand-edited `config.json` with `"myaccount"` in `workspaceApps.bookmarkedApps` would surface it in the "+" menu. Closing that properly is config validation, not a handler branch.
- No single-instance dedupe was added: every entry point into the window path is already unreachable for `singleInstance` apps.
- Nothing has been verified visually in the running app. Notable unverified behavior: with no bookmarked apps and no other tabs, opening an app as a window now reveals the strip (consistent with detach, since the entry counts as a second tab).

## Test plan

1. Shift+click a bookmarked app in the strip's "+" menu → the app opens in a new window and a windowed entry (window badge/indicator) appears at the end of the unpinned section.
2. Click that entry → the existing window is focused; nothing embeds in the main window.
3. Right-click the entry → "Move to Tab" → the window closes, the app becomes the active embedded tab, exactly one strip entry (no duplicate). Same via the window titlebar menu's "Move to Tab".
4. Detach it again via "Move to New Window" → indistinguishable from the step-1 entry, including "Move to Tab" in its titlebar menu.
5. Close the app window with its window controls → the strip entry disappears; "Reopen Closed Tab" restores it as an embedded tab.
6. Pin a windowed entry, then close its window → the entry stays in the pinned section as dormant; clicking it materializes an embedded tab; the pin survives an app restart.
7. Set open behavior to "New Window" and click a Docs/Drive link in Gmail → opens as a window with a strip entry. Same for Shift+click on a link with behavior "Tab".
8. Open Google Account (My Account) from the Gmail avatar menu → it opens in its own window and **no** strip entry appears; its titlebar menu contains only Copy Link / Open in Default Browser (no "Move to Tab", no leading separator). Closing it changes nothing in the strip and adds nothing to Reopen Closed Tab.
9. Popup exclusions — no strip entry and no "Move to Tab" in the titlebar menu for any of: a PDF attachment's viewer window, a Google sign-in/OAuth popup, a `mailto:` compose window, a Gmail message pop-out. Closing them leaves the strip untouched.
10. Multi-account: open an app window on account A → no entry in account B's strip; back on A the entry remains and focuses the right window.
11. With a windowed entry present, open Settings → the app window stays visible while embedded views hide; close Settings → strip returns unchanged.
12. Middle-click / hover-close a windowed entry → window closes, entry removed. "Close Other Tabs" / "Close Tabs Below" also close unpinned windowed entries with their windows.
13. With no bookmarked apps and only Gmail open, Shift+click-open an app link as a window → the strip appears showing Gmail plus the windowed entry.
14. Right-click an ordinary app tab → "New … Tab" present; on the Gmail tab → absent (single-instance). Modifier-click on an ordinary app tab still opens second instances; My Account has no tab to modifier-click.
15. Crash regression: open apps as windows (including one still loading), quit via Cmd+Q → clean exit, no "Object has been destroyed" dialog. Same with a detached tab window open, and when quitting mid-navigation in a windowed app.
16. macOS: close the main window with app windows open → no crash; reopen from the dock → the strip still lists the windowed entries.
