### PR TITLE
route menu zoom to the active tab

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -23,6 +23,28 @@ import { licenseKey } from "./license-key";
 import { createMeruMessageUrl } from "./protocol";
 import { appState } from "./state";
 
+function setGmailZoomFactor(zoomFactor: number) {
+  const clampedZoomFactor = clamp(zoomFactor, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR);
+
+  for (const [_accountId, instance] of accounts.instances) {
+    instance.gmail.view.webContents.setZoomFactor(clampedZoomFactor);
+  }
+
+  config.set("gmail.zoomFactor", clampedZoomFactor);
+}
+
+const gmailZoomTarget = {
+  zoomIn: () => {
+    setGmailZoomFactor(config.get("gmail.zoomFactor") + 0.1);
+  },
+  zoomOut: () => {
+    setGmailZoomFactor(config.get("gmail.zoomFactor") - 0.1);
+  },
+  resetZoom: () => {
+    setGmailZoomFactor(1);
+  },
+};
+
 export class AppMenu {
   private _menu: Menu | undefined;
 
@@ -111,44 +133,26 @@ export class AppMenu {
 
     const focusedWindow = BrowserWindow.getFocusedWindow();
 
-    const zoomIn = () => {
+    const getActiveZoomTarget = () => {
       if (focusedWindow && focusedWindow !== main.window) {
-        WorkspaceApp.tryFromWebContents(focusedWindow.webContents)?.zoomIn();
-
-        return;
+        return WorkspaceApp.tryFromWebContents(focusedWindow.webContents);
       }
 
-      const zoomFactor = clamp(
-        config.get("gmail.zoomFactor") + 0.1,
-        MIN_ZOOM_FACTOR,
-        MAX_ZOOM_FACTOR,
-      );
+      const activeTab = accounts.getSelectedAccount().instance.tabs.activeTab;
 
-      for (const [_accountId, instance] of accounts.instances) {
-        instance.gmail.view.webContents.setZoomFactor(zoomFactor);
+      if (activeTab instanceof WorkspaceApp && !activeTab.isWindowed) {
+        return activeTab;
       }
 
-      config.set("gmail.zoomFactor", zoomFactor);
+      return gmailZoomTarget;
+    };
+
+    const zoomIn = () => {
+      getActiveZoomTarget()?.zoomIn();
     };
 
     const zoomOut = () => {
-      if (focusedWindow && focusedWindow !== main.window) {
-        WorkspaceApp.tryFromWebContents(focusedWindow.webContents)?.zoomOut();
-
-        return;
-      }
-
-      const zoomFactor = clamp(
-        config.get("gmail.zoomFactor") - 0.1,
-        MIN_ZOOM_FACTOR,
-        MAX_ZOOM_FACTOR,
-      );
-
-      for (const [_accountId, instance] of accounts.instances) {
-        instance.gmail.view.webContents.setZoomFactor(zoomFactor);
-      }
-
-      config.set("gmail.zoomFactor", zoomFactor);
+      getActiveZoomTarget()?.zoomOut();
     };
 
     const selectedAccount = accounts.getSelectedAccount();
@@ -384,19 +388,7 @@ export class AppMenu {
             label: "Reset Zoom",
             accelerator: "CommandOrControl+0",
             click: () => {
-              if (focusedWindow && focusedWindow !== main.window) {
-                WorkspaceApp.tryFromWebContents(focusedWindow.webContents)?.resetZoom();
-
-                return;
-              }
-
-              const defaultZoomFactor = 1;
-
-              for (const [_accountId, instance] of accounts.instances) {
-                instance.gmail.view.webContents.setZoomFactor(defaultZoomFactor);
-              }
-
-              config.set("gmail.zoomFactor", defaultZoomFactor);
+              getActiveZoomTarget()?.resetZoom();
             },
           },
           {


### PR DESCRIPTION
## Problem

The View menu's zoom items (and their accelerators) always drive `gmail.zoomFactor`, even when a workspace-app tab is active — zooming with a Docs tab in front zooms Gmail behind it. `WorkspaceApp` already has clamped `zoomIn`/`zoomOut`/`resetZoom` methods, but until now the only route to them was focusing a detached app window.

## Changes

One file (`menu.ts`), routing only — no new config, no persistence changes (a follow-up PR stacks `workspaceApps.zoomFactors` + a persistence toggle on top of this):

- New `getActiveZoomTarget()` resolves the zoom target the same way the existing Reload/DevTools items resolve theirs: a focused non-main window → that `WorkspaceApp`; otherwise the selected account's active tab → the app instance when it's an embedded `WorkspaceApp`, else Gmail. All three handlers become `getActiveZoomTarget()?.zoomIn()` etc.
- The Gmail path is extracted verbatim into `setGmailZoomFactor` + a `gmailZoomTarget` object: same clamp, same apply-to-every-account's-view loop, same `config.set` order. (Reset previously set a literal `1` without clamping; it now clamps, and `clamp(1) === 1`.)
- One deliberate deviation from the Reload precedent: the target reads `accounts.getSelectedAccount()` and `activeTab` at **click time**, not menu-build time — the menu is never rebuilt on tab activation or account switch, so a captured target would go stale immediately.
- Windowed tabs can't be mis-targeted: `activateTab` never assigns `activeTabId` for a windowed tab (it just focuses the window), and the resolver additionally guards with `!activeTab.isWindowed`, falling back to Gmail.
- App-tab zoom is session-only and per-instance for now: two tabs of the same app zoom independently, and nothing survives a restart.

### Discovered while implementing (pre-existing, deliberately untouched)

- `gmail.zoomFactor` is **global across accounts** — one top-level key applied to all Gmail views — not per-account.
- Nothing ever reads the key back: there's no startup application and no change listener, so Gmail zoom does not actually survive a restart today despite being written to config. Both belong to the persistence follow-up, not this routing change.

Nothing has been verified in the running app; behavior claims come from reading the code (including that `WorkspaceApp`'s zoom methods had no callers besides this menu).

## Test plan

1. Gmail tab active: Cmd/Ctrl+Plus a few times → Gmail zooms; switch accounts → the other Gmail is at the same level (global, as before); Cmd/Ctrl+0 → 100%.
2. Activate a workspace-app tab, zoom in → only that app's view zooms; switch back to Gmail → Gmail's zoom untouched.
3. Open a second tab of the same app, zoom one → the other is unaffected.
4. Detach an app tab, focus its window, use all three zoom actions → the window zooms; main-window tabs unaffected. With the window open but the main window focused and Gmail active → Gmail zooms, not the window.
5. Adopt the window back into tabs, zoom → it zooms as the active tab.
6. Click a windowed strip entry (focuses its window), then focus the main window and zoom → Gmail zooms (windowed tabs are never the active tab).
7. Zoom an app tab, restart the app → back at 100% (session-only is intentional here).
8. Open Settings while an app tab is active, press Cmd/Ctrl+0 → no crash; after closing Settings the tab is at 100%.
9. Verify via both the View menu items and the accelerators, from the main window and from an app window.
