### PR TITLE
persist workspace app zoom levels

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -9,6 +9,7 @@ import { licenseKey } from "./license-key";
 import { main } from "./main";
 import { appState } from "./state";
 import { isWindowedTab } from "./tabs";
+import { WorkspaceApp } from "./workspace-app";
 
 class Accounts {
   instances: Map<string, Account> = new Map();
@@ -50,6 +51,10 @@ class Accounts {
 
     config.onDidChange("workspaceApps.tabStripWidth", () => {
       accounts.updateAllViewBounds();
+    });
+
+    config.onDidChange("workspaceApps.zoomFactors", () => {
+      WorkspaceApp.applyPersistedZoomFactors();
     });
   }
 

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -99,6 +99,8 @@ export const config = new Store<Config>({
     "workspaceApps.bookmarkedApps": [],
     "workspaceApps.showAccountColor": true,
     "workspaceApps.showAccountLabel": true,
+    "workspaceApps.persistZoom": true,
+    "workspaceApps.zoomFactors": {},
     "verificationCodes.autoCopy": false,
     "verificationCodes.autoDelete": false,
     "verificationCodes.autoMarkAsRead": false,

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -54,11 +54,14 @@ export class DormantTab {
 
   title: string;
 
-  constructor(pinnedTab: PinnedTab) {
+  zoomFactor: number | undefined;
+
+  constructor(pinnedTab: PinnedTab, zoomFactor?: number) {
     this.app = pinnedTab.app;
     this.url = pinnedTab.url;
     this.title = pinnedTab.title;
     this.loadOnLaunch = Boolean(pinnedTab.loadOnLaunch);
+    this.zoomFactor = zoomFactor;
   }
 }
 
@@ -180,6 +183,7 @@ export class Tabs {
       pinned: true,
       loadOnLaunch: dormantTab.loadOnLaunch,
       app: dormantTab.app,
+      zoomFactor: dormantTab.zoomFactor,
     });
 
     this.tabs.splice(this.tabs.indexOf(dormantTab), 1, workspaceApp);
@@ -260,12 +264,15 @@ export class Tabs {
       this.tabs.splice(
         this.tabs.indexOf(windowedTab),
         1,
-        new DormantTab({
-          app: windowedTab.app,
-          url: windowedTab.url,
-          title: windowedTab.title,
-          loadOnLaunch: windowedTab.loadOnLaunch,
-        }),
+        new DormantTab(
+          {
+            app: windowedTab.app,
+            url: windowedTab.url,
+            title: windowedTab.title,
+            loadOnLaunch: windowedTab.loadOnLaunch,
+          },
+          windowedTab.zoomFactor,
+        ),
       );
 
       this.broadcastTabsChanged();

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -83,6 +83,7 @@ type WorkspaceAppOptions = {
   pinned?: boolean;
   loadOnLaunch?: boolean;
   app?: SupportedWorkspaceApp;
+  zoomFactor?: number;
 };
 
 export class WorkspaceApp {
@@ -103,6 +104,12 @@ export class WorkspaceApp {
       if (instance._window?.webContents.id === webContents.id) {
         return instance;
       }
+    }
+  }
+
+  static applyPersistedZoomFactors() {
+    for (const instance of WorkspaceApp.instances.values()) {
+      instance.applyPersistedZoomFactor();
     }
   }
 
@@ -362,6 +369,7 @@ export class WorkspaceApp {
     pinned,
     loadOnLaunch,
     app,
+    zoomFactor,
   }: WorkspaceAppOptions) {
     this.accountId = accountId;
     this.app = app ?? getWorkspaceAppFromUrl(url);
@@ -376,6 +384,10 @@ export class WorkspaceApp {
 
     this.updateViewBounds();
     this.registerViewListeners();
+
+    this.view.webContents.once("did-navigate", () => {
+      this.applyInitialZoomFactor(zoomFactor);
+    });
 
     this.view.webContents.once("destroyed", () => {
       this.viewDestroyed = true;
@@ -770,22 +782,94 @@ export class WorkspaceApp {
   }
 
   zoomIn() {
-    this.setZoomFactor(this.zoomFactor + 0.1);
+    const zoomFactor = this.zoomFactor;
+
+    if (zoomFactor === undefined) {
+      return;
+    }
+
+    this.updateZoomFactor(zoomFactor + 0.1);
   }
 
   zoomOut() {
-    this.setZoomFactor(this.zoomFactor - 0.1);
+    const zoomFactor = this.zoomFactor;
+
+    if (zoomFactor === undefined) {
+      return;
+    }
+
+    this.updateZoomFactor(zoomFactor - 0.1);
   }
 
   resetZoom() {
-    this.setZoomFactor(1);
+    this.updateZoomFactor(1);
   }
 
-  private get zoomFactor() {
+  get zoomFactor() {
+    if (this.viewDestroyed) {
+      return undefined;
+    }
+
     return this.view.webContents.getZoomFactor();
   }
 
+  private get persistableZoomApp() {
+    if (!config.get("workspaceApps.persistZoom") || !this.app || this.app === "gmail") {
+      return undefined;
+    }
+
+    return this.app;
+  }
+
+  private updateZoomFactor(zoomFactor: number) {
+    const clampedZoomFactor = clamp(zoomFactor, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR);
+
+    this.setZoomFactor(clampedZoomFactor);
+
+    const persistableZoomApp = this.persistableZoomApp;
+
+    if (!persistableZoomApp) {
+      return;
+    }
+
+    const zoomFactors = { ...config.get("workspaceApps.zoomFactors") };
+
+    if (clampedZoomFactor === 1) {
+      delete zoomFactors[persistableZoomApp];
+    } else {
+      zoomFactors[persistableZoomApp] = clampedZoomFactor;
+    }
+
+    config.set("workspaceApps.zoomFactors", zoomFactors);
+  }
+
+  private applyInitialZoomFactor(dormantZoomFactor: number | undefined) {
+    if (this.persistableZoomApp) {
+      this.applyPersistedZoomFactor();
+
+      return;
+    }
+
+    if (dormantZoomFactor !== undefined) {
+      this.setZoomFactor(dormantZoomFactor);
+    }
+  }
+
+  applyPersistedZoomFactor() {
+    const persistableZoomApp = this.persistableZoomApp;
+
+    if (!persistableZoomApp) {
+      return;
+    }
+
+    this.setZoomFactor(config.get("workspaceApps.zoomFactors")[persistableZoomApp] ?? 1);
+  }
+
   private setZoomFactor(zoomFactor: number) {
+    if (this.viewDestroyed) {
+      return;
+    }
+
     this.view.webContents.setZoomFactor(clamp(zoomFactor, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR));
   }
 

--- a/packages/renderer-main/routes/settings/workspace-apps.tsx
+++ b/packages/renderer-main/routes/settings/workspace-apps.tsx
@@ -195,6 +195,12 @@ export function WorkspaceAppsSettings() {
           )}
           <FieldSeparator />
           <ConfigSwitchField
+            label="Persist Zoom"
+            description="Remember the zoom level of Workspace Apps across restarts. Each app keeps its own zoom level, shared by all its tabs and windows."
+            configKey="workspaceApps.persistZoom"
+            licenseKeyRequired
+          />
+          <ConfigSwitchField
             label="Show Account Label"
             description="Show the account label in the titlebar of Workspace Apps windows if using more than one account."
             configKey="workspaceApps.showAccountLabel"

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -128,6 +128,8 @@ export type Config = {
   "workspaceApps.bookmarkedApps": BookmarkableWorkspaceApp[];
   "workspaceApps.showAccountColor": boolean;
   "workspaceApps.showAccountLabel": boolean;
+  "workspaceApps.persistZoom": boolean;
+  "workspaceApps.zoomFactors": Partial<Record<SupportedWorkspaceApp, number>>;
   "verificationCodes.autoCopy": boolean;
   "verificationCodes.autoDelete": boolean;
   "verificationCodes.autoMarkAsRead": boolean;


### PR DESCRIPTION
## Problem

Workspace-app zoom is session-only and per-instance: every new view opens at 100%, and a zoom level chosen for an app is forgotten on restart. Zoom should persist per app — globally across accounts — with a setting to opt out. Gmail's zoom stays entirely on its existing `gmail.zoomFactor` path.

## Changes

Builds on #673's routing (merged).

- **`workspaceApps.zoomFactors`** (`Partial<Record<SupportedWorkspaceApp, number>>`, default `{}`) and **`workspaceApps.persistZoom`** (boolean, default `true`) added to the config types and defaults.
- **Writing**: `zoomIn`/`zoomOut`/`resetZoom` now go through `updateZoomFactor`, which clamps, applies to the view, and — when persistence applies — writes the factor back. A factor of exactly 1 deletes the app's entry instead of storing it, so "absent = 100%" is the single interpretation everywhere and reset keeps the config clean.
- **Applying on creation**: on the view's first `did-navigate` (Chromium stores zoom per host, so setting earlier would target `about:blank`), the stored factor is applied.
- **Live sync**: one `config.onDidChange("workspaceApps.zoomFactors")` listener registered in `Accounts.init` (the manager-level pattern) calls a `WorkspaceApp` static that re-applies each instance's persisted factor — so all instances of an app follow a zoom change, across accounts. `setZoomFactor` never writes config, so the listener can't loop.
- **Persistence scope**: one predicate (`persistableZoomApp`, a narrowing getter) gates every read and write: persistence requires the setting on, an `app`, and **`app !== "gmail"`** — Gmail compose/mailto pop-outs are `WorkspaceApp`s with `app === "gmail"`, and letting them write `zoomFactors.gmail` would shift the embedded Gmail view through the shared origin, violating "Gmail stays separate". Gmail instances behave exactly as before this PR.
- **Persist OFF**: no config reads or writes at all; zoom is session-only. Stored factors remain untouched, so re-enabling restores them. Dormant tabs carry their zoom in memory (`DormantTab` gains a constructor-arg `zoomFactor`, not part of the persisted pinned-tab schema) and restore it on materialize — with persist ON the config value wins instead, since a stale carry could resurrect a value the user reset elsewhere.
- **Settings**: "Persist Zoom" `ConfigSwitchField` on the Workspace Apps page (outside the Open-in-App group, since app views also exist via bookmarks), `licenseKeyRequired` like its siblings.

## Caveats (flagged, need running-app verification)

- **Chromium propagates zoom per origin per session.** All of an account's views share one session, so two tabs of the same app in the *same account* will influence each other natively **regardless of the persistZoom setting** — strict per-instance isolation isn't achievable without per-tab sessions. Cross-account isolation holds (separate sessions); the config listener is what syncs across accounts when persistence is on. The persist-off expectation is therefore "not saved to disk", not "tabs fully independent". This also likely makes the dormant carry redundant within a running session (the session already remembers the origin's zoom) — harmless either way.
- Toggling `persistZoom` is not retroactive: existing views keep their zoom until the next zoom action or view creation.
- Login-redirect edge: the initial factor applies on the *first* navigation commit; if a signed-out app first lands on `accounts.google.com`, the factor is applied to that host and not re-applied after the redirect. Rare, unhandled.
- Stored values can carry float drift from step-based zooming (e.g. `1.1000000000000003`) — pre-existing stepping behavior, harmless; reset stores an exact deletion.
- Nothing has been run; all behavior claims are from code reading.

## Test plan

1. Persist on (default): zoom a Calendar tab to ~130%, quit, relaunch, open Calendar → restored at the same level. Open Docs → 100% (per-app, not global).
2. Open a second Calendar tab → opens at the stored level; zoom one tab → the other follows; Cmd/Ctrl+0 on either → both at 100% and the `calendar` entry disappears from the config file.
3. Zoom Calendar in account A → open Calendar in account B → same level (cross-account sync via the listener).
4. Zoom a *windowed* Calendar (detached or Shift-opened) → embedded Calendar tabs follow; relaunch → the window reopens at the stored level.
5. Pin a Calendar tab, detach, zoom, close the window (goes dormant), click the dormant tab → materializes at the stored level.
6. Turn Persist Zoom off: zoom Calendar, quit, relaunch → back at 100%. Re-enable → the pre-off stored levels apply again to new views.
7. Persist off: pinned windowed Calendar zoomed then window closed → reopening the dormant tab restores the zoom (in-memory carry).
8. Gmail: menu zoom on the Gmail tab still drives `gmail.zoomFactor` for all accounts exactly as before; no `gmail` key ever appears in `workspaceApps.zoomFactors` — including after zooming a compose/mailto pop-out window (which stays session-only).
9. Unlicensed: the Persist Zoom switch renders disabled like its siblings.
10. Settings page: the switch sits above "Show Account Label", visible regardless of the Open-in-App toggle.
