### PR TITLE
make closed pinned tabs dormant instead of removing them

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -435,17 +435,27 @@ class Ipc {
         {
           type: "separator",
         },
-        {
-          label: "Close",
-          enabled: !(tab instanceof DormantTab),
-          click: () => {
-            account.instance.tabs.closeTab(tabId);
+        tab instanceof DormantTab
+          ? {
+              label: "Open",
+              click: () => {
+                account.instance.tabs.activateTab(tabId);
 
-            if (account.config.selected) {
-              accounts.refreshSelectedAccountView();
+                if (account.config.selected) {
+                  accounts.refreshSelectedAccountView();
+                }
+              },
             }
-          },
-        },
+          : {
+              label: "Close",
+              click: () => {
+                account.instance.tabs.closeTab(tabId);
+
+                if (account.config.selected) {
+                  accounts.refreshSelectedAccountView();
+                }
+              },
+            },
         {
           label: "Close Other Tabs",
           enabled: hasOtherClosableTabs,

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -437,6 +437,7 @@ class Ipc {
         },
         {
           label: "Close",
+          enabled: !(tab instanceof DormantTab),
           click: () => {
             account.instance.tabs.closeTab(tabId);
 

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -242,23 +242,17 @@ export class Tabs {
   closeTab(tabId: string) {
     const closableTab = this.getTab(tabId);
 
-    if (closableTab instanceof WorkspaceApp) {
-      if (isPinnedWorkspaceApp(closableTab)) {
-        this.dormantizePinnedTab(closableTab);
-      } else {
-        this.recordRecentlyClosedTab(closableTab.url);
-      }
-
-      closableTab.close();
-
+    if (!(closableTab instanceof WorkspaceApp)) {
       return;
     }
 
-    if (closableTab instanceof DormantTab) {
+    if (isPinnedWorkspaceApp(closableTab)) {
+      this.dormantizePinnedTab(closableTab);
+    } else {
       this.recordRecentlyClosedTab(closableTab.url);
-
-      this.removeTab(tabId);
     }
+
+    closableTab.close();
   }
 
   handleWindowedTabClosed(windowedTab: WorkspaceApp) {

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -26,6 +26,12 @@ export function isWindowedTab(tab: Tab) {
   return tab instanceof WorkspaceApp && tab.isWindowed;
 }
 
+type PinnedWorkspaceApp = WorkspaceApp & { app: SupportedWorkspaceApp };
+
+function isPinnedWorkspaceApp(tab: Tab): tab is PinnedWorkspaceApp {
+  return tab instanceof WorkspaceApp && tab.pinned && tab.app !== undefined;
+}
+
 export type Tab = {
   id: string;
   app: SupportedWorkspaceApp | undefined;
@@ -237,7 +243,11 @@ export class Tabs {
     const closableTab = this.getTab(tabId);
 
     if (closableTab instanceof WorkspaceApp) {
-      this.recordRecentlyClosedTab(closableTab.url);
+      if (isPinnedWorkspaceApp(closableTab)) {
+        this.dormantizePinnedTab(closableTab);
+      } else {
+        this.recordRecentlyClosedTab(closableTab.url);
+      }
 
       closableTab.close();
 
@@ -256,21 +266,8 @@ export class Tabs {
       return;
     }
 
-    if (windowedTab.pinned && windowedTab.app) {
-      this.tabs.splice(
-        this.tabs.indexOf(windowedTab),
-        1,
-        new DormantTab({
-          app: windowedTab.app,
-          url: windowedTab.url,
-          title: windowedTab.title,
-          loadOnLaunch: windowedTab.loadOnLaunch,
-        }),
-      );
-
-      this.broadcastTabsChanged();
-
-      accounts.savePinnedTabs();
+    if (isPinnedWorkspaceApp(windowedTab)) {
+      this.dormantizePinnedTab(windowedTab);
 
       return;
     }
@@ -278,6 +275,27 @@ export class Tabs {
     this.recordRecentlyClosedTab(windowedTab.url);
 
     this.removeTab(windowedTab.id);
+  }
+
+  private dormantizePinnedTab(pinnedWorkspaceApp: PinnedWorkspaceApp) {
+    this.tabs.splice(
+      this.tabs.indexOf(pinnedWorkspaceApp),
+      1,
+      new DormantTab({
+        app: pinnedWorkspaceApp.app,
+        url: pinnedWorkspaceApp.url,
+        title: pinnedWorkspaceApp.title,
+        loadOnLaunch: pinnedWorkspaceApp.loadOnLaunch,
+      }),
+    );
+
+    if (this.activeTabId === pinnedWorkspaceApp.id) {
+      this.activeTabId = GMAIL_TAB_ID;
+    }
+
+    this.broadcastTabsChanged();
+
+    accounts.savePinnedTabs();
   }
 
   private recordRecentlyClosedTab(closedTabUrl: string) {


### PR DESCRIPTION
## Problem

Closing a pinned tab (via the tab context menu's "Close" — the only close path reachable for pinned tabs) removes it from the pinned section entirely. It should become dormant in place instead, exactly like a pinned windowed tab whose window is closed already does.

## Changes

One file (`tabs.ts`):

- New shared `Tabs.dormantizePinnedTab`: splices a `DormantTab` (preserving `app`/`url`/`title`/`loadOnLaunch`) into the tab's slot, moves activation to Gmail if the tab was active (before broadcasting, so no consumer ever sees a dangling `activeTabId`), broadcasts, and re-saves pinned tabs. Both `handleWindowedTabClosed` (previously inline) and `closeTab` (the fix) now call it. The eligibility check is a type guard, `isPinnedWorkspaceApp` (`WorkspaceApp` + `pinned` + has `app`), which also narrows `app` without a non-null assertion.
- In `closeTab`, a pinned app tab dormantizes instead of being recorded in recently-closed — so "Reopen Closed Tab" can't resurrect a duplicate of a tab still visible in the strip. Unpinned tabs are byte-identical to before.
- View/window teardown is unchanged: `closableTab.close()` still runs in full; the `removeTab` inside it no-ops against the fresh `DormantTab` id (one redundant identical-state broadcast, expected imperceptible).
- Follow-up commits from review — **dormant tabs can't be closed, and offer "Open" instead**: the context menu shows an enabled "Open" item in place of "Close" for a `DormantTab` (a ternary in the same slot, matching the existing Pin/Unpin ternary), whose click runs the exact strip-click activation path (`activateTab` → materialize in place → `refreshSelectedAccountView` raises and focuses the view). `closeTab` also early-returns for anything that isn't a live `WorkspaceApp`, so no caller can remove a dormant entry through the close path. Verified invariant: dormant ⇒ pinned (the `pinned` field is a hardcoded initializer and `pinTab`/`unpinTab` are `WorkspaceApp`-guarded), so the bulk-close items and strip close buttons can never reach one either.
- Merge with main after #676: `dormantizePinnedTab` passes the tab's live `zoomFactor` into the `DormantTab`, so a closed pinned tab keeps its zoom through dormancy — the direct-close path gets the same carry the windowed-close path gained in #676.
- Pre-existing and deliberately untouched: **Unpin on a dormant tab removes it entirely** — a dormant tab exists only as a pinned record, so there is nothing to demote it to. This remains the one user-facing way to drop a dormant entry.

Deliberately unchanged, verified during the audit:

- "Close Other Tabs" / "Close Tabs Below" already skip pinned tabs.
- The strip's close button and middle-click are already gated off pinned tabs in the UI.
- Account removal (`closeAll`) still tears everything down without dormantizing (the account is being destroyed).
- A crashed view (`destroyed` event) still removes the tab outright.
- A pinned tab *without* an `app` (possible via pinning an adopted plain-URL window; never persisted anyway) is still removed and recorded, matching the windowed-close path's existing rule.
- No keyboard accelerator closes a tab (Cmd/Ctrl+W is `role: "close"` on the window), so the context menu is the complete surface.

Not verified in a running app: the one-frame visual sequence while the old view tears down after the dormant entry is painted.

Note: expected merge conflicts with #672/#676, which also touch `tabs.ts` — will be resolved on whichever lands later.

## Test plan

1. Pin an app tab (e.g. Calendar), activate a different tab, right-click the pinned tab → Close → it stays in the pinned section at the same position, dimmed (dormant); no reordering.
2. Click the dormant tab → it rematerializes in place and becomes active.
3. Close a pinned tab while it is the **active** tab → it goes dormant and Gmail becomes active (a dormant tab is never shown active).
4. After closing a pinned tab, "Reopen Closed Tab" → does not duplicate it (reopens the last *unpinned* closed tab, or is disabled).
5. Close a pinned tab, quit, relaunch → restored dormant in the same slot; with "Load on Launch" checked it materializes on launch.
6. "Move to New Window" on a pinned tab, close the window → dormant in place, unchanged from before.
7. Close unpinned tabs via button, middle-click, and context menu → unchanged (removed + reopenable).
8. "Close Other Tabs" / "Close Tabs Below" with pinned tabs present → pinned tabs untouched.
9. Pin an adopted plain-URL window's tab (no app), Close it → removed entirely and reopenable (matches existing windowed rule).
10. Remove an account with pinned tabs → full teardown, no stray dormant entries.
11. Right-click a dormant pinned tab → an enabled "Open" item sits where "Close" does for live tabs; "Reload" is still greyed; "Duplicate", "Copy Link", "Open in Default Browser", "Unpin", and "Load on Launch" stay enabled.
12. Click "Open" → the tab materializes in place (dimming gone, position kept), becomes active with its view raised and focused, and restores its persisted zoom — identical to left-clicking it. Right-click it again → the menu shows "Close" once more, and closing returns it to dormant.
13. With a dormant tab present, run "Close Other Tabs" / "Close Tabs Below" from a live tab → the dormant entry stays dimmed in its slot, untouched.
14. Unpin a dormant tab → it is removed from the strip entirely (pre-existing behavior, deliberately unchanged).
