### PR TITLE
exclude the titlebar border from its 40px content box

### DIFF
--- a/packages/app/lib/window.ts
+++ b/packages/app/lib/window.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { is, platform } from "@electron-toolkit/utils";
-import { APP_TITLEBAR_HEIGHT } from "@meru/shared/constants";
+import { APP_TITLEBAR_CONTENT_HEIGHT } from "@meru/shared/constants";
 import type { Config } from "@meru/shared/types";
 import {
   BrowserWindow,
@@ -80,7 +80,7 @@ export function getTitleBarOptions() {
       ? {
           color: getBackgroundColor(),
           symbolColor: nativeTheme.shouldUseDarkColors ? "#fafafa" : "#0a0a0a",
-          height: APP_TITLEBAR_HEIGHT - 1,
+          height: APP_TITLEBAR_CONTENT_HEIGHT,
         }
       : false;
 

--- a/packages/shared/constants.ts
+++ b/packages/shared/constants.ts
@@ -2,7 +2,11 @@ export const APP_ID = "sh.zoid.meru";
 
 export const BASE_SPACING = 8;
 
-export const APP_TITLEBAR_HEIGHT = BASE_SPACING * 5;
+export const APP_TITLEBAR_CONTENT_HEIGHT = BASE_SPACING * 5;
+
+export const APP_TITLEBAR_BORDER_WIDTH = 1;
+
+export const APP_TITLEBAR_HEIGHT = APP_TITLEBAR_CONTENT_HEIGHT + APP_TITLEBAR_BORDER_WIDTH;
 
 export const APP_TAB_STRIP_NARROW_WIDTH = BASE_SPACING * 8;
 

--- a/packages/ui/components/titlebar.tsx
+++ b/packages/ui/components/titlebar.tsx
@@ -7,11 +7,11 @@ import { Button } from "./button";
 export function Titlebar({ children }: { children: ReactNode }) {
   return (
     <div
-      className="relative bg-background select-none draggable"
+      className="relative border-b bg-background select-none draggable"
       style={{ height: APP_TITLEBAR_HEIGHT }}
     >
       <div
-        className="absolute top-0 bottom-px flex items-center justify-between px-1.5"
+        className="absolute top-0 bottom-0 flex items-center justify-between px-1.5"
         style={{
           left: "env(titlebar-area-x, 0)",
           width: "env(titlebar-area-width, 100%)",
@@ -19,7 +19,6 @@ export function Titlebar({ children }: { children: ReactNode }) {
       >
         {children}
       </div>
-      <div className="absolute inset-x-0 bottom-0 h-px bg-border" />
     </div>
   );
 }

--- a/packages/ui/components/titlebar.tsx
+++ b/packages/ui/components/titlebar.tsx
@@ -7,11 +7,11 @@ import { Button } from "./button";
 export function Titlebar({ children }: { children: ReactNode }) {
   return (
     <div
-      className="relative border-b bg-background select-none draggable"
+      className="relative bg-background select-none draggable"
       style={{ height: APP_TITLEBAR_HEIGHT }}
     >
       <div
-        className="absolute top-0 bottom-0 flex items-center justify-between px-1.5"
+        className="absolute top-0 bottom-px flex items-center justify-between px-1.5"
         style={{
           left: "env(titlebar-area-x, 0)",
           width: "env(titlebar-area-width, 100%)",
@@ -19,6 +19,7 @@ export function Titlebar({ children }: { children: ReactNode }) {
       >
         {children}
       </div>
+      <div className="absolute inset-x-0 bottom-0 h-px bg-border" />
     </div>
   );
 }


### PR DESCRIPTION
## Problem

The titlebar is a 40px border-box with `border-b` inside it, so its content (padding) box is 39px — an odd height that puts the vertical center of every titlebar child at a half pixel (y=19.5). Anything centered against a titlebar anchor inherits that half pixel; the concrete symptom was #674's horizontal launcher dropdown sitting 3px from the top of the band but 2px from the bottom, with no integer offset able to fix it (the gaps sum to an odd number).

## Changes

Seven lines across two files — no component markup changes at all:

- `APP_TITLEBAR_HEIGHT` becomes 41, expressed as named parts: `APP_TITLEBAR_CONTENT_HEIGHT` (40) + `APP_TITLEBAR_BORDER_WIDTH` (1).
- The native `titleBarOverlay` height — the one consumer that genuinely meant the content area — changes from the magic `APP_TITLEBAR_HEIGHT - 1` to `APP_TITLEBAR_CONTENT_HEIGHT`.

That's the whole diff. The geometry fix falls out of border-box math: the `Titlebar` component keeps `border-b` and `height: APP_TITLEBAR_HEIGHT`; at 41px total with the 1px border, the padding box is exactly 40px, and `absolute top-0 bottom-0` children resolve against the padding box — so the content row is 40px and every titlebar child centers at integer y=20. (An explicit variant — removing `border-b` and drawing the line as an absolute 1px element with the content row bounded above it — was implemented first and swapped for this one, which reaches the identical geometry with `titlebar.tsx` byte-identical to main.)

Every other `APP_TITLEBAR_HEIGHT` consumer was audited and stays untouched because they all mean "where content below the titlebar begins" or "the block's own height": Gmail and workspace-app view bounds (views now start flush below the border at y=41, no overlap, no dead gap), the recent-downloads popup offset (still one spacing unit below the block), both titlebar renderers (main window and workspace-app windows share the component). No hardcoded 40/`h-10` encodes this geometry elsewhere; window sizes never derive from the constant, so no window dimensions change — only the in-window split point moves down 1px.

Result: once this and #674 are both in, the launcher dropdown's position computes to an exact integer at every display scaling (gaps 3px/3px including its ring) with no per-menu compensation.

Nothing has been verified on a display; the arithmetic is derived from the classes and box-model semantics. The border itself is literally unchanged CSS, so there's no visual-parity risk for the line.

## Test plan

1. Main window: views (Gmail, in-window workspace app with strip visible and hidden) start immediately below the titlebar border — no 1px background stripe, no view pixel painted over the border.
2. Same check in a workspace-app window (same component and constant).
3. Titlebar buttons (nav, downloads, DND, account chips, trial badge) look vertically centered; nothing reads as shifted after the 1px total growth.
4. Windows/Linux native window controls: the overlay strip is 40px, flush above the border, and minimize/maximize/close hit-test correctly; macOS traffic lights stay centered.
5. Recent-downloads popup opens 8px below the titlebar block, no overlap.
6. Workspace-app windows still open at 1280×800; resizing the main window leaves no seam artifacts.
7. With #674 checked out on top: the launcher's horizontal dropdown shows equal gaps above and below at 100%/125%/150%/Retina scaling.
