### PR TITLE
revert the titlebar border exclusion

### DIFF
--- a/packages/app/lib/window.ts
+++ b/packages/app/lib/window.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { is, platform } from "@electron-toolkit/utils";
-import { APP_TITLEBAR_CONTENT_HEIGHT } from "@meru/shared/constants";
+import { APP_TITLEBAR_HEIGHT } from "@meru/shared/constants";
 import type { Config } from "@meru/shared/types";
 import {
   BrowserWindow,
@@ -80,7 +80,7 @@ export function getTitleBarOptions() {
       ? {
           color: getBackgroundColor(),
           symbolColor: nativeTheme.shouldUseDarkColors ? "#fafafa" : "#0a0a0a",
-          height: APP_TITLEBAR_CONTENT_HEIGHT,
+          height: APP_TITLEBAR_HEIGHT - 1,
         }
       : false;
 

--- a/packages/shared/constants.ts
+++ b/packages/shared/constants.ts
@@ -2,11 +2,7 @@ export const APP_ID = "sh.zoid.meru";
 
 export const BASE_SPACING = 8;
 
-export const APP_TITLEBAR_CONTENT_HEIGHT = BASE_SPACING * 5;
-
-export const APP_TITLEBAR_BORDER_WIDTH = 1;
-
-export const APP_TITLEBAR_HEIGHT = APP_TITLEBAR_CONTENT_HEIGHT + APP_TITLEBAR_BORDER_WIDTH;
+export const APP_TITLEBAR_HEIGHT = BASE_SPACING * 5;
 
 export const APP_TAB_STRIP_NARROW_WIDTH = BASE_SPACING * 8;
 


### PR DESCRIPTION
## Problem

#678 grew the titlebar block to 41px so its content box would be a round 40px. The real cause of the launcher-dropdown off-centering turned out to be Base UI's default `collisionPadding` clamp, fixed separately in #674 — so the titlebar change is being reverted and the titlebar returns to its original 40px total (39px content box above the border).

## Changes

Clean `git revert` of the #678 squash: `APP_TITLEBAR_HEIGHT` back to `BASE_SPACING * 5` (40), the `APP_TITLEBAR_CONTENT_HEIGHT`/`APP_TITLEBAR_BORDER_WIDTH` split removed, and `titleBarOverlay.height` back to `APP_TITLEBAR_HEIGHT - 1`. No component markup was involved in either direction.

Known consequence, accepted with this revert: the titlebar's content box is again 39px, so the launcher dropdown's ideal position is fractional (y=3.5). On HiDPI displays (DPR 2, e.g. Retina) floating-ui's device-pixel rounding represents 3.5 exactly, so the popup is truly centered — verified visually. Only at DPR 1 does whole-pixel rounding force y=4, leaving a 1px top-heavy offset (4/3 layout gaps). If that 1px reads as off later, the in-menu fix is giving the horizontal popup an odd height (the previously reverted `py-[3.5px]` parity padding), not another titlebar change.

## Test plan

1. The titlebar returns to its previous 40px total height; views (Gmail, workspace apps, windowed apps) sit flush below the border with no gap or overlap.
2. Windows/Linux native window-controls overlay is back at 39px (`- 1`) and aligns as before #678.
3. The launcher dropdown still opens inside the titlebar band, dismisses on titlebar clicks, and its items work. On a Retina/HiDPI display it is exactly centered; on a 100%-scaling display expect the known 1px top-heavy offset described above.
4. Recent-downloads popup and workspace-app windows are unaffected.
