### PR TITLE
migrate gmail zoom factor into workspace apps zoom factors

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -44,7 +44,6 @@ export const config = new Store<Config>({
     "dock.unreadBadge": true,
     "externalLinks.confirm": true,
     "externalLinks.trustedHosts": [],
-    "gmail.zoomFactor": 1,
     "downloads.saveAs": false,
     "downloads.openFolderWhenDone": false,
     "downloads.location": app.getPath("downloads"),
@@ -369,6 +368,19 @@ export const config = new Store<Config>({
 
         store.set("accounts", accounts);
       }
+
+      // @ts-expect-error: `gmail.zoomFactor` is now an entry in 'workspaceApps.zoomFactors'
+      const gmailZoomFactor = store.get("gmail.zoomFactor");
+
+      if (typeof gmailZoomFactor === "number" && gmailZoomFactor !== 1) {
+        store.set("workspaceApps.zoomFactors", {
+          ...store.get("workspaceApps.zoomFactors"),
+          gmail: gmailZoomFactor,
+        });
+      }
+
+      // @ts-expect-error
+      store.delete("gmail.zoomFactor");
     },
   },
 });

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -13,7 +13,7 @@ import {
   parseGmailMessageId,
 } from "@meru/shared/gmail";
 import { ms } from "@meru/shared/ms";
-import { wait } from "@meru/shared/utils";
+import { clamp, wait } from "@meru/shared/utils";
 import type { SupportedWorkspaceApp } from "@meru/shared/workspace-apps";
 import {
   app,
@@ -47,7 +47,7 @@ import {
 } from "@/notifications";
 import { registerTabBroadcasts } from "@/tabs";
 import { appTray } from "@/tray";
-import { WorkspaceApp } from "@/workspace-app";
+import { MAX_ZOOM_FACTOR, MIN_ZOOM_FACTOR, WorkspaceApp } from "@/workspace-app";
 import gmailCSS from "./gmail.css";
 import meruCSS from "./meru.css";
 
@@ -405,6 +405,16 @@ export class Gmail {
     setupWindowContextMenu(this.view);
 
     this.updateViewBounds();
+
+    this.view.webContents.once("did-navigate", () => {
+      const gmailZoomFactor = config.get("workspaceApps.zoomFactors").gmail;
+
+      if (gmailZoomFactor !== undefined) {
+        this.view.webContents.setZoomFactor(
+          clamp(gmailZoomFactor, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR),
+        );
+      }
+    });
 
     this.view.webContents.on("dom-ready", () => {
       if (this.view.webContents.getURL().startsWith(GMAIL_URL)) {

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -30,15 +30,23 @@ function setGmailZoomFactor(zoomFactor: number) {
     instance.gmail.view.webContents.setZoomFactor(clampedZoomFactor);
   }
 
-  config.set("gmail.zoomFactor", clampedZoomFactor);
+  const zoomFactors = { ...config.get("workspaceApps.zoomFactors") };
+
+  if (clampedZoomFactor === 1) {
+    delete zoomFactors.gmail;
+  } else {
+    zoomFactors.gmail = clampedZoomFactor;
+  }
+
+  config.set("workspaceApps.zoomFactors", zoomFactors);
 }
 
 const gmailZoomTarget = {
   zoomIn: () => {
-    setGmailZoomFactor(config.get("gmail.zoomFactor") + 0.1);
+    setGmailZoomFactor((config.get("workspaceApps.zoomFactors").gmail ?? 1) + 0.1);
   },
   zoomOut: () => {
-    setGmailZoomFactor(config.get("gmail.zoomFactor") - 0.1);
+    setGmailZoomFactor((config.get("workspaceApps.zoomFactors").gmail ?? 1) - 0.1);
   },
   resetZoom: () => {
     setGmailZoomFactor(1);

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -68,7 +68,6 @@ export type Config = {
   "dock.unreadBadge": boolean;
   "externalLinks.confirm": boolean;
   "externalLinks.trustedHosts": string[];
-  "gmail.zoomFactor": number;
   "downloads.saveAs": boolean;
   "downloads.openFolderWhenDone": boolean;
   "downloads.location": string;


### PR DESCRIPTION
## Problem

Gmail zoom had two long-standing issues, both discovered during the zoom work in #673/#676 and recorded as a memo:

- `gmail.zoomFactor` was a standalone config key while every other app's zoom lives in `workspaceApps.zoomFactors`.
- The value was written on every menu zoom action but **never re-applied on startup**, so Gmail zoom silently reset to 100% on every app restart.

## Changes

- **Config migration** (appended to the unreleased `>3.57.0` block): a non-default `gmail.zoomFactor` moves into `workspaceApps.zoomFactors` as the `gmail` entry (merged with any existing entries); the old key is deleted unconditionally. `"gmail"` is already a `SupportedWorkspaceApp`, so no type widening — the key is simply removed from the config types and defaults.
- **Menu zoom target** (`setGmailZoomFactor`/`gmailZoomTarget`): still applies the clamped factor to every account's Gmail view directly, but now reads and writes the `gmail` entry of `workspaceApps.zoomFactors`, following the established shape from `WorkspaceApp.updateZoomFactor` — a value of 1 deletes the entry (absent = 100%), anything else sets it.
- **Startup fix**: `Gmail.createView` applies the persisted factor on the view's first `did-navigate`, mirroring `WorkspaceApp.applyInitialZoomFactor`. No entry → nothing happens (native 100%).

## Deliberate semantics (unchanged from today)

- Gmail zoom remains **permanent** — it is not gated by the `workspaceApps.persistZoom` toggle, exactly as before; only its storage location moved. Folding it under the toggle can be revisited separately.
- `persistableZoomApp` still excludes `"gmail"`, so compose pop-out windows (which have `app === "gmail"`) continue to never write config; zooming a pop-out stays session-only. The `Accounts.init` listener on `workspaceApps.zoomFactors` therefore also never pushes the gmail entry onto any `WorkspaceApp` instance — Gmail views are only driven by the menu target and the startup application.

## Test plan

1. On a config that has an old `gmail.zoomFactor` ≠ 1 (set one by zooming in a build of current `main`, or hand-edit): launch this build → the config file shows the value under `workspaceApps.zoomFactors.gmail`, `gmail.zoomFactor` is gone, and Gmail renders at that zoom immediately after load.
2. With `gmail.zoomFactor: 1` in the old config: after migration there is **no** `gmail` entry in `workspaceApps.zoomFactors` and the key is gone.
3. View → Zoom In/Out with Gmail active → all accounts' Gmail views zoom together (multi-account check), and the config's `workspaceApps.zoomFactors.gmail` updates live.
4. Reset Zoom (Cmd/Ctrl+0) with Gmail active → 100% and the `gmail` entry is deleted from the config.
5. Restart the app → Gmail comes back at the persisted zoom (the bug this fixes); with no entry, at 100%.
6. Toggle **Persist zoom** off in Settings → Gmail zoom still persists across a restart (deliberate: the toggle governs workspace apps only, as before).
7. Zoom a compose pop-out window → no `gmail` entry appears/changes in the config, and the embedded Gmail zoom setting is unaffected on next restart (the live shared-origin zoom shift within the session is pre-existing Chromium behavior).
8. Workspace-app zoom regression: zoom a workspace app tab and a workspace app window → their entries in `workspaceApps.zoomFactors` still persist/apply per #676, unaffected by the gmail entry.
