### PR TITLE
unify workspace apps menu wording and center the titlebar cluster

### DIFF
--- a/packages/renderer-main/components/app-tab-strip.tsx
+++ b/packages/renderer-main/components/app-tab-strip.tsx
@@ -202,7 +202,7 @@ function NewTabButton({ isWide }: { isWide: boolean }) {
           variant="ghost"
           size={isWide ? "sm" : "icon"}
           className={cn("opacity-50 hover:opacity-100", isWide && "w-full")}
-          title="New Tab"
+          title="Workspace Apps"
         >
           <LayoutGridIcon />
         </Button>

--- a/packages/renderer-main/components/app-titlebar.tsx
+++ b/packages/renderer-main/components/app-titlebar.tsx
@@ -415,7 +415,7 @@ export function AppTitlebar() {
           </TitlebarButtonGroup>
         </TitlebarLeft>
         <div className="flex items-center gap-4">
-          <div className="flex gap-2">
+          <div className="flex items-center gap-2">
             <Trial />
             <FindInPage />
             <WorkspaceAppsLauncher />

--- a/packages/renderer-main/routes/settings/workspace-apps.tsx
+++ b/packages/renderer-main/routes/settings/workspace-apps.tsx
@@ -231,8 +231,8 @@ export function WorkspaceAppsSettings() {
                 {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
               </FieldLabel>
               <FieldDescription>
-                Bookmark Workspace Apps to open them from the tab strip's New Tab menu and drag to
-                reorder.
+                Bookmark Workspace Apps to open them from the tab strip's Workspace Apps menu and
+                drag to reorder.
               </FieldDescription>
             </FieldContent>
             <div className="flex flex-col gap-4">


### PR DESCRIPTION
## Problem

Two small leftovers flagged during the launcher work (#674):

- The tab strip's launcher button and the titlebar launcher share the same `LayoutGridIcon` and open the same bookmarked-apps menu, but their tooltips disagreed: "New Tab" in the strip vs "Workspace Apps" in the titlebar.
- The inner right-titlebar cluster (`Trial` / `FindInPage` / `WorkspaceAppsLauncher` / `RecentDownloadHistoryButton` / `DoNotDisturb`) is a `flex` row without `items-center`, so any child taller than its siblings would stretch the others to its height. Latent today (all children are equal height), but it bit during the #674 centering audit as a risk worth closing.

## Changes

- The strip launcher's tooltip is now "Workspace Apps", matching the titlebar launcher. "New Tab" no longer appears anywhere in user-facing text.
- The Bookmarked Apps settings description follows suit: "…open them from the tab strip's Workspace Apps menu…" — it previously pointed users at the "New Tab menu", a label that would no longer exist anywhere in the UI after the tooltip change.
- `items-center` added to the inner cluster wrapper. The outer cluster div already had it; this is purely hardening — no visual change with the current children.

Deliberately untouched: the `NewTabButton` component identifier keeps its name — code-only, not user-facing, and renaming it would widen the diff.

## Test plan

1. With a workspace app open (strip visible): hover the strip's grid-icon button → tooltip reads "Workspace Apps"; clicking still opens the bookmarked-apps menu and opens tabs as before.
2. With only Gmail open and ≥4 bookmarks: hover the titlebar launcher → also "Workspace Apps" (unchanged) — the two entry points now read identically.
3. Settings → Workspace Apps → Bookmarked Apps: the description reads "…open them from the tab strip's Workspace Apps menu and drag to reorder."
4. Right titlebar cluster (trial badge, find-in-page, launcher/inline icons, downloads, DND) renders pixel-identical to before: all buttons vertically centered, no size changes.
