### PR TITLE
track only windows in the account windows set

### DIFF
--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -4,12 +4,11 @@ import type { AccountConfig } from "@meru/shared/schemas";
 import type { SelectedDesktopSource } from "@meru/shared/types";
 import {
   app,
-  BrowserWindow,
+  type BrowserWindow,
   type IpcMainEvent,
   ipcMain,
   type Session,
   session,
-  type WebContentsView,
 } from "electron";
 import { blocker } from "./blocker";
 import { config } from "./config";
@@ -27,7 +26,7 @@ export class Account {
 
   tabs: Tabs;
 
-  windows: Set<BrowserWindow | WebContentsView> = new Set();
+  windows: Set<BrowserWindow> = new Set();
 
   constructor(accountConfig: AccountConfig) {
     this.session = session.fromPartition(`persist:${accountConfig.id}`);
@@ -95,32 +94,31 @@ export class Account {
     });
   }
 
+  private findGoogleMeetParentWindow() {
+    for (const workspaceAppWindow of this.windows) {
+      const workspaceApp = WorkspaceApp.tryFromWebContents(workspaceAppWindow.webContents);
+
+      if (workspaceApp?.view.webContents.getURL().startsWith(GOOGLE_MEET_URL)) {
+        return workspaceAppWindow;
+      }
+    }
+
+    const hasEmbeddedGoogleMeetTab = this.tabs.tabs.some(
+      (tab) =>
+        tab instanceof WorkspaceApp &&
+        !tab.isWindowed &&
+        tab.view.webContents.getURL().startsWith(GOOGLE_MEET_URL),
+    );
+
+    if (hasEmbeddedGoogleMeetTab) {
+      return main.window;
+    }
+  }
+
   private registerSessionDisplayMediaRequestHandler() {
     this.session.setDisplayMediaRequestHandler(
       async (_request, callback) => {
-        let googleMeetParentWindow: BrowserWindow | undefined;
-
-        for (const workspaceAppWindowOrView of this.windows) {
-          if (workspaceAppWindowOrView instanceof BrowserWindow) {
-            const workspaceApp = WorkspaceApp.tryFromWebContents(
-              workspaceAppWindowOrView.webContents,
-            );
-
-            if (workspaceApp?.view.webContents.getURL().startsWith(GOOGLE_MEET_URL)) {
-              googleMeetParentWindow = workspaceAppWindowOrView;
-
-              break;
-            }
-
-            continue;
-          }
-
-          if (workspaceAppWindowOrView.webContents.getURL().startsWith(GOOGLE_MEET_URL)) {
-            googleMeetParentWindow = main.window;
-
-            break;
-          }
-        }
+        const googleMeetParentWindow = this.findGoogleMeetParentWindow();
 
         if (!googleMeetParentWindow) {
           callback({});

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -683,7 +683,7 @@ class Ipc {
     ipc.main.on("gmail.closeComposeWindow", (event) => {
       for (const accountInstance of accounts.instances.values()) {
         for (const window of accountInstance.windows) {
-          if (window instanceof BrowserWindow && window.webContents.id === event.sender.id) {
+          if (window.webContents.id === event.sender.id) {
             window.hide();
 
             const browserWindowId = window.id;

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -413,8 +413,6 @@ export class WorkspaceApp {
     if (this._window) {
       this.registerWindowListeners();
     } else {
-      this.account.instance.windows.add(this.view);
-
       if (appState.isSettingsOpen) {
         this.view.setVisible(false);
       }
@@ -524,12 +522,8 @@ export class WorkspaceApp {
 
     if (this._window) {
       this.account.instance.windows.delete(this._window);
-    } else {
-      if (!main.window.isDestroyed()) {
-        main.window.contentView.removeChildView(this.view);
-      }
-
-      this.account.instance.windows.delete(this.view);
+    } else if (!main.window.isDestroyed()) {
+      main.window.contentView.removeChildView(this.view);
     }
 
     this.teardownApp();
@@ -612,8 +606,6 @@ export class WorkspaceApp {
   detachToWindow() {
     main.window.contentView.removeChildView(this.view);
 
-    this.account.instance.windows.delete(this.view);
-
     this._window = this.createBrowserWindow();
 
     this.window.contentView.addChildView(this.view);
@@ -660,8 +652,6 @@ export class WorkspaceApp {
     discardedWindow.destroy();
 
     main.window.contentView.addChildView(this.view, 0);
-
-    this.account.instance.windows.add(this.view);
 
     if (appState.isSettingsOpen) {
       this.view.setVisible(false);


### PR DESCRIPTION
## Problem

Step 3 of the Gmail/WorkspaceApp convergence backlog. `Account.windows` is a `Set<BrowserWindow | WebContentsView>` that predates the tabs collection — embedded workspace-app views are tracked twice (in the set and as tabs), and every consumer pays for it with `instanceof BrowserWindow` filtering.

## Changes

- `Account.windows` is now `Set<BrowserWindow>` — only real app windows are tracked. All view add/delete bookkeeping in `WorkspaceApp` (constructor, teardown, detach/adopt flows) is gone; window bookkeeping is untouched.
- The display-media (screen-share) handler keeps both detection paths, extracted into `Account.findGoogleMeetParentWindow()`:
  - Windowed Meet: iterate the (now homogeneous) windows set, no `instanceof`.
  - Embedded Meet (the #659 fix — must keep working): detected from the account's tabs collection — `tab instanceof WorkspaceApp && !tab.isWindowed && <view URL is Meet>` — which skips dormant tabs (no view) and the Gmail entry; parent stays `main.window`. The tabs collection covers every embedded app: all non-window `WorkspaceApp` constructions go through `Tabs.openTab`/`materializeDormantTab`, and window→tab adoption re-enters via `tabs.adoptTab`.
- `gmail.closeComposeWindow` drops its now-redundant `instanceof BrowserWindow` check.

One deliberate micro-change in semantics: the old mixed set matched in insertion order, so with BOTH a windowed and an embedded Meet open, whichever was opened first won. Now a windowed Meet always wins over an embedded one. Everything else is behavior-identical bookkeeping consolidation.

Review follow-up (stacked on this PR): investigating whether the set is needed at all turned up that `gmail.closeComposeWindow` — one of its two remaining consumers — has been silently broken since #541 (it matches the window's chrome webContents id against the compose view's sender id, which never match). #686 fixes that without the set, and #687 then removes the set entirely.

## Test plan

1. Open Google Meet as an embedded tab, start a meeting, share screen → the source picker opens parented to the main window and sharing works (the #659 regression check).
2. Open Google Meet as a window, share screen → picker parents to the Meet window.
3. With no Meet open anywhere, a Meet-less workspace app requesting display media gets the empty callback (no picker), as before.
4. Compose in a pop-out window (with "close compose window after send" enabled), send → behavior is unchanged by this PR. (Note: the feature turns out to be broken on main independently of this change — the fix is stacked in #686.)
5. Detach a tab to a window and adopt it back → no errors, screen-share still resolves correctly in both states afterwards.

