### PR TITLE
share view creation between gmail and workspace apps

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -20,7 +20,7 @@ import {
   BrowserWindow,
   clipboard,
   type Session,
-  WebContentsView,
+  type WebContentsView,
   type WebContentsViewConstructorOptions,
 } from "electron";
 import z from "zod";
@@ -28,14 +28,9 @@ import { subscribeWithSelector } from "zustand/middleware";
 import { createStore } from "zustand/vanilla";
 import { accounts } from "@/accounts";
 import { config } from "@/config";
-import { setupWindowContextMenu } from "@/context-menu";
 import { ipc } from "@/ipc";
 import { log } from "@/lib/log";
-import {
-  applyViewZoomLimits,
-  broadcastFoundInPageResults,
-  openViewDevToolsInDev,
-} from "@/lib/web-contents";
+import { createChildWebContentsView, openViewDevToolsInDev } from "@/lib/web-contents";
 import { getPreloadPath } from "@/lib/window";
 import { xmlParser } from "@/lib/xml";
 import { licenseKey } from "@/license-key";
@@ -382,27 +377,21 @@ export class Gmail {
   }
 
   createView(options?: WebContentsViewConstructorOptions) {
-    this.view = new WebContentsView({
-      ...options,
-      webPreferences: {
-        preload: getPreloadPath("gmail"),
-        additionalArguments: this.additionalArguments,
-        ...options?.webPreferences,
-        session: this.session,
+    this.view = createChildWebContentsView({
+      session: this.session,
+      preload: getPreloadPath("gmail"),
+      additionalArguments: this.additionalArguments,
+      viewOptions: options,
+      attachView: (view) => {
+        main.window.contentView.addChildView(view);
+      },
+      getFindInPageTargetWebContents: () => main.window.webContents,
+      registerWindowOpenHandler: (view) => {
+        this.registerWindowOpenHandler(view);
       },
     });
 
-    main.window.contentView.addChildView(this.view);
-
     this.registerNavigationHandler(this.view);
-
-    broadcastFoundInPageResults(this.view, () => main.window.webContents);
-
-    this.registerWindowOpenHandler(this.view);
-
-    applyViewZoomLimits(this.view);
-
-    setupWindowContextMenu(this.view);
 
     this.updateViewBounds();
 

--- a/packages/app/lib/web-contents.ts
+++ b/packages/app/lib/web-contents.ts
@@ -1,5 +1,11 @@
 import { is } from "@electron-toolkit/utils";
-import type { WebContents, WebContentsView } from "electron";
+import {
+  type Session,
+  type WebContents,
+  WebContentsView,
+  type WebContentsViewConstructorOptions,
+} from "electron";
+import { setupWindowContextMenu } from "@/context-menu";
 import { ipc } from "@/ipc";
 
 export function applyViewZoomLimits(view: WebContentsView) {
@@ -24,4 +30,44 @@ export function broadcastFoundInPageResults(
       totalMatches: result.matches,
     });
   });
+}
+
+export function createChildWebContentsView({
+  session,
+  preload,
+  additionalArguments,
+  viewOptions,
+  attachView,
+  getFindInPageTargetWebContents,
+  registerWindowOpenHandler,
+}: {
+  session: Session;
+  preload: string;
+  additionalArguments?: string[];
+  viewOptions?: WebContentsViewConstructorOptions;
+  attachView: (view: WebContentsView) => void;
+  getFindInPageTargetWebContents: () => WebContents;
+  registerWindowOpenHandler: (view: WebContentsView) => void;
+}) {
+  const view = new WebContentsView({
+    ...viewOptions,
+    webPreferences: {
+      ...(additionalArguments && { additionalArguments }),
+      ...viewOptions?.webPreferences,
+      session,
+      preload,
+    },
+  });
+
+  attachView(view);
+
+  setupWindowContextMenu(view);
+
+  applyViewZoomLimits(view);
+
+  broadcastFoundInPageResults(view, getFindInPageTargetWebContents);
+
+  registerWindowOpenHandler(view);
+
+  return view;
 }

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -17,18 +17,13 @@ import {
   globalShortcut,
   powerSaveBlocker,
   type WebContents,
-  WebContentsView,
+  type WebContentsView,
   type WebContentsViewConstructorOptions,
 } from "electron";
 import { accounts } from "./accounts";
 import { config } from "./config";
-import { setupWindowContextMenu } from "./context-menu";
 import { ipc } from "./ipc";
-import {
-  applyViewZoomLimits,
-  broadcastFoundInPageResults,
-  openViewDevToolsInDev,
-} from "./lib/web-contents";
+import { createChildWebContentsView, openViewDevToolsInDev } from "./lib/web-contents";
 import {
   createBrowserWindow,
   getCascadedWindowBounds,
@@ -459,28 +454,22 @@ export class WorkspaceApp {
     url: string;
     options?: WebContentsViewConstructorOptions;
   }) {
-    const view = new WebContentsView({
-      ...options,
-      webPreferences: {
-        ...options?.webPreferences,
-        session: this.account.instance.session,
-        preload: getPreloadPath("workspace-app"),
+    const view = createChildWebContentsView({
+      session: this.account.instance.session,
+      preload: getPreloadPath("workspace-app"),
+      viewOptions: options,
+      attachView: (createdView) => {
+        if (this._window) {
+          this._window.contentView.addChildView(createdView);
+        } else {
+          main.window.contentView.addChildView(createdView, 0);
+        }
+      },
+      getFindInPageTargetWebContents: () => this.chromeWebContents,
+      registerWindowOpenHandler: (createdView) => {
+        this.setWindowOpenHandler(createdView);
       },
     });
-
-    if (this._window) {
-      this._window.contentView.addChildView(view);
-    } else {
-      main.window.contentView.addChildView(view, 0);
-    }
-
-    setupWindowContextMenu(view);
-
-    applyViewZoomLimits(view);
-
-    broadcastFoundInPageResults(view, () => this.chromeWebContents);
-
-    this.setWindowOpenHandler(view);
 
     view.webContents.loadURL(url);
 


### PR DESCRIPTION
## Problem

First step of the Gmail/WorkspaceApp convergence backlog. `Gmail.createView` and `WorkspaceApp.createView` duplicate the same ~10-step recipe — construct a `WebContentsView` with session + preload, attach it as a child view, wire context menu, zoom limits, find-in-page broadcast, a window-open handler, devtools-in-dev, and load the URL. Every view-level feature so far has had to land twice, and the two recipes have already drifted more than once (crash guards, title stripping, zoom).

## Changes

New `createChildWebContentsView` in `packages/app/lib/web-contents.ts`: constructs the view with merged `webPreferences` (session + preload + optional `additionalArguments` + caller extras), then attach → context menu → zoom limits → find-in-page broadcast → window-open handler. Both classes call it; class-specific wiring (Gmail's navigation handler, CSS injection, title handling, tab broadcasts, startup zoom, bounds; WorkspaceApp's `loadURL`-before-devtools order) stays at the call sites. Attachment and window-open registration are callbacks, because they're the two steps where the classes genuinely differ (windowed-vs-embedded branch with z-index 0, different handler shapes).

Every asymmetry between the two recipes is preserved:

- Gmail attaches with no z-index; embedded WorkspaceApp views attach with z-index 0 (below other child views), windowed ones attach to their own window.
- Find-in-page targets differ (main window vs the app window's chrome).
- Gmail's `additionalArguments` spread conditionally so WorkspaceApp's `webPreferences` object stays byte-identical.
- `Gmail.createView` still returns the `loadURL` promise (consumed by `Promise.all` in `Accounts.createViews`); all listeners register before load in both classes, and same-event registration pairs (`did-navigate` nav handler before the zoom `once`; zoom-limit `dom-ready` before the CSS `dom-ready`) keep their relative order.

Two checked near-changes, both inert:

- The shared block's internal order now follows WorkspaceApp's sequence in Gmail too (context menu/zoom/find/window-open before the navigation handler instead of after) — no two of those steps touch the same event, so observable behavior is unchanged.
- The `webPreferences` merge puts `preload` last (WorkspaceApp's old precedence); Gmail's old merge would have let caller extras override it. The only caller passing options (`Accounts.createViews`) sends just `backgroundThrottling: false`, so nothing changes — and preload-always-wins is the safer contract.

`bun types:ci` and `bun run build:js` both pass (the new `lib/web-contents` → `context-menu` import edge is only referenced inside a function body, so the module cycle is inert in the bundle).

## Test plan

1. Gmail loads normally per account: custom CSS applies, unread counts and notifications work, find-in-page overlays and reports matches, right-click context menu works, zoom limits confine pinch-zoom.
2. Open a workspace app as a tab → renders below the titlebar/strip, context menu and find-in-page work, links opening new windows/tabs behave as before.
3. Open a workspace app as a window → view attaches to its own window, find-in-page targets that window's titlebar UI.
4. The embedded stacking check: with a workspace app tab open, the recent-downloads popup and any other main-window child views still paint above the app view (z-index 0 preserved).
5. Dev-mode only: devtools still auto-open at the bottom for each created view.
