### PR TITLE
unify gmail zoom with the workspace app zoom api

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -51,6 +51,10 @@ class Accounts {
 
     config.onDidChange("workspaceApps.zoomFactors", () => {
       WorkspaceApp.applyPersistedZoomFactors();
+
+      for (const account of accounts.instances.values()) {
+        account.gmail.applyPersistedZoomFactor();
+      }
     });
   }
 

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -396,13 +396,7 @@ export class Gmail {
     this.updateViewBounds();
 
     this.view.webContents.once("did-navigate", () => {
-      const gmailZoomFactor = config.get("workspaceApps.zoomFactors").gmail;
-
-      if (gmailZoomFactor !== undefined) {
-        this.view.webContents.setZoomFactor(
-          clamp(gmailZoomFactor, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR),
-        );
-      }
+      this.applyPersistedZoomFactor();
     });
 
     this.view.webContents.on("dom-ready", () => {
@@ -485,6 +479,46 @@ export class Gmail {
       width: width - tabStripWidth,
       height: height - APP_TITLEBAR_HEIGHT,
     });
+  }
+
+  zoomIn() {
+    this.updateZoomFactor(this.persistedZoomFactor + 0.1);
+  }
+
+  zoomOut() {
+    this.updateZoomFactor(this.persistedZoomFactor - 0.1);
+  }
+
+  resetZoom() {
+    this.updateZoomFactor(1);
+  }
+
+  private get persistedZoomFactor() {
+    return config.get("workspaceApps.zoomFactors").gmail ?? 1;
+  }
+
+  private updateZoomFactor(zoomFactor: number) {
+    const clampedZoomFactor = clamp(zoomFactor, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR);
+
+    const zoomFactors = { ...config.get("workspaceApps.zoomFactors") };
+
+    if (clampedZoomFactor === 1) {
+      delete zoomFactors.gmail;
+    } else {
+      zoomFactors.gmail = clampedZoomFactor;
+    }
+
+    config.set("workspaceApps.zoomFactors", zoomFactors);
+  }
+
+  applyPersistedZoomFactor() {
+    if (!this._view) {
+      return;
+    }
+
+    this.view.webContents.setZoomFactor(
+      clamp(this.persistedZoomFactor, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR),
+    );
   }
 
   destroy() {

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -1,6 +1,5 @@
 import { is, platform } from "@electron-toolkit/utils";
 import { GITHUB_REPO_URL, WEBSITE_URL } from "@meru/shared/constants";
-import { clamp } from "@meru/shared/utils";
 import {
   app,
   BrowserWindow,
@@ -18,40 +17,10 @@ import { log } from "@/lib/log";
 import { main } from "@/main";
 import { appUpdater } from "@/updater";
 import { openExternalUrl } from "@/url";
-import { WorkspaceApp, MAX_ZOOM_FACTOR, MIN_ZOOM_FACTOR } from "@/workspace-app";
+import { WorkspaceApp } from "@/workspace-app";
 import { licenseKey } from "./license-key";
 import { createMeruMessageUrl } from "./protocol";
 import { appState } from "./state";
-
-function setGmailZoomFactor(zoomFactor: number) {
-  const clampedZoomFactor = clamp(zoomFactor, MIN_ZOOM_FACTOR, MAX_ZOOM_FACTOR);
-
-  for (const [_accountId, instance] of accounts.instances) {
-    instance.gmail.view.webContents.setZoomFactor(clampedZoomFactor);
-  }
-
-  const zoomFactors = { ...config.get("workspaceApps.zoomFactors") };
-
-  if (clampedZoomFactor === 1) {
-    delete zoomFactors.gmail;
-  } else {
-    zoomFactors.gmail = clampedZoomFactor;
-  }
-
-  config.set("workspaceApps.zoomFactors", zoomFactors);
-}
-
-const gmailZoomTarget = {
-  zoomIn: () => {
-    setGmailZoomFactor((config.get("workspaceApps.zoomFactors").gmail ?? 1) + 0.1);
-  },
-  zoomOut: () => {
-    setGmailZoomFactor((config.get("workspaceApps.zoomFactors").gmail ?? 1) - 0.1);
-  },
-  resetZoom: () => {
-    setGmailZoomFactor(1);
-  },
-};
 
 export class AppMenu {
   private _menu: Menu | undefined;
@@ -152,7 +121,7 @@ export class AppMenu {
         return activeTab;
       }
 
-      return gmailZoomTarget;
+      return accounts.getSelectedAccount().instance.gmail;
     };
 
     const zoomIn = () => {


### PR DESCRIPTION
## Problem

Second step of the Gmail/WorkspaceApp convergence backlog, stacked on #683. Since #680 Gmail zoom is stored in `workspaceApps.zoomFactors.gmail` and applied on startup, but it is still driven by module-level machinery in `menu.ts` (`setGmailZoomFactor` + the `gmailZoomTarget` object) while workspace apps have instance methods on their class. Two drivers for the same behavior, and the menu module owns logic that belongs to the Gmail class.

## Changes

- `Gmail` gets the same class-level zoom API as `WorkspaceApp`: `zoomIn`/`zoomOut`/`resetZoom` plus `applyPersistedZoomFactor`, backed by a private `persistedZoomFactor` getter (`workspaceApps.zoomFactors.gmail ?? 1`) and a private `updateZoomFactor` that clamps, spreads the config map into a new object, deletes the `gmail` entry at factor 1, and writes config.
- `setGmailZoomFactor` and `gmailZoomTarget` are deleted from `menu.ts`; `getActiveZoomTarget()`'s fallback returns the selected account's `gmail` instance, which now satisfies the same zoom-target shape as an active workspace-app tab.
- Cross-account fan-out moves from a direct loop in the menu handler to the existing `workspaceApps.zoomFactors` listener in `Accounts.init`, which now also calls `applyPersistedZoomFactor()` on every account's Gmail. A menu zoom writes config once and the listener syncs all Gmail views, including the initiating one.
- The startup `did-navigate` block in `Gmail.createView` now calls `applyPersistedZoomFactor()` instead of duplicating the read/clamp/apply logic.

Deliberate differences from `WorkspaceApp`'s zoom internals:

- Gmail steps from the persisted config value, not from `webContents.getZoomFactor()` — same as the deleted `gmailZoomTarget`. This keeps every account's Gmail stepping in lockstep and avoids float drift between per-account views.
- `Gmail.updateZoomFactor` never touches the webContents directly; Gmail zoom is always persisted, so the config write plus listener fan-out covers every view. (`WorkspaceApp` can't do this because its zoom may be non-persisted.)
- Gmail zoom stays permanent: it is not gated by `workspaceApps.persistZoom`, and `persistableZoomApp` still excludes `gmail`, so compose pop-outs never write the shared entry.

One behavioral footnote: `config.onDidChange` only fires when the stored value actually changes, so a no-op zoom (reset while already at 100%, zoom-in while clamped at max) writes nothing and applies nothing — the views already sit at that factor.

`bun types:ci` and `bun run build:js` pass.

## Test plan

1. With Gmail focused in the main window, press Cmd/Ctrl+Plus / Minus / 0 → Gmail zooms in/out/resets, and with a second account added, its Gmail view follows in lockstep.
2. Zoom Gmail to e.g. 110%, quit, relaunch → Gmail comes back at 110% (entry visible in the config file under `workspaceApps.zoomFactors.gmail`).
3. Reset zoom (Cmd/Ctrl+0) → the `gmail` entry disappears from the config file.
4. With a workspace-app tab active, the same shortcuts zoom only that app (existing behavior untouched), and its persistence still follows the `persistZoom` setting.
5. Zoom repeatedly past the min/max bounds → factor clamps and nothing errors; a further zoom-in at max is a no-op.
6. Compose pop-out window (Gmail compose in its own window): menu zoom targets that window while focused, and closing/reopening it does not disturb the stored `gmail` factor.
