### PR TITLE
fix close compose window after send

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -681,31 +681,29 @@ class Ipc {
     });
 
     ipc.main.on("gmail.closeComposeWindow", (event) => {
-      for (const accountInstance of accounts.instances.values()) {
-        for (const window of accountInstance.windows) {
-          if (window.webContents.id === event.sender.id) {
-            window.hide();
+      const composeWorkspaceApp = WorkspaceApp.tryFromViewWebContents(event.sender);
 
-            const browserWindowId = window.id;
-
-            window.once("closed", () => {
-              ipc.renderer.send(
-                accountInstance.gmail.view.webContents,
-                "gmail.dismissMessageSentNotification",
-                browserWindowId,
-              );
-            });
-
-            ipc.renderer.send(
-              accountInstance.gmail.view.webContents,
-              "gmail.showMessageSentNotification",
-              browserWindowId,
-            );
-
-            return;
-          }
-        }
+      if (!composeWorkspaceApp?.isWindowed) {
+        return;
       }
+
+      const composeWindow = composeWorkspaceApp.window;
+
+      const gmailWebContents = composeWorkspaceApp.account.instance.gmail.view.webContents;
+
+      composeWindow.hide();
+
+      const browserWindowId = composeWindow.id;
+
+      composeWindow.once("closed", () => {
+        ipc.renderer.send(
+          gmailWebContents,
+          "gmail.dismissMessageSentNotification",
+          browserWindowId,
+        );
+      });
+
+      ipc.renderer.send(gmailWebContents, "gmail.showMessageSentNotification", browserWindowId);
     });
 
     ipc.main.on("gmail.undoMessageSent", (_event, browserWindowId) => {
@@ -715,9 +713,15 @@ class Ipc {
         throw new Error('Could not find compose window with the given "browserWindowId"');
       }
 
+      const composeWorkspaceApp = WorkspaceApp.tryFromWebContents(composeWindow.webContents);
+
+      if (!composeWorkspaceApp) {
+        throw new Error('Could not find compose workspace app with the given "browserWindowId"');
+      }
+
       composeWindow.show();
 
-      ipc.renderer.send(composeWindow.webContents, "gmail.undoMessageSent");
+      ipc.renderer.send(composeWorkspaceApp.view.webContents, "gmail.undoMessageSent");
     });
 
     ipc.main.on("gmail.setUserEmail", (event, email) => {

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -107,6 +107,14 @@ export class WorkspaceApp {
     }
   }
 
+  static tryFromViewWebContents(webContents: WebContents) {
+    for (const instance of WorkspaceApp.instances.values()) {
+      if (instance.view.webContents.id === webContents.id) {
+        return instance;
+      }
+    }
+  }
+
   static applyPersistedZoomFactors() {
     for (const instance of WorkspaceApp.instances.values()) {
       instance.applyPersistedZoomFactor();


### PR DESCRIPTION
## Problem

"Close compose window after send" is silently broken in shipped releases. The `gmail.closeComposeWindow` handler matches `window.webContents.id === event.sender.id`, but `window.webContents` is the app window's chrome/titlebar renderer while the sender is the compose **view**'s webContents (where the `preload-workspace-app` mail preload runs). The id match was written in January when compose windows loaded Gmail directly into the window's own webContents; ever since #541 gave app windows the chrome + child-view structure, the ids never match, the loop falls through, and nothing happens.

The undo path has the same bug: `gmail.undoMessageSent` sends its renderer event to `composeWindow.webContents` (chrome), but the `once` listener lives in the compose view's preload — so even when a toast was shown, Undo would re-show the window without clicking Gmail's undo link.

Stacked on #682 because it rewrites the same handler that PR touches.

## Changes

- New `WorkspaceApp.tryFromViewWebContents(webContents)` static, the view-matching sibling of the existing chrome-matching `tryFromWebContents`.
- `gmail.closeComposeWindow` no longer loops accounts and the `Account.windows` set: it resolves the sending compose view straight to its `WorkspaceApp`, early-returns unless that instance is windowed, hides the window, and keeps the existing notification flow (`showMessageSentNotification` immediately, `dismissMessageSentNotification` on `closed`) targeted at the instance's own account's Gmail view.
- `gmail.undoMessageSent` resolves the window back to its `WorkspaceApp` via `tryFromWebContents` and sends the undo event to the **view** webContents. The lookup happens before `composeWindow.show()` so a failed lookup doesn't leave a re-shown window behind; the existing throw-on-missing style is kept for both guards.
- Flow traced end to end (compose view → main → Gmail view toast → undo → compose view → dismiss on `closed`): every send now targets a webContents that actually has a listener. No preload changes were needed.

`bun types:ci` passes.

## Test plan

1. Enable Settings → Gmail → "Close compose window after send". Pop out a compose window (or use File → New Message with compose-in-new-window), write a mail, hit Send → the compose window disappears and a "Message sent" toast with Undo appears in the main Gmail view.
2. Click Undo on the toast → the compose window reappears and Gmail's own undo has been triggered (the mail is back in compose, not sent).
3. Let the toast sit until Gmail's popout closes itself after the send completes → the toast is dismissed.
4. With the setting disabled, sending from a compose window changes nothing (window stays, no toast).
5. Send from the embedded Gmail view (no pop-out) → no toast, no errors.
