### PR TITLE
remove the account windows set

### DIFF
--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -2,14 +2,7 @@ import { platform } from "@electron-toolkit/utils";
 import { GOOGLE_MEET_URL } from "@meru/shared/constants";
 import type { AccountConfig } from "@meru/shared/schemas";
 import type { SelectedDesktopSource } from "@meru/shared/types";
-import {
-  app,
-  type BrowserWindow,
-  type IpcMainEvent,
-  ipcMain,
-  type Session,
-  session,
-} from "electron";
+import { app, type IpcMainEvent, ipcMain, type Session, session } from "electron";
 import { blocker } from "./blocker";
 import { config } from "./config";
 import { Gmail } from "./gmail";
@@ -20,15 +13,17 @@ import { Tabs } from "./tabs";
 import { WorkspaceApp } from "./workspace-app";
 
 export class Account {
+  accountId: AccountConfig["id"];
+
   session: Session;
 
   gmail: Gmail;
 
   tabs: Tabs;
 
-  windows: Set<BrowserWindow> = new Set();
-
   constructor(accountConfig: AccountConfig) {
+    this.accountId = accountConfig.id;
+
     this.session = session.fromPartition(`persist:${accountConfig.id}`);
 
     this.setCustomUserAgent();
@@ -95,11 +90,9 @@ export class Account {
   }
 
   private findGoogleMeetParentWindow() {
-    for (const workspaceAppWindow of this.windows) {
-      const workspaceApp = WorkspaceApp.tryFromWebContents(workspaceAppWindow.webContents);
-
-      if (workspaceApp?.view.webContents.getURL().startsWith(GOOGLE_MEET_URL)) {
-        return workspaceAppWindow;
+    for (const windowedWorkspaceApp of WorkspaceApp.getAccountWindowedInstances(this.accountId)) {
+      if (windowedWorkspaceApp.view.webContents.getURL().startsWith(GOOGLE_MEET_URL)) {
+        return windowedWorkspaceApp.window;
       }
     }
 

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -127,6 +127,12 @@ export class WorkspaceApp {
       .map((instance) => instance.window);
   }
 
+  static getAccountWindowedInstances(accountId: AccountConfig["id"]) {
+    return Array.from(WorkspaceApp.instances.values()).filter(
+      (instance) => instance.accountId === accountId && instance._window,
+    );
+  }
+
   static handleNavigate(url: string) {
     if (!url.startsWith(`${GOOGLE_ACCOUNTS_URL}/v3/signin/challenge/pk/presend`)) {
       return;
@@ -528,9 +534,7 @@ export class WorkspaceApp {
       this.view.webContents.close();
     }
 
-    if (this._window) {
-      this.account.instance.windows.delete(this._window);
-    } else if (!main.window.isDestroyed()) {
+    if (!this._window && !main.window.isDestroyed()) {
       main.window.contentView.removeChildView(this.view);
     }
 
@@ -607,8 +611,6 @@ export class WorkspaceApp {
 
       WorkspaceApp.instances.set(this.id, this);
     });
-
-    this.account.instance.windows.add(this.window);
   }
 
   detachToWindow() {
@@ -652,8 +654,6 @@ export class WorkspaceApp {
     this.unregisterWindowedViewListeners();
 
     discardedWindow.contentView.removeChildView(this.view);
-
-    this.account.instance.windows.delete(discardedWindow);
 
     this._window = undefined;
 


### PR DESCRIPTION
## Problem

Follow-up to #682, stacked on the compose fix. With `gmail.closeComposeWindow` no longer using it, the `Account.windows` set has exactly one consumer left — windowed Google Meet detection for the screen-share picker — and that is answerable from the `WorkspaceApp` instances registry, which already backs `getAllWindows()`. The set and all its add/delete bookkeeping across the window lifecycle are pure duplication.

## Changes

- `Account.windows` is deleted, along with every `windows.add`/`windows.delete` in `WorkspaceApp` (`registerWindowListeners`, teardown, `adoptIntoTabs`). The teardown `if/else if` collapses to a single `if (!this._window && !main.window.isDestroyed())`.
- New `WorkspaceApp.getAccountWindowedInstances(accountId)` static (sibling of `getAllWindows`), returning the account's windowed instances.
- `Account.findGoogleMeetParentWindow`'s windowed branch iterates that query and returns the matching instance's window; the embedded-tab branch and the windowed-wins-over-embedded precedence from #682 are unchanged.
- `Account` gains an `accountId` field (the id previously only lived on its child `Gmail`/`Tabs`) so the account can query for its own instances.

Micro-semantic note, same spirit as #682's: with **multiple** windowed Meets in one account, the winner is now decided by the instances-registry order (which reorders on window focus) instead of the old set's insertion order. Single-Meet behavior is identical.

Repo-wide search confirms no reference to the account windows set remains.

`bun types:ci` and `bun run build:js` pass.

## Test plan

1. Open Google Meet as a window, start a meeting, share screen → the source picker opens parented to the Meet window and sharing works.
2. Open Google Meet as an embedded tab instead → picker parents to the main window (the #659 regression check).
3. With no Meet open, a display-media request from another workspace app gets the empty callback (no picker), as before.
4. Detach a tab to a window and adopt it back, then repeat the screen-share checks → still resolves correctly in both states.
5. Close a workspace-app window and quit the app → no errors from the removed bookkeeping paths.
