### PR TITLE
close hidden compose window when the undo send window lapses

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { IpcEmitter, IpcListener } from "@electron-toolkit/typed-ipc/main";
 import { MAX_RECENT_DOWNLOAD_HISTORY_ITEMS } from "@meru/shared/constants";
 import { getWorkspaceAppUrl } from "@meru/shared/google";
+import { ms } from "@meru/shared/ms";
 import { GMAIL_TAB_ID } from "@meru/shared/tabs";
 import type { IpcMainEvents, IpcRendererEvent } from "@meru/shared/types";
 import { workspaceApps } from "@meru/shared/workspace-apps";
@@ -37,6 +38,18 @@ import { createNewEmailNotification } from "./notifications";
 import { MAILTO_PROTOCOL } from "./protocol";
 import { appUpdater } from "./updater";
 import { openExternalUrl } from "./url";
+
+const undoSendLapseTimeouts = new Map<number, NodeJS.Timeout>();
+
+function clearUndoSendLapseTimeout(browserWindowId: number) {
+  const undoSendLapseTimeout = undoSendLapseTimeouts.get(browserWindowId);
+
+  if (undoSendLapseTimeout) {
+    clearTimeout(undoSendLapseTimeout);
+  }
+
+  undoSendLapseTimeouts.delete(browserWindowId);
+}
 
 function getNavigationWebContents(workspaceAppId?: string) {
   if (workspaceAppId) {
@@ -695,13 +708,35 @@ class Ipc {
 
       const browserWindowId = composeWindow.id;
 
+      clearUndoSendLapseTimeout(browserWindowId);
+
+      // Gmail's undo send period is configurable up to 30 seconds
+      undoSendLapseTimeouts.set(
+        browserWindowId,
+        setTimeout(() => {
+          if (!composeWindow.isDestroyed() && !composeWindow.isVisible()) {
+            composeWindow.close();
+          }
+        }, ms("30s")),
+      );
+
       composeWindow.once("closed", () => {
+        clearUndoSendLapseTimeout(browserWindowId);
+
+        if (gmailWebContents.isDestroyed()) {
+          return;
+        }
+
         ipc.renderer.send(
           gmailWebContents,
           "gmail.dismissMessageSentNotification",
           browserWindowId,
         );
       });
+
+      if (gmailWebContents.isDestroyed()) {
+        return;
+      }
 
       ipc.renderer.send(gmailWebContents, "gmail.showMessageSentNotification", browserWindowId);
     });
@@ -710,14 +745,16 @@ class Ipc {
       const composeWindow = BrowserWindow.fromId(browserWindowId);
 
       if (!composeWindow) {
-        throw new Error('Could not find compose window with the given "browserWindowId"');
+        return;
       }
 
       const composeWorkspaceApp = WorkspaceApp.tryFromWebContents(composeWindow.webContents);
 
       if (!composeWorkspaceApp) {
-        throw new Error('Could not find compose workspace app with the given "browserWindowId"');
+        return;
       }
+
+      clearUndoSendLapseTimeout(browserWindowId);
 
       composeWindow.show();
 


### PR DESCRIPTION
## Problem

Residue found while tracing the compose flow for #686. When "close compose window after send" fires, the compose window is only ever hidden — the toast (infinite duration) and the window are cleaned up solely by the window's `closed` event, which relies on Gmail's popout closing itself after the undo-send period. If Gmail never does, the hidden window and the toast live forever with no user-reachable way to close either. Two adjacent hazards in the same handlers: the `closed`-path sends can hit a destroyed Gmail view during quit or account removal, and `gmail.undoMessageSent` throws uncaught in the main process when the window or workspace app is gone.

## Changes

All in `packages/app/ipc.ts`:

- After hiding the compose window, a 30-second timer (`ms("30s")` — Gmail's maximum configurable undo-send period, counted from the same sent-confirmation that starts Gmail's own countdown) closes the window if it is still alive and still hidden. `close()` rather than `destroy()` so `WorkspaceApp.handleClose` runs its normal teardown (verified: `destroy()` skips the `close` event and would leak the instance registry entry); the compose pop-out is a popup, so `tabs.handleWindowedTabClosed` early-returns and no tab-strip state is touched. Closing fires `closed`, so the toast dismisses through the existing path.
- Timers are tracked in a module-level map keyed by window id and cleared in three places: a re-send for the same window replaces the pending timer (otherwise an undo + quick re-send would inherit the first timer and lose part of its undo window), the `closed` listener drops it on both the self-close and timer-close paths, and a successful undo disarms it before re-showing the window. The not-visible guard inside the timer stays as defense in depth for an already-queued callback.
- The `showMessageSentNotification`/`dismissMessageSentNotification` sends are guarded with `isDestroyed()` on the Gmail view webContents. The captured-up-front webContents is kept deliberately: re-resolving through `WorkspaceApp.account` goes via `accounts.getAccount()`, which throws exactly in the account-removal case the guard is for.
- The two throws in `gmail.undoMessageSent` become silent early returns — with the timer, "window gone when Undo is clicked" is a legitimate race, not a programming error.

`bun types:ci` and `bun run build:js` pass. Not verified in the running app.

## Test plan

1. Enable "close compose window after send", pop out a compose window, send → window hides, "Message sent" toast with Undo appears in the Gmail view; when Gmail's popout closes itself, the toast dismisses (unchanged normal path).
2. Click Undo within the undo period → the compose window reappears with the send undone, and it does NOT get closed from under you 30 seconds after the original send (the disarmed-timer check).
3. After undoing, edit and send again → the second send gets its full undo period; the toast for the second send works, and the window closes/dismisses normally afterwards.
4. Simulate Gmail failing to self-close (e.g. block the popout's self-close with devtools, or observe any naturally lingering popout): ~30s after sending, the hidden window closes on its own and the toast dismisses.
5. Send from a pop-out, then quit the app while the toast is showing → clean shutdown, no uncaught exceptions in the main process.
6. Send, then click Undo at the very edge of the 30s window → either the undo lands or the window is already closed and the click is a silent no-op; no main-process error dialog either way.
