### PR TITLE
group titlebar buttons with spacing between groups

### DIFF
--- a/packages/renderer-main/components/app-titlebar.tsx
+++ b/packages/renderer-main/components/app-titlebar.tsx
@@ -245,6 +245,18 @@ export function AppTitlebar() {
     return;
   }
 
+  const shouldShowUnifiedInboxButton =
+    isLicenseKeyValid && config["unifiedInbox.enabled"] && accounts.length > 1;
+
+  const shouldShowSavedSearchesButton =
+    config["gmail.savedSearches"].length > 0 && Boolean(config.licenseKey);
+
+  const shouldShowOutOfOfficeButton =
+    accounts.length === 1 &&
+    Boolean(accounts[0]?.gmail.outOfOffice) &&
+    config["gmail.hideOutOfOfficeBanner"] &&
+    isLicenseKeyValid;
+
   const renderAccounts = () => {
     if (isGmailSavedSearchesOpen) {
       return config["gmail.savedSearches"].map((savedSearch) => (
@@ -342,6 +354,8 @@ export function AppTitlebar() {
       );
     }
 
+    const accountButtons = renderAccounts();
+
     return (
       <>
         <TitlebarLeft>
@@ -364,41 +378,45 @@ export function AppTitlebar() {
                 ipc.main.send("workspaceApp.stop");
               }}
             />
-            {isLicenseKeyValid && config["unifiedInbox.enabled"] && accounts.length > 1 && (
-              <Button
-                variant={matchUnifiedInboxRoute ? "secondary" : "ghost"}
-                size="icon"
-                className="size-7 draggable-none"
-                onClick={() => {
-                  navigate("/unified-inbox");
+          </TitlebarButtonGroup>
+          {(shouldShowUnifiedInboxButton || shouldShowSavedSearchesButton) && (
+            <TitlebarButtonGroup>
+              {shouldShowUnifiedInboxButton && (
+                <Button
+                  variant={matchUnifiedInboxRoute ? "secondary" : "ghost"}
+                  size="icon"
+                  className="size-7 draggable-none"
+                  onClick={() => {
+                    navigate("/unified-inbox");
 
-                  ipc.main.send("settings.toggleIsOpen", true);
+                    ipc.main.send("settings.toggleIsOpen", true);
 
-                  setIsGmailSavedSearchesOpen(false);
-                }}
-                title="Unified Inbox"
-              >
-                <InboxIcon />
-              </Button>
-            )}
-            {config["gmail.savedSearches"].length > 0 && config.licenseKey && (
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                className="draggable-none"
-                onClick={() => {
-                  setIsGmailSavedSearchesOpen((isOpen) => !isOpen);
-                }}
-                title="Saved Searches"
-                disabled={matchUnifiedInboxRoute}
-              >
-                {isGmailSavedSearchesOpen ? <CircleXIcon /> : <MailSearchIcon />}
-              </Button>
-            )}
-            {accounts.length === 1 &&
-              accounts[0]?.gmail.outOfOffice &&
-              config["gmail.hideOutOfOfficeBanner"] &&
-              isLicenseKeyValid && (
+                    setIsGmailSavedSearchesOpen(false);
+                  }}
+                  title="Unified Inbox"
+                >
+                  <InboxIcon />
+                </Button>
+              )}
+              {shouldShowSavedSearchesButton && (
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  className="draggable-none"
+                  onClick={() => {
+                    setIsGmailSavedSearchesOpen((isOpen) => !isOpen);
+                  }}
+                  title="Saved Searches"
+                  disabled={matchUnifiedInboxRoute}
+                >
+                  {isGmailSavedSearchesOpen ? <CircleXIcon /> : <MailSearchIcon />}
+                </Button>
+              )}
+            </TitlebarButtonGroup>
+          )}
+          {(shouldShowOutOfOfficeButton || accountButtons) && (
+            <TitlebarButtonGroup>
+              {shouldShowOutOfOfficeButton && (
                 <Button
                   variant="ghost"
                   size="icon-sm"
@@ -411,8 +429,9 @@ export function AppTitlebar() {
                   <BriefcaseIcon />
                 </Button>
               )}
-            {renderAccounts()}
-          </TitlebarButtonGroup>
+              {accountButtons}
+            </TitlebarButtonGroup>
+          )}
         </TitlebarLeft>
         <div className="flex items-center gap-4">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Problem

The titlebar's left side rendered navigation controls, the unified inbox button, the saved searches toggle, the out-of-office button, and the account buttons all in a single `TitlebarButtonGroup`, so every button sat at the same uniform `gap-1` with no visual separation between logically distinct groups.

## Changes

- Split the left side of `AppTitlebar` into three `TitlebarButtonGroup`s: navigation (back/forward/reload), views (unified inbox + saved searches), and accounts (out-of-office + account/saved-search buttons).
- Within-group spacing stays `gap-1`; the larger between-group spacing comes from `TitlebarLeft`'s existing `gap-2` — no shared component changes.
- Hoisted the button visibility conditions into `shouldShowUnifiedInboxButton`, `shouldShowSavedSearchesButton`, and `shouldShowOutOfOfficeButton` so the second and third groups only render when they have content, avoiding stray double-gaps from empty groups.

No behavior changes — every button keeps its exact conditions and handlers.

## Test plan

1. Run the app with multiple accounts and a Pro license with unified inbox enabled and at least one saved search: the titlebar shows three button clusters (navigation / unified inbox + saved searches / accounts) with visibly larger gaps between clusters than within them.
2. Click the saved searches toggle: the account buttons swap to saved-search buttons within the third cluster, spacing unchanged.
3. Run with a single account and no unified inbox or saved searches: only the navigation cluster renders, with no trailing extra gap after it.
4. With a single account that has out-of-office enabled (banner hidden, valid license): the briefcase button appears as its own third cluster, separated from the navigation controls.