### PR TITLE
apply the workspace app open behavior setting to the app launcher

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -609,10 +609,12 @@ class Ipc {
       });
     });
 
-    ipc.main.on("workspaceApps.openApp", (_event, app, openBehavior = "tab") => {
+    ipc.main.on("workspaceApps.openApp", (_event, app, modifierOpenBehavior) => {
       if (!licenseKey.isValid) {
         return;
       }
+
+      const openBehavior = modifierOpenBehavior ?? config.get("workspaceApps.openBehavior");
 
       const selectedAccount = accounts.getSelectedAccount();
 


### PR DESCRIPTION
The `workspaceApps.openBehavior` setting only took effect for workspace apps opened from within the app (links intercepted in `WorkspaceApp`). Apps opened from the workspace app launcher — the bookmarked apps menu in the titlebar and sidebar — always opened in a foreground tab.

The launcher sends `workspaceApps.openApp` with the open behavior derived from modifier keys, which is `undefined` on a plain click. The main-process handler defaulted that to a hardcoded `"tab"` instead of falling back to the configured behavior.

## Changes

- `workspaceApps.openApp` now falls back to `config.get("workspaceApps.openBehavior")` when the sender doesn't specify one, so plain clicks in the launcher respect the setting.
- Modifier-key behavior is unchanged — Cmd/Ctrl, Shift, and middle click still override the setting, since those senders pass an explicit behavior.

Not verified in the running app; the change is a one-line default swap, and the behavior is covered by the test plan below.

## Test plan

1. Open Settings → Workspace Apps and set **Open Behavior** to **Tab**. Click a bookmarked app in the titlebar launcher → it opens in a tab and that tab becomes active.
2. Set **Open Behavior** to **Background Tab**. Click a bookmarked app → the tab opens but the current tab stays active.
3. Set **Open Behavior** to **New Window**. Click a bookmarked app → it opens in a separate window; no new tab appears in the tab strip.
4. Repeat steps 1–3 from the sidebar launcher → same behavior as the titlebar launcher.
5. With **Open Behavior** set to **New Window**, Cmd-click (macOS) / Ctrl-click a bookmarked app → it opens in a background tab, not a new window. Cmd+Shift-click / Ctrl+Shift-click → foreground tab. Shift-click → new window.
6. Middle-click a bookmarked app with any setting → always opens in a background tab.
7. Open a workspace app link from inside Gmail (e.g. a Calendar link) → still follows the configured open behavior as before.
8. With an invalid/absent license key, clicking a launcher entry → nothing opens (the license gate is unchanged).
