### PR TITLE
fix crash on quit while a compose popup is open

### DIFF
--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -518,7 +518,16 @@ export class WorkspaceApp {
 
   private teardown() {
     if (!this.viewDestroyed) {
-      this.view.webContents.removeAllListeners();
+      // Electron pairs a "destroyed" listener on this webContents with a
+      // "current-render-view-deleted" listener on its opener when the view was
+      // created via a window open handler. Removing the "destroyed" listener
+      // leaves the opener-side listener dangling, which then crashes the app by
+      // calling into this destroyed webContents (e.g. on quit).
+      for (const registeredEvent of this.view.webContents.eventNames()) {
+        if (registeredEvent !== "destroyed") {
+          this.view.webContents.removeAllListeners(registeredEvent);
+        }
+      }
 
       this.view.webContents.close();
     }


### PR DESCRIPTION
## Problem

Quitting the app while a compose popup is open crashes with an uncaught exception:

```
TypeError: Object has been destroyed
    at WebContents.closedByEmbedder (node:electron/js2c/browser_init:2:118653)
```

A compose popup's view webContents is returned from the `createWindow` callback in `Gmail.registerWindowOpenHandler`, which makes it a guest of the Gmail view. Electron's guest-window manager then pairs two internal listeners: `closedByEmbedder` (`once("current-render-view-deleted")` on the Gmail view, closes the guest when the opener dies) and `closedByUser` (`once("destroyed")` on the guest, unhooks `closedByEmbedder` when the guest dies first — the only guard, since `closedByEmbedder` calls `guest.destroy()` without an `isDestroyed()` check).

`WorkspaceApp.teardown()` called `webContents.removeAllListeners()`, which strips `closedByUser`. So closing a compose popup leaks a stale `closedByEmbedder` on the Gmail view; when the Gmail view is destroyed on quit, the stale listener fires and calls into the already-destroyed compose webContents. Quit is the reliable trigger, but the listener also leaks when a popup is closed normally (including the hidden undo-send window), so any later render-view swap in the Gmail view could crash too.

## Changes

- `WorkspaceApp.teardown()` now removes listeners per event, skipping `"destroyed"`, so Electron's internal cleanup pairing stays intact. The blunt removal is kept for all other events since late events (e.g. `page-title-updated`) would otherwise send IPC to a destroyed window.
- The app's own `once("destroyed")` handler also survives teardown now; its re-entry paths are guarded by `isClosing`, which is always set before `teardown()` runs.

## Test plan

1. Open a compose popup (with "Open compose in new window" enabled, click Compose), then quit the app → app exits cleanly with no "Object has been destroyed" error dialog.
2. Same, but with the compose popup being a Gmail pop-out (Shift-click the compose expand button) → same clean exit.
3. With "Close compose window after send" enabled, send an email from a compose popup (hides the window for the undo-send period), then quit before the 30s lapse → clean exit.
4. Close a compose popup manually, keep using Gmail, then quit → clean exit.
5. Regression: open a workspace app tab, detach it to a window, close the window, and quit → no crash, no stray error output.