### PR TITLE
remove the reload button from the titlebar

### DIFF
--- a/packages/app/context-menu.ts
+++ b/packages/app/context-menu.ts
@@ -52,6 +52,18 @@ export function setupWindowContextMenu(window: BrowserWindow | WebContentsView) 
         }
       }
 
+      menuItems.push(
+        {
+          label: "Reload",
+          click: () => {
+            window.webContents.reload();
+          },
+        },
+        {
+          type: "separator",
+        },
+      );
+
       if (window !== selectedAccount.instance.gmail.view) {
         menuItems.push(
           {

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -231,10 +231,6 @@ export class Gmail {
     this._view = view;
   }
 
-  get isLoading() {
-    return this._view ? this._view.webContents.isLoading() : false;
-  }
-
   get navigationHistory() {
     if (!this._view) {
       return { canGoBack: false, canGoForward: false };

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -128,18 +128,6 @@ class Ipc {
       getNavigationWebContents(workspaceAppId).navigationHistory.goForward();
     });
 
-    this.main.on("workspaceApp.reload", (_event, workspaceAppId) => {
-      getNavigationWebContents(workspaceAppId).reload();
-    });
-
-    this.main.on("workspaceApp.stop", (_event, workspaceAppId) => {
-      getNavigationWebContents(workspaceAppId).stop();
-    });
-
-    this.main.handle("workspaceApp.getLoadingState", (_event, workspaceAppId) => {
-      return getNavigationWebContents(workspaceAppId).isLoading();
-    });
-
     this.main.on("gmail.setOutOfOffice", (event, outOfOffice) => {
       const accountInstance = accounts.findInstanceByGmailWebContentsId(event.sender.id);
 

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -18,8 +18,6 @@ export function registerTabBroadcasts(view: WebContentsView) {
   view.webContents.on("did-navigate", broadcastTabsChanged);
   view.webContents.on("did-navigate-in-page", broadcastTabsChanged);
   view.webContents.on("page-title-updated", broadcastTabsChanged);
-  view.webContents.on("did-start-loading", broadcastTabsChanged);
-  view.webContents.on("did-stop-loading", broadcastTabsChanged);
 }
 
 export function isWindowedTab(tab: Tab) {
@@ -37,7 +35,6 @@ export type Tab = {
   app: SupportedWorkspaceApp | undefined;
   title: string;
   pinned: boolean;
-  isLoading: boolean;
   navigationHistory: { canGoBack: boolean; canGoForward: boolean };
   view?: WebContentsView;
   updateViewBounds?: () => void;
@@ -51,8 +48,6 @@ export class DormantTab {
   url: string;
 
   pinned = true;
-
-  isLoading = false;
 
   navigationHistory = { canGoBack: false, canGoForward: false };
 
@@ -90,9 +85,6 @@ export class Tabs {
         pinned: false,
         get title() {
           return gmail.title;
-        },
-        get isLoading() {
-          return gmail.isLoading;
         },
         get navigationHistory() {
           return gmail.navigationHistory;
@@ -504,7 +496,6 @@ export class Tabs {
       pinned: tab.pinned,
       dormant: tab instanceof DormantTab,
       windowed: isWindowedTab(tab),
-      loading: tab.isLoading,
       navigationHistory: tab.navigationHistory,
       active: tab.id === this.activeTabId,
     }));

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -590,15 +590,11 @@ export class WorkspaceApp {
   private registerWindowedViewListeners() {
     this.view.webContents.on("did-navigate", this.broadcastNavigationState);
     this.view.webContents.on("did-navigate-in-page", this.broadcastNavigationState);
-    this.view.webContents.on("did-start-loading", this.broadcastLoadingState);
-    this.view.webContents.on("did-stop-loading", this.broadcastLoadingState);
   }
 
   private unregisterWindowedViewListeners() {
     this.view.webContents.off("did-navigate", this.broadcastNavigationState);
     this.view.webContents.off("did-navigate-in-page", this.broadcastNavigationState);
-    this.view.webContents.off("did-start-loading", this.broadcastLoadingState);
-    this.view.webContents.off("did-stop-loading", this.broadcastLoadingState);
   }
 
   private registerWindowListeners() {
@@ -628,8 +624,6 @@ export class WorkspaceApp {
 
     this.window.webContents.once("did-finish-load", () => {
       this.broadcastNavigationState();
-
-      this.broadcastLoadingState();
 
       ipc.renderer.send(this.chromeWebContents, "workspaceApp.pageTitleChanged", this.title);
     });
@@ -731,14 +725,6 @@ export class WorkspaceApp {
 
     this.window.setTitle(`${accountLabelPrefix}${this.title} - ${app.name}`);
   }
-
-  broadcastLoadingState = () => {
-    ipc.renderer.send(
-      this.chromeWebContents,
-      "workspaceApp.loadingStateChanged",
-      this.view.webContents.isLoading(),
-    );
-  };
 
   updateViewBounds = () => {
     if (!this._window) {
@@ -876,10 +862,6 @@ export class WorkspaceApp {
 
   stop() {
     this.view.webContents.stop();
-  }
-
-  get isLoading() {
-    return this.view.webContents.isLoading();
   }
 
   get url() {

--- a/packages/renderer-main/components/app-titlebar.tsx
+++ b/packages/renderer-main/components/app-titlebar.tsx
@@ -368,19 +368,12 @@ export function AppTitlebar() {
             <TitlebarNavigationControls
               canGoBack={Boolean(activeTab?.navigationHistory.canGoBack)}
               canGoForward={Boolean(activeTab?.navigationHistory.canGoForward)}
-              isLoading={Boolean(activeTab?.loading)}
               disabled={matchUnifiedInboxRoute}
               onGoBack={() => {
                 ipc.main.send("workspaceApp.goBack");
               }}
               onGoForward={() => {
                 ipc.main.send("workspaceApp.goForward");
-              }}
-              onReload={() => {
-                ipc.main.send("workspaceApp.reload");
-              }}
-              onStop={() => {
-                ipc.main.send("workspaceApp.stop");
               }}
             />
           </TitlebarButtonGroup>

--- a/packages/renderer-workspace-app/index.tsx
+++ b/packages/renderer-workspace-app/index.tsx
@@ -42,40 +42,21 @@ function NavigationControls({ workspaceAppId }: { workspaceAppId: string }) {
     canGoBack: false,
     canGoForward: false,
   });
-  const [isLoading, setIsLoading] = useState(false);
-
   useEffect(() => {
     return ipc.renderer.on("workspaceApp.navigationStateChanged", (_event, state) => {
       setNavigationState(state);
     });
   }, []);
 
-  useEffect(() => {
-    const unsubscribe = ipc.renderer.on("workspaceApp.loadingStateChanged", (_event, loading) => {
-      setIsLoading(loading);
-    });
-
-    ipc.main.invoke("workspaceApp.getLoadingState", workspaceAppId).then(setIsLoading);
-
-    return unsubscribe;
-  }, [workspaceAppId]);
-
   return (
     <TitlebarNavigationControls
       canGoBack={navigationState.canGoBack}
       canGoForward={navigationState.canGoForward}
-      isLoading={isLoading}
       onGoBack={() => {
         ipc.main.send("workspaceApp.goBack", workspaceAppId);
       }}
       onGoForward={() => {
         ipc.main.send("workspaceApp.goForward", workspaceAppId);
-      }}
-      onReload={() => {
-        ipc.main.send("workspaceApp.reload", workspaceAppId);
-      }}
-      onStop={() => {
-        ipc.main.send("workspaceApp.stop", workspaceAppId);
       }}
     />
   );

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -11,7 +11,6 @@ export type TabState = {
   pinned: boolean;
   dormant: boolean;
   windowed: boolean;
-  loading: boolean;
   navigationHistory: { canGoBack: boolean; canGoForward: boolean };
   active: boolean;
 };

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -153,8 +153,6 @@ export type IpcMainEvents =
       "settings.toggleIsOpen": [open?: boolean];
       "workspaceApp.goBack": [workspaceAppId?: string];
       "workspaceApp.goForward": [workspaceAppId?: string];
-      "workspaceApp.reload": [workspaceAppId?: string];
-      "workspaceApp.stop": [workspaceAppId?: string];
       "gmail.unreadCountChanged": [unreadCountString: string];
       "gmail.setOutOfOffice": [outOfOffice: boolean];
       "gmail.search": [searchQuery: string];
@@ -209,7 +207,6 @@ export type IpcMainEvents =
       "app.setAsDefaultMailtoClient": () => void;
       "about.getInfo": () => { version: string; os: string; deviceId: string };
       "about.exportLogs": () => { canceled: boolean };
-      "workspaceApp.getLoadingState": (workspaceAppId?: string) => boolean;
     };
 
 export type IpcRendererEvent = {
@@ -238,6 +235,5 @@ export type IpcRendererEvent = {
   ];
   "workspaceApp.navigationStateChanged": [state: { canGoBack: boolean; canGoForward: boolean }];
   "workspaceApp.pageTitleChanged": [title: string];
-  "workspaceApp.loadingStateChanged": [loading: boolean];
   "config.configChanged": [config: Config];
 };

--- a/packages/ui/components/titlebar.tsx
+++ b/packages/ui/components/titlebar.tsx
@@ -1,6 +1,6 @@
 import { APP_TITLEBAR_HEIGHT } from "@meru/shared/constants";
-import { ArrowLeftIcon, ArrowRightIcon, LoaderCircleIcon, RotateCwIcon, XIcon } from "lucide-react";
-import { type ComponentProps, type ReactNode, useState } from "react";
+import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
+import type { ComponentProps, ReactNode } from "react";
 import { cn } from "../lib/utils";
 import { Button } from "./button";
 
@@ -52,24 +52,16 @@ export function TitlebarIconButton({ className, ...props }: ComponentProps<typeo
 export function TitlebarNavigationControls({
   canGoBack,
   canGoForward,
-  isLoading,
   disabled,
   onGoBack,
   onGoForward,
-  onReload,
-  onStop,
 }: {
   canGoBack: boolean;
   canGoForward: boolean;
-  isLoading: boolean;
   disabled?: boolean;
   onGoBack: () => void;
   onGoForward: () => void;
-  onReload: () => void;
-  onStop: () => void;
 }) {
-  const [isReloadHovered, setIsReloadHovered] = useState(false);
-
   return (
     <>
       <TitlebarIconButton title="Back" disabled={disabled || !canGoBack} onClick={onGoBack}>
@@ -81,23 +73,6 @@ export function TitlebarNavigationControls({
         onClick={onGoForward}
       >
         <ArrowRightIcon />
-      </TitlebarIconButton>
-      <TitlebarIconButton
-        title={isLoading ? "Stop" : "Reload"}
-        disabled={disabled}
-        onMouseEnter={() => setIsReloadHovered(true)}
-        onMouseLeave={() => setIsReloadHovered(false)}
-        onClick={isLoading ? onStop : onReload}
-      >
-        {isLoading ? (
-          isReloadHovered ? (
-            <XIcon />
-          ) : (
-            <LoaderCircleIcon className="animate-spin" />
-          )
-        ) : (
-          <RotateCwIcon />
-        )}
       </TitlebarIconButton>
     </>
   );


### PR DESCRIPTION
The titlebar's third navigation button doubled as reload and stop-loading — a `RotateCwIcon` that became a spinner while loading and an `XIcon` on hover to cancel. Reload is already available from the app menu (`Cmd/Ctrl+R`, plus `Hard Reload` on `Cmd/Ctrl+Shift+R`) and from the tab context menu, so the button is redundant chrome in every window. This removes it from both the main window and workspace app windows and makes the right-click menu the mouse-reachable path.

## Changes

- `TitlebarNavigationControls` keeps only Back and Forward. Its `isLoading`, `onReload`, and `onStop` props are gone, along with the hover state that swapped the spinner for the cancel icon.
- A `Reload` item is added to the page right-click menu in `setupWindowContextMenu`, above the `Copy Link` group, so it appears on Gmail views, embedded workspace app tabs, and workspace app windows alike. `Hard Reload` deliberately stays app-menu-only.
- The button was the only consumer of the loading plumbing, so the following are removed as dead code: the `workspaceApp.reload`, `workspaceApp.stop`, and `workspaceApp.getLoadingState` IPC handlers and their type entries; the `workspaceApp.loadingStateChanged` broadcast, its `did-start-loading`/`did-stop-loading` listeners on windowed views, and the renderer subscription that fed it; `WorkspaceApp.isLoading` and `Gmail.isLoading`; `Tab.isLoading` and `TabState.loading` with their serialization; and the `did-start-loading`/`did-stop-loading` tab broadcasts in `registerTabBroadcasts`, which existed only to push that flag to the strip.
- `WorkspaceApp.stop()` and `WorkspaceApp.hardReload()` are left in place — both were already unreferenced before this branch, so removing them is out of scope here.

Side effect worth naming: with the loading flag gone there is no longer any loading indication in the UI at all — no spinner in the titlebar and nothing in the tab strip (the strip never rendered one). Navigation feedback is whatever the page itself shows.

## Test plan

1. Open the main window — the titlebar shows only Back and Forward at the left of the navigation group; no reload icon, and no spinner appears while a page loads.
2. Right-click anywhere in the Gmail view — a `Reload` item appears above `Inspect Element`; click it and the view reloads.
3. Press `Cmd/Ctrl+R` in the main window — the active tab reloads. Press `Cmd/Ctrl+Shift+R` — it hard-reloads.
4. Open a workspace app in a tab, right-click its page — `Reload` appears above `Copy Link` / `Open in Default Browser`, and reloads that tab only.
5. Right-click that tab in the tab strip — the existing `Reload` item still works.
6. Open a workspace app as a separate window — its titlebar has only Back and Forward; right-click the page and reload from there; confirm `Cmd/Ctrl+R` also reloads the focused window's view and not the main window's tab.
7. Navigate back and forward in both windows — the arrows still enable and disable correctly, confirming the navigation-state broadcast survived the loading-listener removal.
8. Open the unified inbox in the main window — Back and Forward stay disabled as before.
9. With a workspace app window open, trigger a slow page load and confirm nothing in either window is stuck in a stale loading state (the state is no longer tracked at all).
