### PR TITLE
show saved searches in a dropdown like the workspace apps launcher

### DIFF
--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -5,17 +5,12 @@ import { useConfig } from "@meru/shared/renderer/react-query";
 import { bookmarkableWorkspaceApps } from "@meru/shared/workspace-apps";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
-import {
-  DropdownMenu,
-  DropdownMenuBackdrop,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@meru/ui/components/dropdown-menu";
 import { FindInPage as UiFindInPage } from "@meru/ui/components/find-in-page";
 import {
   Titlebar,
   TitlebarButtonGroup,
+  TitlebarDropdownMenu,
+  TitlebarDropdownMenuItem,
   TitlebarIconButton,
   TitlebarLeft,
   TitlebarNavigationControls,
@@ -36,7 +31,7 @@ import {
 import { useState } from "react";
 import { useRoute } from "wouter";
 import { navigate } from "wouter/use-hash-location";
-import { useCloseMenuOnWindowBlur, useIsLicenseKeyValid } from "@/lib/hooks";
+import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { getModifierOpenBehavior } from "@/lib/workspace-apps";
 import {
   useAccountsStore,
@@ -73,50 +68,37 @@ function WorkspaceAppsLauncher() {
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-  useCloseMenuOnWindowBlur(isMenuOpen, setIsMenuOpen);
-
   if (!config || !isLicenseKeyValid || config["workspaceApps.bookmarkedApps"].length === 0) {
     return;
   }
 
   return (
     <TitlebarButtonGroup>
-      <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen} orientation="horizontal">
-        <DropdownMenuTrigger
-          render={
-            <TitlebarIconButton title="Workspace Apps">
-              <LayoutGridIcon />
-            </TitlebarIconButton>
-          }
-        />
-        <DropdownMenuBackdrop className="draggable-none" />
-        <DropdownMenuContent
-          side="right"
-          align="center"
-          collisionPadding={0}
-          className="flex w-auto min-w-0 flex-row gap-1 draggable-none"
-        >
-          {config["workspaceApps.bookmarkedApps"].map((app) => (
-            <DropdownMenuItem
-              key={app}
-              className="justify-center"
-              title={bookmarkableWorkspaceApps[app]}
-              onClick={(event) => {
-                ipc.main.send("workspaceApps.openApp", app, getModifierOpenBehavior(event));
-              }}
-              onAuxClick={(event) => {
-                if (event.button === 1) {
-                  ipc.main.send("workspaceApps.openApp", app, "backgroundTab");
+      <TitlebarDropdownMenu
+        title="Workspace Apps"
+        icon={<LayoutGridIcon />}
+        isOpen={isMenuOpen}
+        onOpenChange={setIsMenuOpen}
+      >
+        {config["workspaceApps.bookmarkedApps"].map((app) => (
+          <TitlebarDropdownMenuItem
+            key={app}
+            title={bookmarkableWorkspaceApps[app]}
+            onClick={(event) => {
+              ipc.main.send("workspaceApps.openApp", app, getModifierOpenBehavior(event));
+            }}
+            onAuxClick={(event) => {
+              if (event.button === 1) {
+                ipc.main.send("workspaceApps.openApp", app, "backgroundTab");
 
-                  setIsMenuOpen(false);
-                }
-              }}
-            >
-              <WorkspaceAppIcon app={app} className="size-4" />
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuContent>
-      </DropdownMenu>
+                setIsMenuOpen(false);
+              }
+            }}
+          >
+            <WorkspaceAppIcon app={app} className="size-4" />
+          </TitlebarDropdownMenuItem>
+        ))}
+      </TitlebarDropdownMenu>
     </TitlebarButtonGroup>
   );
 }
@@ -225,8 +207,6 @@ export function AppTitlebar() {
   const { config } = useConfig();
 
   const [isGmailSavedSearchesOpen, setIsGmailSavedSearchesOpen] = useState(false);
-
-  useCloseMenuOnWindowBlur(isGmailSavedSearchesOpen, setIsGmailSavedSearchesOpen);
 
   const [isAppUpdateDetailsOpen, setIsAppUpdateDetailsOpen] = useState(false);
 
@@ -373,37 +353,24 @@ export function AppTitlebar() {
                 </Button>
               )}
               {shouldShowSavedSearchesButton && (
-                <DropdownMenu
-                  open={isGmailSavedSearchesOpen}
+                <TitlebarDropdownMenu
+                  title="Saved Searches"
+                  icon={<MailSearchIcon />}
+                  disabled={matchUnifiedInboxRoute}
+                  isOpen={isGmailSavedSearchesOpen}
                   onOpenChange={setIsGmailSavedSearchesOpen}
-                  orientation="horizontal"
                 >
-                  <DropdownMenuTrigger
-                    render={
-                      <TitlebarIconButton title="Saved Searches" disabled={matchUnifiedInboxRoute}>
-                        <MailSearchIcon />
-                      </TitlebarIconButton>
-                    }
-                  />
-                  <DropdownMenuBackdrop className="draggable-none" />
-                  <DropdownMenuContent
-                    side="right"
-                    align="center"
-                    collisionPadding={0}
-                    className="flex w-auto min-w-0 flex-row gap-1 p-0.5 draggable-none"
-                  >
-                    {config["gmail.savedSearches"].map((savedSearch) => (
-                      <DropdownMenuItem
-                        key={savedSearch.id}
-                        onClick={() => {
-                          ipc.main.send("gmail.search", savedSearch.query);
-                        }}
-                      >
-                        {savedSearch.label}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                  {config["gmail.savedSearches"].map((savedSearch) => (
+                    <TitlebarDropdownMenuItem
+                      key={savedSearch.id}
+                      onClick={() => {
+                        ipc.main.send("gmail.search", savedSearch.query);
+                      }}
+                    >
+                      {savedSearch.label}
+                    </TitlebarDropdownMenuItem>
+                  ))}
+                </TitlebarDropdownMenu>
               )}
             </TitlebarButtonGroup>
           )}

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -25,7 +25,6 @@ import { cn } from "@meru/ui/lib/utils";
 import {
   BriefcaseIcon,
   CircleAlertIcon,
-  CircleXIcon,
   DownloadIcon,
   EllipsisVerticalIcon,
   InboxIcon,
@@ -34,10 +33,10 @@ import {
   MoonIcon,
   SparklesIcon,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useRoute } from "wouter";
 import { navigate } from "wouter/use-hash-location";
-import { useIsLicenseKeyValid } from "@/lib/hooks";
+import { useCloseMenuOnWindowBlur, useIsLicenseKeyValid } from "@/lib/hooks";
 import { getModifierOpenBehavior } from "@/lib/workspace-apps";
 import {
   useAccountsStore,
@@ -74,21 +73,7 @@ function WorkspaceAppsLauncher() {
 
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-  useEffect(() => {
-    if (!isMenuOpen) {
-      return;
-    }
-
-    const handleWindowBlur = () => {
-      setIsMenuOpen(false);
-    };
-
-    window.addEventListener("blur", handleWindowBlur);
-
-    return () => {
-      window.removeEventListener("blur", handleWindowBlur);
-    };
-  }, [isMenuOpen]);
+  useCloseMenuOnWindowBlur(isMenuOpen, setIsMenuOpen);
 
   if (!config || !isLicenseKeyValid || config["workspaceApps.bookmarkedApps"].length === 0) {
     return;
@@ -241,6 +226,8 @@ export function AppTitlebar() {
 
   const [isGmailSavedSearchesOpen, setIsGmailSavedSearchesOpen] = useState(false);
 
+  useCloseMenuOnWindowBlur(isGmailSavedSearchesOpen, setIsGmailSavedSearchesOpen);
+
   const [isAppUpdateDetailsOpen, setIsAppUpdateDetailsOpen] = useState(false);
 
   const isLicenseKeyValid = useIsLicenseKeyValid();
@@ -262,22 +249,6 @@ export function AppTitlebar() {
     isLicenseKeyValid;
 
   const renderAccounts = () => {
-    if (isGmailSavedSearchesOpen) {
-      return config["gmail.savedSearches"].map((savedSearch) => (
-        <Button
-          key={savedSearch.id}
-          variant="outline"
-          size="sm"
-          className="draggable-none"
-          onClick={() => {
-            ipc.main.send("gmail.search", savedSearch.query);
-          }}
-        >
-          {savedSearch.label}
-        </Button>
-      ));
-    }
-
     if (accounts.length === 1) {
       return;
     }
@@ -395,8 +366,6 @@ export function AppTitlebar() {
                     navigate("/main/unified-inbox");
 
                     ipc.main.send("settings.toggleIsOpen", true);
-
-                    setIsGmailSavedSearchesOpen(false);
                   }}
                   title="Unified Inbox"
                 >
@@ -404,18 +373,37 @@ export function AppTitlebar() {
                 </Button>
               )}
               {shouldShowSavedSearchesButton && (
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  className="draggable-none"
-                  onClick={() => {
-                    setIsGmailSavedSearchesOpen((isOpen) => !isOpen);
-                  }}
-                  title="Saved Searches"
-                  disabled={matchUnifiedInboxRoute}
+                <DropdownMenu
+                  open={isGmailSavedSearchesOpen}
+                  onOpenChange={setIsGmailSavedSearchesOpen}
+                  orientation="horizontal"
                 >
-                  {isGmailSavedSearchesOpen ? <CircleXIcon /> : <MailSearchIcon />}
-                </Button>
+                  <DropdownMenuTrigger
+                    render={
+                      <TitlebarIconButton title="Saved Searches" disabled={matchUnifiedInboxRoute}>
+                        <MailSearchIcon />
+                      </TitlebarIconButton>
+                    }
+                  />
+                  <DropdownMenuBackdrop className="draggable-none" />
+                  <DropdownMenuContent
+                    side="right"
+                    align="center"
+                    collisionPadding={0}
+                    className="flex w-auto min-w-0 flex-row gap-1 draggable-none"
+                  >
+                    {config["gmail.savedSearches"].map((savedSearch) => (
+                      <DropdownMenuItem
+                        key={savedSearch.id}
+                        onClick={() => {
+                          ipc.main.send("gmail.search", savedSearch.query);
+                        }}
+                      >
+                        {savedSearch.label}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
               )}
             </TitlebarButtonGroup>
           )}

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -390,7 +390,7 @@ export function AppTitlebar() {
                     side="right"
                     align="center"
                     collisionPadding={0}
-                    className="flex w-auto min-w-0 flex-row gap-1 draggable-none"
+                    className="flex w-auto min-w-0 flex-row gap-1 p-0.5 draggable-none"
                   >
                     {config["gmail.savedSearches"].map((savedSearch) => (
                       <DropdownMenuItem

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -2,7 +2,7 @@ import type { GmailInboxMessage } from "@meru/shared/gmail";
 import { ipc } from "@meru/shared/renderer/ipc";
 import { useConfig } from "@meru/shared/renderer/react-query";
 import type { AccountConfig } from "@meru/shared/schemas";
-import { useEffect } from "react";
+import { type Dispatch, type SetStateAction, useEffect } from "react";
 import { useAccountsStore, useTrialStore } from "./stores";
 
 export function useMouseAccountSwitching() {
@@ -21,6 +21,27 @@ export function useMouseAccountSwitching() {
       document.removeEventListener("mousedown", handleMouseBackAndForward);
     };
   }, []);
+}
+
+export function useCloseMenuOnWindowBlur(
+  isMenuOpen: boolean,
+  setIsMenuOpen: Dispatch<SetStateAction<boolean>>,
+) {
+  useEffect(() => {
+    if (!isMenuOpen) {
+      return;
+    }
+
+    const handleWindowBlur = () => {
+      setIsMenuOpen(false);
+    };
+
+    window.addEventListener("blur", handleWindowBlur);
+
+    return () => {
+      window.removeEventListener("blur", handleWindowBlur);
+    };
+  }, [isMenuOpen, setIsMenuOpen]);
 }
 
 export function useIsLicenseKeyValid() {

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -2,7 +2,7 @@ import type { GmailInboxMessage } from "@meru/shared/gmail";
 import { ipc } from "@meru/shared/renderer/ipc";
 import { useConfig } from "@meru/shared/renderer/react-query";
 import type { AccountConfig } from "@meru/shared/schemas";
-import { type Dispatch, type SetStateAction, useEffect } from "react";
+import { useEffect } from "react";
 import { useAccountsStore, useTrialStore } from "./stores";
 
 export function useMouseAccountSwitching() {
@@ -21,27 +21,6 @@ export function useMouseAccountSwitching() {
       document.removeEventListener("mousedown", handleMouseBackAndForward);
     };
   }, []);
-}
-
-export function useCloseMenuOnWindowBlur(
-  isMenuOpen: boolean,
-  setIsMenuOpen: Dispatch<SetStateAction<boolean>>,
-) {
-  useEffect(() => {
-    if (!isMenuOpen) {
-      return;
-    }
-
-    const handleWindowBlur = () => {
-      setIsMenuOpen(false);
-    };
-
-    window.addEventListener("blur", handleWindowBlur);
-
-    return () => {
-      window.removeEventListener("blur", handleWindowBlur);
-    };
-  }, [isMenuOpen, setIsMenuOpen]);
 }
 
 export function useIsLicenseKeyValid() {

--- a/packages/ui/components/titlebar.tsx
+++ b/packages/ui/components/titlebar.tsx
@@ -1,8 +1,15 @@
 import { APP_TITLEBAR_HEIGHT } from "@meru/shared/constants";
 import { ArrowLeftIcon, ArrowRightIcon, LoaderCircleIcon, RotateCwIcon, XIcon } from "lucide-react";
-import { type ComponentProps, type ReactNode, useState } from "react";
+import { type ComponentProps, type ReactNode, useEffect, useState } from "react";
 import { cn } from "../lib/utils";
 import { Button } from "./button";
+import {
+  DropdownMenu,
+  DropdownMenuBackdrop,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./dropdown-menu";
 
 export function Titlebar({ children }: { children: ReactNode }) {
   return (
@@ -47,6 +54,66 @@ export function TitlebarIconButton({ className, ...props }: ComponentProps<typeo
   return (
     <Button variant="ghost" size="icon-sm" className={cn("draggable-none", className)} {...props} />
   );
+}
+
+export function TitlebarDropdownMenu({
+  title,
+  icon,
+  disabled,
+  isOpen,
+  onOpenChange,
+  children,
+}: {
+  title: string;
+  icon: ReactNode;
+  disabled?: boolean;
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  children: ReactNode;
+}) {
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleWindowBlur = () => {
+      onOpenChange(false);
+    };
+
+    window.addEventListener("blur", handleWindowBlur);
+
+    return () => {
+      window.removeEventListener("blur", handleWindowBlur);
+    };
+  }, [isOpen, onOpenChange]);
+
+  return (
+    <DropdownMenu open={isOpen} onOpenChange={onOpenChange} orientation="horizontal">
+      <DropdownMenuTrigger
+        render={
+          <TitlebarIconButton title={title} disabled={disabled}>
+            {icon}
+          </TitlebarIconButton>
+        }
+      />
+      <DropdownMenuBackdrop className="draggable-none" />
+      <DropdownMenuContent
+        side="right"
+        align="center"
+        collisionPadding={0}
+        className="flex w-auto min-w-0 flex-row gap-1 p-0.5 draggable-none"
+      >
+        {children}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export function TitlebarDropdownMenuItem({
+  className,
+  ...props
+}: ComponentProps<typeof DropdownMenuItem>) {
+  return <DropdownMenuItem className={cn("h-7 justify-center", className)} {...props} />;
 }
 
 export function TitlebarNavigationControls({


### PR DESCRIPTION
The titlebar had two different interaction models for the same kind of thing. The workspace apps launcher opens a horizontal dropdown next to its button, while Saved Searches was a toggle that swapped the entire account button row out for a row of saved-search buttons — hiding the accounts, turning its own icon into an X, and needing to be reset whenever the Unified Inbox was opened.

## Changes

- New shared `TitlebarDropdownMenu` + `TitlebarDropdownMenuItem` in `packages/ui/components/titlebar.tsx`. The menu owns the whole recipe — `orientation="horizontal"`, `side="right"`, `align="center"`, `collisionPadding={0}`, the `draggable-none` backdrop, the horizontal-row content, and the close-on-window-blur effect — and takes `title`, `icon`, `disabled`, `isOpen`/`onOpenChange`, and children. Call sites keep only their own open state and their items.
- Both the workspace apps launcher and Saved Searches now render through it, so they are literally the same dropdown.
- Content padding is `p-0.5` (2px) instead of the primitive's `p-1` (4px), and items are fixed at `h-7` (28px), matching the `icon-sm` trigger button. Both popups are 32px tall regardless of whether the items are icons or text — previously the launcher's `size-4` icons made 24px rows and the saved-search `text-sm` labels made 28px ones.
- Removed the account-replacing branch in `renderAccounts`, the `CircleXIcon` toggle state on the Saved Searches trigger, and the `setIsGmailSavedSearchesOpen(false)` call in the Unified Inbox handler, which no longer has anything to reset. The Saved Searches trigger is still disabled on the Unified Inbox route.

Account buttons now stay visible while saved searches are open, which is the main behavioral difference from before. The launcher's total popup height is unchanged (32px); its individual rows are 4px taller.

## Risks / not verified

Saved-search labels are user-defined, so unlike the launcher's fixed-size icons the horizontal popup can grow wide with several long labels. It is only constrained by `collisionPadding={0}`, so a long list clamps at the viewport edge rather than wrapping or scrolling. Not verified in the running app — this is the thing worth eyeballing during review.

`TitlebarDropdownMenu` is intentionally the only consumer of the blur-close effect, so the effect lives inline in the component rather than as a hook in `packages/renderer/lib/hooks.ts`.

## Test plan

1. With a valid license and at least two saved searches configured, click the Saved Searches (magnifier) button in the titlebar — a horizontal dropdown opens to the right of the button, centered on it.
2. Open the workspace apps launcher and then the Saved Searches menu — both popups are the same height (32px) with the same padding, and each row is the same height as the titlebar button that opened it.
3. Click a saved search — Gmail runs that query and the menu closes.
4. While the menu is open, confirm the account buttons remain visible in the titlebar (previously they were replaced).
5. With either menu open, click another application to blur the Meru window — the menu closes rather than staying open over the Gmail view.
6. With either menu open, click into the Gmail view — the backdrop dismisses the menu and the click does not fall through to the drag region.
7. In the launcher, middle-click an app — it opens in a background tab and the menu closes. Cmd/Ctrl- and Shift-click still follow the modifier open behavior.
8. Open the Unified Inbox (requires >1 account with unified inbox enabled) — the Saved Searches button is disabled and cannot be opened, while the launcher still opens.
9. Remove all saved searches in Settings — the Saved Searches button disappears from the titlebar. Remove all bookmarked apps — the launcher disappears.
10. Without a license key, confirm neither the Saved Searches button nor the launcher is rendered.
11. With a single account configured, confirm the titlebar renders correctly with no account buttons and both dropdowns still work.
12. Add a saved search with a long label (~40 chars) plus a few short ones and open the menu — check the popup stays within the window and remains usable.
