### PR TITLE
fix crash in renderers loaded without the accounts search param

### DIFF
--- a/packages/renderer/lib/stores.ts
+++ b/packages/renderer/lib/stores.ts
@@ -11,19 +11,13 @@ export const useAccountsStore = create<{
   accounts: AccountInstances;
   isAddAccountDialogOpen: boolean;
   setIsAddAccountDialogOpen: (isOpen: boolean) => void;
-}>((set) => {
-  if (!accountsSearchParam) {
-    throw new Error("No accounts found in search params");
-  }
-
-  return {
-    accounts: JSON.parse(accountsSearchParam),
-    isAddAccountDialogOpen: false,
-    setIsAddAccountDialogOpen: (isOpen) => {
-      set({ isAddAccountDialogOpen: isOpen });
-    },
-  };
-});
+}>((set) => ({
+  accounts: accountsSearchParam ? JSON.parse(accountsSearchParam) : [],
+  isAddAccountDialogOpen: false,
+  setIsAddAccountDialogOpen: (isOpen) => {
+    set({ isAddAccountDialogOpen: isOpen });
+  },
+}));
 
 ipc.renderer.on("accounts.changed", (_event, accounts) => {
   useAccountsStore.setState({ accounts });


### PR DESCRIPTION
## Problem

Opening the recent download history popup throws at module load:

```
Uncaught Error: No accounts found in search params
    at stores.ts:16:11
```

The workspace app titlebar fails the same way.

Since `combine all renderers into one vite server` (6de7435), every renderer surface — main window, popups (recent download history, desktop sources), download history window, workspace app titlebar — shares the same entry (`packages/renderer/app.tsx`). That entry statically imports `AppTitlebar`/`AppTabStrip`/`AppMain`/`lib/hooks`, which pull in `lib/stores.ts`, so the `useAccountsStore` initializer runs regardless of route. Only the main window is loaded with an `accounts` search param (`packages/app/main.ts`), so every other surface hit the `throw` and rendered nothing.

## Changes

`useAccountsStore` now falls back to an empty account list when the `accounts` search param is absent instead of throwing. This matches how `useTrialStore` already tolerates a missing `trialDaysLeft` param. Only surfaces that render account UI read the store, and those are exclusively main-window routes, which always get the param.

## Notes

- No route-level code splitting was added — the store no longer throwing is enough to unblock all surfaces, and lazy-loading the main-window subtree is a bigger change than this fix warrants.
- `useMouseAccountSwitching()` still runs in popup renderers (unchanged, pre-existing behavior); it only forwards mouse buttons 3/4 to the main process.

## Test plan

1. Open the main window with multiple accounts configured — the tab strip, sidebar, and titlebar still list all accounts and account switching works.
2. Click the download icon in the main window titlebar — the recent download history popup opens with no console error and lists recent downloads (or the "No downloads yet" empty state on a fresh profile).
3. Open a workspace app (e.g. Calendar) — its titlebar renders with navigation controls, page title, and the download button, no console error.
4. With more than one account, confirm the workspace app titlebar still shows the account badge for the owning account.
5. Open the full download history window from the popup footer — it renders normally.
6. Start a screen share to trigger the desktop sources popup — it renders and lists sources.