### PR TITLE
move vertical tabs width setting to appearance and rename tab strip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ This installs dependencies and runs postinstall scripts (including the lefthook 
 - Never repeat shared classes across the branches of a conditional `className`. Hoist them and merge with the `cn` helper (`@meru/ui/lib/utils`): `cn("absolute hidden", isWide ? "size-5" : "size-4")`.
 - Consider the platform when showing platform-specific information (modifier keys, OS names): branch on the existing `platform` helper — `@meru/shared/renderer/utils` in renderers, `@electron-toolkit/utils` in the main process — e.g. `platform.isMacOS ? "Cmd" : "Ctrl"`.
 - Render keyboard keys in user-facing text with the `Kbd` component (`@meru/ui/components/kbd`), not as plain text: `Hold <Kbd>Shift</Kbd> to …`.
-- Child `WebContentsView`s always paint above the main window's HTML, so renderer-drawn overlays (dropdowns, tooltips, dialogs) get covered wherever a view sits. Keep overlays inside the regions the renderer owns (titlebar, tab strip) — e.g. tab strip menus open with `side="top"` at anchor width. For overlays over view content, use a native `Menu.popup` or a dedicated `WebContentsView` (see the recent-downloads popup).
+- Child `WebContentsView`s always paint above the main window's HTML, so renderer-drawn overlays (dropdowns, tooltips, dialogs) get covered wherever a view sits. Keep overlays inside the regions the renderer owns (titlebar, vertical tabs) — e.g. vertical tabs menus open with `side="top"` at anchor width. For overlays over view content, use a native `Menu.popup` or a dedicated `WebContentsView` (see the recent-downloads popup).
 
 ## React State
 

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { platform } from "@electron-toolkit/utils";
 import type { AccountConfig } from "@meru/shared/schemas";
-import { getTabStripWidth } from "@meru/shared/tabs";
+import { getVerticalTabsWidth } from "@meru/shared/tabs";
 import { Account } from "./account";
 import { config } from "./config";
 import { ipc } from "./ipc";
@@ -103,8 +103,8 @@ class Accounts {
     });
   }
 
-  getTabStripWidth() {
-    return getTabStripWidth(
+  getVerticalTabsWidth() {
+    return getVerticalTabsWidth(
       this.getSelectedAccount().instance.tabs.serialize(),
       config.get("verticalTabs.width"),
     );

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -45,7 +45,7 @@ class Accounts {
       }
     });
 
-    config.onDidChange("workspaceApps.tabStripWidth", () => {
+    config.onDidChange("verticalTabs.width", () => {
       accounts.updateAllViewBounds();
     });
 
@@ -106,7 +106,7 @@ class Accounts {
   getTabStripWidth() {
     return getTabStripWidth(
       this.getSelectedAccount().instance.tabs.serialize(),
-      config.get("workspaceApps.tabStripWidth"),
+      config.get("verticalTabs.width"),
     );
   }
 

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -94,7 +94,6 @@ export const config = new Store<Config>({
     "workspaceApps.openInApp": true,
     "workspaceApps.openInAppExcludedApps": [],
     "workspaceApps.openBehavior": "tab",
-    "workspaceApps.tabStripWidth": "auto",
     "workspaceApps.bookmarkedApps": [],
     "workspaceApps.showAccountColor": true,
     "workspaceApps.showAccountLabel": true,
@@ -111,6 +110,7 @@ export const config = new Store<Config>({
     "unifiedInbox.showSenderIcons": true,
     "unifiedInbox.rowsPerPage": 10,
     "spellchecker.languages": [],
+    "verticalTabs.width": "auto",
   },
   migrations: {
     ">=3.4.0": (store) => {

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -471,12 +471,12 @@ export class Gmail {
   updateViewBounds() {
     const { width, height } = main.getWindowBounds();
 
-    const tabStripWidth = accounts.getTabStripWidth();
+    const verticalTabsWidth = accounts.getVerticalTabsWidth();
 
     this.view.setBounds({
-      x: tabStripWidth,
+      x: verticalTabsWidth,
       y: APP_TITLEBAR_HEIGHT,
-      width: width - tabStripWidth,
+      width: width - verticalTabsWidth,
       height: height - APP_TITLEBAR_HEIGHT,
     });
   }

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -496,7 +496,7 @@ class Ipc {
       ]).popup();
     });
 
-    ipc.main.on("tabs.showTabStripContextMenu", (_event, accountId) => {
+    ipc.main.on("tabs.showVerticalTabsContextMenu", (_event, accountId) => {
       const account = accounts.getAccount(accountId);
 
       Menu.buildFromTemplate([

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -743,12 +743,12 @@ export class WorkspaceApp {
     if (!this._window) {
       const { width, height } = main.getWindowBounds();
 
-      const tabStripWidth = accounts.getTabStripWidth();
+      const verticalTabsWidth = accounts.getVerticalTabsWidth();
 
       this.view.setBounds({
-        x: tabStripWidth,
+        x: verticalTabsWidth,
         y: APP_TITLEBAR_HEIGHT,
-        width: width - tabStripWidth,
+        width: width - verticalTabsWidth,
         height: height - APP_TITLEBAR_HEIGHT,
       });
 

--- a/packages/renderer/app.tsx
+++ b/packages/renderer/app.tsx
@@ -7,7 +7,7 @@ import { AppMain } from "@/components/app-main";
 import { AppTitlebar } from "@/components/app-titlebar";
 import { WorkspaceApp } from "@/routes/workspace-app";
 import { AppSidebar } from "./components/app-sidebar";
-import { AppTabStrip } from "./components/app-tab-strip";
+import { VerticalTabs } from "./components/vertical-tabs";
 import { useMouseAccountSwitching } from "./lib/hooks";
 import { DesktopSources } from "./routes/desktop-sources";
 import { RecentDownloadHistory } from "./routes/recent-download-history";
@@ -56,7 +56,7 @@ export function App() {
           <div className="flex h-screen flex-col">
             <AppTitlebar />
             <div className="flex flex-1 overflow-hidden">
-              <AppTabStrip />
+              <VerticalTabs />
               <AppSidebar />
               <AppMain />
             </div>

--- a/packages/renderer/components/app-tab-strip.tsx
+++ b/packages/renderer/components/app-tab-strip.tsx
@@ -238,7 +238,7 @@ export function AppTabStrip() {
   );
 
   const tabStripWidth = selectedAccountTabs
-    ? getTabStripWidth(selectedAccountTabs.tabs, config?.["workspaceApps.tabStripWidth"] ?? "auto")
+    ? getTabStripWidth(selectedAccountTabs.tabs, config?.["verticalTabs.width"] ?? "auto")
     : 0;
 
   if (isSettingsOpen || !selectedAccount || !selectedAccountTabs || tabStripWidth === 0) {

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -2,11 +2,11 @@ import { Accessibility, defaultPreset, PointerActivationConstraints } from "@dnd
 import { move } from "@dnd-kit/helpers";
 import { type DragEndEvent, DragDropProvider, PointerSensor } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
-import { APP_TAB_STRIP_WIDE_WIDTH } from "@meru/shared/constants";
+import { VERTICAL_TABS_WIDE_WIDTH } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
 import { useConfig } from "@meru/shared/renderer/react-query";
 import type { AccountConfig } from "@meru/shared/schemas";
-import { GMAIL_TAB_ID, getTabStripWidth, type TabState } from "@meru/shared/tabs";
+import { GMAIL_TAB_ID, getVerticalTabsWidth, type TabState } from "@meru/shared/tabs";
 import { workspaceApps } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import { UnreadCountBadge } from "@meru/ui/components/unread-count-badge";
@@ -17,9 +17,9 @@ import type { Ref } from "react";
 import { getModifierOpenBehavior } from "@/lib/workspace-apps";
 import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
 
-const tabStripPlugins = defaultPreset.plugins.filter((plugin) => plugin !== Accessibility);
+const verticalTabsPlugins = defaultPreset.plugins.filter((plugin) => plugin !== Accessibility);
 
-const tabStripSensors = [
+const verticalTabsSensors = [
   PointerSensor.configure({
     activationConstraints: [new PointerActivationConstraints.Distance({ value: 5 })],
     preventActivation: (event) =>
@@ -98,7 +98,7 @@ function GmailTabStatusBadge({ attentionRequired, unreadCount }: GmailTabStatus)
   );
 }
 
-function StripTab({
+function VerticalTab({
   ref,
   tab,
   accountId,
@@ -191,7 +191,7 @@ function StripTab({
   );
 }
 
-function SortableStripTab({
+function SortableVerticalTab({
   tab,
   accountId,
   presentation,
@@ -213,7 +213,7 @@ function SortableStripTab({
   });
 
   return (
-    <StripTab
+    <VerticalTab
       ref={ref}
       tab={tab}
       accountId={accountId}
@@ -224,7 +224,7 @@ function SortableStripTab({
   );
 }
 
-export function AppTabStrip() {
+export function VerticalTabs() {
   const accounts = useAccountsStore((state) => state.accounts);
   const accountsTabs = useTabsStore((state) => state.accountsTabs);
   const isSettingsOpen = useSettingsStore((state) => state.isOpen);
@@ -237,15 +237,15 @@ export function AppTabStrip() {
     (accountTabs) => accountTabs.accountId === selectedAccount?.config.id,
   );
 
-  const tabStripWidth = selectedAccountTabs
-    ? getTabStripWidth(selectedAccountTabs.tabs, config?.["verticalTabs.width"] ?? "auto")
+  const verticalTabsWidth = selectedAccountTabs
+    ? getVerticalTabsWidth(selectedAccountTabs.tabs, config?.["verticalTabs.width"] ?? "auto")
     : 0;
 
-  if (isSettingsOpen || !selectedAccount || !selectedAccountTabs || tabStripWidth === 0) {
+  if (isSettingsOpen || !selectedAccount || !selectedAccountTabs || verticalTabsWidth === 0) {
     return;
   }
 
-  const isWide = tabStripWidth === APP_TAB_STRIP_WIDE_WIDTH;
+  const isWide = verticalTabsWidth === VERTICAL_TABS_WIDE_WIDTH;
 
   const pinnedSectionTabs = selectedAccountTabs.tabs.filter(
     (tab) => tab.id === GMAIL_TAB_ID || tab.pinned,
@@ -263,7 +263,7 @@ export function AppTabStrip() {
   return (
     <div
       className={cn("flex flex-col border-r", isWide ? "gap-1 p-2" : "items-center gap-2 py-2")}
-      style={{ width: tabStripWidth, minWidth: tabStripWidth }}
+      style={{ width: verticalTabsWidth, minWidth: verticalTabsWidth }}
       onContextMenu={(event) => {
         if (event.defaultPrevented) {
           return;
@@ -271,12 +271,12 @@ export function AppTabStrip() {
 
         event.preventDefault();
 
-        ipc.main.send("tabs.showTabStripContextMenu", selectedAccount.config.id);
+        ipc.main.send("tabs.showVerticalTabsContextMenu", selectedAccount.config.id);
       }}
     >
       <DragDropProvider
-        plugins={tabStripPlugins}
-        sensors={tabStripSensors}
+        plugins={verticalTabsPlugins}
+        sensors={verticalTabsSensors}
         onDragEnd={(event) => {
           moveSectionTab(selectedAccount.config.id, pinnedSectionTabs, event);
         }}
@@ -284,7 +284,7 @@ export function AppTabStrip() {
         {isWide ? (
           <div className="mb-1 grid w-full grid-cols-2 gap-2">
             {pinnedSectionTabs.map((tab, pinnedSectionTabIndex) => (
-              <SortableStripTab
+              <SortableVerticalTab
                 key={tab.id}
                 tab={tab}
                 accountId={selectedAccount.config.id}
@@ -299,7 +299,7 @@ export function AppTabStrip() {
           </div>
         ) : (
           pinnedSectionTabs.map((tab, pinnedSectionTabIndex) => (
-            <SortableStripTab
+            <SortableVerticalTab
               key={tab.id}
               tab={tab}
               accountId={selectedAccount.config.id}
@@ -311,14 +311,14 @@ export function AppTabStrip() {
         )}
       </DragDropProvider>
       <DragDropProvider
-        plugins={tabStripPlugins}
-        sensors={tabStripSensors}
+        plugins={verticalTabsPlugins}
+        sensors={verticalTabsSensors}
         onDragEnd={(event) => {
           moveSectionTab(selectedAccount.config.id, unpinnedTabs, event);
         }}
       >
         {unpinnedTabs.map((tab, unpinnedTabIndex) => (
-          <SortableStripTab
+          <SortableVerticalTab
             key={tab.id}
             tab={tab}
             accountId={selectedAccount.config.id}

--- a/packages/renderer/routes/settings/appearance.tsx
+++ b/packages/renderer/routes/settings/appearance.tsx
@@ -1,6 +1,7 @@
 import { ipc } from "@meru/shared/renderer/ipc";
 import { useConfig } from "@meru/shared/renderer/react-query";
 import { platform } from "@meru/shared/renderer/utils";
+import { tabStripWidths } from "@meru/shared/tabs";
 import {
   Field,
   FieldContent,
@@ -166,6 +167,21 @@ export function AppearanceSettings() {
               description="Hide all unread badges if disabled regardless of individual account settings."
               configKey="accounts.unreadBadge"
               restartRequired
+            />
+          </FieldSet>
+          <FieldSeparator />
+          <FieldSet>
+            <FieldLegend>Vertical Tabs</FieldLegend>
+            <ConfigSelectField
+              label="Width"
+              description="How wide the vertical tabs sidebar is. Auto switches between narrow and wide automatically based on the open tabs."
+              configKey="verticalTabs.width"
+              placeholder="Select width"
+              licenseKeyRequired
+              items={Object.entries(tabStripWidths).map(([value, label]) => ({
+                value,
+                label,
+              }))}
             />
           </FieldSet>
           <FieldSeparator />

--- a/packages/renderer/routes/settings/appearance.tsx
+++ b/packages/renderer/routes/settings/appearance.tsx
@@ -1,7 +1,7 @@
 import { ipc } from "@meru/shared/renderer/ipc";
 import { useConfig } from "@meru/shared/renderer/react-query";
 import { platform } from "@meru/shared/renderer/utils";
-import { tabStripWidths } from "@meru/shared/tabs";
+import { verticalTabsWidths } from "@meru/shared/tabs";
 import {
   Field,
   FieldContent,
@@ -178,7 +178,7 @@ export function AppearanceSettings() {
               configKey="verticalTabs.width"
               placeholder="Select width"
               licenseKeyRequired
-              items={Object.entries(tabStripWidths).map(([value, label]) => ({
+              items={Object.entries(verticalTabsWidths).map(([value, label]) => ({
                 value,
                 label,
               }))}

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -9,7 +9,6 @@ import {
   type SupportedWorkspaceApp,
   workspaceAppOpenBehaviors,
   workspaceApps,
-  workspaceAppTabStripWidths,
 } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import { ButtonGroup } from "@meru/ui/components/button-group";
@@ -213,17 +212,6 @@ export function WorkspaceAppsSettings() {
             licenseKeyRequired
           />
           <FieldSeparator />
-          <ConfigSelectField
-            label="Tab Strip Width"
-            description="How wide the tab strip is. Auto switches between narrow and wide automatically based on the open tabs."
-            configKey="workspaceApps.tabStripWidth"
-            placeholder="Select width"
-            licenseKeyRequired
-            items={Object.entries(workspaceAppTabStripWidths).map(([value, label]) => ({
-              value,
-              label,
-            }))}
-          />
           <Field>
             <FieldContent>
               <FieldLabel className="flex items-center gap-2">
@@ -231,7 +219,7 @@ export function WorkspaceAppsSettings() {
                 {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
               </FieldLabel>
               <FieldDescription>
-                Bookmark Workspace Apps to open them from the tab strip's Workspace Apps menu and
+                Bookmark Workspace Apps to open them from the vertical tabs' Workspace Apps menu and
                 drag to reorder.
               </FieldDescription>
             </FieldContent>

--- a/packages/shared/constants.ts
+++ b/packages/shared/constants.ts
@@ -4,9 +4,9 @@ export const BASE_SPACING = 8;
 
 export const APP_TITLEBAR_HEIGHT = BASE_SPACING * 5;
 
-export const APP_TAB_STRIP_NARROW_WIDTH = BASE_SPACING * 8;
+export const VERTICAL_TABS_NARROW_WIDTH = BASE_SPACING * 8;
 
-export const APP_TAB_STRIP_WIDE_WIDTH = BASE_SPACING * 28;
+export const VERTICAL_TABS_WIDE_WIDTH = BASE_SPACING * 28;
 
 export const GOOGLE_ACCOUNTS_URL = "https://accounts.google.com";
 

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -1,8 +1,16 @@
 import { APP_TAB_STRIP_NARROW_WIDTH, APP_TAB_STRIP_WIDE_WIDTH } from "./constants";
 import type { AccountConfig } from "./schemas";
-import type { SupportedWorkspaceApp, WorkspaceAppTabStripWidth } from "./workspace-apps";
+import type { SupportedWorkspaceApp } from "./workspace-apps";
 
 export const GMAIL_TAB_ID = "gmail";
+
+export const tabStripWidths = {
+  auto: "Auto",
+  narrow: "Narrow",
+  wide: "Wide",
+} as const;
+
+export type TabStripWidth = keyof typeof tabStripWidths;
 
 export type TabState = {
   id: string;
@@ -23,7 +31,7 @@ export type AccountTabsState = {
 
 export function getTabStripWidth(
   tabs: Pick<TabState, "app" | "pinned">[],
-  configuredTabStripWidth: WorkspaceAppTabStripWidth,
+  configuredTabStripWidth: TabStripWidth,
 ) {
   if (tabs.length <= 1) {
     return 0;

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -1,16 +1,16 @@
-import { APP_TAB_STRIP_NARROW_WIDTH, APP_TAB_STRIP_WIDE_WIDTH } from "./constants";
+import { VERTICAL_TABS_NARROW_WIDTH, VERTICAL_TABS_WIDE_WIDTH } from "./constants";
 import type { AccountConfig } from "./schemas";
 import type { SupportedWorkspaceApp } from "./workspace-apps";
 
 export const GMAIL_TAB_ID = "gmail";
 
-export const tabStripWidths = {
+export const verticalTabsWidths = {
   auto: "Auto",
   narrow: "Narrow",
   wide: "Wide",
 } as const;
 
-export type TabStripWidth = keyof typeof tabStripWidths;
+export type VerticalTabsWidth = keyof typeof verticalTabsWidths;
 
 export type TabState = {
   id: string;
@@ -29,20 +29,20 @@ export type AccountTabsState = {
   tabs: TabState[];
 };
 
-export function getTabStripWidth(
+export function getVerticalTabsWidth(
   tabs: Pick<TabState, "app" | "pinned">[],
-  configuredTabStripWidth: TabStripWidth,
+  configuredVerticalTabsWidth: VerticalTabsWidth,
 ) {
   if (tabs.length <= 1) {
     return 0;
   }
 
-  if (configuredTabStripWidth === "narrow") {
-    return APP_TAB_STRIP_NARROW_WIDTH;
+  if (configuredVerticalTabsWidth === "narrow") {
+    return VERTICAL_TABS_NARROW_WIDTH;
   }
 
-  if (configuredTabStripWidth === "wide") {
-    return APP_TAB_STRIP_WIDE_WIDTH;
+  if (configuredVerticalTabsWidth === "wide") {
+    return VERTICAL_TABS_WIDE_WIDTH;
   }
 
   const workspaceAppTabCounts = new Map<SupportedWorkspaceApp, number>();
@@ -57,5 +57,5 @@ export function getTabStripWidth(
     (workspaceAppTabCount) => workspaceAppTabCount > 1,
   );
 
-  return hasWorkspaceAppWithMultipleTabs ? APP_TAB_STRIP_WIDE_WIDTH : APP_TAB_STRIP_NARROW_WIDTH;
+  return hasWorkspaceAppWithMultipleTabs ? VERTICAL_TABS_WIDE_WIDTH : VERTICAL_TABS_NARROW_WIDTH;
 }

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -9,12 +9,11 @@ import type {
   GmailLabelColors,
   GmailSavedSearches,
 } from "./schemas";
-import type { AccountTabsState } from "./tabs";
+import type { AccountTabsState, TabStripWidth } from "./tabs";
 import type {
   BookmarkableWorkspaceApp,
   SupportedWorkspaceApp,
   WorkspaceAppOpenBehavior,
-  WorkspaceAppTabStripWidth,
 } from "./workspace-apps";
 
 export type DesktopSource = { id: string; name: string; thumbnail: string };
@@ -123,7 +122,6 @@ export type Config = {
   "workspaceApps.openInApp": boolean;
   "workspaceApps.openInAppExcludedApps": SupportedWorkspaceApp[];
   "workspaceApps.openBehavior": WorkspaceAppOpenBehavior;
-  "workspaceApps.tabStripWidth": WorkspaceAppTabStripWidth;
   "workspaceApps.bookmarkedApps": BookmarkableWorkspaceApp[];
   "workspaceApps.showAccountColor": boolean;
   "workspaceApps.showAccountLabel": boolean;
@@ -140,6 +138,7 @@ export type Config = {
   "unifiedInbox.showSenderIcons": boolean;
   "unifiedInbox.rowsPerPage": number;
   "spellchecker.languages": string[];
+  "verticalTabs.width": TabStripWidth;
 };
 
 export type IpcMainEvents =

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -9,7 +9,7 @@ import type {
   GmailLabelColors,
   GmailSavedSearches,
 } from "./schemas";
-import type { AccountTabsState, TabStripWidth } from "./tabs";
+import type { AccountTabsState, VerticalTabsWidth } from "./tabs";
 import type {
   BookmarkableWorkspaceApp,
   SupportedWorkspaceApp,
@@ -138,7 +138,7 @@ export type Config = {
   "unifiedInbox.showSenderIcons": boolean;
   "unifiedInbox.rowsPerPage": number;
   "spellchecker.languages": string[];
-  "verticalTabs.width": TabStripWidth;
+  "verticalTabs.width": VerticalTabsWidth;
 };
 
 export type IpcMainEvents =
@@ -177,7 +177,7 @@ export type IpcMainEvents =
       "tabs.closeTab": [accountId: AccountConfig["id"], tabId: string];
       "tabs.moveTab": [accountId: AccountConfig["id"], tabId: string, targetSectionIndex: number];
       "tabs.showTabContextMenu": [accountId: AccountConfig["id"], tabId: string];
-      "tabs.showTabStripContextMenu": [accountId: AccountConfig["id"]];
+      "tabs.showVerticalTabsContextMenu": [accountId: AccountConfig["id"]];
       "workspaceApps.openApp": [
         app: SupportedWorkspaceApp,
         openBehavior?: WorkspaceAppOpenBehavior,

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -56,11 +56,3 @@ export const workspaceAppOpenBehaviors = {
 } as const;
 
 export type WorkspaceAppOpenBehavior = keyof typeof workspaceAppOpenBehaviors;
-
-export const workspaceAppTabStripWidths = {
-  auto: "Auto",
-  narrow: "Narrow",
-  wide: "Wide",
-} as const;
-
-export type WorkspaceAppTabStripWidth = keyof typeof workspaceAppTabStripWidths;


### PR DESCRIPTION
## Problem

The vertical tabs width setting lived under **Workspace Apps**, but the sidebar it controls isn't workspace-apps-only — the Gmail tab renders in it too (#695, #696). Its width is a chrome/appearance concern, not a Workspace Apps one.

Separately, "tab strip" is Chromium-internal jargon. Edge, Firefox, Vivaldi, and Zen all ship this feature as **vertical tabs**, which is the term users arrive with and is self-describing.

## Changes

Two commits, readable independently:

**1. `move vertical tabs width setting to appearance settings`**
- Moves the width select from Workspace Apps into Appearance, in its own **Vertical Tabs** section (between Accounts and the dock/tray icon settings).
- Renames the config key `workspaceApps.tabStripWidth` → `verticalTabs.width`.
- Moves the width options out of `shared/workspace-apps.ts` into `shared/tabs.ts`, since they're no longer workspace-app-scoped.
- Updates the bookmarked-apps description to say "vertical tabs" instead of "tab strip".

**2. `rename tab strip to vertical tabs`**
- Mechanical rename of the internal terminology: `getTabStripWidth` → `getVerticalTabsWidth`, `APP_TAB_STRIP_{NARROW,WIDE}_WIDTH` → `VERTICAL_TABS_{NARROW,WIDE}_WIDTH`, `AppTabStrip` → `VerticalTabs`, `StripTab` → `VerticalTab`, IPC event `tabs.showTabStripContextMenu` → `tabs.showVerticalTabsContextMenu`, and `components/app-tab-strip.tsx` → `components/vertical-tabs.tsx`.
- Updates the overlay guidance in `CLAUDE.md` that referenced the tab strip.

No behavior changes — the sidebar, its widths, and the auto heuristic are untouched.

## Notes for review

- **No config migration.** `workspaceApps.tabStripWidth` was added on 2026-08-05 (#662), after the `v3.57.0` tag, so it has never shipped in a release and no user config can hold the old key. Anyone running a dev build off `main` will silently fall back to the `auto` default and keep a harmless orphan key.
- **The license-key badge is kept** on the field. The sidebar only appears once there's more than one tab, which requires the license-gated "Open in App". It's now the only gated field on the Appearance page, which looks slightly odd but is accurate.
- Not verified in the running app — type checks pass (`bun types:ci`), but I haven't exercised the UI.

## Test plan

1. Open **Settings → Appearance**. A **Vertical Tabs** section appears between **Accounts** and the dock/menu-bar (macOS) or system tray (Linux/Windows) section, containing a single **Width** select defaulting to **Auto**.
2. Open **Settings → Workspace Apps**. The **Tab Strip Width** field is gone; **Bookmarked Apps** now reads "…from the vertical tabs' Workspace Apps menu…".
3. With a valid license and at least two tabs open in an account, set **Width → Narrow**. The sidebar snaps to the narrow layout immediately and the tab content resizes to fill the remaining width, with no gap or overlap at the boundary.
4. Set **Width → Wide**. The sidebar snaps to the wide layout and content resizes again.
5. Set **Width → Auto**, then open two tabs of the *same* Workspace App. The sidebar switches to wide. Close one so no app has more than one tab — it returns to narrow.
6. Close all but one tab. The sidebar disappears entirely and the tab content spans the full window width.
7. Right-click empty space in the sidebar. The context menu still opens (verifies the renamed IPC event is wired on both ends).
8. Drag a tab to reorder it within the sidebar, in both narrow and wide layouts. Reordering still works.
9. Without a valid license, open **Settings → Appearance**. The **Width** field shows the license-required badge and the select is disabled.
10. Quit and relaunch. The chosen width persists (stored under `verticalTabs.width` in `config.json`).