### PR TITLE
disable the message menu items when gmail is not the visible surface

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -1,5 +1,6 @@
 import { is, platform } from "@electron-toolkit/utils";
 import { GITHUB_REPO_URL, WEBSITE_URL } from "@meru/shared/constants";
+import { GMAIL_TAB_ID } from "@meru/shared/tabs";
 import {
   app,
   BrowserWindow,
@@ -42,25 +43,25 @@ export class AppMenu {
   }
 
   init() {
-    this.menu = this.createMenu();
-
     this._subscribeToSelectedAccount();
 
-    Menu.setApplicationMenu(this.menu);
+    this.refresh();
 
     config.onDidChange("accounts", () => {
-      this.menu = this.createMenu();
-
       this._subscribeToSelectedAccount();
 
-      Menu.setApplicationMenu(this.menu);
+      this.refresh();
     });
 
     app.on("browser-window-focus", () => {
-      this.menu = this.createMenu();
-
-      Menu.setApplicationMenu(this.menu);
+      this.refresh();
     });
+  }
+
+  refresh() {
+    this.menu = this.createMenu();
+
+    Menu.setApplicationMenu(this.menu);
   }
 
   private _subscribeToSelectedAccount() {
@@ -74,17 +75,15 @@ export class AppMenu {
 
     const gmailWebContents = selectedAccount.instance.gmail.view.webContents;
 
-    const rebuildMenu = () => {
-      this.menu = this.createMenu();
-
-      Menu.setApplicationMenu(this.menu);
+    const refreshMenu = () => {
+      this.refresh();
     };
 
-    gmailWebContents.on("did-navigate-in-page", rebuildMenu);
+    gmailWebContents.on("did-navigate-in-page", refreshMenu);
 
     this._selectedAccountUnsubscribeFns.add(() => {
       if (!gmailWebContents.isDestroyed()) {
-        gmailWebContents.removeListener("did-navigate-in-page", rebuildMenu);
+        gmailWebContents.removeListener("did-navigate-in-page", refreshMenu);
       }
     });
   }
@@ -167,11 +166,16 @@ export class AppMenu {
       main.show();
     };
 
+    const isGmailVisible =
+      focusedWindow === main.window &&
+      !appState.isSettingsOpen &&
+      selectedAccount.instance.tabs.activeTab.id === GMAIL_TAB_ID;
+
     const userEmail = selectedAccount.instance.gmail.userEmail;
     const messageId = selectedAccount.instance.gmail.messageId;
 
     const copyOrShareMessageLink =
-      userEmail && messageId && createMeruMessageUrl(userEmail, messageId);
+      isGmailVisible && userEmail && messageId && createMeruMessageUrl(userEmail, messageId);
 
     const allAccounts = accounts.getAccounts();
 
@@ -317,7 +321,7 @@ export class AppMenu {
         submenu: [
           {
             label: "Copy Message Link",
-            enabled: focusedWindow === main.window && Boolean(copyOrShareMessageLink),
+            enabled: Boolean(copyOrShareMessageLink),
             accelerator: "CommandOrControl+Shift+C",
             click: () => {
               if (copyOrShareMessageLink) {
@@ -325,7 +329,7 @@ export class AppMenu {
               }
             },
           },
-          focusedWindow === main.window && copyOrShareMessageLink
+          copyOrShareMessageLink
             ? {
                 role: "shareMenu",
                 sharingItem: {

--- a/packages/app/state.ts
+++ b/packages/app/state.ts
@@ -1,6 +1,7 @@
 import { ipc } from "@/ipc";
 import { main } from "@/main";
 import { accounts } from "./accounts";
+import { appMenu } from "./menu";
 
 class AppState {
   isQuittingApp = false;
@@ -17,18 +18,12 @@ class AppState {
     } else {
       accounts.show();
     }
+
+    appMenu.refresh();
   }
 
   toggleIsSettingsOpen() {
-    this.isSettingsOpen = !this.isSettingsOpen;
-
-    ipc.renderer.send(main.window.webContents, "settings.setIsOpen", this.isSettingsOpen);
-
-    if (this.isSettingsOpen) {
-      accounts.hide();
-    } else {
-      accounts.show();
-    }
+    this.setIsSettingsOpen(!this.isSettingsOpen);
   }
 }
 

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -6,6 +6,7 @@ import type { WebContentsView } from "electron";
 import { accounts } from "./accounts";
 import type { Gmail } from "./gmail";
 import { main } from "./main";
+import { appMenu } from "./menu";
 import { WorkspaceApp } from "./workspace-app";
 
 const MAX_RECENTLY_CLOSED_TAB_URLS = 20;
@@ -76,7 +77,7 @@ export class Tabs {
 
   tabs: Tab[];
 
-  activeTabId: string = GMAIL_TAB_ID;
+  private _activeTabId: string = GMAIL_TAB_ID;
 
   private recentlyClosedTabUrls: string[] = [];
 
@@ -109,6 +110,20 @@ export class Tabs {
 
   get hasWorkspaceTabs() {
     return this.tabs.length > 1;
+  }
+
+  get activeTabId() {
+    return this._activeTabId;
+  }
+
+  set activeTabId(tabId: string) {
+    if (this._activeTabId === tabId) {
+      return;
+    }
+
+    this._activeTabId = tabId;
+
+    appMenu.refresh();
   }
 
   get activeTab() {


### PR DESCRIPTION
## Problem

**Message → Copy Message Link / Share** were only gated on the focused window being the main window, plus a message being open in Gmail. Two cases slipped through:

- Switching to a workspace app **tab** keeps the focus on the main window, so the items stayed enabled while Gmail was no longer visible.
- Opening Settings / Downloads / Unified Inbox hides the account views the same way, and also left the items enabled.

The menu was also never rebuilt on either transition, so even a correct condition wouldn't have been re-evaluated.

## Changes

- `menu.ts`: gate the message link on Gmail actually being the visible surface — focused window is the main window, settings aren't open, and the active tab is the Gmail tab. Folded the old `focusedWindow === main.window` checks into `copyOrShareMessageLink` so both items share one condition.
- `menu.ts`: extracted the repeated `createMenu()` + `setApplicationMenu()` pair into a public `refresh()`.
- `tabs.ts`: `activeTabId` is now a getter/setter that refreshes the app menu when the active tab changes.
- `state.ts`: `setIsSettingsOpen` refreshes the app menu; `toggleIsSettingsOpen` now delegates to it instead of duplicating its body.

Note the settings/unified-inbox case wasn't reported, but it's the same defect and the same single condition — say the word and I'll drop it.

## Test plan

1. Open a message in Gmail → **Message → Copy Message Link** and **Share** are enabled; ⌘⇧C copies the `meru://` link.
2. With the message still open, switch to a workspace app tab in the same window → both items are disabled.
3. Switch back to the Gmail tab → both items are enabled again.
4. With the message open, open Settings (or Downloads / Unified Inbox) → both items are disabled; close it → enabled again.
5. With the message open, open a workspace app as a separate window and focus it → both items are disabled (unchanged behavior); focus the main window again → enabled.
6. Go back to the Gmail inbox list (no message open) → both items are disabled.
7. With multiple accounts, open a message in account A, switch to account B where no message is open → both items are disabled.