### PR TITLE
rename bookmarked apps to launcher apps

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -346,22 +346,15 @@ export const config = new Store<Config>({
       // @ts-expect-error: `workspaceApps.openAppsInNewWindow` was removed
       store.delete("workspaceApps.openAppsInNewWindow");
 
-      const previousLauncherAppsKeys = [
-        "workspaceApps.pinnedApps",
-        "workspaceApps.bookmarkedApps",
-      ] as const;
+      // @ts-expect-error: `workspaceApps.pinnedApps` is now 'workspaceApps.launcherApps'
+      const pinnedApps = store.get("workspaceApps.pinnedApps");
 
-      for (const previousLauncherAppsKey of previousLauncherAppsKeys) {
-        // @ts-expect-error: `workspaceApps.pinnedApps` and `workspaceApps.bookmarkedApps` are now 'workspaceApps.launcherApps'
-        const launcherApps = store.get(previousLauncherAppsKey);
-
-        if (typeof launcherApps !== "undefined") {
-          // @ts-expect-error
-          store.set("workspaceApps.launcherApps", launcherApps);
-        }
+      if (typeof pinnedApps !== "undefined") {
+        // @ts-expect-error
+        store.set("workspaceApps.launcherApps", pinnedApps);
 
         // @ts-expect-error
-        store.delete(previousLauncherAppsKey);
+        store.delete("workspaceApps.pinnedApps");
       }
 
       const accounts = store.get("accounts");

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -94,7 +94,7 @@ export const config = new Store<Config>({
     "workspaceApps.openInApp": true,
     "workspaceApps.openInAppExcludedApps": [],
     "workspaceApps.openBehavior": "tab",
-    "workspaceApps.bookmarkedApps": [],
+    "workspaceApps.launcherApps": [],
     "workspaceApps.showAccountColor": true,
     "workspaceApps.showAccountLabel": true,
     "workspaceApps.persistZoom": true,
@@ -324,7 +324,7 @@ export const config = new Store<Config>({
         ["googleApps.openInApp", "workspaceApps.openInApp"],
         ["googleApps.openInAppExcludedApps", "workspaceApps.openInAppExcludedApps"],
         ["googleApps.openAppsInNewWindow", "workspaceApps.openAppsInNewWindow"],
-        ["googleApps.pinnedApps", "workspaceApps.bookmarkedApps"],
+        ["googleApps.pinnedApps", "workspaceApps.launcherApps"],
         ["googleApps.showAccountColor", "workspaceApps.showAccountColor"],
         ["googleApps.showAccountLabel", "workspaceApps.showAccountLabel"],
         ["notifications.allowFromGoogleApps", "notifications.allowFromWorkspaceApps"],
@@ -346,15 +346,22 @@ export const config = new Store<Config>({
       // @ts-expect-error: `workspaceApps.openAppsInNewWindow` was removed
       store.delete("workspaceApps.openAppsInNewWindow");
 
-      // @ts-expect-error: `workspaceApps.pinnedApps` is now 'workspaceApps.bookmarkedApps'
-      const pinnedApps = store.get("workspaceApps.pinnedApps");
+      const previousLauncherAppsKeys = [
+        "workspaceApps.pinnedApps",
+        "workspaceApps.bookmarkedApps",
+      ] as const;
 
-      if (typeof pinnedApps !== "undefined") {
-        // @ts-expect-error
-        store.set("workspaceApps.bookmarkedApps", pinnedApps);
+      for (const previousLauncherAppsKey of previousLauncherAppsKeys) {
+        // @ts-expect-error: `workspaceApps.pinnedApps` and `workspaceApps.bookmarkedApps` are now 'workspaceApps.launcherApps'
+        const launcherApps = store.get(previousLauncherAppsKey);
+
+        if (typeof launcherApps !== "undefined") {
+          // @ts-expect-error
+          store.set("workspaceApps.launcherApps", launcherApps);
+        }
 
         // @ts-expect-error
-        store.delete("workspaceApps.pinnedApps");
+        store.delete(previousLauncherAppsKey);
       }
 
       const accounts = store.get("accounts");

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -1,7 +1,7 @@
 import { accountColorsMap } from "@meru/shared/accounts";
 import { WEBSITE_URL } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
-import { bookmarkableWorkspaceApps } from "@meru/shared/workspace-apps";
+import { launcherWorkspaceApps } from "@meru/shared/workspace-apps";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import { cn } from "@meru/ui/lib/utils";
@@ -178,7 +178,7 @@ export function AppTitlebar() {
   }
 
   const shouldShowWorkspaceAppsLauncher =
-    isLicenseKeyValid && config["workspaceApps.bookmarkedApps"].length > 0;
+    isLicenseKeyValid && config["workspaceApps.launcherApps"].length > 0;
 
   const shouldShowUnifiedInboxButton =
     isLicenseKeyValid && config["unifiedInbox.enabled"] && accounts.length > 1;
@@ -308,10 +308,10 @@ export function AppTitlebar() {
                   isOpen={isWorkspaceAppsLauncherOpen}
                   onOpenChange={setIsWorkspaceAppsLauncherOpen}
                 >
-                  {config["workspaceApps.bookmarkedApps"].map((app) => (
+                  {config["workspaceApps.launcherApps"].map((app) => (
                     <TitlebarDropdownMenuItem
                       key={app}
-                      title={bookmarkableWorkspaceApps[app]}
+                      title={launcherWorkspaceApps[app]}
                       onClick={(event) => {
                         ipc.main.send("workspaceApps.openApp", app, getModifierOpenBehavior(event));
                       }}

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -2,8 +2,8 @@ import { move } from "@dnd-kit/helpers";
 import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import {
-  type BookmarkableWorkspaceApp,
-  bookmarkableWorkspaceApps,
+  type LauncherWorkspaceApp,
+  launcherWorkspaceApps,
   type SupportedWorkspaceApp,
   workspaceAppOpenBehaviors,
   workspaceApps,
@@ -37,13 +37,13 @@ import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useConfig, useConfigMutation } from "@/lib/react-query";
 import { platform } from "@/lib/utils";
 
-function SortableBookmarkedAppItem({
+function SortableLauncherAppItem({
   app,
   index,
   onRemove,
   disabled,
 }: {
-  app: BookmarkableWorkspaceApp;
+  app: LauncherWorkspaceApp;
   index: number;
   onRemove: () => void;
   disabled: boolean;
@@ -58,18 +58,18 @@ function SortableBookmarkedAppItem({
         size="xs"
         className="cursor-grab touch-none"
         disabled={disabled}
-        aria-label={`Drag ${bookmarkableWorkspaceApps[app]} to reorder`}
+        aria-label={`Drag ${launcherWorkspaceApps[app]} to reorder`}
       >
         <GripVerticalIcon />
         <WorkspaceAppIcon app={app} className="size-3.5" />
-        {bookmarkableWorkspaceApps[app]}
+        {launcherWorkspaceApps[app]}
       </Button>
       <Button
         variant="outline"
         size="icon-xs"
         onClick={onRemove}
         disabled={disabled}
-        aria-label={`Remove ${bookmarkableWorkspaceApps[app]} bookmark`}
+        aria-label={`Remove ${launcherWorkspaceApps[app]} from launcher`}
       >
         <XIcon />
       </Button>
@@ -88,11 +88,11 @@ export function WorkspaceAppsSettings() {
     return;
   }
 
-  const bookmarkedApps = config["workspaceApps.bookmarkedApps"];
+  const launcherApps = config["workspaceApps.launcherApps"];
 
-  const availableApps = (
-    Object.keys(bookmarkableWorkspaceApps) as BookmarkableWorkspaceApp[]
-  ).filter((app) => !bookmarkedApps.includes(app));
+  const availableApps = (Object.keys(launcherWorkspaceApps) as LauncherWorkspaceApp[]).filter(
+    (app) => !launcherApps.includes(app),
+  );
 
   const excludedApps = config["workspaceApps.openInAppExcludedApps"];
 
@@ -215,20 +215,20 @@ export function WorkspaceAppsSettings() {
           <Field>
             <FieldContent>
               <FieldLabel className="flex items-center gap-2">
-                Bookmarked Apps
+                Launcher Apps
                 {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
               </FieldLabel>
               <FieldDescription>
-                Bookmark Workspace Apps to open them from the vertical tabs' Workspace Apps menu and
+                Add Workspace Apps to the Workspace Apps launcher in the titlebar on the left and
                 drag to reorder.
               </FieldDescription>
             </FieldContent>
             <div className="flex flex-col gap-4">
               <div className="flex flex-col gap-2">
-                <div className="text-xs font-medium text-muted-foreground">Bookmarked</div>
-                {bookmarkedApps.length === 0 ? (
+                <div className="text-xs font-medium text-muted-foreground">In Launcher</div>
+                {launcherApps.length === 0 ? (
                   <p className="rounded-lg border border-dashed px-3 py-4 text-center text-sm text-muted-foreground">
-                    No bookmarked apps. Add apps from Available below.
+                    No apps in the launcher. Add apps from Available below.
                   </p>
                 ) : (
                   <DragDropProvider
@@ -238,19 +238,19 @@ export function WorkspaceAppsSettings() {
                       }
 
                       configMutation.mutate({
-                        "workspaceApps.bookmarkedApps": move(bookmarkedApps, event),
+                        "workspaceApps.launcherApps": move(launcherApps, event),
                       });
                     }}
                   >
                     <div className="flex flex-row flex-wrap gap-2">
-                      {bookmarkedApps.map((app, index) => (
-                        <SortableBookmarkedAppItem
+                      {launcherApps.map((app, index) => (
+                        <SortableLauncherAppItem
                           key={app}
                           app={app}
                           index={index}
                           onRemove={() => {
                             configMutation.mutate({
-                              "workspaceApps.bookmarkedApps": bookmarkedApps.filter(
+                              "workspaceApps.launcherApps": launcherApps.filter(
                                 (value) => value !== app,
                               ),
                             });
@@ -273,14 +273,14 @@ export function WorkspaceAppsSettings() {
                         size="xs"
                         onClick={() => {
                           configMutation.mutate({
-                            "workspaceApps.bookmarkedApps": [...bookmarkedApps, app],
+                            "workspaceApps.launcherApps": [...launcherApps, app],
                           });
                         }}
                         disabled={!isLicenseKeyValid}
-                        aria-label={`Bookmark ${bookmarkableWorkspaceApps[app]}`}
+                        aria-label={`Add ${launcherWorkspaceApps[app]} to launcher`}
                       >
                         <WorkspaceAppIcon app={app} className="size-3.5" />
-                        {bookmarkableWorkspaceApps[app]}
+                        {launcherWorkspaceApps[app]}
                         <PlusIcon />
                       </Button>
                     ))}

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -1,6 +1,3 @@
-import { move } from "@dnd-kit/helpers";
-import { DragDropProvider } from "@dnd-kit/react";
-import { useSortable } from "@dnd-kit/react/sortable";
 import {
   type LauncherWorkspaceApp,
   launcherWorkspaceApps,
@@ -9,7 +6,6 @@ import {
   workspaceApps,
 } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
-import { ButtonGroup } from "@meru/ui/components/button-group";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -25,7 +21,7 @@ import {
   FieldSeparator,
 } from "@meru/ui/components/field";
 import { Kbd } from "@meru/ui/components/kbd";
-import { ChevronDownIcon, GripVerticalIcon, PlusIcon, XIcon } from "lucide-react";
+import { ChevronDownIcon, PlusIcon, XIcon } from "lucide-react";
 import type { Entries } from "type-fest";
 import { ConfigSelectField } from "@/components/config-select-field";
 import { ConfigSwitchField } from "@/components/config-switch-field";
@@ -36,46 +32,6 @@ import { WorkspaceAppIcon } from "@/components/workspace-app-icon";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useConfig, useConfigMutation } from "@/lib/react-query";
 import { platform } from "@/lib/utils";
-
-function SortableLauncherAppItem({
-  app,
-  index,
-  onRemove,
-  disabled,
-}: {
-  app: LauncherWorkspaceApp;
-  index: number;
-  onRemove: () => void;
-  disabled: boolean;
-}) {
-  const { ref, handleRef, isDragging } = useSortable({ id: app, index, disabled });
-
-  return (
-    <ButtonGroup ref={ref} className={isDragging ? "opacity-50" : undefined}>
-      <Button
-        ref={handleRef}
-        variant="outline"
-        size="xs"
-        className="cursor-grab touch-none"
-        disabled={disabled}
-        aria-label={`Drag ${launcherWorkspaceApps[app]} to reorder`}
-      >
-        <GripVerticalIcon />
-        <WorkspaceAppIcon app={app} className="size-3.5" />
-        {launcherWorkspaceApps[app]}
-      </Button>
-      <Button
-        variant="outline"
-        size="icon-xs"
-        onClick={onRemove}
-        disabled={disabled}
-        aria-label={`Remove ${launcherWorkspaceApps[app]} from launcher`}
-      >
-        <XIcon />
-      </Button>
-    </ButtonGroup>
-  );
-}
 
 export function WorkspaceAppsSettings() {
   const { config } = useConfig();
@@ -219,8 +175,7 @@ export function WorkspaceAppsSettings() {
                 {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
               </FieldLabel>
               <FieldDescription>
-                Add Workspace Apps to the Workspace Apps launcher in the titlebar on the left and
-                drag to reorder.
+                Add Workspace Apps to the Workspace Apps launcher in the titlebar on the left.
               </FieldDescription>
             </FieldContent>
             <div className="flex flex-col gap-4">
@@ -231,35 +186,28 @@ export function WorkspaceAppsSettings() {
                     No apps in the launcher. Add apps from Available below.
                   </p>
                 ) : (
-                  <DragDropProvider
-                    onDragEnd={(event) => {
-                      if (event.canceled) {
-                        return;
-                      }
-
-                      configMutation.mutate({
-                        "workspaceApps.launcherApps": move(launcherApps, event),
-                      });
-                    }}
-                  >
-                    <div className="flex flex-row flex-wrap gap-2">
-                      {launcherApps.map((app, index) => (
-                        <SortableLauncherAppItem
-                          key={app}
-                          app={app}
-                          index={index}
-                          onRemove={() => {
-                            configMutation.mutate({
-                              "workspaceApps.launcherApps": launcherApps.filter(
-                                (value) => value !== app,
-                              ),
-                            });
-                          }}
-                          disabled={!isLicenseKeyValid}
-                        />
-                      ))}
-                    </div>
-                  </DragDropProvider>
+                  <div className="flex flex-row flex-wrap gap-2">
+                    {launcherApps.map((app) => (
+                      <Button
+                        key={app}
+                        variant="outline"
+                        size="xs"
+                        onClick={() => {
+                          configMutation.mutate({
+                            "workspaceApps.launcherApps": launcherApps.filter(
+                              (value) => value !== app,
+                            ),
+                          });
+                        }}
+                        disabled={!isLicenseKeyValid}
+                        aria-label={`Remove ${launcherWorkspaceApps[app]} from launcher`}
+                      >
+                        <WorkspaceAppIcon app={app} className="size-3.5" />
+                        {launcherWorkspaceApps[app]}
+                        <XIcon />
+                      </Button>
+                    ))}
+                  </div>
                 )}
               </div>
               {availableApps.length > 0 && (

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -1,3 +1,6 @@
+import { move } from "@dnd-kit/helpers";
+import { DragDropProvider } from "@dnd-kit/react";
+import { useSortable } from "@dnd-kit/react/sortable";
 import {
   type LauncherWorkspaceApp,
   launcherWorkspaceApps,
@@ -6,6 +9,7 @@ import {
   workspaceApps,
 } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
+import { ButtonGroup } from "@meru/ui/components/button-group";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -21,7 +25,7 @@ import {
   FieldSeparator,
 } from "@meru/ui/components/field";
 import { Kbd } from "@meru/ui/components/kbd";
-import { ChevronDownIcon, PlusIcon, XIcon } from "lucide-react";
+import { ChevronDownIcon, GripVerticalIcon, PlusIcon, XIcon } from "lucide-react";
 import type { Entries } from "type-fest";
 import { ConfigSelectField } from "@/components/config-select-field";
 import { ConfigSwitchField } from "@/components/config-switch-field";
@@ -32,6 +36,46 @@ import { WorkspaceAppIcon } from "@/components/workspace-app-icon";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useConfig, useConfigMutation } from "@/lib/react-query";
 import { platform } from "@/lib/utils";
+
+function SortableLauncherAppItem({
+  app,
+  index,
+  onRemove,
+  disabled,
+}: {
+  app: LauncherWorkspaceApp;
+  index: number;
+  onRemove: () => void;
+  disabled: boolean;
+}) {
+  const { ref, handleRef, isDragging } = useSortable({ id: app, index, disabled });
+
+  return (
+    <ButtonGroup ref={ref} className={isDragging ? "opacity-50" : undefined}>
+      <Button
+        ref={handleRef}
+        variant="outline"
+        size="xs"
+        className="cursor-grab touch-none"
+        disabled={disabled}
+        aria-label={`Drag ${launcherWorkspaceApps[app]} to reorder`}
+      >
+        <GripVerticalIcon />
+        <WorkspaceAppIcon app={app} className="size-3.5" />
+        {launcherWorkspaceApps[app]}
+      </Button>
+      <Button
+        variant="outline"
+        size="icon-xs"
+        onClick={onRemove}
+        disabled={disabled}
+        aria-label={`Remove ${launcherWorkspaceApps[app]} from launcher`}
+      >
+        <XIcon />
+      </Button>
+    </ButtonGroup>
+  );
+}
 
 export function WorkspaceAppsSettings() {
   const { config } = useConfig();
@@ -186,28 +230,35 @@ export function WorkspaceAppsSettings() {
                     No apps in the launcher. Add apps from Available below.
                   </p>
                 ) : (
-                  <div className="flex flex-row flex-wrap gap-2">
-                    {launcherApps.map((app) => (
-                      <Button
-                        key={app}
-                        variant="outline"
-                        size="xs"
-                        onClick={() => {
-                          configMutation.mutate({
-                            "workspaceApps.launcherApps": launcherApps.filter(
-                              (value) => value !== app,
-                            ),
-                          });
-                        }}
-                        disabled={!isLicenseKeyValid}
-                        aria-label={`Remove ${launcherWorkspaceApps[app]} from launcher`}
-                      >
-                        <WorkspaceAppIcon app={app} className="size-3.5" />
-                        {launcherWorkspaceApps[app]}
-                        <XIcon />
-                      </Button>
-                    ))}
-                  </div>
+                  <DragDropProvider
+                    onDragEnd={(event) => {
+                      if (event.canceled) {
+                        return;
+                      }
+
+                      configMutation.mutate({
+                        "workspaceApps.launcherApps": move(launcherApps, event),
+                      });
+                    }}
+                  >
+                    <div className="flex flex-row flex-wrap gap-2">
+                      {launcherApps.map((app, index) => (
+                        <SortableLauncherAppItem
+                          key={app}
+                          app={app}
+                          index={index}
+                          onRemove={() => {
+                            configMutation.mutate({
+                              "workspaceApps.launcherApps": launcherApps.filter(
+                                (value) => value !== app,
+                              ),
+                            });
+                          }}
+                          disabled={!isLicenseKeyValid}
+                        />
+                      ))}
+                    </div>
+                  </DragDropProvider>
                 )}
               </div>
               {availableApps.length > 0 && (

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -11,7 +11,7 @@ import type {
 } from "./schemas";
 import type { AccountTabsState, VerticalTabsWidth } from "./tabs";
 import type {
-  BookmarkableWorkspaceApp,
+  LauncherWorkspaceApp,
   SupportedWorkspaceApp,
   WorkspaceAppOpenBehavior,
 } from "./workspace-apps";
@@ -122,7 +122,7 @@ export type Config = {
   "workspaceApps.openInApp": boolean;
   "workspaceApps.openInAppExcludedApps": SupportedWorkspaceApp[];
   "workspaceApps.openBehavior": WorkspaceAppOpenBehavior;
-  "workspaceApps.bookmarkedApps": BookmarkableWorkspaceApp[];
+  "workspaceApps.launcherApps": LauncherWorkspaceApp[];
   "workspaceApps.showAccountColor": boolean;
   "workspaceApps.showAccountLabel": boolean;
   "workspaceApps.persistZoom": boolean;

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -3,7 +3,7 @@ import { GMAIL_URL } from "./gmail";
 type WorkspaceAppDefinition = {
   label: string;
   url?: string;
-  bookmarkable?: boolean;
+  availableInLauncher?: boolean;
   popupOnly?: boolean;
   singleInstance?: boolean;
 };
@@ -17,11 +17,11 @@ const workspaceAppDefinitions = {
   drive: { label: "Drive" },
   forms: { label: "Forms" },
   gemini: { label: "Gemini" },
-  gmail: { label: "Gmail", url: GMAIL_URL, bookmarkable: false, singleInstance: true },
+  gmail: { label: "Gmail", url: GMAIL_URL, availableInLauncher: false, singleInstance: true },
   groups: { label: "Groups" },
   keep: { label: "Keep" },
   meet: { label: "Meet" },
-  myaccount: { label: "My Account", bookmarkable: false, popupOnly: true },
+  myaccount: { label: "My Account", availableInLauncher: false, popupOnly: true },
   notebooklm: { label: "NotebookLM" },
   sheets: { label: "Sheets" },
   sites: { label: "Sites" },
@@ -32,9 +32,9 @@ const workspaceAppDefinitions = {
 
 export type SupportedWorkspaceApp = keyof typeof workspaceAppDefinitions;
 
-export type BookmarkableWorkspaceApp = {
+export type LauncherWorkspaceApp = {
   [App in SupportedWorkspaceApp]: (typeof workspaceAppDefinitions)[App] extends {
-    bookmarkable: false;
+    availableInLauncher: false;
   }
     ? never
     : App;
@@ -43,11 +43,11 @@ export type BookmarkableWorkspaceApp = {
 export const workspaceApps: Record<SupportedWorkspaceApp, WorkspaceAppDefinition> =
   workspaceAppDefinitions;
 
-export const bookmarkableWorkspaceApps = Object.fromEntries(
+export const launcherWorkspaceApps = Object.fromEntries(
   Object.entries(workspaceApps)
-    .filter(([, workspaceAppDefinition]) => workspaceAppDefinition.bookmarkable !== false)
+    .filter(([, workspaceAppDefinition]) => workspaceAppDefinition.availableInLauncher !== false)
     .map(([workspaceApp, workspaceAppDefinition]) => [workspaceApp, workspaceAppDefinition.label]),
-) as Record<BookmarkableWorkspaceApp, string>;
+) as Record<LauncherWorkspaceApp, string>;
 
 export const workspaceAppOpenBehaviors = {
   tab: "Tab",


### PR DESCRIPTION
"Bookmarked Apps" is confusing now that the apps only appear in the Workspace Apps launcher in the titlebar, and the term needs to be free for bookmarked tabs later (shown in the tabs list with their title, unlike pinned tabs in the icon grid).

This is a rename and copy change only: the launcher's behavior, visibility and license gating are untouched. It still stays hidden until at least one app is added, still requires a valid license, and launcher clicks keep respecting `workspaceApps.openInApp`, `workspaceApps.openInAppExcludedApps` and `workspaceApps.openBehavior` (so an app that is both in the launcher and excluded still opens in the external browser).

## Changes

- `workspaceApps.bookmarkedApps` → `workspaceApps.launcherApps`, `BookmarkableWorkspaceApp` → `LauncherWorkspaceApp`, `bookmarkableWorkspaceApps` → `launcherWorkspaceApps`, and the app definition flag `bookmarkable: false` → `availableInLauncher: false` (Gmail and My Account, unchanged set).
- Settings field "Bookmarked Apps" → "Launcher Apps", group heading "Bookmarked" → "In Launcher", and the empty state now reads "No apps in the launcher.". The description also stops pointing at the vertical tabs' menu — the launcher moved to the titlebar in bc03c3e — and now says the apps appear in the Workspace Apps launcher in the titlebar on the left. It also no longer spells out "drag to reorder" — the drag handles say that themselves — but reordering itself is unchanged.
- aria-labels: "Bookmark X" → "Add X to launcher", "Remove X bookmark" → "Remove X from launcher".

## Migration

`workspaceApps.bookmarkedApps` never shipped — 3.57.0 is the latest release and the `">3.57.0"` block is still unreleased — so no migration is added for it. The existing block is only retargeted at the new name: `googleApps.pinnedApps` → `workspaceApps.launcherApps` in the rename table, and the `workspaceApps.pinnedApps` fallback below it now writes `workspaceApps.launcherApps`. The config diff is a pure rename.

Consequence for anyone running `main`: a `workspaceApps.bookmarkedApps` key already on disk is ignored (and left in place), so the launcher starts empty and the apps have to be re-added once.

## Not included

Bookmarked tabs themselves — this only frees the vocabulary for that work.

## Test plan

1. Run this branch on a config that has `workspaceApps.bookmarkedApps` from `main`: the launcher starts empty (expected — that key never shipped, so it is not migrated) and no launcher button shows in the titlebar.
2. Open Settings → Workspace Apps and check the copy: field reads "Launcher Apps", description points at the launcher in the titlebar on the left with no mention of reordering, groups read "In Launcher" and "Available".
3. Add apps from "Available" and drag the "In Launcher" entries by their grip handles: the order changes, the titlebar launcher's icon order follows, and it survives a restart.
4. Click the X on an entry in "In Launcher": it moves back to "Available" and disappears from the titlebar launcher.
5. Remove every app from the launcher: the empty state reads "No apps in the launcher. Add apps from Available below." and the launcher button disappears from the titlebar.
6. Add one app back: the launcher button reappears and opens it in a tab; Cmd/Ctrl-click opens it as a background tab and Shift-click in a new window.
7. With no license key, Settings → Workspace Apps shows the Launcher Apps field disabled with the license badge and no launcher button appears in the titlebar.
8. Add Meet to the launcher and also to Excluded Apps: clicking Meet in the launcher opens the external browser while other launcher apps still open in tabs (unchanged behavior).
9. Gmail and My Account never appear in the "Available" list.
