### PR TITLE
use the default cursor over renderer text

### DIFF
--- a/packages/ui/styles/globals.css
+++ b/packages/ui/styles/globals.css
@@ -126,7 +126,12 @@
   }
 
   body {
-    @apply bg-background text-foreground antialiased;
+    @apply cursor-default bg-background text-foreground antialiased;
+  }
+
+  input,
+  textarea {
+    @apply cursor-text;
   }
 }
 


### PR DESCRIPTION
## Problem

Hovering text anywhere in the renderer-drawn UI — settings, unified inbox, titlebar, recent downloads, desktop sources, workspace app shell — shows the I-beam text cursor, because the browser default `cursor: auto` resolves to `text` over text content. Native desktop apps show the arrow cursor over their chrome.

## Changes

One edit in `packages/ui/styles/globals.css`, in the `@layer base` block that already styles `body`:

- `cursor-default` on `body`. `cursor` is inherited, so this flows to every descendant.
- `cursor-text` on `input, textarea` so form fields keep the I-beam regardless of what the UA stylesheet declares.

Elements that declare their own cursor still win over inheritance, so links keep the pointer hand and existing utilities are unaffected — `cursor-grab` on the drag handles in Accounts / Saved Searches / Workspace Apps, `cursor-pointer` on the Gmail label color input, `cursor-not-allowed` on disabled controls.

`packages/ui/styles/globals.css` is also imported by `packages/preload-gmail/globals.css`, but that one is injected as a `<style>` inside the toaster's shadow root, where a `body` selector matches nothing — Gmail's own page is untouched.

## Scope and known gaps

- Cursor only. Text stays selectable by drag; `user-select: none` was deliberately left out so labels and error messages can still be copied out of settings.
- `cursor-default` on the unified inbox `TableRow` (`packages/renderer/routes/unified-inbox.tsx:317`) is now redundant. Left in place to keep the diff to one file.
- The `input, textarea` rule applies to every input type. The only non-text input in the codebase is the Gmail label `type="color"` picker, which already sets `cursor-pointer` and so is unaffected; the Base UI checkbox/switch/radio components render buttons, not inputs.
- Verified with `bun types:ci` only — not run in the app.

## Test plan

1. Open Settings and hover over section headings, field labels, and descriptions — cursor stays an arrow.
2. Click into a text input (e.g. an account name) and into a textarea — I-beam inside the field, arrow outside it.
3. Hover the drag handles in Settings → Accounts, Saved Searches, and Workspace Apps — still the grab hand.
4. Hover an external link in Settings — still the pointer hand.
5. Hover the Gmail label color swatch in Settings → Gmail → Label Colors — still the pointer hand.
6. Open the Unified Inbox, hover a row — arrow cursor, and clicking a row still opens the message.
7. Hover the titlebar, the recent-downloads popup, and the desktop sources picker — arrow cursor.
8. Drag across a settings description — text still selects and copies.
9. Hover message text inside Gmail itself — unchanged I-beam, and Meru toasts over Gmail still look right.