### PR TITLE
hide the compose menu item when gmail is not the visible surface

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -235,6 +235,7 @@ export class AppMenu {
         submenu: [
           {
             label: "Compose",
+            visible: isGmailVisible,
             click: () => {
               ipc.renderer.send(
                 selectedAccount.instance.gmail.view.webContents,
@@ -247,6 +248,7 @@ export class AppMenu {
           },
           {
             type: "separator",
+            visible: isGmailVisible,
           },
           {
             role: "close",


### PR DESCRIPTION
## Problem

File → Compose was always visible and clickable, even when Gmail wasn't the visible surface (settings open, a workspace app tab active, or a non-main window focused). Clicking it navigated the hidden Gmail view.

## Changes

- Gate File → Compose (and its trailing separator) on the existing `isGmailVisible` check already used for the Message menu items, so the item is hidden rather than shown as a no-op.

The Message menu disables its items; Compose is hidden instead, matching the request.

## Test plan

1. Launch the app with Gmail as the active tab in the main window — File → Compose is visible and opens a compose view.
2. Open Settings — File → Compose disappears; the File menu only shows Close.
3. Close Settings — Compose reappears.
4. Switch to a workspace app tab — Compose disappears; switch back to the Gmail tab — it reappears.
5. Open a compose or workspace app window and focus it — Compose is hidden while that window is focused, and returns when the main window is focused again.