### PR TITLE
derive the visible surface from the renderer route

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -130,7 +130,7 @@ class Accounts {
 
     activeTab.updateViewBounds?.();
 
-    if (main.visibleSurface === "account") {
+    if (main.route === "/") {
       activeTab.view.webContents.focus();
     }
   }

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -130,7 +130,7 @@ class Accounts {
 
     activeTab.updateViewBounds?.();
 
-    if (!appState.isSettingsOpen) {
+    if (appState.visibleSurface === "account") {
       activeTab.view.webContents.focus();
     }
   }
@@ -288,9 +288,7 @@ class Accounts {
 
     this.sendTabsChangedToRenderer();
 
-    this.show();
-
-    appState.setIsSettingsOpen(false);
+    main.navigate("/");
   }
 
   async removeAccount(selectedAccountId: string) {

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -130,7 +130,7 @@ class Accounts {
 
     activeTab.updateViewBounds?.();
 
-    if (appState.visibleSurface === "account") {
+    if (main.visibleSurface === "account") {
       activeTab.view.webContents.focus();
     }
   }

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -130,7 +130,7 @@ class Accounts {
 
     activeTab.updateViewBounds?.();
 
-    if (main.route === "/") {
+    if (main.location === "/") {
       activeTab.view.webContents.focus();
     }
   }

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -175,7 +175,7 @@ async function init() {
 
   if (!app.commandLine.hasSwitch("disable-bring-to-top-on-focus")) {
     main.window.on("focus", () => {
-      if (main.route === "/") {
+      if (main.location === "/") {
         accounts.getSelectedAccount().instance.gmail.view.webContents.focus();
       }
     });

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -175,7 +175,7 @@ async function init() {
 
   if (!app.commandLine.hasSwitch("disable-bring-to-top-on-focus")) {
     main.window.on("focus", () => {
-      if (!appState.isSettingsOpen) {
+      if (appState.visibleSurface === "account") {
         accounts.getSelectedAccount().instance.gmail.view.webContents.focus();
       }
     });

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -175,7 +175,7 @@ async function init() {
 
   if (!app.commandLine.hasSwitch("disable-bring-to-top-on-focus")) {
     main.window.on("focus", () => {
-      if (main.visibleSurface === "account") {
+      if (main.route === "/") {
         accounts.getSelectedAccount().instance.gmail.view.webContents.focus();
       }
     });

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -175,7 +175,7 @@ async function init() {
 
   if (!app.commandLine.hasSwitch("disable-bring-to-top-on-focus")) {
     main.window.on("focus", () => {
-      if (appState.visibleSurface === "account") {
+      if (main.visibleSurface === "account") {
         accounts.getSelectedAccount().instance.gmail.view.webContents.focus();
       }
     });

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -27,7 +27,6 @@ import { config } from "@/config";
 import { licenseKey } from "@/license-key";
 import { main } from "@/main";
 import { appMenu } from "@/menu";
-import { appState } from "@/state";
 import { DormantTab } from "@/tabs";
 import { WorkspaceApp } from "@/workspace-app";
 import { DoNotDisturb, doNotDisturb } from "./do-not-disturb";
@@ -68,10 +67,6 @@ class Ipc {
   renderer = new IpcEmitter<IpcRendererEvent>();
 
   init() {
-    this.main.on("route.changed", (_event, rendererRoute) => {
-      appState.setRendererRoute(rendererRoute);
-    });
-
     config.onDidAnyChange(() => {
       ipc.renderer.send(main.window.webContents, "config.configChanged", config.store);
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -68,12 +68,8 @@ class Ipc {
   renderer = new IpcEmitter<IpcRendererEvent>();
 
   init() {
-    this.main.on("settings.toggleIsOpen", (_event, open) => {
-      if (typeof open === "boolean") {
-        appState.setIsSettingsOpen(open);
-      } else {
-        appState.toggleIsSettingsOpen();
-      }
+    this.main.on("route.changed", (_event, rendererRoute) => {
+      appState.setRendererRoute(rendererRoute);
     });
 
     config.onDidAnyChange(() => {

--- a/packages/app/main.ts
+++ b/packages/app/main.ts
@@ -18,20 +18,20 @@ import { trial } from "./trial";
 class Main {
   private _window: BrowserWindow | undefined;
 
-  route = "/";
+  location = "/";
 
-  private setRoute(route: string) {
-    const wasAccountRoute = this.route === "/";
+  private setLocation(location: string) {
+    const wasAccountLocation = this.location === "/";
 
-    this.route = route;
+    this.location = location;
 
-    const isAccountRoute = route === "/";
+    const isAccountLocation = location === "/";
 
-    if (isAccountRoute === wasAccountRoute) {
+    if (isAccountLocation === wasAccountLocation) {
       return;
     }
 
-    if (isAccountRoute) {
+    if (isAccountLocation) {
       accounts.show();
     } else {
       accounts.hide();
@@ -130,7 +130,7 @@ class Main {
     }
 
     this.window.webContents.on("did-navigate-in-page", (_event, url) => {
-      this.setRoute(`/${new URL(url).hash.replace(/^#?\/?/, "")}`);
+      this.setLocation(`/${new URL(url).hash.replace(/^#?\/?/, "")}`);
     });
 
     this.window.webContents.setWindowOpenHandler(({ url }) => {
@@ -205,7 +205,7 @@ class Main {
   }
 
   navigate(to: string) {
-    this.setRoute(to);
+    this.setLocation(to);
 
     ipc.renderer.send(main.window.webContents, "navigate", to);
 

--- a/packages/app/main.ts
+++ b/packages/app/main.ts
@@ -18,30 +18,20 @@ import { trial } from "./trial";
 class Main {
   private _window: BrowserWindow | undefined;
 
-  rendererRoute = "/";
+  route = "/";
 
-  get visibleSurface() {
-    if (this.rendererRoute === "/") {
-      return "account";
-    }
+  private setRoute(route: string) {
+    const wasAccountRoute = this.route === "/";
 
-    if (this.rendererRoute === "/unified-inbox") {
-      return "unifiedInbox";
-    }
+    this.route = route;
 
-    return "settings";
-  }
+    const isAccountRoute = route === "/";
 
-  private setRendererRoute(route: string) {
-    const previousVisibleSurface = this.visibleSurface;
-
-    this.rendererRoute = route;
-
-    if (this.visibleSurface === previousVisibleSurface) {
+    if (isAccountRoute === wasAccountRoute) {
       return;
     }
 
-    if (this.visibleSurface === "account") {
+    if (isAccountRoute) {
       accounts.show();
     } else {
       accounts.hide();
@@ -140,7 +130,7 @@ class Main {
     }
 
     this.window.webContents.on("did-navigate-in-page", (_event, url) => {
-      this.setRendererRoute(`/${new URL(url).hash.replace(/^#?\/?/, "")}`);
+      this.setRoute(`/${new URL(url).hash.replace(/^#?\/?/, "")}`);
     });
 
     this.window.webContents.setWindowOpenHandler(({ url }) => {
@@ -215,7 +205,7 @@ class Main {
   }
 
   navigate(to: string) {
-    this.setRendererRoute(to);
+    this.setRoute(to);
 
     ipc.renderer.send(main.window.webContents, "navigate", to);
 

--- a/packages/app/main.ts
+++ b/packages/app/main.ts
@@ -178,7 +178,7 @@ class Main {
   }
 
   navigate(to: string) {
-    appState.setIsSettingsOpen(true);
+    appState.setRendererRoute(to);
 
     ipc.renderer.send(main.window.webContents, "navigate", to);
 

--- a/packages/app/main.ts
+++ b/packages/app/main.ts
@@ -9,6 +9,7 @@ import {
   isWindowVisibleOnConnectedDisplay,
   loadRenderer,
 } from "@/lib/window";
+import { appMenu } from "@/menu";
 import { appState } from "@/state";
 import { openExternalUrl } from "@/url";
 import { ipc } from "./ipc";
@@ -16,6 +17,38 @@ import { trial } from "./trial";
 
 class Main {
   private _window: BrowserWindow | undefined;
+
+  rendererRoute = "/";
+
+  get visibleSurface() {
+    if (this.rendererRoute === "/") {
+      return "account";
+    }
+
+    if (this.rendererRoute === "/unified-inbox") {
+      return "unifiedInbox";
+    }
+
+    return "settings";
+  }
+
+  private setRendererRoute(route: string) {
+    const previousVisibleSurface = this.visibleSurface;
+
+    this.rendererRoute = route;
+
+    if (this.visibleSurface === previousVisibleSurface) {
+      return;
+    }
+
+    if (this.visibleSurface === "account") {
+      accounts.show();
+    } else {
+      accounts.hide();
+    }
+
+    appMenu.refresh();
+  }
 
   get window() {
     if (!this._window) {
@@ -106,6 +139,10 @@ class Main {
       }
     }
 
+    this.window.webContents.on("did-navigate-in-page", (_event, url) => {
+      this.setRendererRoute(`/${new URL(url).hash.replace(/^#?\/?/, "")}`);
+    });
+
     this.window.webContents.setWindowOpenHandler(({ url }) => {
       openExternalUrl(url, { skipTrustedHostCheck: true });
 
@@ -178,7 +215,7 @@ class Main {
   }
 
   navigate(to: string) {
-    appState.setRendererRoute(to);
+    this.setRendererRoute(to);
 
     ipc.renderer.send(main.window.webContents, "navigate", to);
 

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -150,26 +150,22 @@ export class AppMenu {
     const selectNextTab = () => {
       accounts.getSelectedAccount().instance.tabs.activateNextTab();
 
-      appState.setIsSettingsOpen(false);
+      main.navigate("/");
 
       accounts.refreshSelectedAccountView();
-
-      main.show();
     };
 
     const selectPreviousTab = () => {
       accounts.getSelectedAccount().instance.tabs.activatePreviousTab();
 
-      appState.setIsSettingsOpen(false);
+      main.navigate("/");
 
       accounts.refreshSelectedAccountView();
-
-      main.show();
     };
 
     const isGmailVisible =
       focusedWindow === main.window &&
-      !appState.isSettingsOpen &&
+      appState.visibleSurface === "account" &&
       selectedAccount.instance.tabs.activeTab.id === GMAIL_TAB_ID;
 
     const userEmail = selectedAccount.instance.gmail.userEmail;
@@ -513,9 +509,7 @@ export class AppMenu {
             click: () => {
               accounts.selectAccount(account.config.id);
 
-              appState.setIsSettingsOpen(false);
-
-              main.show();
+              main.navigate("/");
             },
             accelerator: `${platform.isLinux ? "Alt" : "CommandOrControl"}+${index + 1}`,
           })),
@@ -528,9 +522,7 @@ export class AppMenu {
             click: () => {
               accounts.selectNextAccount();
 
-              appState.setIsSettingsOpen(false);
-
-              main.show();
+              main.navigate("/");
             },
           },
           {
@@ -541,9 +533,7 @@ export class AppMenu {
             click: () => {
               accounts.selectNextAccount();
 
-              appState.setIsSettingsOpen(false);
-
-              main.show();
+              main.navigate("/");
             },
           },
           {
@@ -552,9 +542,7 @@ export class AppMenu {
             click: () => {
               accounts.selectPreviousAccount();
 
-              appState.setIsSettingsOpen(false);
-
-              main.show();
+              main.navigate("/");
             },
           },
           {
@@ -565,9 +553,7 @@ export class AppMenu {
             click: () => {
               accounts.selectPreviousAccount();
 
-              appState.setIsSettingsOpen(false);
-
-              main.show();
+              main.navigate("/");
             },
           },
           {

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -164,7 +164,7 @@ export class AppMenu {
 
     const isGmailVisible =
       focusedWindow === main.window &&
-      main.visibleSurface === "account" &&
+      main.route === "/" &&
       selectedAccount.instance.tabs.activeTab.id === GMAIL_TAB_ID;
 
     const userEmail = selectedAccount.instance.gmail.userEmail;

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -22,7 +22,6 @@ import { openExternalUrl } from "@/url";
 import { WorkspaceApp } from "@/workspace-app";
 import { licenseKey } from "./license-key";
 import { createMeruMessageUrl } from "./protocol";
-import { appState } from "./state";
 
 export class AppMenu {
   private _menu: Menu | undefined;
@@ -165,7 +164,7 @@ export class AppMenu {
 
     const isGmailVisible =
       focusedWindow === main.window &&
-      appState.visibleSurface === "account" &&
+      main.visibleSurface === "account" &&
       selectedAccount.instance.tabs.activeTab.id === GMAIL_TAB_ID;
 
     const userEmail = selectedAccount.instance.gmail.userEmail;

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -164,7 +164,7 @@ export class AppMenu {
 
     const isGmailVisible =
       focusedWindow === main.window &&
-      main.route === "/" &&
+      main.location === "/" &&
       selectedAccount.instance.tabs.activeTab.id === GMAIL_TAB_ID;
 
     const userEmail = selectedAccount.instance.gmail.userEmail;

--- a/packages/app/state.ts
+++ b/packages/app/state.ts
@@ -1,40 +1,5 @@
-import { accounts } from "./accounts";
-import { appMenu } from "./menu";
-
 class AppState {
   isQuittingApp = false;
-
-  rendererRoute = "/";
-
-  get visibleSurface() {
-    if (this.rendererRoute === "/") {
-      return "account";
-    }
-
-    if (this.rendererRoute === "/unified-inbox") {
-      return "unifiedInbox";
-    }
-
-    return "settings";
-  }
-
-  setRendererRoute(route: string) {
-    const previousVisibleSurface = this.visibleSurface;
-
-    this.rendererRoute = route;
-
-    if (this.visibleSurface === previousVisibleSurface) {
-      return;
-    }
-
-    if (this.visibleSurface === "account") {
-      accounts.show();
-    } else {
-      accounts.hide();
-    }
-
-    appMenu.refresh();
-  }
 }
 
 export const appState = new AppState();

--- a/packages/app/state.ts
+++ b/packages/app/state.ts
@@ -1,29 +1,39 @@
-import { ipc } from "@/ipc";
-import { main } from "@/main";
 import { accounts } from "./accounts";
 import { appMenu } from "./menu";
 
 class AppState {
   isQuittingApp = false;
 
-  isSettingsOpen = false;
+  rendererRoute = "/";
 
-  setIsSettingsOpen(value: boolean) {
-    this.isSettingsOpen = value;
+  get visibleSurface() {
+    if (this.rendererRoute === "/") {
+      return "account";
+    }
 
-    ipc.renderer.send(main.window.webContents, "settings.setIsOpen", this.isSettingsOpen);
+    if (this.rendererRoute === "/unified-inbox") {
+      return "unifiedInbox";
+    }
 
-    if (this.isSettingsOpen) {
-      accounts.hide();
-    } else {
+    return "settings";
+  }
+
+  setRendererRoute(route: string) {
+    const previousVisibleSurface = this.visibleSurface;
+
+    this.rendererRoute = route;
+
+    if (this.visibleSurface === previousVisibleSurface) {
+      return;
+    }
+
+    if (this.visibleSurface === "account") {
       accounts.show();
+    } else {
+      accounts.hide();
     }
 
     appMenu.refresh();
-  }
-
-  toggleIsSettingsOpen() {
-    this.setIsSettingsOpen(!this.isSettingsOpen);
   }
 }
 

--- a/packages/app/tray.ts
+++ b/packages/app/tray.ts
@@ -4,7 +4,6 @@ import Electron, { nativeTheme } from "electron";
 import { accounts } from "@/accounts";
 import { config } from "@/config";
 import { main } from "@/main";
-import { appState } from "./state";
 
 export class AppTray {
   private tray: Electron.Tray | undefined;
@@ -60,7 +59,7 @@ export class AppTray {
         if (accountWithUnread) {
           accounts.selectAccount(accountWithUnread.id);
 
-          appState.setIsSettingsOpen(false);
+          main.navigate("/");
         }
       }
 

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -421,7 +421,7 @@ export class WorkspaceApp {
     if (this._window) {
       this.registerWindowListeners();
     } else {
-      if (main.route !== "/") {
+      if (main.location !== "/") {
         this.view.setVisible(false);
       }
     }
@@ -657,7 +657,7 @@ export class WorkspaceApp {
 
     main.window.contentView.addChildView(this.view, 0);
 
-    if (main.route !== "/") {
+    if (main.location !== "/") {
       this.view.setVisible(false);
     }
 

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -33,7 +33,6 @@ import {
 } from "./lib/window";
 import { licenseKey } from "./license-key";
 import { main } from "./main";
-import { appState } from "./state";
 import { registerTabBroadcasts } from "./tabs";
 import { openExternalUrl } from "./url";
 
@@ -422,7 +421,7 @@ export class WorkspaceApp {
     if (this._window) {
       this.registerWindowListeners();
     } else {
-      if (appState.visibleSurface !== "account") {
+      if (main.visibleSurface !== "account") {
         this.view.setVisible(false);
       }
     }
@@ -658,7 +657,7 @@ export class WorkspaceApp {
 
     main.window.contentView.addChildView(this.view, 0);
 
-    if (appState.visibleSurface !== "account") {
+    if (main.visibleSurface !== "account") {
       this.view.setVisible(false);
     }
 

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -421,7 +421,7 @@ export class WorkspaceApp {
     if (this._window) {
       this.registerWindowListeners();
     } else {
-      if (main.visibleSurface !== "account") {
+      if (main.route !== "/") {
         this.view.setVisible(false);
       }
     }
@@ -657,7 +657,7 @@ export class WorkspaceApp {
 
     main.window.contentView.addChildView(this.view, 0);
 
-    if (main.visibleSurface !== "account") {
+    if (main.route !== "/") {
       this.view.setVisible(false);
     }
 

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -422,7 +422,7 @@ export class WorkspaceApp {
     if (this._window) {
       this.registerWindowListeners();
     } else {
-      if (appState.isSettingsOpen) {
+      if (appState.visibleSurface !== "account") {
         this.view.setVisible(false);
       }
     }
@@ -658,7 +658,7 @@ export class WorkspaceApp {
 
     main.window.contentView.addChildView(this.view, 0);
 
-    if (appState.isSettingsOpen) {
+    if (appState.visibleSurface !== "account") {
       this.view.setVisible(false);
     }
 

--- a/packages/renderer/components/app-main.tsx
+++ b/packages/renderer/components/app-main.tsx
@@ -1,4 +1,3 @@
-import { ipc } from "@meru/shared/renderer/ipc";
 import { Button } from "@meru/ui/components/button";
 import { ScrollArea } from "@meru/ui/components/scroll-area";
 import { cn } from "@meru/ui/lib/utils";
@@ -6,18 +5,13 @@ import { XIcon } from "lucide-react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { Route, useRoute } from "wouter";
 import { navigate } from "wouter/use-hash-location";
-import { useSettingsStore } from "@/lib/stores";
 import { DownloadHistory } from "@/routes/download-history";
 import { UnifiedInbox } from "@/routes/unified-inbox";
 import { sidebarNavItems } from "./app-sidebar";
 
-ipc.renderer.on("navigate", (_event, to) => {
-  navigate(to);
-});
-
 function CloseButton() {
   const closeSettings = () => {
-    ipc.main.send("settings.toggleIsOpen", false);
+    navigate("/");
   };
 
   useHotkeys("esc", closeSettings);
@@ -35,12 +29,6 @@ function CloseButton() {
 export function AppMain() {
   const [matchUnifiedInboxRoute] = useRoute("/unified-inbox");
   const [matchDownloadHistoryRoute] = useRoute("/download-history");
-
-  const isSettingsOpen = useSettingsStore((state) => state.isOpen);
-
-  if (!isSettingsOpen) {
-    return;
-  }
 
   const isFullWidthRoute = matchUnifiedInboxRoute || matchDownloadHistoryRoute;
 

--- a/packages/renderer/components/app-sidebar.tsx
+++ b/packages/renderer/components/app-sidebar.tsx
@@ -3,7 +3,6 @@ import { ScrollArea } from "@meru/ui/components/scroll-area";
 import { Separator } from "@meru/ui/components/separator";
 import { cn } from "@meru/ui/lib/utils";
 import { type RouteProps, useLocation } from "wouter";
-import { useSettingsStore } from "@/lib/stores";
 import { platform } from "@/lib/utils";
 import { AboutSettings } from "@/routes/settings/about";
 import { AccountsSettings } from "@/routes/settings/accounts";
@@ -131,12 +130,6 @@ type SidebarNavItemProps =
 
 export function AppSidebar() {
   const [location, navigate] = useLocation();
-
-  const isSettingsOpen = useSettingsStore((state) => state.isOpen);
-
-  if (!isSettingsOpen) {
-    return;
-  }
 
   return (
     <div className="bg-sidebar p-4 pr-0">

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -38,7 +38,6 @@ import {
   useAccountsStore,
   useAppUpdaterStore,
   useFindInPageStore,
-  useSettingsStore,
   useTabsStore,
   useTrialStore,
 } from "../lib/stores";
@@ -158,10 +157,10 @@ export function AppTitlebar() {
 
   const [matchUnifiedInboxRoute] = useRoute("/unified-inbox");
 
+  const [matchAccountRoute] = useRoute("/");
+
   const appUpdateVersion = useAppUpdaterStore((state) => state.version);
   const dismissAppUpdate = useAppUpdaterStore((state) => state.dismiss);
-
-  const isSettingsOpen = useSettingsStore((state) => state.isOpen);
 
   const { config } = useConfig();
 
@@ -202,15 +201,11 @@ export function AppTitlebar() {
     return accounts.map((account) => (
       <Button
         key={account.config.id}
-        variant={
-          account.config.selected && !matchUnifiedInboxRoute && !isSettingsOpen
-            ? "secondary"
-            : "ghost"
-        }
+        variant={account.config.selected && matchAccountRoute ? "secondary" : "ghost"}
         size="sm"
         className="draggable-none"
         onClick={() => {
-          ipc.main.send("settings.toggleIsOpen", false);
+          navigate("/");
 
           ipc.main.send("accounts.selectAccount", account.config.id);
         }}
@@ -335,8 +330,6 @@ export function AppTitlebar() {
                   className="size-7 draggable-none"
                   onClick={() => {
                     navigate("/unified-inbox");
-
-                    ipc.main.send("settings.toggleIsOpen", true);
                   }}
                   title="Unified Inbox"
                 >

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -15,7 +15,7 @@ import { UnreadCountBadge } from "@/components/unread-count-badge";
 import { WorkspaceAppIcon } from "@/components/workspace-app-icon";
 import { useConfig } from "@/lib/react-query";
 import { getModifierOpenBehavior } from "@/lib/workspace-apps";
-import { useAccountsStore, useSettingsStore, useTabsStore } from "../lib/stores";
+import { useAccountsStore, useTabsStore } from "../lib/stores";
 
 const verticalTabsPlugins = defaultPreset.plugins.filter((plugin) => plugin !== Accessibility);
 
@@ -227,7 +227,6 @@ function SortableVerticalTab({
 export function VerticalTabs() {
   const accounts = useAccountsStore((state) => state.accounts);
   const accountsTabs = useTabsStore((state) => state.accountsTabs);
-  const isSettingsOpen = useSettingsStore((state) => state.isOpen);
 
   const { config } = useConfig();
 
@@ -241,7 +240,7 @@ export function VerticalTabs() {
     ? getVerticalTabsWidth(selectedAccountTabs.tabs, config?.["verticalTabs.width"] ?? "auto")
     : 0;
 
-  if (isSettingsOpen || !selectedAccount || !selectedAccountTabs || verticalTabsWidth === 0) {
+  if (!selectedAccount || !selectedAccountTabs || verticalTabsWidth === 0) {
     return;
   }
 

--- a/packages/renderer/lib/ipc.ts
+++ b/packages/renderer/lib/ipc.ts
@@ -1,5 +1,18 @@
 import { ipc } from "@meru/shared/renderer/ipc";
+import { navigate } from "wouter/use-hash-location";
 import { playNotificationSound } from "./notifications";
+
+ipc.renderer.on("navigate", (_event, to) => {
+  navigate(to);
+});
+
+function sendRouteChanged() {
+  ipc.main.send("route.changed", `/${window.location.hash.replace(/^#?\/?/, "")}`);
+}
+
+window.addEventListener("hashchange", sendRouteChanged);
+
+sendRouteChanged();
 
 ipc.renderer.on("taskbar.setOverlayIcon", (_event, unreadCount) => {
   const canvas = document.createElement("canvas");

--- a/packages/renderer/lib/ipc.ts
+++ b/packages/renderer/lib/ipc.ts
@@ -6,14 +6,6 @@ ipc.renderer.on("navigate", (_event, to) => {
   navigate(to);
 });
 
-function sendRouteChanged() {
-  ipc.main.send("route.changed", `/${window.location.hash.replace(/^#?\/?/, "")}`);
-}
-
-window.addEventListener("hashchange", sendRouteChanged);
-
-sendRouteChanged();
-
 ipc.renderer.on("taskbar.setOverlayIcon", (_event, unreadCount) => {
   const canvas = document.createElement("canvas");
 

--- a/packages/renderer/lib/stores.ts
+++ b/packages/renderer/lib/stores.ts
@@ -2,7 +2,6 @@ import { ipc } from "@meru/shared/renderer/ipc";
 import type { AccountInstances } from "@meru/shared/schemas";
 import type { AccountTabsState } from "@meru/shared/tabs";
 import { toast } from "sonner";
-import { navigate } from "wouter/use-hash-location";
 import { create } from "zustand";
 import { getConfig } from "./react-query";
 import { accountsSearchParam, trialDaysLeftSearchParam } from "./search-params";
@@ -45,20 +44,6 @@ export const useTabsStore = create<{
 
 ipc.renderer.on("tabs.changed", (_event, accountsTabs) => {
   useTabsStore.setState({ accountsTabs });
-});
-
-export const useSettingsStore = create<{
-  isOpen: boolean;
-}>(() => ({
-  isOpen: false,
-}));
-
-ipc.renderer.on("settings.setIsOpen", (_event, isOpen) => {
-  useSettingsStore.setState({ isOpen });
-
-  if (!isOpen) {
-    navigate("/");
-  }
 });
 
 export const useFindInPageStore = create<{

--- a/packages/renderer/main.tsx
+++ b/packages/renderer/main.tsx
@@ -10,17 +10,6 @@ import { renderApp } from "@/lib/react";
 import { useThemeStore } from "@/lib/theme";
 import "@/lib/ipc";
 
-function FullWidthLayout() {
-  return (
-    <div className="flex h-screen flex-col">
-      <AppTitlebar />
-      <div className="flex flex-1 overflow-hidden">
-        <AppMain />
-      </div>
-    </div>
-  );
-}
-
 function Main() {
   const theme = useThemeStore((state) => state.theme);
 
@@ -28,25 +17,27 @@ function Main() {
 
   return (
     <Router hook={useHashLocation}>
-      <Switch>
-        <Route path="/unified-inbox">
-          <FullWidthLayout />
-        </Route>
-        <Route path="/download-history">
-          <FullWidthLayout />
-        </Route>
-        <Route path="/*?">
-          <div className="flex h-screen flex-col">
-            <AppTitlebar />
-            <div className="flex flex-1 overflow-hidden">
+      <div className="flex h-screen flex-col">
+        <AppTitlebar />
+        <div className="flex flex-1 overflow-hidden">
+          <Switch>
+            <Route path="/">
               <VerticalTabs />
+            </Route>
+            <Route path="/unified-inbox">
+              <AppMain />
+            </Route>
+            <Route path="/download-history">
+              <AppMain />
+            </Route>
+            <Route>
               <AppSidebar />
               <AppMain />
-            </div>
-          </div>
-          <Toaster theme={theme} />
-        </Route>
-      </Switch>
+            </Route>
+          </Switch>
+        </div>
+      </div>
+      <Toaster theme={theme} />
     </Router>
   );
 }

--- a/packages/renderer/routes/unified-inbox.tsx
+++ b/packages/renderer/routes/unified-inbox.tsx
@@ -36,6 +36,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
+import { navigate } from "wouter/use-hash-location";
 import { AccountBadge } from "@/components/account-badge";
 import { SettingsHeader, SettingsTitle } from "@/components/settings";
 import { createDateTimeFormatter, dayjs } from "@/lib/date";
@@ -180,7 +181,7 @@ function UnifiedInboxTable({
   const gPrefixTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const openMessage = (message: UnifiedInboxMessage) => {
-    ipc.main.send("settings.toggleIsOpen", false);
+    navigate("/");
 
     ipc.main.send("accounts.selectAccount", message.account.id);
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -149,7 +149,7 @@ export type IpcMainEvents =
       "accounts.addAccount": [account: AccountConfigInput];
       "accounts.removeAccount": [accountId: AccountConfig["id"]];
       "accounts.updateAccount": [account: AccountConfig];
-      "settings.toggleIsOpen": [open?: boolean];
+      "route.changed": [location: string];
       "workspaceApp.goBack": [workspaceAppId?: string];
       "workspaceApp.goForward": [workspaceAppId?: string];
       "workspaceApp.reload": [workspaceAppId?: string];
@@ -213,7 +213,6 @@ export type IpcMainEvents =
 
 export type IpcRendererEvent = {
   navigate: [to: string];
-  "settings.setIsOpen": [isOpen: boolean];
   "gmail.navigateTo": [hashLocation: GmailHashLocation];
   "gmail.handleMessage": [messageId: string, action: keyof typeof GMAIL_ACTION_CODE_MAP];
   "gmail.openMessage": [messageId: string];

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -149,7 +149,6 @@ export type IpcMainEvents =
       "accounts.addAccount": [account: AccountConfigInput];
       "accounts.removeAccount": [accountId: AccountConfig["id"]];
       "accounts.updateAccount": [account: AccountConfig];
-      "route.changed": [location: string];
       "workspaceApp.goBack": [workspaceAppId?: string];
       "workspaceApp.goForward": [workspaceAppId?: string];
       "workspaceApp.reload": [workspaceAppId?: string];


### PR DESCRIPTION
## Problem

Two parallel sources of truth track what the main window shows: `appState.isSettingsOpen` in the main process and the wouter route in the renderer. They are kept in sync by convention at every call site — `settings.toggleIsOpen` IPC sent next to `navigate()` calls, `main.navigate()` setting the flag *and* sending a navigate event, and the `settings.setIsOpen` echo navigating the renderer home on close. The titlebar then has to combine the flag with route matching to know what to render.

## Changes

The renderer route is now the single source of truth. `"/"` means the renderer shows only its own chrome (titlebar + vertical tabs) and the account views are visible; any other route means the renderer owns the window.

**Renderer**
- No route reporting logic at all — main observes the renderer's navigations itself (see below). The `navigate` listener moved from `app-main.tsx` to `lib/ipc.ts`.
- `useSettingsStore` and the `settings.setIsOpen`/`settings.toggleIsOpen` events are deleted. Call sites just navigate: ESC/close → `navigate("/")`, unified inbox button → `navigate("/unified-inbox")`, opening a message from the unified inbox → `navigate("/")` before selecting the account.
- `main.tsx` now structures the layout by route (`/` → vertical tabs, `/unified-inbox` and `/download-history` → full-width content, fallback → sidebar + settings), so the per-component `isSettingsOpen` gates in `AppMain`, `AppSidebar`, and `VerticalTabs` are gone. The titlebar and layout shell are hoisted above the `Switch`, which absorbed #704's `FullWidthLayout` helper. `Toaster` is hoisted too (it was previously missing on the unified-inbox branch).

**Main**
- `Main` (which owns the window loading the renderer) tracks `location` by listening to `did-navigate-in-page` on its webContents and parsing the hash — no custom IPC event needed. Transitions into and out of `"/"` hide/show the account views and refresh the menu — same effects as the old flag, in one place. `appState` shrinks to just `isQuittingApp`.
- `main.navigate(to)` sets the route optimistically before sending `navigate`, so main-initiated transitions (menu, tray) stay synchronous exactly as before — the `did-navigate-in-page` echo is idempotent. Menu/tray call sites that did `setIsSettingsOpen(false)` + `main.show()` collapse to `main.navigate("/")`.
- Readers (`menu.ts` `isGmailVisible`, focus handlers, workspace-app view visibility) become `main.location === "/"` checks — the route itself is descriptive enough that no derived surface enum is needed.
- The no-arg toggle branch of `settings.toggleIsOpen` had no senders and disappears with the event.

No visual or behavioral changes intended — this is plumbing for a follow-up that collapses the titlebar to a centered title on non-`"/"` routes.

Menu refresh coverage was verified for the paths that previously relied on the unconditional refresh in `setIsSettingsOpen`: tab switches refresh via the `activeTabId` setter, account switches via the `config.onDidChange("accounts")` listener.

## Test plan

1. Open settings from the menu → account views hide, settings render; press ESC → settings close, Gmail visible and focused (typing goes to Gmail).
2. Navigate between settings sections in the sidebar → sections render normally.
3. With settings open, switch account via menu accelerator (Cmd/Alt+2) → settings close, that account's view shows and is focused. Also switch via the titlebar account buttons while settings are open → same result, typing goes to Gmail afterwards (this path relies on the `did-navigate-in-page` commit arriving before the account selection IPC).
4. With settings open, switch tabs via the next/previous tab accelerators → settings close, the tab shows.
5. With 2+ accounts and unified inbox enabled: open the unified inbox from the titlebar → views hide, inbox renders, titlebar Inbox button highlights; open a message → inbox closes, correct account selected, message opens.
6. Add a new account from settings → settings close and the new account's Gmail shows.
7. Tray icon click with "select account with unread" enabled while settings are open → settings close, account with unread selected.
8. With settings open, check the Gmail menu (e.g. Compose) stays hidden/disabled, and reappears after closing settings.
9. Open a workspace app in its own window → its titlebar and navigation still work (workspace-app windows are unaffected by route reporting).
