### PR TITLE
collapse the titlebar to a settings title on settings routes

### DIFF
--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -19,7 +19,6 @@ import {
 import { useState } from "react";
 import { useLocation } from "wouter";
 import { navigate } from "wouter/use-hash-location";
-import { sidebarNavItems } from "@/components/app-sidebar";
 import { FindInPage as UiFindInPage } from "@/components/find-in-page";
 import {
   Titlebar,
@@ -166,18 +165,6 @@ function DoNotDisturb() {
   );
 }
 
-function getLocationTitle(location: string) {
-  if (location === "/unified-inbox") {
-    return "Unified Inbox";
-  }
-
-  if (location === "/download-history") {
-    return "Download History";
-  }
-
-  return sidebarNavItems.find((navItem) => navItem.path === location)?.label;
-}
-
 export function AppTitlebar() {
   const accounts = useAccountsStore((state) => state.accounts);
 
@@ -205,11 +192,9 @@ export function AppTitlebar() {
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
   if (location !== "/") {
-    const locationTitle = getLocationTitle(location);
-
     return (
       <Titlebar>
-        {locationTitle && <TitlebarTitle>{locationTitle}</TitlebarTitle>}
+        {location.startsWith("/settings/") && <TitlebarTitle>Settings</TitlebarTitle>}
         <AppMenuButton className="ml-auto" />
       </Titlebar>
     );

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -191,10 +191,10 @@ export function AppTitlebar() {
 
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
-  if (location !== "/") {
+  if (location.startsWith("/settings/")) {
     return (
       <Titlebar>
-        {location.startsWith("/settings/") && <TitlebarTitle>Settings</TitlebarTitle>}
+        <TitlebarTitle>Settings</TitlebarTitle>
         <AppMenuButton className="ml-auto" />
       </Titlebar>
     );
@@ -203,6 +203,10 @@ export function AppTitlebar() {
   if (!config || !accounts) {
     return;
   }
+
+  const isAccountLocation = location === "/";
+
+  const isUnifiedInboxLocation = location === "/unified-inbox";
 
   const shouldShowWorkspaceAppsLauncher =
     isLicenseKeyValid && config["workspaceApps.launcherApps"].length > 0;
@@ -229,7 +233,7 @@ export function AppTitlebar() {
     return accounts.map((account) => (
       <Button
         key={account.config.id}
-        variant={account.config.selected ? "secondary" : "ghost"}
+        variant={account.config.selected && isAccountLocation ? "secondary" : "ghost"}
         size="sm"
         className="draggable-none"
         onClick={() => {
@@ -306,6 +310,7 @@ export function AppTitlebar() {
               canGoBack={Boolean(activeTab?.navigationHistory.canGoBack)}
               canGoForward={Boolean(activeTab?.navigationHistory.canGoForward)}
               isLoading={Boolean(activeTab?.loading)}
+              disabled={isUnifiedInboxLocation}
               onGoBack={() => {
                 ipc.main.send("workspaceApp.goBack");
               }}
@@ -326,6 +331,7 @@ export function AppTitlebar() {
                 <TitlebarDropdownMenu
                   title="Workspace Apps"
                   icon={<LayoutGridIcon />}
+                  disabled={isUnifiedInboxLocation}
                   isOpen={isWorkspaceAppsLauncherOpen}
                   onOpenChange={setIsWorkspaceAppsLauncherOpen}
                 >
@@ -351,7 +357,7 @@ export function AppTitlebar() {
               )}
               {shouldShowUnifiedInboxButton && (
                 <Button
-                  variant="ghost"
+                  variant={isUnifiedInboxLocation ? "secondary" : "ghost"}
                   size="icon"
                   className="size-7 draggable-none"
                   onClick={() => {
@@ -392,7 +398,7 @@ export function AppTitlebar() {
                 title="Saved Searches"
                 icon={<MailSearchIcon />}
                 side="left"
-                disabled={isWorkspaceAppTabActive}
+                disabled={isUnifiedInboxLocation || isWorkspaceAppTabActive}
                 isOpen={isGmailSavedSearchesOpen}
                 onOpenChange={setIsGmailSavedSearchesOpen}
               >

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -17,8 +17,9 @@ import {
   SparklesIcon,
 } from "lucide-react";
 import { useState } from "react";
-import { useRoute } from "wouter";
+import { useLocation } from "wouter";
 import { navigate } from "wouter/use-hash-location";
+import { sidebarNavItems } from "@/components/app-sidebar";
 import { FindInPage as UiFindInPage } from "@/components/find-in-page";
 import {
   Titlebar,
@@ -28,6 +29,7 @@ import {
   TitlebarIconButton,
   TitlebarLeft,
   TitlebarNavigationControls,
+  TitlebarTitle,
 } from "@/components/titlebar";
 import { UnreadCountBadge } from "@/components/unread-count-badge";
 import { WorkspaceAppIcon } from "@/components/workspace-app-icon";
@@ -58,6 +60,26 @@ function RecentDownloadHistoryButton() {
     >
       <DownloadIcon />
     </TitlebarIconButton>
+  );
+}
+
+function AppMenuButton({ className }: { className?: string }) {
+  if (window.electron.process.platform === "darwin") {
+    return;
+  }
+
+  return (
+    <div className={cn("draggable-none", className)}>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={() => {
+          ipc.main.send("titleBar.toggleAppMenu");
+        }}
+      >
+        <EllipsisVerticalIcon />
+      </Button>
+    </div>
   );
 }
 
@@ -144,6 +166,18 @@ function DoNotDisturb() {
   );
 }
 
+function getLocationTitle(location: string) {
+  if (location === "/unified-inbox") {
+    return "Unified Inbox";
+  }
+
+  if (location === "/download-history") {
+    return "Download History";
+  }
+
+  return sidebarNavItems.find((navItem) => navItem.path === location)?.label;
+}
+
 export function AppTitlebar() {
   const accounts = useAccountsStore((state) => state.accounts);
 
@@ -155,9 +189,7 @@ export function AppTitlebar() {
     .find((accountTabs) => accountTabs.accountId === selectedAccount?.config.id)
     ?.tabs.find((tab) => tab.active);
 
-  const [matchUnifiedInboxRoute] = useRoute("/unified-inbox");
-
-  const [matchAccountRoute] = useRoute("/");
+  const [location] = useLocation();
 
   const appUpdateVersion = useAppUpdaterStore((state) => state.version);
   const dismissAppUpdate = useAppUpdaterStore((state) => state.dismiss);
@@ -171,6 +203,17 @@ export function AppTitlebar() {
   const [isAppUpdateDetailsOpen, setIsAppUpdateDetailsOpen] = useState(false);
 
   const isLicenseKeyValid = useIsLicenseKeyValid();
+
+  if (location !== "/") {
+    const locationTitle = getLocationTitle(location);
+
+    return (
+      <Titlebar>
+        {locationTitle && <TitlebarTitle>{locationTitle}</TitlebarTitle>}
+        <AppMenuButton className="ml-auto" />
+      </Titlebar>
+    );
+  }
 
   if (!config || !accounts) {
     return;
@@ -201,7 +244,7 @@ export function AppTitlebar() {
     return accounts.map((account) => (
       <Button
         key={account.config.id}
-        variant={account.config.selected && matchAccountRoute ? "secondary" : "ghost"}
+        variant={account.config.selected ? "secondary" : "ghost"}
         size="sm"
         className="draggable-none"
         onClick={() => {
@@ -278,7 +321,6 @@ export function AppTitlebar() {
               canGoBack={Boolean(activeTab?.navigationHistory.canGoBack)}
               canGoForward={Boolean(activeTab?.navigationHistory.canGoForward)}
               isLoading={Boolean(activeTab?.loading)}
-              disabled={matchUnifiedInboxRoute}
               onGoBack={() => {
                 ipc.main.send("workspaceApp.goBack");
               }}
@@ -299,7 +341,6 @@ export function AppTitlebar() {
                 <TitlebarDropdownMenu
                   title="Workspace Apps"
                   icon={<LayoutGridIcon />}
-                  disabled={matchUnifiedInboxRoute}
                   isOpen={isWorkspaceAppsLauncherOpen}
                   onOpenChange={setIsWorkspaceAppsLauncherOpen}
                 >
@@ -325,7 +366,7 @@ export function AppTitlebar() {
               )}
               {shouldShowUnifiedInboxButton && (
                 <Button
-                  variant={matchUnifiedInboxRoute ? "secondary" : "ghost"}
+                  variant="ghost"
                   size="icon"
                   className="size-7 draggable-none"
                   onClick={() => {
@@ -366,7 +407,7 @@ export function AppTitlebar() {
                 title="Saved Searches"
                 icon={<MailSearchIcon />}
                 side="left"
-                disabled={matchUnifiedInboxRoute || isWorkspaceAppTabActive}
+                disabled={isWorkspaceAppTabActive}
                 isOpen={isGmailSavedSearchesOpen}
                 onOpenChange={setIsGmailSavedSearchesOpen}
               >
@@ -396,19 +437,7 @@ export function AppTitlebar() {
               <SparklesIcon /> Update Available
             </Button>
           )}
-          {window.electron.process.platform !== "darwin" && (
-            <div className="draggable-none">
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={() => {
-                  ipc.main.send("titleBar.toggleAppMenu");
-                }}
-              >
-                <EllipsisVerticalIcon />
-              </Button>
-            </div>
-          )}
+          <AppMenuButton />
         </div>
       </>
     );

--- a/packages/renderer/components/titlebar.tsx
+++ b/packages/renderer/components/titlebar.tsx
@@ -50,6 +50,17 @@ export function TitlebarPageTitle({ children }: { children: string }) {
   );
 }
 
+export function TitlebarTitle({ children }: { children: string }) {
+  return (
+    <div
+      className="absolute top-1/2 left-1/2 max-w-xs -translate-x-1/2 -translate-y-1/2 truncate text-xs"
+      title={children}
+    >
+      {children}
+    </div>
+  );
+}
+
 export function TitlebarIconButton({ className, ...props }: ComponentProps<typeof Button>) {
   return (
     <Button variant="ghost" size="icon-sm" className={cn("draggable-none", className)} {...props} />


### PR DESCRIPTION
## Problem

When settings are open, the titlebar still renders the full account-surface control set — navigation controls, workspace-apps launcher, account switcher, saved searches, find-in-page, download history, do-not-disturb. Several of these act on the hidden account views and are dead or misleading there, and the busy titlebar makes settings feel less like a native app.

Follow-up to #705, which made the renderer location the single source of truth (`"/"` = account surface visible).

## Changes

`AppTitlebar` branches on a single `useLocation()`:

- **`/settings/*`** — only a centered "Settings" title and (non-macOS) the ⋮ app-menu button, which stays because on Linux/Windows it is the only way to reach the app menu. No navigation controls, launcher, accounts, trial badge, find-in-page, saved searches, download history, do-not-disturb, or update button.
- **Everything else** (`/`, `/unified-inbox`, `/download-history`) — the full titlebar, unchanged from `main`. The former `useRoute` matches became `isAccountLocation` / `isUnifiedInboxLocation` booleans derived from the same location value; all the disabled states and highlight variants behave exactly as before.

New `TitlebarTitle` component in `titlebar.tsx`, absolutely centered in the titlebar-area container so it doesn't shift with the ⋮ button, reusing `TitlebarPageTitle`'s text styling. The ⋮ button is extracted into an `AppMenuButton` component used by both modes (behavior unchanged; in title mode it needs `ml-auto` since the centered title is out of flow).

Note: while settings are open, Cmd+F's find bar no longer has a home in the titlebar; gating the "Find..." menu item accordingly is #707.

## Test plan

1. Open settings → titlebar shows only a centered "Settings" title and, on Linux/Windows, the ⋮ button on the right; the window can still be dragged by the titlebar.
2. Switch sidebar sections → the "Settings" title stays put.
3. On Linux/Windows: click ⋮ while settings are open → the app menu opens.
4. Press ESC → full titlebar returns with all controls working (navigation, launcher, account buttons, downloads, DND).
5. Open the unified inbox → full titlebar as on `main`: Inbox button highlighted, navigation controls and launcher disabled, account buttons visible and clickable.
6. Open the download history → full titlebar as on `main`.
7. With 2+ accounts: the selected account button highlights only on `"/"`.
8. Trigger an update-available state → the Update Available button and banner behave as before on `"/"` and the unified inbox; while in settings, no update button shows (the Updates settings page still covers it).
