### PR TITLE
disable find in page when no account view is visible

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -173,6 +173,10 @@ export class AppMenu {
     const copyOrShareMessageLink =
       isGmailVisible && userEmail && messageId && createMeruMessageUrl(userEmail, messageId);
 
+    const isFindInPageEnabled =
+      Boolean(focusedWindow && WorkspaceApp.tryFromWebContents(focusedWindow.webContents)) ||
+      main.location === "/";
+
     const allAccounts = accounts.getAccounts();
 
     const template: MenuItemConstructorOptions[] = [
@@ -294,6 +298,7 @@ export class AppMenu {
           {
             label: "Find...",
             accelerator: "CommandOrControl+F",
+            enabled: isFindInPageEnabled,
             click: () => {
               const focusedWindow = BrowserWindow.getFocusedWindow();
 


### PR DESCRIPTION
## Problem

The "Find..." menu item (Cmd/Ctrl+F) is always enabled. With settings, the unified inbox, or the download history open, its click handler activates find in the main window's renderer while the actual find requests target the hidden account view's webContents (`findInPage` in `packages/app/ipc.ts` falls back to `getNavigationWebContents()`) — searching an invisible page and leaving stale find UI state behind. With the titlebar collapsing to a title on those surfaces (#706), the find bar no longer even has a place to render there.

## Changes

Gate the "Find..." item with `enabled`, mirroring the click handler's own target resolution: enabled when the focused window is a workspace-app window (works regardless of location), otherwise only when `main.location === "/"` (the account surface from #705). Same surface-gating precedent as the Compose item (858faae), using `enabled` instead of `visible` since the item still applies conceptually.

`isGmailVisible` would be the wrong condition — find must also work on non-Gmail workspace-app tabs in the main window.

The menu already rebuilds on every location boundary transition and on window focus, so the enabled state stays current without extra wiring.

## Test plan

1. On the account surface (`"/"`), press Cmd/Ctrl+F on the Gmail tab → find bar activates and searches Gmail.
2. Switch to a workspace-app tab in the main window → Cmd/Ctrl+F still works.
3. Open settings → the Edit menu shows "Find..." greyed out; Cmd/Ctrl+F does nothing.
4. Same in the unified inbox and download history.
5. Close settings (ESC) → "Find..." is enabled again immediately, no app restart needed.
6. Focus a workspace app opened as its own window while settings are open in the main window → Cmd/Ctrl+F works in that window.
