### PR TITLE
move the quitting flag onto main and remove app state

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -7,7 +7,6 @@ import { config } from "./config";
 import { ipc } from "./ipc";
 import { licenseKey } from "./license-key";
 import { main } from "./main";
-import { appState } from "./state";
 import { isWindowedTab } from "./tabs";
 import { WorkspaceApp } from "./workspace-app";
 
@@ -375,7 +374,7 @@ class Accounts {
   }
 
   savePinnedTabs() {
-    if (appState.isQuittingApp) {
+    if (main.isQuittingApp) {
       return;
     }
 

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -10,7 +10,6 @@ import { initLinuxWindowControls } from "@/lib/linux";
 import { licenseKey } from "@/license-key";
 import { main } from "@/main";
 import { appMenu } from "@/menu";
-import { appState } from "@/state";
 import { theme } from "@/theme";
 import { appTray } from "@/tray";
 import { appUpdater } from "@/updater";
@@ -182,12 +181,12 @@ async function init() {
   }
 
   app.on("before-quit", () => {
-    if (!appState.isQuittingApp) {
+    if (!main.isQuittingApp) {
       main.saveWindowState();
 
       accounts.savePinnedTabs();
 
-      appState.isQuittingApp = true;
+      main.isQuittingApp = true;
     }
   });
 }

--- a/packages/app/main.ts
+++ b/packages/app/main.ts
@@ -10,7 +10,6 @@ import {
   loadRenderer,
 } from "@/lib/window";
 import { appMenu } from "@/menu";
-import { appState } from "@/state";
 import { openExternalUrl } from "@/url";
 import { ipc } from "./ipc";
 import { trial } from "./trial";
@@ -54,6 +53,8 @@ class Main {
 
   shouldLaunchMinimized =
     app.commandLine.hasSwitch("launch-minimized") || config.get("launchMinimized");
+
+  isQuittingApp = false;
 
   loadURL() {
     const searchParams = new URLSearchParams();
@@ -152,7 +153,7 @@ class Main {
         this.window.setFullScreen(false);
       }
 
-      if (!appState.isQuittingApp) {
+      if (!this.isQuittingApp) {
         event.preventDefault();
 
         this.window.blur();

--- a/packages/app/state.ts
+++ b/packages/app/state.ts
@@ -1,5 +1,0 @@
-class AppState {
-  isQuittingApp = false;
-}
-
-export const appState = new AppState();

--- a/packages/app/updater.ts
+++ b/packages/app/updater.ts
@@ -4,7 +4,6 @@ import { config } from "@/config";
 import { ipc } from "./ipc";
 import { log } from "./lib/log";
 import { main } from "./main";
-import { appState } from "./state";
 
 class AppUpdater {
   init() {
@@ -45,7 +44,7 @@ class AppUpdater {
   quitAndInstall() {
     main.saveWindowState();
 
-    appState.isQuittingApp = true;
+    main.isQuittingApp = true;
 
     autoUpdater.quitAndInstall();
   }


### PR DESCRIPTION
## Problem

`packages/app/state.ts` was left holding a single field, `isQuittingApp`, after everything else moved out of it. A module-level singleton for one boolean is an unnecessary indirection, and the flag's only readers already deal with the main window.

## Changes

- Move `isQuittingApp` onto the `Main` class in `packages/app/main.ts`, next to `shouldLaunchMinimized`.
- Update the four call sites to use `main.isQuittingApp` (`this.isQuittingApp` inside `Main`): the window `close` handler, `accounts.savePinnedTabs()`, `appUpdater.quitAndInstall()`, and the `before-quit` handler in `index.ts`.
- Delete `packages/app/state.ts`.

No new imports were needed — every file that touched `appState` already imported `main`. Behavior is unchanged; this is a pure move.

## Test plan

1. Launch the app, then close the main window with the window close button (or `Cmd/Ctrl+W`) — the window hides instead of quitting, and the app stays in the tray/dock.
2. Reopen the window from the tray/dock — it shows again with its previous bounds.
3. Pin a tab in an account, then quit the app properly (`Cmd+Q` / tray → Quit) and relaunch — the pinned tab is still there, and the window reopens at the size and position it had at quit.
4. Resize/move the window, quit, and relaunch — the window state was saved on `before-quit`.
5. On macOS, put the window in full screen and press the close button — it leaves full screen first and then hides, without a black screen.
6. Trigger an update install (or call `appUpdater.quitAndInstall()`) — the app quits and restarts without the window-hide path intercepting the close.