### PR TITLE
model tab persistence as pinned or bookmarked

### DIFF
--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -46,7 +46,7 @@ export class Account {
 
     this.tabs = new Tabs(accountConfig.id, this.gmail);
 
-    this.tabs.restorePinnedTabs(accountConfig.workspaceApps.pinnedTabs);
+    this.tabs.restoreSavedTabs(accountConfig.workspaceApps.savedTabs);
   }
 
   setSpellCheckerLanguages() {

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -271,7 +271,7 @@ class Accounts {
         delegatedAccountId: null,
       },
       workspaceApps: {
-        pinnedTabs: [],
+        savedTabs: [],
       },
     };
 
@@ -373,7 +373,7 @@ class Accounts {
     }
   }
 
-  savePinnedTabs() {
+  saveTabs() {
     if (main.isQuittingApp) {
       return;
     }
@@ -390,7 +390,7 @@ class Accounts {
         return {
           ...accountConfig,
           workspaceApps: {
-            pinnedTabs: instance.tabs.serializePinnedTabs(),
+            savedTabs: instance.tabs.serializeSavedTabs(),
           },
         };
       }),

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -28,7 +28,7 @@ export const config = new Store<Config>({
           unifiedInbox: true,
         },
         workspaceApps: {
-          pinnedTabs: [],
+          savedTabs: [],
         },
       },
     ],
@@ -362,7 +362,7 @@ export const config = new Store<Config>({
       if (Array.isArray(accounts)) {
         for (const account of accounts) {
           if (typeof account.workspaceApps === "undefined") {
-            account.workspaceApps = { pinnedTabs: [] };
+            account.workspaceApps = { savedTabs: [] };
           }
         }
 

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -184,7 +184,7 @@ async function init() {
     if (!main.isQuittingApp) {
       main.saveWindowState();
 
-      accounts.savePinnedTabs();
+      accounts.saveTabs();
 
       main.isQuittingApp = true;
     }

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -296,7 +296,9 @@ class Ipc {
 
       const hasOtherClosableTabs = account.instance.tabs.tabs.some(
         (accountTab) =>
-          accountTab.id !== tabId && accountTab.id !== GMAIL_TAB_ID && !accountTab.pinned,
+          accountTab.id !== tabId &&
+          accountTab.id !== GMAIL_TAB_ID &&
+          accountTab.persistence !== "pinned",
       );
 
       const contextTabIndex = account.instance.tabs.tabs.findIndex(
@@ -305,7 +307,7 @@ class Ipc {
 
       const hasClosableTabsBelow = account.instance.tabs.tabs
         .slice(contextTabIndex + 1)
-        .some((accountTab) => !accountTab.pinned);
+        .some((accountTab) => accountTab.persistence !== "pinned");
 
       Menu.buildFromTemplate([
         ...(tabApp && !workspaceApps[tabApp].singleInstance && !workspaceApps[tabApp].popupOnly
@@ -411,20 +413,20 @@ class Ipc {
         {
           type: "separator",
         },
-        tab.pinned
+        tab.persistence === "pinned"
           ? {
               label: "Unpin",
               click: () => {
-                account.instance.tabs.unpinTab(tabId);
+                account.instance.tabs.setTabPersistence(tabId, null);
               },
             }
           : {
               label: "Pin",
               click: () => {
-                account.instance.tabs.pinTab(tabId);
+                account.instance.tabs.setTabPersistence(tabId, "pinned");
               },
             },
-        ...(tab.pinned
+        ...(tab.persistence === "pinned"
           ? [
               {
                 label: "Load on Launch",
@@ -433,7 +435,7 @@ class Ipc {
                 click: () => {
                   tab.loadOnLaunch = !tab.loadOnLaunch;
 
-                  accounts.savePinnedTabs();
+                  accounts.saveTabs();
                 },
               },
             ]

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { PinnedTab } from "@meru/shared/schemas";
+import type { SavedTab, TabPersistence } from "@meru/shared/schemas";
 import { GMAIL_TAB_ID, type TabState } from "@meru/shared/tabs";
 import type { SupportedWorkspaceApp } from "@meru/shared/workspace-apps";
 import type { WebContentsView } from "electron";
@@ -27,17 +27,20 @@ export function isWindowedTab(tab: Tab) {
   return tab instanceof WorkspaceApp && tab.isWindowed;
 }
 
-type PinnedWorkspaceApp = WorkspaceApp & { app: SupportedWorkspaceApp };
+type SavedWorkspaceApp = WorkspaceApp & {
+  app: SupportedWorkspaceApp;
+  persistence: TabPersistence;
+};
 
-function isPinnedWorkspaceApp(tab: Tab): tab is PinnedWorkspaceApp {
-  return tab instanceof WorkspaceApp && tab.pinned && tab.app !== undefined;
+function isSavedWorkspaceApp(tab: Tab): tab is SavedWorkspaceApp {
+  return tab instanceof WorkspaceApp && tab.persistence !== null && tab.app !== undefined;
 }
 
 export type Tab = {
   id: string;
   app: SupportedWorkspaceApp | undefined;
   title: string;
-  pinned: boolean;
+  persistence: TabPersistence | null;
   isLoading: boolean;
   navigationHistory: { canGoBack: boolean; canGoForward: boolean };
   view?: WebContentsView;
@@ -51,7 +54,7 @@ export class DormantTab {
 
   url: string;
 
-  pinned = true;
+  persistence: TabPersistence;
 
   isLoading = false;
 
@@ -63,11 +66,12 @@ export class DormantTab {
 
   zoomFactor: number | undefined;
 
-  constructor(pinnedTab: PinnedTab, zoomFactor?: number) {
-    this.app = pinnedTab.app;
-    this.url = pinnedTab.url;
-    this.title = pinnedTab.title;
-    this.loadOnLaunch = Boolean(pinnedTab.loadOnLaunch);
+  constructor(savedTab: SavedTab, zoomFactor?: number) {
+    this.app = savedTab.app;
+    this.url = savedTab.url;
+    this.title = savedTab.title;
+    this.persistence = savedTab.persistence;
+    this.loadOnLaunch = Boolean(savedTab.loadOnLaunch);
     this.zoomFactor = zoomFactor;
   }
 }
@@ -88,7 +92,7 @@ export class Tabs {
       {
         id: GMAIL_TAB_ID,
         app: gmail.app,
-        pinned: false,
+        persistence: null,
         get title() {
           return gmail.title;
         },
@@ -186,8 +190,8 @@ export class Tabs {
 
     this.broadcastTabsChanged();
 
-    if (removedTab?.pinned) {
-      accounts.savePinnedTabs();
+    if (removedTab?.persistence) {
+      accounts.saveTabs();
     }
   }
 
@@ -217,7 +221,7 @@ export class Tabs {
     const workspaceApp = new WorkspaceApp({
       accountId: this.accountId,
       url: dormantTab.url,
-      pinned: true,
+      persistence: dormantTab.persistence,
       loadOnLaunch: dormantTab.loadOnLaunch,
       app: dormantTab.app,
       zoomFactor: dormantTab.zoomFactor,
@@ -238,9 +242,9 @@ export class Tabs {
     this.broadcastTabsChanged();
   }
 
-  restorePinnedTabs(pinnedTabs: PinnedTab[]) {
-    for (const pinnedTab of pinnedTabs) {
-      this.tabs.push(new DormantTab(pinnedTab));
+  restoreSavedTabs(savedTabs: SavedTab[]) {
+    for (const savedTab of savedTabs) {
+      this.tabs.push(new DormantTab(savedTab));
     }
   }
 
@@ -281,8 +285,8 @@ export class Tabs {
       return;
     }
 
-    if (isPinnedWorkspaceApp(closableTab)) {
-      this.dormantizePinnedTab(closableTab);
+    if (isSavedWorkspaceApp(closableTab)) {
+      this.dormantizeSavedTab(closableTab);
     } else {
       this.recordRecentlyClosedTab(closableTab.url);
     }
@@ -295,8 +299,8 @@ export class Tabs {
       return;
     }
 
-    if (isPinnedWorkspaceApp(windowedTab)) {
-      this.dormantizePinnedTab(windowedTab);
+    if (isSavedWorkspaceApp(windowedTab)) {
+      this.dormantizeSavedTab(windowedTab);
 
       return;
     }
@@ -306,28 +310,29 @@ export class Tabs {
     this.removeTab(windowedTab.id);
   }
 
-  private dormantizePinnedTab(pinnedWorkspaceApp: PinnedWorkspaceApp) {
+  private dormantizeSavedTab(savedWorkspaceApp: SavedWorkspaceApp) {
     this.tabs.splice(
-      this.tabs.indexOf(pinnedWorkspaceApp),
+      this.tabs.indexOf(savedWorkspaceApp),
       1,
       new DormantTab(
         {
-          app: pinnedWorkspaceApp.app,
-          url: pinnedWorkspaceApp.url,
-          title: pinnedWorkspaceApp.title,
-          loadOnLaunch: pinnedWorkspaceApp.loadOnLaunch,
+          app: savedWorkspaceApp.app,
+          url: savedWorkspaceApp.url,
+          title: savedWorkspaceApp.title,
+          persistence: savedWorkspaceApp.persistence,
+          loadOnLaunch: savedWorkspaceApp.loadOnLaunch,
         },
-        pinnedWorkspaceApp.zoomFactor,
+        savedWorkspaceApp.zoomFactor,
       ),
     );
 
-    if (this.activeTabId === pinnedWorkspaceApp.id) {
+    if (this.activeTabId === savedWorkspaceApp.id) {
       this.activeTabId = GMAIL_TAB_ID;
     }
 
     this.broadcastTabsChanged();
 
-    accounts.savePinnedTabs();
+    accounts.saveTabs();
   }
 
   private recordRecentlyClosedTab(closedTabUrl: string) {
@@ -364,7 +369,7 @@ export class Tabs {
     const previousActiveTabId = this.activeTabId;
 
     for (const tab of this.tabs.slice()) {
-      if (tab.id !== keptTabId && tab.id !== GMAIL_TAB_ID && !tab.pinned) {
+      if (tab.id !== keptTabId && tab.id !== GMAIL_TAB_ID && tab.persistence !== "pinned") {
         this.closeTab(tab.id);
       }
     }
@@ -380,7 +385,7 @@ export class Tabs {
     const tabIndex = this.tabs.findIndex((tab) => tab.id === tabId);
 
     for (const tab of this.tabs.slice(tabIndex + 1)) {
-      if (!tab.pinned) {
+      if (tab.persistence !== "pinned") {
         this.closeTab(tab.id);
       }
     }
@@ -390,42 +395,28 @@ export class Tabs {
     }
   }
 
-  pinTab(tabId: string) {
-    const pinnableTab = this.getTab(tabId);
+  setTabPersistence(tabId: string, persistence: TabPersistence | null) {
+    const persistableTab = this.getTab(tabId);
 
-    if (!(pinnableTab instanceof WorkspaceApp)) {
+    if (persistableTab instanceof DormantTab) {
+      if (!persistence) {
+        this.removeTab(tabId);
+
+        return;
+      }
+
+      persistableTab.persistence = persistence;
+    } else if (persistableTab instanceof WorkspaceApp) {
+      persistableTab.persistence = persistence;
+    } else {
       return;
     }
-
-    pinnableTab.pinned = true;
 
     this.reorderTabs();
 
     this.broadcastTabsChanged();
 
-    accounts.savePinnedTabs();
-  }
-
-  unpinTab(tabId: string) {
-    const unpinnableTab = this.getTab(tabId);
-
-    if (unpinnableTab instanceof DormantTab) {
-      this.removeTab(tabId);
-
-      return;
-    }
-
-    if (!(unpinnableTab instanceof WorkspaceApp)) {
-      return;
-    }
-
-    unpinnableTab.pinned = false;
-
-    this.reorderTabs();
-
-    this.broadcastTabsChanged();
-
-    accounts.savePinnedTabs();
+    accounts.saveTabs();
   }
 
   moveTab(tabId: string, targetSectionIndex: number) {
@@ -441,17 +432,19 @@ export class Tabs {
 
     const remainingTabs = this.tabs.filter((tab) => tab.id !== tabId);
 
+    const isMovedTabPinned = movedTab.persistence === "pinned";
+
     const remainingPinnedSectionTabCount = remainingTabs.filter(
-      (tab) => tab.id === GMAIL_TAB_ID || tab.pinned,
+      (tab) => tab.id === GMAIL_TAB_ID || tab.persistence === "pinned",
     ).length;
 
-    const sectionStartIndex = movedTab.pinned ? 0 : remainingPinnedSectionTabCount;
+    const sectionStartIndex = isMovedTabPinned ? 0 : remainingPinnedSectionTabCount;
 
-    const sectionTabCount = movedTab.pinned
+    const sectionTabCount = isMovedTabPinned
       ? remainingPinnedSectionTabCount
       : remainingTabs.length - remainingPinnedSectionTabCount;
 
-    const minimumSectionIndex = movedTab.pinned ? 1 : 0;
+    const minimumSectionIndex = isMovedTabPinned ? 1 : 0;
 
     const clampedSectionIndex = Math.min(
       Math.max(targetSectionIndex, minimumSectionIndex),
@@ -466,41 +459,43 @@ export class Tabs {
 
     this.broadcastTabsChanged();
 
-    if (movedTab.pinned) {
-      accounts.savePinnedTabs();
+    if (movedTab.persistence) {
+      accounts.saveTabs();
     }
   }
 
   private reorderTabs() {
     this.tabs = [
       ...this.tabs.filter((tab) => tab.id === GMAIL_TAB_ID),
-      ...this.tabs.filter((tab) => tab.id !== GMAIL_TAB_ID && tab.pinned),
-      ...this.tabs.filter((tab) => tab.id !== GMAIL_TAB_ID && !tab.pinned),
+      ...this.tabs.filter((tab) => tab.id !== GMAIL_TAB_ID && tab.persistence === "pinned"),
+      ...this.tabs.filter((tab) => tab.id !== GMAIL_TAB_ID && tab.persistence !== "pinned"),
     ];
   }
 
-  serializePinnedTabs(): PinnedTab[] {
-    const pinnedTabs: PinnedTab[] = [];
+  serializeSavedTabs(): SavedTab[] {
+    const savedTabs: SavedTab[] = [];
 
     for (const tab of this.tabs) {
-      if (tab instanceof WorkspaceApp && tab.pinned && tab.app) {
-        pinnedTabs.push({
+      if (tab instanceof WorkspaceApp && tab.persistence && tab.app) {
+        savedTabs.push({
           app: tab.app,
           url: tab.url,
           title: tab.title,
+          persistence: tab.persistence,
           loadOnLaunch: tab.loadOnLaunch,
         });
       } else if (tab instanceof DormantTab) {
-        pinnedTabs.push({
+        savedTabs.push({
           app: tab.app,
           url: tab.url,
           title: tab.title,
+          persistence: tab.persistence,
           loadOnLaunch: tab.loadOnLaunch,
         });
       }
     }
 
-    return pinnedTabs;
+    return savedTabs;
   }
 
   closeAll() {
@@ -516,7 +511,7 @@ export class Tabs {
       id: tab.id,
       app: tab.app,
       title: tab.title,
-      pinned: tab.pinned,
+      persistence: tab.persistence,
       dormant: tab instanceof DormantTab,
       windowed: isWindowedTab(tab),
       loading: tab.isLoading,

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { APP_TITLEBAR_HEIGHT, GOOGLE_ACCOUNTS_URL } from "@meru/shared/constants";
 import { getWorkspaceAppUrl } from "@meru/shared/google";
-import type { AccountConfig } from "@meru/shared/schemas";
+import type { AccountConfig, TabPersistence } from "@meru/shared/schemas";
 import { clamp } from "@meru/shared/utils";
 import {
   type SupportedWorkspaceApp,
@@ -74,7 +74,7 @@ type WorkspaceAppOptions = {
   window?: BrowserWindowConstructorOptions;
   view?: WebContentsViewConstructorOptions;
   asWindow?: boolean;
-  pinned?: boolean;
+  persistence?: TabPersistence | null;
   loadOnLaunch?: boolean;
   app?: SupportedWorkspaceApp;
   zoomFactor?: number;
@@ -363,7 +363,7 @@ export class WorkspaceApp {
 
   view: WebContentsView;
 
-  pinned = false;
+  persistence: TabPersistence | null;
 
   loadOnLaunch = false;
 
@@ -379,14 +379,14 @@ export class WorkspaceApp {
     window,
     view,
     asWindow,
-    pinned,
+    persistence,
     loadOnLaunch,
     app,
     zoomFactor,
   }: WorkspaceAppOptions) {
     this.accountId = accountId;
     this.app = app ?? getWorkspaceAppFromUrl(url);
-    this.pinned = Boolean(pinned);
+    this.persistence = persistence ?? null;
     this.loadOnLaunch = Boolean(loadOnLaunch);
 
     if (asWindow) {

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -113,7 +113,7 @@ function VerticalTab({
   gmailStatus?: GmailTabStatus;
   className?: string;
 }) {
-  const isPinnedSectionTab = tab.id === GMAIL_TAB_ID || tab.pinned;
+  const isPinnedSectionTab = tab.id === GMAIL_TAB_ID || tab.persistence === "pinned";
 
   const isCloseable = !isPinnedSectionTab;
 
@@ -247,11 +247,11 @@ export function VerticalTabs() {
   const isWide = verticalTabsWidth === VERTICAL_TABS_WIDE_WIDTH;
 
   const pinnedSectionTabs = selectedAccountTabs.tabs.filter(
-    (tab) => tab.id === GMAIL_TAB_ID || tab.pinned,
+    (tab) => tab.id === GMAIL_TAB_ID || tab.persistence === "pinned",
   );
 
   const unpinnedTabs = selectedAccountTabs.tabs.filter(
-    (tab) => tab.id !== GMAIL_TAB_ID && !tab.pinned,
+    (tab) => tab.id !== GMAIL_TAB_ID && tab.persistence !== "pinned",
   );
 
   const gmailTabStatus = {

--- a/packages/shared/schemas.ts
+++ b/packages/shared/schemas.ts
@@ -21,16 +21,21 @@ export const accountColors = [
   "pink",
 ] as const;
 
-export const pinnedTabSchema = z.object({
+export const tabPersistenceSchema = z.enum(["pinned", "bookmarked"]);
+
+export type TabPersistence = z.infer<typeof tabPersistenceSchema>;
+
+export const savedTabSchema = z.object({
   app: z.custom<SupportedWorkspaceApp>(
     (value) => typeof value === "string" && value in workspaceApps,
   ),
   url: z.string(),
   title: z.string(),
+  persistence: tabPersistenceSchema,
   loadOnLaunch: z.boolean(),
 });
 
-export type PinnedTab = z.infer<typeof pinnedTabSchema>;
+export type SavedTab = z.infer<typeof savedTabSchema>;
 
 export const accountConfigSchema = z.object({
   id: z.string(),
@@ -44,7 +49,7 @@ export const accountConfigSchema = z.object({
     unifiedInbox: z.boolean(),
   }),
   workspaceApps: z.object({
-    pinnedTabs: z.array(pinnedTabSchema),
+    savedTabs: z.array(savedTabSchema),
   }),
 });
 

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -1,5 +1,5 @@
 import { VERTICAL_TABS_NARROW_WIDTH, VERTICAL_TABS_WIDE_WIDTH } from "./constants";
-import type { AccountConfig } from "./schemas";
+import type { AccountConfig, TabPersistence } from "./schemas";
 import type { SupportedWorkspaceApp } from "./workspace-apps";
 
 export const GMAIL_TAB_ID = "gmail";
@@ -16,7 +16,7 @@ export type TabState = {
   id: string;
   app: SupportedWorkspaceApp | undefined;
   title: string;
-  pinned: boolean;
+  persistence: TabPersistence | null;
   dormant: boolean;
   windowed: boolean;
   loading: boolean;
@@ -30,7 +30,7 @@ export type AccountTabsState = {
 };
 
 export function getVerticalTabsWidth(
-  tabs: Pick<TabState, "app" | "pinned">[],
+  tabs: Pick<TabState, "app" | "persistence">[],
   configuredVerticalTabsWidth: VerticalTabsWidth,
 ) {
   if (tabs.length <= 1) {
@@ -48,7 +48,7 @@ export function getVerticalTabsWidth(
   const workspaceAppTabCounts = new Map<SupportedWorkspaceApp, number>();
 
   for (const tab of tabs) {
-    if (tab.app && !tab.pinned) {
+    if (tab.app && tab.persistence !== "pinned") {
       workspaceAppTabCounts.set(tab.app, (workspaceAppTabCounts.get(tab.app) ?? 0) + 1);
     }
   }


### PR DESCRIPTION
Groundwork for bookmarked tabs. A tab's persistence is currently a single `pinned: boolean` that means "lives in the top grid" *and* "survives restarts". Bookmarks need the second without the first, so the boolean becomes a three-state field.

## Changes

- `pinned: boolean` → `persistence: TabPersistence | null` (`"pinned" | "bookmarked" | null`) on `Tab`, `TabState`, `WorkspaceApp` and `DormantTab`.
- `pinnedTabSchema` → `savedTabSchema` with a `persistence` field, and the account config key `workspaceApps.pinnedTabs` → `workspaceApps.savedTabs`.
- `pinTab` / `unpinTab` collapse into `setTabPersistence(tabId, persistence)`; `null` on a dormant tab still removes it.
- Renames along the same path: `serializePinnedTabs` → `serializeSavedTabs`, `restorePinnedTabs` → `restoreSavedTabs`, `dormantizePinnedTab` → `dormantizeSavedTab`, `isPinnedWorkspaceApp` → `isSavedWorkspaceApp`, `accounts.savePinnedTabs()` → `accounts.saveTabs()`.

Behavior is unchanged: every former `tab.pinned` read is now `tab.persistence === "pinned"`, and `"bookmarked"` is not yet produced anywhere. Bookmarks themselves land in the follow-up PR.

## Config

`workspaceApps.pinnedTabs` has never shipped in a release (added in #644, after v3.57.0), so no migration is needed — the unreleased `>3.57.0` migration now seeds `savedTabs: []` instead.

**If you're running a dev build from after #644**, `config.dev.json` still has `workspaceApps.pinnedTabs` on each account and no migration can fix it while the version is 3.57.0. Rename the key to `savedTabs` in that file (and add `"persistence": "pinned"` to each entry) before launching, or the tab restore reads `undefined` at startup.

## Test plan

1. Launch with pinned tabs restored from config — they appear in the top grid in the same order, dimmed if dormant.
2. Right-click a pinned tab → **Unpin**: it moves out of the grid into the normal list; right-click a normal tab → **Pin**: it moves into the grid.
3. Right-click a dormant pinned tab → **Unpin**: it disappears from the list entirely.
4. Toggle **Load on Launch** on a pinned tab, quit, relaunch: the tab loads eagerly instead of staying dormant.
5. Close a pinned tab: it goes dormant in place rather than being removed. Close a normal tab: it is removed, and **Reopen Closed Tab** brings it back.
6. **Close Other Tabs** / **Close Tabs Below** leave pinned tabs untouched.
7. Drag to reorder within the pinned grid and within the normal list; quit and relaunch to confirm the pinned order persisted. Gmail stays first.
