### PR TITLE
add bookmarked tabs

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -298,7 +298,8 @@ class Ipc {
         (accountTab) =>
           accountTab.id !== tabId &&
           accountTab.id !== GMAIL_TAB_ID &&
-          accountTab.persistence !== "pinned",
+          accountTab.persistence !== "pinned" &&
+          !accountTab.dormant,
       );
 
       const contextTabIndex = account.instance.tabs.tabs.findIndex(
@@ -307,7 +308,7 @@ class Ipc {
 
       const hasClosableTabsBelow = account.instance.tabs.tabs
         .slice(contextTabIndex + 1)
-        .some((accountTab) => accountTab.persistence !== "pinned");
+        .some((accountTab) => accountTab.persistence !== "pinned" && !accountTab.dormant);
 
       Menu.buildFromTemplate([
         ...(tabApp && !workspaceApps[tabApp].singleInstance && !workspaceApps[tabApp].popupOnly
@@ -410,34 +411,51 @@ class Ipc {
             openExternalUrl(tab.url, { skipTrustedHostCheck: true });
           },
         },
-        {
-          type: "separator",
-        },
-        tab.persistence === "pinned"
-          ? {
-              label: "Unpin",
-              click: () => {
-                account.instance.tabs.setTabPersistence(tabId, null);
-              },
-            }
-          : {
-              label: "Pin",
-              click: () => {
-                account.instance.tabs.setTabPersistence(tabId, "pinned");
-              },
-            },
-        ...(tab.persistence === "pinned"
+        ...(tabApp
           ? [
               {
-                label: "Load on Launch",
-                type: "checkbox" as const,
-                checked: tab.loadOnLaunch,
-                click: () => {
-                  tab.loadOnLaunch = !tab.loadOnLaunch;
-
-                  accounts.saveTabs();
-                },
+                type: "separator" as const,
               },
+              tab.persistence === "pinned"
+                ? {
+                    label: "Unpin",
+                    click: () => {
+                      account.instance.tabs.setTabPersistence(tabId, null);
+                    },
+                  }
+                : {
+                    label: "Pin",
+                    click: () => {
+                      account.instance.tabs.setTabPersistence(tabId, "pinned");
+                    },
+                  },
+              tab.persistence === "bookmarked"
+                ? {
+                    label: "Remove Bookmark",
+                    click: () => {
+                      account.instance.tabs.setTabPersistence(tabId, null);
+                    },
+                  }
+                : {
+                    label: "Bookmark",
+                    click: () => {
+                      account.instance.tabs.setTabPersistence(tabId, "bookmarked");
+                    },
+                  },
+              ...(tab.persistence === "pinned"
+                ? [
+                    {
+                      label: "Load on Launch",
+                      type: "checkbox" as const,
+                      checked: tab.loadOnLaunch,
+                      click: () => {
+                        tab.loadOnLaunch = !tab.loadOnLaunch;
+
+                        accounts.saveTabs();
+                      },
+                    },
+                  ]
+                : []),
             ]
           : []),
         {

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { SavedTab, TabPersistence } from "@meru/shared/schemas";
-import { GMAIL_TAB_ID, type TabState } from "@meru/shared/tabs";
+import { getTabSection, GMAIL_TAB_ID, type TabState, tabSections } from "@meru/shared/tabs";
 import type { SupportedWorkspaceApp } from "@meru/shared/workspace-apps";
 import type { WebContentsView } from "electron";
 import { accounts } from "./accounts";
@@ -41,6 +41,7 @@ export type Tab = {
   app: SupportedWorkspaceApp | undefined;
   title: string;
   persistence: TabPersistence | null;
+  dormant: boolean;
   isLoading: boolean;
   navigationHistory: { canGoBack: boolean; canGoForward: boolean };
   view?: WebContentsView;
@@ -55,6 +56,8 @@ export class DormantTab {
   url: string;
 
   persistence: TabPersistence;
+
+  dormant = true;
 
   isLoading = false;
 
@@ -93,6 +96,7 @@ export class Tabs {
         id: GMAIL_TAB_ID,
         app: gmail.app,
         persistence: null,
+        dormant: false,
         get title() {
           return gmail.title;
         },
@@ -229,6 +233,8 @@ export class Tabs {
 
     this.tabs.splice(this.tabs.indexOf(dormantTab), 1, workspaceApp);
 
+    this.reorderTabs();
+
     return workspaceApp;
   }
 
@@ -330,6 +336,8 @@ export class Tabs {
       this.activeTabId = GMAIL_TAB_ID;
     }
 
+    this.reorderTabs();
+
     this.broadcastTabsChanged();
 
     accounts.saveTabs();
@@ -412,6 +420,10 @@ export class Tabs {
       return;
     }
 
+    if (persistence !== "pinned") {
+      persistableTab.loadOnLaunch = false;
+    }
+
     this.reorderTabs();
 
     this.broadcastTabsChanged();
@@ -432,19 +444,17 @@ export class Tabs {
 
     const remainingTabs = this.tabs.filter((tab) => tab.id !== tabId);
 
-    const isMovedTabPinned = movedTab.persistence === "pinned";
+    const movedTabSection = getTabSection(movedTab);
 
-    const remainingPinnedSectionTabCount = remainingTabs.filter(
-      (tab) => tab.id === GMAIL_TAB_ID || tab.persistence === "pinned",
+    const sectionStartIndex = remainingTabs.filter(
+      (tab) => tabSections.indexOf(getTabSection(tab)) < tabSections.indexOf(movedTabSection),
     ).length;
 
-    const sectionStartIndex = isMovedTabPinned ? 0 : remainingPinnedSectionTabCount;
+    const sectionTabCount = remainingTabs.filter(
+      (tab) => getTabSection(tab) === movedTabSection,
+    ).length;
 
-    const sectionTabCount = isMovedTabPinned
-      ? remainingPinnedSectionTabCount
-      : remainingTabs.length - remainingPinnedSectionTabCount;
-
-    const minimumSectionIndex = isMovedTabPinned ? 1 : 0;
+    const minimumSectionIndex = movedTabSection === "pinned" ? 1 : 0;
 
     const clampedSectionIndex = Math.min(
       Math.max(targetSectionIndex, minimumSectionIndex),
@@ -465,11 +475,9 @@ export class Tabs {
   }
 
   private reorderTabs() {
-    this.tabs = [
-      ...this.tabs.filter((tab) => tab.id === GMAIL_TAB_ID),
-      ...this.tabs.filter((tab) => tab.id !== GMAIL_TAB_ID && tab.persistence === "pinned"),
-      ...this.tabs.filter((tab) => tab.id !== GMAIL_TAB_ID && tab.persistence !== "pinned"),
-    ];
+    this.tabs = tabSections.flatMap((tabSection) =>
+      this.tabs.filter((tab) => getTabSection(tab) === tabSection),
+    );
   }
 
   serializeSavedTabs(): SavedTab[] {
@@ -512,7 +520,7 @@ export class Tabs {
       app: tab.app,
       title: tab.title,
       persistence: tab.persistence,
-      dormant: tab instanceof DormantTab,
+      dormant: tab.dormant,
       windowed: isWindowedTab(tab),
       loading: tab.isLoading,
       navigationHistory: tab.navigationHistory,

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -365,6 +365,8 @@ export class WorkspaceApp {
 
   persistence: TabPersistence | null;
 
+  dormant = false;
+
   loadOnLaunch = false;
 
   private powerSaveBlockerId: number | undefined;

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -5,11 +5,16 @@ import { useSortable } from "@dnd-kit/react/sortable";
 import { VERTICAL_TABS_WIDE_WIDTH } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
 import type { AccountConfig } from "@meru/shared/schemas";
-import { GMAIL_TAB_ID, getVerticalTabsWidth, type TabState } from "@meru/shared/tabs";
+import {
+  GMAIL_TAB_ID,
+  getTabSection,
+  getVerticalTabsWidth,
+  type TabState,
+} from "@meru/shared/tabs";
 import { workspaceApps } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import { cn } from "@meru/ui/lib/utils";
-import { AppWindowIcon, CircleAlertIcon, GlobeIcon, XIcon } from "lucide-react";
+import { AppWindowIcon, BookmarkIcon, CircleAlertIcon, GlobeIcon, XIcon } from "lucide-react";
 import type { Ref } from "react";
 import { UnreadCountBadge } from "@/components/unread-count-badge";
 import { WorkspaceAppIcon } from "@/components/workspace-app-icon";
@@ -113,9 +118,9 @@ function VerticalTab({
   gmailStatus?: GmailTabStatus;
   className?: string;
 }) {
-  const isPinnedSectionTab = tab.id === GMAIL_TAB_ID || tab.persistence === "pinned";
+  const isPinnedSectionTab = getTabSection(tab) === "pinned";
 
-  const isCloseable = !isPinnedSectionTab;
+  const isCloseable = !isPinnedSectionTab && !tab.dormant;
 
   const isWideRow = presentation === "wideRow";
 
@@ -164,6 +169,9 @@ function VerticalTab({
         )}
         {isWideRow && tab.windowed && (
           <AppWindowIcon className="size-3 shrink-0 text-muted-foreground" />
+        )}
+        {isWideRow && tab.persistence === "bookmarked" && (
+          <BookmarkIcon className="size-3 shrink-0 text-muted-foreground" />
         )}
       </Button>
       {!isWideRow && tab.windowed && <WindowedTabBadge className="-right-1 -bottom-1" />}
@@ -247,11 +255,13 @@ export function VerticalTabs() {
   const isWide = verticalTabsWidth === VERTICAL_TABS_WIDE_WIDTH;
 
   const pinnedSectionTabs = selectedAccountTabs.tabs.filter(
-    (tab) => tab.id === GMAIL_TAB_ID || tab.persistence === "pinned",
+    (tab) => getTabSection(tab) === "pinned",
   );
 
-  const unpinnedTabs = selectedAccountTabs.tabs.filter(
-    (tab) => tab.id !== GMAIL_TAB_ID && tab.persistence !== "pinned",
+  const normalTabs = selectedAccountTabs.tabs.filter((tab) => getTabSection(tab) === "normal");
+
+  const bookmarkedTabs = selectedAccountTabs.tabs.filter(
+    (tab) => getTabSection(tab) === "bookmarks",
   );
 
   const gmailTabStatus = {
@@ -313,16 +323,33 @@ export function VerticalTabs() {
         plugins={verticalTabsPlugins}
         sensors={verticalTabsSensors}
         onDragEnd={(event) => {
-          moveSectionTab(selectedAccount.config.id, unpinnedTabs, event);
+          moveSectionTab(selectedAccount.config.id, normalTabs, event);
         }}
       >
-        {unpinnedTabs.map((tab, unpinnedTabIndex) => (
+        {normalTabs.map((tab, normalTabIndex) => (
           <SortableVerticalTab
             key={tab.id}
             tab={tab}
             accountId={selectedAccount.config.id}
             presentation={isWide ? "wideRow" : "narrowIcon"}
-            sectionIndex={unpinnedTabIndex}
+            sectionIndex={normalTabIndex}
+          />
+        ))}
+      </DragDropProvider>
+      <DragDropProvider
+        plugins={verticalTabsPlugins}
+        sensors={verticalTabsSensors}
+        onDragEnd={(event) => {
+          moveSectionTab(selectedAccount.config.id, bookmarkedTabs, event);
+        }}
+      >
+        {bookmarkedTabs.map((tab, bookmarkedTabIndex) => (
+          <SortableVerticalTab
+            key={tab.id}
+            tab={tab}
+            accountId={selectedAccount.config.id}
+            presentation={isWide ? "wideRow" : "narrowIcon"}
+            sectionIndex={bookmarkedTabIndex}
           />
         ))}
       </DragDropProvider>

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -29,6 +29,22 @@ export type AccountTabsState = {
   tabs: TabState[];
 };
 
+export const tabSections = ["pinned", "normal", "bookmarks"] as const;
+
+export type TabSection = (typeof tabSections)[number];
+
+export function getTabSection(tab: Pick<TabState, "id" | "persistence" | "dormant">): TabSection {
+  if (tab.id === GMAIL_TAB_ID || tab.persistence === "pinned") {
+    return "pinned";
+  }
+
+  if (tab.persistence === "bookmarked" && tab.dormant) {
+    return "bookmarks";
+  }
+
+  return "normal";
+}
+
 export function getVerticalTabsWidth(
   tabs: Pick<TabState, "app" | "persistence">[],
   configuredVerticalTabsWidth: VerticalTabsWidth,
@@ -42,6 +58,10 @@ export function getVerticalTabsWidth(
   }
 
   if (configuredVerticalTabsWidth === "wide") {
+    return VERTICAL_TABS_WIDE_WIDTH;
+  }
+
+  if (tabs.some((tab) => tab.persistence === "bookmarked")) {
     return VERTICAL_TABS_WIDE_WIDTH;
   }
 


### PR DESCRIPTION
Pinning a tab has been the only way to keep it across restarts, and it always means "put it in the icon grid at the top". That grid is the wrong home for something you want to keep but rarely look at — a Google Doc you'll revisit next week. It has no room for a title and it competes with the apps you live in.

A bookmarked tab is the lighter alternative: it survives restarts, sits at the bottom of the list, always shows its icon and title, and starts dormant on launch. Opening it moves it up into the normal tabs list; closing it sends it back down. Pinned and bookmarked are mutually exclusive.

Stacked on #710, which turns `pinned: boolean` into `persistence: "pinned" | "bookmarked" | null`.

## Changes

- **Sections.** `getTabSection` (`packages/shared/tabs.ts`) is now the single rule for where a tab belongs — `pinned` (Gmail + pinned tabs), `normal`, `bookmarks` — and both the main process ordering and the renderer's three drag-and-drop lists derive from it. Order is pinned grid → normal → bookmarks.
- A pinned tab keeps its grid slot whether dormant or open. A bookmarked tab is only in the bookmarks section while dormant; materializing it reorders it into the normal list, and `dormantizeSavedTab` sends it back on close.
- Bookmarks never load on launch: `setTabPersistence` clears `loadOnLaunch` for anything not pinned, and the **Load on Launch** checkbox stays pinned-only.
- **Context menu** gains **Bookmark** / **Remove Bookmark** next to **Pin** / **Unpin**. Both toggles are now hidden when the tab has no recognized Workspace app — persistence requires one, so previously **Pin** was offered on e.g. an external link tab and silently did nothing.
- **Close Other Tabs** / **Close Tabs Below** now close open bookmarked tabs (they survive as dormant entries) and skip only pinned tabs. Their enabled state also ignores dormant tabs, which aren't closable.
- **Renderer.** A bookmark icon renders at the right of the row for every bookmarked tab, open or dormant, so an open tab still reads as bookmarked. Dormant tabs (bookmarked or pinned) no longer show a close button. `getVerticalTabsWidth` returns the wide strip in `auto` whenever a bookmark exists, so titles are always visible; an explicit `narrow` setting still wins and falls back to icon-only.

## Notes / not done

- Bookmarking is only reachable from the tab context menu — no keyboard shortcut, no star button, no bookmarks manager.
- Bookmarks can be reordered within their section but not dragged between sections, matching how pinned and normal tabs already behave.
- Not verified in a running app; I don't run the app on this machine.

## Test plan

1. Right-click a Google Doc tab → **Bookmark**. It stays open where it is and now shows a bookmark icon on the right of the row.
2. Close it. It drops to the bottom of the list, dimmed, still showing icon and title, with no close button.
3. Quit and relaunch. It's still at the bottom, dormant, and did not load.
4. Click it. It loads and moves up into the normal tabs list. Close it again — back to the bottom.
5. Right-click a bookmarked tab → **Pin**. It moves into the top grid and the bookmark icon goes away. Right-click a pinned tab → **Bookmark** for the reverse (a dormant one lands at the bottom, an open one stays in the normal list).
6. **Load on Launch** appears only on pinned tabs. Enable it, bookmark that tab, pin it again — the checkbox is back off, and relaunch confirms it stays dormant.
7. Right-click a dormant bookmark → **Remove Bookmark**. It disappears; relaunch confirms it's gone.
8. Drag to reorder within the bookmarks section, quit, relaunch — the order persisted. Confirm a bookmark can't be dragged into the pinned grid or the normal list.
9. With several tabs open including a bookmarked one, **Close Other Tabs** and **Close Tabs Below**: pinned tabs stay, the open bookmark closes and reappears at the bottom. With only dormant bookmarks left, both menu items are disabled.
10. With a bookmark present and `verticalTabs.width` on `auto`, the strip is wide. Switch the setting to `narrow`: everything is icon-only, including bookmarks.
11. Right-click a tab that isn't a Workspace app (e.g. an external link opened as a tab): neither **Pin** nor **Bookmark** is offered.
12. Bookmark a tab, move it to a new window, then close the window: it returns to the bookmarks section as dormant.
