### PR TITLE
derive the workspace app from the tab url on navigation

### DIFF
--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -576,6 +576,7 @@ export class WorkspaceApp {
   }
 
   private registerViewListeners() {
+    this.view.webContents.on("did-navigate", this.updateAppFromNavigation);
     this.view.webContents.on("did-navigate", this.handlePasskeyChallenge);
     this.view.webContents.on("will-redirect", this.handleGoogleRedirect);
     this.view.webContents.on("page-title-updated", this.handlePageTitleUpdated);
@@ -677,6 +678,20 @@ export class WorkspaceApp {
 
     this.updateViewBounds();
   }
+
+  private updateAppFromNavigation = (_event: Electron.Event, url: string) => {
+    const navigatedApp = getWorkspaceAppFromUrl(url);
+
+    if (navigatedApp === this.app) {
+      return;
+    }
+
+    this.teardownApp();
+
+    this.app = navigatedApp;
+
+    this.setupApp();
+  };
 
   private handlePasskeyChallenge = (_event: Electron.Event, url: string) => {
     WorkspaceApp.handleNavigate(url);


### PR DESCRIPTION
`WorkspaceApp.app` is derived once in the constructor (`app ?? getWorkspaceAppFromUrl(url)`) and never recomputed, so a tab's identity is frozen at whatever URL it was opened with. Nothing guards in-place navigation in a tab view — only `window.open` goes through `setWindowOpenHandler` — so a tab can navigate anywhere and keep claiming to be the app it started as.

Two visible consequences:

- Navigate a Docs tab to a non-Google page and it keeps the Docs icon. Pin it, and the saved entry is `app: "docs"` with that URL, so after a restart you get a dormant tab wearing the Docs icon that opens somewhere else entirely.
- **Duplicate** builds the new tab from `view.webContents.getURL()`, so duplicating that tab produces one with no `app` at all — the case where **Pin** and **Bookmark** are hidden from the context menu.

## Changes

`app` is now recomputed on every committed main-frame navigation (`did-navigate`), so a tab's icon, title, and saved entry follow where it actually is. In-page navigations can't cross origins, so `did-navigate` alone is enough.

Because `app` is mutable now, a change runs `teardownApp()` / `setupApp()` around it. That matters for Meet: without it, a Meet tab that navigates elsewhere would never stop its `powerSaveBlocker` or unregister the global mic/camera shortcuts, since teardown is keyed on `this.app === "meet"`.

The listener is registered before `registerTabBroadcasts`, so the tabs broadcast that follows the same event already sees the new value.

## Notes

- Follow-up (next PR in the stack) blocks navigation out of Google origins entirely, which removes most of the ways a tab can end up app-less in the first place.
- Consequence worth knowing: if a pinned or bookmarked tab does reach a URL with no recognized app, it stops being serializable and quietly drops out of the saved tabs on the next save. After the follow-up this is effectively unreachable, so I haven't added anything to handle it — say the word if you'd rather it explicitly unpin itself instead.
- The `workspaceApp` search param passed to a windowed tab's chrome is still the construction-time app; it isn't re-loaded on navigation. The window title does follow, since it reads `this.app` live.
- Not verified in a running app.

## Test plan

1. Open a Docs tab from the launcher. **View → Developer Tools**, then in the console: `location.href = "https://example.com"`. The tab's icon becomes a globe and the title follows the page.
2. Right-click that tab: **Pin** and **Bookmark** are no longer offered (they need a recognized app to persist).
3. Navigate back (`Cmd/Ctrl+[` or History → Back) to the Docs URL: the Docs icon returns and Pin/Bookmark reappear.
4. Right-click the off-domain tab → **Duplicate**: the duplicate also shows a globe, same as the original — no longer a mismatch between the two.
5. Pin a Docs tab, quit, relaunch: it restores dormant with the Docs icon and correct title, as before.
6. Join a Google Meet call in a tab, confirm the display doesn't sleep and `Cmd/Ctrl+Shift+1`/`2` toggle mic and camera. Navigate that tab to another Workspace app, then quit: no lingering power-save blocker, and the shortcuts stop responding.
7. Open two Meet tabs, navigate one away, confirm the shortcuts still work for the remaining one.
