### PR TITLE
open external navigations from workspace apps in the browser

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -459,6 +459,10 @@ export class Gmail {
       }
     });
 
+    window.webContents.on("will-navigate", (event) => {
+      WorkspaceApp.handleWillNavigate(event, window.webContents);
+    });
+
     window.webContents.on("will-redirect", (event, url) => {
       if (url.startsWith("https://workspace.google.com/u/0/marketplace/appfinder")) {
         return;

--- a/packages/app/url.ts
+++ b/packages/app/url.ts
@@ -2,6 +2,10 @@ import { clipboard, dialog, shell } from "electron";
 import { config } from "@/config";
 import { licenseKey } from "./license-key";
 
+export function isHttpUrl(url: string) {
+  return url.startsWith("http://") || url.startsWith("https://");
+}
+
 export function getCleanUrl(url: string): string {
   if (url.includes("google.com/url")) {
     return new URL(url).searchParams.get("q") ?? url;

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { APP_TITLEBAR_HEIGHT, GOOGLE_ACCOUNTS_URL } from "@meru/shared/constants";
-import { getWorkspaceAppUrl } from "@meru/shared/google";
+import { getWorkspaceAppUrl, isGoogleUrl } from "@meru/shared/google";
 import type { AccountConfig, TabPersistence } from "@meru/shared/schemas";
 import { clamp } from "@meru/shared/utils";
 import {
@@ -34,7 +34,7 @@ import {
 import { licenseKey } from "./license-key";
 import { main } from "./main";
 import { registerTabBroadcasts } from "./tabs";
-import { openExternalUrl } from "./url";
+import { isHttpUrl, openExternalUrl } from "./url";
 
 export const MIN_ZOOM_FACTOR = 0.1;
 export const MAX_ZOOM_FACTOR = 3;
@@ -150,6 +150,27 @@ export class WorkspaceApp {
     event.preventDefault();
 
     webContents.loadURL(`${GOOGLE_ACCOUNTS_URL}/ServiceLogin?service=mail`);
+  }
+
+  static handleWillNavigate(
+    event: Electron.Event<Electron.WebContentsWillNavigateEventParams>,
+    webContents: WebContents,
+  ) {
+    if (!event.isMainFrame || !isHttpUrl(event.url) || isGoogleUrl(event.url)) {
+      return;
+    }
+
+    const currentUrl = webContents.getURL();
+
+    // Sign-in hands off to third-party identity providers, so navigations away
+    // from the accounts origin have to stay in the view to keep SSO working.
+    if (!isGoogleUrl(currentUrl) || currentUrl.startsWith(GOOGLE_ACCOUNTS_URL)) {
+      return;
+    }
+
+    event.preventDefault();
+
+    openExternalUrl(event.url, { focusBrowser: true });
   }
 
   static handleWindowOpen({
@@ -578,6 +599,7 @@ export class WorkspaceApp {
   private registerViewListeners() {
     this.view.webContents.on("did-navigate", this.updateAppFromNavigation);
     this.view.webContents.on("did-navigate", this.handlePasskeyChallenge);
+    this.view.webContents.on("will-navigate", this.handleExternalNavigation);
     this.view.webContents.on("will-redirect", this.handleGoogleRedirect);
     this.view.webContents.on("page-title-updated", this.handlePageTitleUpdated);
 
@@ -695,6 +717,12 @@ export class WorkspaceApp {
 
   private handlePasskeyChallenge = (_event: Electron.Event, url: string) => {
     WorkspaceApp.handleNavigate(url);
+  };
+
+  private handleExternalNavigation = (
+    event: Electron.Event<Electron.WebContentsWillNavigateEventParams>,
+  ) => {
+    WorkspaceApp.handleWillNavigate(event, this.view.webContents);
   };
 
   private handleGoogleRedirect = (event: Electron.Event, url: string) => {

--- a/packages/shared/google.test.ts
+++ b/packages/shared/google.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { isGoogleUrl } from "./google";
+
+describe("isGoogleUrl", () => {
+  test("matches workspace app hosts", () => {
+    expect(isGoogleUrl("https://docs.google.com/document/d/abc/edit")).toBe(true);
+    expect(isGoogleUrl("https://mail.google.com/mail/u/0/#inbox")).toBe(true);
+    expect(isGoogleUrl("https://accounts.google.com/ServiceLogin?service=mail")).toBe(true);
+    expect(isGoogleUrl("https://google.com")).toBe(true);
+  });
+
+  test("matches user content hosts serving attachments and exports", () => {
+    expect(isGoogleUrl("https://doc-0s-4c-docs.googleusercontent.com/viewer/secure/pdf")).toBe(
+      true,
+    );
+    expect(isGoogleUrl("https://googleusercontent.com")).toBe(true);
+  });
+
+  test("does not match hosts that only look like google", () => {
+    expect(isGoogleUrl("https://notgoogle.com")).toBe(false);
+    expect(isGoogleUrl("https://google.com.example.com")).toBe(false);
+    expect(isGoogleUrl("https://googleusercontent.com.example.com")).toBe(false);
+    expect(isGoogleUrl("https://example.com/?redirect=https://docs.google.com")).toBe(false);
+  });
+
+  test("does not match other google top level domains", () => {
+    expect(isGoogleUrl("https://www.google.de/search?q=meru")).toBe(false);
+  });
+
+  test("does not match unparseable urls", () => {
+    expect(isGoogleUrl("about:blank")).toBe(false);
+    expect(isGoogleUrl("")).toBe(false);
+  });
+});

--- a/packages/shared/google.ts
+++ b/packages/shared/google.ts
@@ -4,6 +4,22 @@ export function getWorkspaceAppUrl(app: SupportedWorkspaceApp) {
   return workspaceApps[app].url ?? `https://${app}.google.com`;
 }
 
+const GOOGLE_HOSTNAMES = ["google.com", "googleusercontent.com"];
+
+export function isGoogleUrl(url: string) {
+  let hostname: string;
+
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    return false;
+  }
+
+  return GOOGLE_HOSTNAMES.some(
+    (googleHostname) => hostname === googleHostname || hostname.endsWith(`.${googleHostname}`),
+  );
+}
+
 export function getGoogleDomainFaviconUrl(domain: string, size: number) {
   return `https://www.google.com/s2/favicons?domain=${domain}&sz=${size}`;
 }


### PR DESCRIPTION
Nothing currently guards in-place navigation inside a view. `setWindowOpenHandler` covers `window.open` and `target="_blank"` links, sending anything that isn't a Workspace app to the browser, but a page navigating itself — `location.href`, a link without a target, a form POST — walks straight out of Google and loads in the app, with the account's session cookies and the app's preload attached.

That's also what makes a tab lose its identity: after #713 derives `app` from the current URL, a tab navigated to a non-Google page becomes app-less and stops being pinnable or bookmarkable. This PR removes the cause rather than the symptom.

Stacked on #713.

## Changes

- `isGoogleUrl` (`packages/shared/google.ts`) matches hostnames that are, or are subdomains of, `google.com` or `googleusercontent.com` — the latter serves Chat attachments, the PDF viewer, and Docs/Drive exports. Suffix comparison is anchored on a leading dot, so `google.com.example.com` doesn't pass. Unit-tested.
- `WorkspaceApp.handleWillNavigate` prevents main-frame `http(s)` navigations that leave a Google origin and hands the URL to `openExternalUrl` with `focusBrowser: true`, matching what a `target="_blank"` link to the same URL already does — including the "open this external link?" confirmation when `externalLinks.confirm` is on.
- Registered on every `WorkspaceApp` view and on the Gmail view (which already shares `WorkspaceApp.handleRedirect` the same way).

## Why it's scoped this narrowly

Two carve-outs keep sign-in working, which is the one place where leaving Google is legitimate:

1. **Only `will-navigate`, never `will-redirect`.** SAML/OIDC SSO reaches the identity provider through server-side 302s, which fire `will-redirect` — untouched here.
2. **Navigations away from `accounts.google.com` are never intercepted.** Some identity providers bounce via JS or an auto-submitted form, which *does* fire `will-navigate`. Blocking that would strand every SSO user at the login screen — a failure that wouldn't show up in testing on a personal account.

Once the view is on a third-party origin, further navigation is left alone, so an auth chain (IdP → MFA provider → back to Google) is never interrupted mid-flight. The cost is that an external link clicked from a page that is itself external stays in-app, which is exactly today's behavior.

Subframes are untouched (`isMainFrame`), so embedded add-ons, reCAPTCHA, and payment iframes keep working. Non-`http(s)` schemes are left alone, so `mailto:` still reaches the existing protocol handling. `will-navigate` doesn't fire for main-process `loadURL`, so the `handleRedirect` ServiceLogin bounce and Gmail's delegated-account switching are unaffected.

## Risks

- The allowlist is deliberately just those two hostnames. Other Google TLDs (`google.de`) and `googleapis.com` now go to the browser; if something legitimate turns out to live there, it's a one-line addition to `GOOGLE_HOSTNAMES`.
- A page that expects its self-navigation to succeed will sit still instead. Same trade-off `action: "deny"` already makes in the window-open handler.
- I can't test a real SSO tenant here, so carve-out 2 is reasoned from how those flows work, not observed. Worth a look if you have access to an SSO account.
- Not verified in a running app.

## Test plan

1. Open a Docs tab. **View → Developer Tools**, console: `location.href = "https://example.com"`. The tab stays on Docs and example.com opens in your default browser.
2. With `externalLinks.confirm` on, repeat: the "open this external link in your default browser?" dialog appears first, and **Cancel** leaves the tab on Docs with nothing opened.
3. Console: `location.href = "https://drive.google.com"`. The tab navigates normally — Google origins are unaffected.
4. In the Gmail view, same console test: the external URL opens in the browser and Gmail stays put.
5. Click a normal external link in an email and in a Doc — unchanged, opens in the browser.
6. Open a PDF attachment from Gmail and download a file from Drive — the viewer window and the download both still work (`googleusercontent.com` is allowed).
7. Sign out and sign back in, including adding a second account via **Add Account**: the whole flow through `accounts.google.com` completes in-app.
8. If you have an SSO account, sign in with it and confirm the handoff to the identity provider and back completes in-app.
9. Open a Doc with an embedded add-on or a reCAPTCHA and confirm the iframe still loads.
10. Click a `mailto:` link in a Doc: it still opens a compose window rather than being pushed to the browser.
