### PR TITLE
reuse the did-navigate listener for the tab app and passkey handling

### DIFF
--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -576,8 +576,7 @@ export class WorkspaceApp {
   }
 
   private registerViewListeners() {
-    this.view.webContents.on("did-navigate", this.updateAppFromNavigation);
-    this.view.webContents.on("did-navigate", this.handlePasskeyChallenge);
+    this.view.webContents.on("did-navigate", this.handleDidNavigate);
     this.view.webContents.on("will-redirect", this.handleGoogleRedirect);
     this.view.webContents.on("page-title-updated", this.handlePageTitleUpdated);
 
@@ -679,7 +678,7 @@ export class WorkspaceApp {
     this.updateViewBounds();
   }
 
-  private updateAppFromNavigation = (_event: Electron.Event, url: string) => {
+  private updateAppFromNavigation(url: string) {
     const navigatedApp = getWorkspaceAppFromUrl(url);
 
     if (navigatedApp === this.app) {
@@ -691,9 +690,11 @@ export class WorkspaceApp {
     this.app = navigatedApp;
 
     this.setupApp();
-  };
+  }
 
-  private handlePasskeyChallenge = (_event: Electron.Event, url: string) => {
+  private handleDidNavigate = (_event: Electron.Event, url: string) => {
+    this.updateAppFromNavigation(url);
+
     WorkspaceApp.handleNavigate(url);
   };
 


### PR DESCRIPTION
#713 registered a second `did-navigate` listener on the view instead of extending the one already there for the passkey challenge.

Both now run from a single `handleDidNavigate`. `updateAppFromNavigation` goes back to being a plain method, since it no longer needs to be a bound listener.

The windowed listeners (`registerWindowedViewListeners`) and the tab broadcasts (`registerTabBroadcasts`) keep their own registrations — those are attached and detached independently as a tab moves between the window and the tab strip, so folding them in would break that.

Behavior is unchanged: same event, same order, one listener.

## Test plan

1. Open a Docs tab, navigate it elsewhere (**View → Developer Tools**, then `location.href = "https://drive.google.com"`): the icon and title follow the new app, as before.
2. Sign in with an account that has a passkey challenge and confirm the "Passkey sign-in not supported yet" dialog still appears.
3. Move a tab to a new window and back (**Move to New Window**, then **Move to Tab**): navigation and loading state still update in both places.
