### PR TITLE
allow saving tabs without a workspace app

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -411,51 +411,47 @@ class Ipc {
             openExternalUrl(tab.url, { skipTrustedHostCheck: true });
           },
         },
-        ...(tabApp
+        {
+          type: "separator",
+        },
+        tab.persistence === "pinned"
+          ? {
+              label: "Unpin",
+              click: () => {
+                account.instance.tabs.setTabPersistence(tabId, null);
+              },
+            }
+          : {
+              label: "Pin",
+              click: () => {
+                account.instance.tabs.setTabPersistence(tabId, "pinned");
+              },
+            },
+        tab.persistence === "bookmarked"
+          ? {
+              label: "Remove Bookmark",
+              click: () => {
+                account.instance.tabs.setTabPersistence(tabId, null);
+              },
+            }
+          : {
+              label: "Bookmark",
+              click: () => {
+                account.instance.tabs.setTabPersistence(tabId, "bookmarked");
+              },
+            },
+        ...(tab.persistence === "pinned"
           ? [
               {
-                type: "separator" as const,
-              },
-              tab.persistence === "pinned"
-                ? {
-                    label: "Unpin",
-                    click: () => {
-                      account.instance.tabs.setTabPersistence(tabId, null);
-                    },
-                  }
-                : {
-                    label: "Pin",
-                    click: () => {
-                      account.instance.tabs.setTabPersistence(tabId, "pinned");
-                    },
-                  },
-              tab.persistence === "bookmarked"
-                ? {
-                    label: "Remove Bookmark",
-                    click: () => {
-                      account.instance.tabs.setTabPersistence(tabId, null);
-                    },
-                  }
-                : {
-                    label: "Bookmark",
-                    click: () => {
-                      account.instance.tabs.setTabPersistence(tabId, "bookmarked");
-                    },
-                  },
-              ...(tab.persistence === "pinned"
-                ? [
-                    {
-                      label: "Load on Launch",
-                      type: "checkbox" as const,
-                      checked: tab.loadOnLaunch,
-                      click: () => {
-                        tab.loadOnLaunch = !tab.loadOnLaunch;
+                label: "Load on Launch",
+                type: "checkbox" as const,
+                checked: tab.loadOnLaunch,
+                click: () => {
+                  tab.loadOnLaunch = !tab.loadOnLaunch;
 
-                        accounts.saveTabs();
-                      },
-                    },
-                  ]
-                : []),
+                  accounts.saveTabs();
+                },
+              },
             ]
           : []),
         {

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -67,7 +67,7 @@ export class DormantTab {
   zoomFactor: number | undefined;
 
   constructor(savedTab: SavedTab, zoomFactor?: number) {
-    this.app = savedTab.app ?? undefined;
+    this.app = savedTab.app;
     this.url = savedTab.url;
     this.title = savedTab.title;
     this.persistence = savedTab.persistence;
@@ -319,7 +319,7 @@ export class Tabs {
       1,
       new DormantTab(
         {
-          app: savedWorkspaceApp.app ?? null,
+          app: savedWorkspaceApp.app,
           url: savedWorkspaceApp.url,
           title: savedWorkspaceApp.title,
           persistence: savedWorkspaceApp.persistence,
@@ -483,7 +483,7 @@ export class Tabs {
     for (const tab of this.tabs) {
       if (tab instanceof WorkspaceApp && tab.persistence && tab.url) {
         savedTabs.push({
-          app: tab.app ?? null,
+          app: tab.app,
           url: tab.url,
           title: tab.title,
           persistence: tab.persistence,
@@ -491,7 +491,7 @@ export class Tabs {
         });
       } else if (tab instanceof DormantTab) {
         savedTabs.push({
-          app: tab.app ?? null,
+          app: tab.app,
           url: tab.url,
           title: tab.title,
           persistence: tab.persistence,

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -27,13 +27,10 @@ export function isWindowedTab(tab: Tab) {
   return tab instanceof WorkspaceApp && tab.isWindowed;
 }
 
-type SavedWorkspaceApp = WorkspaceApp & {
-  app: SupportedWorkspaceApp;
-  persistence: TabPersistence;
-};
+type SavedWorkspaceApp = WorkspaceApp & { persistence: TabPersistence };
 
 function isSavedWorkspaceApp(tab: Tab): tab is SavedWorkspaceApp {
-  return tab instanceof WorkspaceApp && tab.persistence !== null && tab.app !== undefined;
+  return tab instanceof WorkspaceApp && tab.persistence !== null;
 }
 
 export type Tab = {
@@ -51,7 +48,7 @@ export type Tab = {
 export class DormantTab {
   id = randomUUID();
 
-  app: SupportedWorkspaceApp;
+  app: SupportedWorkspaceApp | undefined;
 
   url: string;
 
@@ -70,7 +67,7 @@ export class DormantTab {
   zoomFactor: number | undefined;
 
   constructor(savedTab: SavedTab, zoomFactor?: number) {
-    this.app = savedTab.app;
+    this.app = savedTab.app ?? undefined;
     this.url = savedTab.url;
     this.title = savedTab.title;
     this.persistence = savedTab.persistence;
@@ -322,7 +319,7 @@ export class Tabs {
       1,
       new DormantTab(
         {
-          app: savedWorkspaceApp.app,
+          app: savedWorkspaceApp.app ?? null,
           url: savedWorkspaceApp.url,
           title: savedWorkspaceApp.title,
           persistence: savedWorkspaceApp.persistence,
@@ -484,9 +481,9 @@ export class Tabs {
     const savedTabs: SavedTab[] = [];
 
     for (const tab of this.tabs) {
-      if (tab instanceof WorkspaceApp && tab.persistence && tab.app) {
+      if (tab instanceof WorkspaceApp && tab.persistence && tab.url) {
         savedTabs.push({
-          app: tab.app,
+          app: tab.app ?? null,
           url: tab.url,
           title: tab.title,
           persistence: tab.persistence,
@@ -494,7 +491,7 @@ export class Tabs {
         });
       } else if (tab instanceof DormantTab) {
         savedTabs.push({
-          app: tab.app,
+          app: tab.app ?? null,
           url: tab.url,
           title: tab.title,
           persistence: tab.persistence,

--- a/packages/shared/schemas.ts
+++ b/packages/shared/schemas.ts
@@ -28,7 +28,7 @@ export type TabPersistence = z.infer<typeof tabPersistenceSchema>;
 export const savedTabSchema = z.object({
   app: z
     .custom<SupportedWorkspaceApp>((value) => typeof value === "string" && value in workspaceApps)
-    .nullable(),
+    .optional(),
   url: z.string(),
   title: z.string(),
   persistence: tabPersistenceSchema,

--- a/packages/shared/schemas.ts
+++ b/packages/shared/schemas.ts
@@ -26,9 +26,9 @@ export const tabPersistenceSchema = z.enum(["pinned", "bookmarked"]);
 export type TabPersistence = z.infer<typeof tabPersistenceSchema>;
 
 export const savedTabSchema = z.object({
-  app: z.custom<SupportedWorkspaceApp>(
-    (value) => typeof value === "string" && value in workspaceApps,
-  ),
+  app: z
+    .custom<SupportedWorkspaceApp>((value) => typeof value === "string" && value in workspaceApps)
+    .nullable(),
   url: z.string(),
   title: z.string(),
   persistence: tabPersistenceSchema,


### PR DESCRIPTION
**Pin** and **Bookmark** are hidden when a tab has no recognized Workspace app, because `savedTabSchema.app` was required and `serializeSavedTabs` skipped anything without one. With in-place navigation staying unrestricted, a tab sitting on a non-Google URL is a normal thing to have — and #713 means `app` now follows the URL, so any tab can reach that state. Hiding the items there is the wrong answer, and showing them without making them work would silently drop the tab on the next launch.

So the limitation goes away instead: any tab can be pinned or bookmarked, whatever it's showing.

## Changes

- `savedTabSchema.app` is optional. Stored entries keep their app when they have one; a tab without one omits the key and restores with the globe icon `TabIcon` already falls back to. Optional rather than nullable so the whole chain stays on `undefined` — `Tab.app`, `TabState.app` and `WorkspaceApp.app` are all `SupportedWorkspaceApp | undefined`, since `getWorkspaceAppFromUrl` returns `undefined`, and a nullable schema would mean converting at every boundary.
- `serializeSavedTabs` now saves any persisted tab with a URL, rather than any persisted tab with an app. The new `url` check also stops a tab with neither from being written as a useless entry.
- `isSavedWorkspaceApp` drops its `app` requirement — persistence alone decides whether closing a tab dormantizes it.
- The context menu always shows **Pin** / **Unpin** and **Bookmark** / **Remove Bookmark**. **New … Tab** and the **Duplicate** URL fallback still depend on a recognized app, so those are unchanged.

No migration: existing entries all carry a valid app string, which still satisfies the optional schema.

## Notes

- This reverses the "Workspace apps only" scoping decision from the original bookmarks work. Bookmarks are now closer to browser bookmarks, which is what they were modelled on.
- Not verified in a running app.

## Test plan

1. Open a Docs tab, **View → Developer Tools**, console: `location.href = "https://example.com"`. The tab shows a globe icon and the page title.
2. Right-click it: **Pin** and **Bookmark** are both offered.
3. **Bookmark** it, close it — it drops to the bookmarks section, dimmed, with the globe icon and the page title. Quit and relaunch: still there, still dormant.
4. Click it: it loads example.com and moves into the normal tabs list.
5. Repeat with **Pin**: it lands in the top grid with a globe icon, and survives a restart. **Load on Launch** works on it too.
6. Pin a normal Docs tab, quit, relaunch: unchanged from before, Docs icon and title intact.
7. Existing pinned and bookmarked tabs from a config written before this change still restore correctly.
8. Right-click a tab on a non-Workspace URL: **New … Tab** is absent (it needs a recognized app), while **Duplicate** still works.
