### PR TITLE
rename full dark theme to extend dark theme

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -81,7 +81,7 @@ export const config = new Store<Config>({
     "gmail.moveAttachmentsToTop": false,
     "gmail.closeComposeWindowAfterSend": false,
     "gmail.replyForwardInPopOut": false,
-    "gmail.fullDarkTheme": false,
+    "gmail.extendDarkTheme": false,
     "gmail.inboxCategoriesToMonitor": "primary",
     "screenShare.useSystemPicker": true,
     "window.lastState": {
@@ -381,6 +381,17 @@ export const config = new Store<Config>({
 
       // @ts-expect-error
       store.delete("gmail.zoomFactor");
+
+      // @ts-expect-error: `gmail.fullDarkTheme` is now 'gmail.extendDarkTheme'
+      const fullDarkTheme = store.get("gmail.fullDarkTheme");
+
+      if (typeof fullDarkTheme !== "undefined") {
+        // @ts-expect-error
+        store.set("gmail.extendDarkTheme", fullDarkTheme);
+      }
+
+      // @ts-expect-error
+      store.delete("gmail.fullDarkTheme");
     },
   },
 });

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -346,8 +346,8 @@ export class Gmail {
         additionalArguments.push(GMAIL_PRELOAD_ARGUMENTS.replyForwardInPopOut);
       }
 
-      if (config.get("gmail.fullDarkTheme")) {
-        additionalArguments.push(GMAIL_PRELOAD_ARGUMENTS.fullDarkTheme);
+      if (config.get("gmail.extendDarkTheme")) {
+        additionalArguments.push(GMAIL_PRELOAD_ARGUMENTS.extendDarkTheme);
       }
     }
 

--- a/packages/preload-gmail/dark-theme/compose.ts
+++ b/packages/preload-gmail/dark-theme/compose.ts
@@ -3,12 +3,12 @@ import { GMAIL_PRELOAD_ARGUMENTS } from "@meru/shared/gmail";
 import { $$ } from "select-dom";
 import composeCss from "./compose.css";
 
-const isFullDarkThemeEnabled = process.argv.includes(GMAIL_PRELOAD_ARGUMENTS.fullDarkTheme);
+const isExtendDarkThemeEnabled = process.argv.includes(GMAIL_PRELOAD_ARGUMENTS.extendDarkTheme);
 
 const controllers = new Map<HTMLDivElement, DarkThemeController>();
 
 export function darkThemeCompose() {
-  if (!isFullDarkThemeEnabled) {
+  if (!isExtendDarkThemeEnabled) {
     return;
   }
 

--- a/packages/preload-gmail/dark-theme/message.ts
+++ b/packages/preload-gmail/dark-theme/message.ts
@@ -3,12 +3,12 @@ import { GMAIL_PRELOAD_ARGUMENTS } from "@meru/shared/gmail";
 import { $$ } from "select-dom";
 import messageCss from "./message.css";
 
-const isFullDarkThemeEnabled = process.argv.includes(GMAIL_PRELOAD_ARGUMENTS.fullDarkTheme);
+const isExtendDarkThemeEnabled = process.argv.includes(GMAIL_PRELOAD_ARGUMENTS.extendDarkTheme);
 
 const controllers = new Map<HTMLElement, DarkThemeController>();
 
 export function darkThemeMessage() {
-  if (!isFullDarkThemeEnabled) {
+  if (!isExtendDarkThemeEnabled) {
     return;
   }
 

--- a/packages/preload-workspace-app/apps/mail.ts
+++ b/packages/preload-workspace-app/apps/mail.ts
@@ -39,13 +39,13 @@ function closeComposeWindowAfterSend() {
   });
 }
 
-const isFullDarkThemeEnabled = process.argv.includes(GMAIL_PRELOAD_ARGUMENTS.fullDarkTheme);
+const isExtendDarkThemeEnabled = process.argv.includes(GMAIL_PRELOAD_ARGUMENTS.extendDarkTheme);
 
 let themedElement: HTMLElement | null = null;
 let controller: DarkThemeController | null = null;
 
 function darkThemeMail() {
-  if (!isFullDarkThemeEnabled) {
+  if (!isExtendDarkThemeEnabled) {
     return;
   }
 

--- a/packages/renderer/routes/settings/gmail/index.tsx
+++ b/packages/renderer/routes/settings/gmail/index.tsx
@@ -69,9 +69,9 @@ export function GmailSettings() {
               licenseKeyRequired
             />
             <ConfigSwitchField
-              label="Full Dark Theme"
-              description="Applies a dark theme to emails and everywhere else Gmail's native dark theme doesn't cover. This feature is experimental — if you run into any issues, please report them so it can be improved."
-              configKey="gmail.fullDarkTheme"
+              label="Extend Dark Theme"
+              description="Extends Gmail's native dark theme to emails and the compose window. Requires Gmail's theme to be set to dark. This feature is experimental — if you run into any issues, please report them so it can be improved."
+              configKey="gmail.extendDarkTheme"
               restartRequired
               licenseKeyRequired
               experimental

--- a/packages/shared/gmail.ts
+++ b/packages/shared/gmail.ts
@@ -25,7 +25,7 @@ export const GMAIL_PRELOAD_ARGUMENTS = {
   moveAttachmentsToTop: "--meru-move-attachments-to-top",
   closeComposeWindowAfterSend: "--meru-close-compose-after-send",
   replyForwardInPopOut: "--meru-reply-forward-in-pop-out",
-  fullDarkTheme: "--meru-full-dark-theme",
+  extendDarkTheme: "--meru-extend-dark-theme",
 };
 
 export function createGmailDelegatedAccountUrl(delegatedAccountId: string) {

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -104,7 +104,7 @@ export type Config = {
   "gmail.moveAttachmentsToTop": boolean;
   "gmail.closeComposeWindowAfterSend": boolean;
   "gmail.replyForwardInPopOut": boolean;
-  "gmail.fullDarkTheme": boolean;
+  "gmail.extendDarkTheme": boolean;
   "gmail.inboxCategoriesToMonitor": "primary" | "all";
   "screenShare.useSystemPicker": boolean;
   "window.lastState": {


### PR DESCRIPTION
## Problem

The Gmail appearance setting **Full Dark Theme** is confusingly named. "Full" suggests it replaces or completes Gmail's theming, when what it actually does is extend Gmail's own native dark theme into the surfaces Gmail leaves untouched — email bodies and the compose window.

## Changes

Renames the feature to **Extend Dark Theme** throughout. No behavior, gating, or theming logic changes — the setting stays `restartRequired`, `licenseKeyRequired`, and `experimental`.

| | Before | After |
|---|---|---|
| UI label | `Full Dark Theme` | `Extend Dark Theme` |
| Config key | `gmail.fullDarkTheme` | `gmail.extendDarkTheme` |
| Preload flag | `--meru-full-dark-theme` | `--meru-extend-dark-theme` |
| Preload identifier | `isFullDarkThemeEnabled` | `isExtendDarkThemeEnabled` |

The description is also reworded. It previously said "Applies a dark theme to emails and everywhere else Gmail's native dark theme doesn't cover" — "everywhere else" is vague, so it now names the two surfaces the feature actually themes, and states the prerequisite that Gmail's own theme must be set to dark:

> Extends Gmail's native dark theme to emails and the compose window. Requires Gmail's theme to be set to dark. This feature is experimental — if you run into any issues, please report them so it can be improved.

`gmail.fullDarkTheme` shipped in v3.55.0, so the persisted key needs a migration. It's appended to the existing `">3.57.0"` block rather than getting its own version key, because that block is still unreleased (latest tag is `v3.57.0`) — same approach as #701 took for the launcher-apps rename.

## Notes for review

- **The "requires dark theme" line is documentation only.** Nothing in the codebase detects Gmail's theme — there's no `prefers-color-scheme` or `nativeTheme` check anywhere in `preload-gmail`, `preload-workspace-app`, or `dark-theme` — so the preloads apply the theming unconditionally. With Gmail set to a light theme the result is dark email bodies inside a light Gmail. Adding a runtime guard felt out of scope for a rename; happy to do it separately if it's worth having.
- No file renames. The `dark-theme/` paths and the `data-dark-theme*` attributes in `packages/dark-theme` never carried the "full" naming.
- Not verified: the migration has only been reasoned through against the `gmail.zoomFactor` precedent in the same block, not exercised against a real pre-upgrade config file. Step 4 of the test plan covers it.
- Release notes aren't touched — worth a line when the next release is drafted.

## Test plan

1. Open **Settings → Gmail → Appearance**. The switch reads "Extend Dark Theme" with the new description, and still shows the Experimental and license-required badges.
2. With Gmail's own theme set to dark, toggle the setting on and restart when prompted. Email bodies and a compose window should render dark.
3. Toggle it off, restart, and confirm Gmail returns to its native theming with no leftover dark styling.
4. Migration: quit the app, set `"gmail.fullDarkTheme": true` in the config JSON (`config.dev.json` in dev) and lower the stored `__internal__.migrations.version` below `3.57.0`, then launch. The old key should be gone from the file, replaced by `"gmail.extendDarkTheme": true`, and the switch should show as enabled.
5. Launch with a fresh profile (no prior config) and confirm the switch defaults to off.
6. Open Gmail as a standalone workspace-app window with the setting enabled and confirm it's themed there too (`preload-workspace-app/apps/mail.ts` reads the same flag).
