### PR TITLE
move extend dark theme to beta

### DIFF
--- a/packages/renderer/components/beta-field-badge.tsx
+++ b/packages/renderer/components/beta-field-badge.tsx
@@ -1,0 +1,5 @@
+import { Badge } from "@meru/ui/components/badge";
+
+export function BetaFieldBadge() {
+  return <Badge variant="outline">Beta</Badge>;
+}

--- a/packages/renderer/components/config-switch-field.tsx
+++ b/packages/renderer/components/config-switch-field.tsx
@@ -4,7 +4,7 @@ import { Switch } from "@meru/ui/components/switch";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useConfig, useConfigMutation } from "@/lib/react-query";
 import { restartRequiredToast } from "@/lib/toast";
-import { ExperimentalFieldBadge } from "./experimental-field-badge";
+import { BetaFieldBadge } from "./beta-field-badge";
 import { LicenseKeyRequiredFieldBadge } from "./license-key-required-field-badge";
 
 export function ConfigSwitchField({
@@ -12,7 +12,7 @@ export function ConfigSwitchField({
   label,
   description,
   licenseKeyRequired,
-  experimental,
+  beta,
   disabled,
   restartRequired,
 }: {
@@ -20,7 +20,7 @@ export function ConfigSwitchField({
   label: string;
   description: string;
   licenseKeyRequired?: boolean;
-  experimental?: boolean;
+  beta?: boolean;
   disabled?: boolean;
   restartRequired?: boolean;
 }) {
@@ -51,7 +51,7 @@ export function ConfigSwitchField({
       <FieldContent>
         <FieldLabel htmlFor={configKey} className="flex items-center gap-2">
           {label}
-          {experimental && <ExperimentalFieldBadge />}
+          {beta && <BetaFieldBadge />}
           {licenseKeyRequired && <LicenseKeyRequiredFieldBadge />}
         </FieldLabel>
         <FieldDescription>{description}</FieldDescription>

--- a/packages/renderer/components/experimental-field-badge.tsx
+++ b/packages/renderer/components/experimental-field-badge.tsx
@@ -1,5 +1,0 @@
-import { Badge } from "@meru/ui/components/badge";
-
-export function ExperimentalFieldBadge() {
-  return <Badge variant="outline">Experimental</Badge>;
-}

--- a/packages/renderer/routes/settings/gmail/index.tsx
+++ b/packages/renderer/routes/settings/gmail/index.tsx
@@ -70,11 +70,11 @@ export function GmailSettings() {
             />
             <ConfigSwitchField
               label="Extend Dark Theme"
-              description="Extends Gmail's native dark theme to emails and the compose window. Requires Gmail's theme to be set to dark. This feature is experimental — if you run into any issues, please report them so it can be improved."
+              description="Extends Gmail's native dark theme to emails and the compose window. Requires Gmail's theme to be set to dark. This feature is in beta — if you run into any issues, please report them so it can be improved."
               configKey="gmail.extendDarkTheme"
               restartRequired
               licenseKeyRequired
-              experimental
+              beta
             />
           </FieldSet>
           <FieldSeparator />


### PR DESCRIPTION
Extend Dark Theme has been stable enough that "Experimental" undersells it, so it moves to a Beta label.

## Changes

- Rename `ExperimentalFieldBadge` → `BetaFieldBadge` (`experimental-field-badge.tsx` → `beta-field-badge.tsx`) and the rendered text from "Experimental" to "Beta".
- Rename the `ConfigSwitchField` `experimental` prop to `beta`.
- Reword the Extend Dark Theme description from "This feature is experimental" to "This feature is in beta".

Extend Dark Theme was the only field using the experimental badge, so the badge is renamed outright rather than keeping an unused "Experimental" stage around. If an experimental stage is wanted again later, it can be reintroduced next to the beta one.

## Test plan

1. Open Settings → Gmail → Appearance.
2. Confirm the Extend Dark Theme field shows a **Beta** badge next to its label, and no "Experimental" badge remains anywhere in settings.
3. Confirm the description reads "… This feature is in beta — if you run into any issues, please report them so it can be improved."
4. Without a valid license key, confirm the field still shows the **License Key Required** badge alongside **Beta**, and the switch stays off and disabled.
5. With a valid license key, toggle the switch and confirm the restart-required toast still appears and the setting persists after a restart.