### PR TITLE
restore pinned tabs that load at launch in a new window

### DIFF
--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -65,6 +65,8 @@ export class DormantTab {
 
   loadOnLaunch: boolean;
 
+  windowed: boolean;
+
   title: string;
 
   zoomFactor: number | undefined;
@@ -75,6 +77,7 @@ export class DormantTab {
     this.title = savedTab.title;
     this.persistence = savedTab.persistence;
     this.loadOnLaunch = Boolean(savedTab.loadOnLaunch);
+    this.windowed = Boolean(savedTab.windowed);
     this.zoomFactor = zoomFactor;
   }
 }
@@ -209,7 +212,11 @@ export class Tabs {
     }
 
     if (activatedTab instanceof DormantTab) {
-      this.activeTabId = this.materializeDormantTab(activatedTab).id;
+      const materializedTab = this.materializeDormantTab(activatedTab);
+
+      if (!materializedTab.isWindowed) {
+        this.activeTabId = materializedTab.id;
+      }
 
       this.broadcastTabsChanged();
 
@@ -227,9 +234,14 @@ export class Tabs {
       url: dormantTab.url,
       persistence: dormantTab.persistence,
       loadOnLaunch: dormantTab.loadOnLaunch,
+      asWindow: dormantTab.windowed,
       app: dormantTab.app,
       zoomFactor: dormantTab.zoomFactor,
     });
+
+    if (workspaceApp.isWindowed) {
+      registerTabBroadcasts(workspaceApp.view);
+    }
 
     this.tabs.splice(this.tabs.indexOf(dormantTab), 1, workspaceApp);
 
@@ -327,6 +339,7 @@ export class Tabs {
           title: savedWorkspaceApp.title,
           persistence: savedWorkspaceApp.persistence,
           loadOnLaunch: savedWorkspaceApp.loadOnLaunch,
+          windowed: savedWorkspaceApp.isWindowed,
         },
         savedWorkspaceApp.zoomFactor,
       ),
@@ -491,6 +504,7 @@ export class Tabs {
           title: tab.title,
           persistence: tab.persistence,
           loadOnLaunch: tab.loadOnLaunch,
+          windowed: tab.isWindowed,
         });
       } else if (tab instanceof DormantTab) {
         savedTabs.push({
@@ -499,6 +513,7 @@ export class Tabs {
           title: tab.title,
           persistence: tab.persistence,
           loadOnLaunch: tab.loadOnLaunch,
+          windowed: tab.windowed,
         });
       }
     }

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -635,6 +635,10 @@ export class WorkspaceApp {
     });
 
     this.account.instance.tabs.deactivateTab(this.id);
+
+    if (this.persistence) {
+      accounts.saveTabs();
+    }
   }
 
   focusWindow() {
@@ -676,6 +680,10 @@ export class WorkspaceApp {
     main.show();
 
     this.updateViewBounds();
+
+    if (this.persistence) {
+      accounts.saveTabs();
+    }
   }
 
   private updateAppFromNavigation(url: string) {

--- a/packages/shared/schemas.ts
+++ b/packages/shared/schemas.ts
@@ -33,6 +33,7 @@ export const savedTabSchema = z.object({
   title: z.string(),
   persistence: tabPersistenceSchema,
   loadOnLaunch: z.boolean(),
+  windowed: z.boolean(),
 });
 
 export type SavedTab = z.infer<typeof savedTabSchema>;


### PR DESCRIPTION
## Problem

A pinned tab living in its own window lost that state when it went dormant. `SavedTab` only recorded `app`, `url`, `title`, `persistence` and `loadOnLaunch`, so closing the window (or quitting) and relaunching brought the tab back inside the main window instead of a separate one — even though it was windowed when the user left it.

## Changes

- Persist a `windowed` flag on `SavedTab`, written both from live `WorkspaceApp`s (`isWindowed`) and from dormant tabs.
- `DormantTab` carries `windowed`, and `materializeDormantTab` passes it as `asWindow`, so restoring — at launch via `loadLaunchTabs` or by clicking the tab — recreates the window. Windowed materialized tabs also register the tab broadcasts, matching `openWindowedTab`.
- `activateTab` no longer makes a materialized tab active when it came back as a window: the window shows and focuses itself, and the main window keeps its current tab.
- `dormantizeSavedTab` records `windowed` so a closed window round-trips.
- `detachToWindow` / `adoptIntoTabs` save tabs when the tab is persisted, so moving a pinned tab between the main window and its own window is stored right away rather than only on quit.

Old configs have no `windowed` key; it is read through `Boolean(...)` and defaults to `false`, the same way `loadOnLaunch` is handled, so no migration is needed.

## Not covered

Launching with "Launch minimized" still opens the windows of windowed launch tabs — the main window stays hidden but the workspace app windows appear. Left as-is; say the word and I'll suppress them too.

## Test plan

1. Open a Google Workspace app in a tab, pin it, then detach it to its own window.
2. Right-click the tab in the vertical tabs and enable **Load on Launch**.
3. Quit and relaunch the app — the tab loads into its own window again, and the main window stays on the tab it launched with (Gmail).
4. Close that window — the tab goes dormant in the pinned section. Click it: it reopens as a window, not inside the main window.
5. Drag the window's tab back into the app (adopt into tabs), quit and relaunch — it now loads at launch as a regular tab inside the main window.
6. Pin a tab that was never windowed, enable **Load on Launch**, relaunch — it still loads inside the main window.
7. With an existing config from before this branch, relaunch — pinned launch tabs load as regular tabs (no `windowed` key, defaults to false).