### PR TITLE
fix workspace app permission handling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -57,6 +57,16 @@ Two things are waiting on it. The nine `Ctrl+Shift+1..9` jumps to pinned tabs ar
 
 Surfaced by the comment audit. `Accounts.init` (`packages/app/accounts.ts:116`) blindly calls `refreshSelectedAccountView()` on the main window's `show` and `restore` events because the account views sometimes don't render after the window comes back — the view just doesn't paint sometimes when only `main.window.contentView.addChildView()` is called. The suspicion is a bug in Electron itself, but that is unconfirmed; the root cause was never found, and the refresh is the workaround. To investigate: pin down a reproduction, check whether a minimal Electron app shows it, search/file an upstream issue, and either link the issue at the workaround or replace it with a real fix.
 
+## HTML fullscreen leaves the app shell visible (2026-08-12)
+
+Found while testing PR #723. Presenting in Slides and going fullscreen in Meet both enter fullscreen inside the view, but the titlebar and the vertical tabs strip stay on screen — the page fills only the region its `WebContentsView` already occupied instead of the whole window.
+
+Nothing in the app listens for `enter-html-full-screen` / `leave-html-full-screen` on a view's `webContents`; the only fullscreen handling is `main.ts:150`, a `leave-full-screen` listener on the `BrowserWindow` for window-level fullscreen. So a page entering HTML fullscreen changes nothing about how the shell is laid out.
+
+Newly reachable rather than newly broken, confirmed by testing on main: before #723 the `fullscreen` permission request fell through the request handler's `switch` without ever invoking `callback`, so it never settled and pages could not enter fullscreen at all.
+
+To decide when picking this up: whether HTML fullscreen should take over the whole window (hide titlebar and strip, resize the view to the full content bounds) or also put the `BrowserWindow` itself into fullscreen, and how that interacts with a workspace app that is already in its own window.
+
 ## Horizontal tabs for pinned workspace apps (parked, 2026-08-09)
 
 Came out of the post-3.58.0 feedback round and was deliberately parked while the launcher and Workspace Apps mode work landed. Not started.

--- a/TODO.md
+++ b/TODO.md
@@ -67,6 +67,16 @@ Newly reachable rather than newly broken, confirmed by testing on main: before #
 
 To decide when picking this up: whether HTML fullscreen should take over the whole window (hide titlebar and strip, resize the view to the full content bounds) or also put the `BrowserWindow` itself into fullscreen, and how that interacts with a workspace app that is already in its own window.
 
+## Google Docs menu paste wants a Chrome extension (2026-08-12)
+
+Found while testing PR #723. Edit → Paste in Docs shows a dialog asking for the Google Docs extension to be installed instead of pasting. Menu Copy works, and Cmd/Ctrl+V is unaffected.
+
+Not a permission problem, despite looking like one. The Docs page requests `chrome-extension://ghbmnnjooekpmoecnnnilnnbdlolhkhi/page_embed_script.js` — the Google Docs Offline extension — and the load fails with `ERR_FAILED`, because Electron has no Chrome extensions installed. Docs reads the missing script as "extension not installed" and offers the dialog without ever consulting a permission. `clipboard-read` is granted since #723 and `navigator.clipboard.readText()` returns the clipboard contents, so the async clipboard path underneath is working.
+
+Routes if picked up: load the extension through `session.loadExtension` (needs a CRX off the Web Store, and Electron supports only part of the extension API), or intercept that `chrome-extension://` URL and serve a stub. Both want a look at what `page_embed_script.js` actually provides before either is worth attempting.
+
+Worth knowing while debugging anything permission-shaped: `navigator.permissions.query()` is not a useful signal in Meru. The check handler in `packages/app/account.ts` returns `true` for everything except notifications, so almost every permission reports `granted` whether or not a request for it would be.
+
 ## Horizontal tabs for pinned workspace apps (parked, 2026-08-09)
 
 Came out of the post-3.58.0 feedback round and was deliberately parked while the launcher and Workspace Apps mode work landed. Not started.

--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -38,6 +38,8 @@ export class Account {
 
     this.registerSessionPermissionsRequestsHandler();
 
+    this.registerSessionPermissionsCheckHandler();
+
     this.registerSessionDisplayMediaRequestHandler();
 
     blocker.setupSession(this.session);
@@ -93,7 +95,20 @@ export class Account {
           callback(config.get("notifications.allowFromWorkspaceApps"));
           break;
         }
+        default: {
+          callback(false);
+        }
       }
+    });
+  }
+
+  private registerSessionPermissionsCheckHandler() {
+    this.session.setPermissionCheckHandler((_webContents, permission) => {
+      if (permission === "notifications") {
+        return config.get("notifications.allowFromWorkspaceApps");
+      }
+
+      return true;
     });
   }
 

--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -87,7 +87,9 @@ export class Account {
     this.session.setPermissionRequestHandler((_webContents, permission, callback) => {
       switch (permission) {
         case "clipboard-sanitized-write":
-        case "media": {
+        case "fullscreen":
+        case "media":
+        case "speaker-selection": {
           callback(true);
           break;
         }

--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -86,6 +86,7 @@ export class Account {
   private registerSessionPermissionsRequestsHandler() {
     this.session.setPermissionRequestHandler((_webContents, permission, callback) => {
       switch (permission) {
+        case "clipboard-read":
         case "clipboard-sanitized-write":
         case "fullscreen":
         case "media":


### PR DESCRIPTION
Electron answers permissions through two separate hooks: `setPermissionRequestHandler` for active grants (`Notification.requestPermission()`, `getUserMedia()`) and `setPermissionCheckHandler` for passive queries (reading `Notification.permission`, `navigator.permissions.query()`). The app only ever registered the first, and Electron's `CheckPermissionWithDetails` returns `true` unconditionally when no check handler exists.

- Registers a check handler on the account session. Without it, `Notification.permission` reported `"granted"` in workspace apps even with **Allow notifications from workspace apps** off — pages believed notifications were on, showed no blocked state, and their notifications were dropped. It returns the setting for `notifications` and `true` for everything else, because registering any check handler replaces Electron's blanket `true`, so denying unlisted permissions would silently revoke things that work today (`fullscreen`, `pointerLock`, `storage-access`, `idle-detection`). Only `notifications` has a user-facing setting behind it.
- Adds `default: callback(false)` to the request handler's `switch`. Anything outside its cases never invoked `callback`, so the request never settled and the page waited forever.
- Adds `clipboard-read`, `fullscreen` and `speaker-selection` to the request handler's granted cases. All three are used by Workspace apps — async clipboard reads, Slides present mode and Meet fullscreen, and Meet's audio output device picker — and the new `default` would otherwise turn them from "hangs" into "denied". `navigator.clipboard.readText()` returns the clipboard contents with the grant in place, and did not before.

The two handlers do not accept the same permission names. `display-capture`, `keyboardLock`, `speaker-selection` and `window-management` only ever reach the request handler; `hid`, `serial` and `usb` only reach the check handler. Meet screen sharing is unaffected by either — `setDisplayMediaRequestHandler` intercepts `getDisplayMedia` before the request handler sees it.

`clipboard-read` does **not** fix Edit → Paste in Google Docs, which still asks for the Google Docs extension. That turned out to be unrelated: Docs loads `page_embed_script.js` from the Google Docs Offline extension, which cannot exist in Electron, and never consults a permission. Noted in `TODO.md`.

Granting `fullscreen` exposes a pre-existing gap rather than fixing one: pages can now enter HTML fullscreen, but the titlebar and vertical tabs strip stay on screen, because nothing listens for `enter-html-full-screen` on a view's `webContents`. Confirmed on main, where fullscreen does not work at all. Noted in `TODO.md` for a separate session.

`clipboard-read` gives a page full read access to the clipboard, which is a real widening — but Docs cannot paste from its own menu without it, and the session is scoped to Google origins.

## Test plan

1. With **Allow notifications from workspace apps** off, reload a workspace app tab (e.g. Google Calendar) and run `Notification.permission` in its DevTools console — expect `"denied"`. Toggle the setting on, reload, expect `"granted"`.
2. In the same console with the setting off, run `navigator.geolocation.getCurrentPosition(console.log, console.log)` — expect the error callback to fire promptly. Before this change it never settled.
3. In a workspace app's DevTools console, copy some text, then run `setTimeout(async () => console.log(await navigator.clipboard.readText()), 3000)` and click into the page before it fires — expect the clipboard contents. It must be run with the page focused; DevTools holding focus throws `Document is not focused` regardless of permissions.
4. In a Google Meet call (embedded tab and popped-out window), share a screen, grant camera/mic, and open the audio output device picker in settings — expect the source picker, media access and speaker selection to all work.
