### PR TITLE
show service worker notifications from workspace apps

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -19,6 +19,7 @@ import {
   nativeImage,
   nativeTheme,
   Notification,
+  type WebContents,
   session,
   shell,
 } from "electron";
@@ -49,6 +50,20 @@ function clearUndoSendLapseTimeout(browserWindowId: number) {
   }
 
   undoSendLapseTimeouts.delete(browserWindowId);
+}
+
+function logWorkspaceAppNotification(
+  senderWebContents: WebContents,
+  message: string,
+  detail?: unknown,
+) {
+  log.info("[meru:notifications]", message, detail);
+
+  senderWebContents
+    .executeJavaScript(
+      `console.log("[meru:notifications] (main)", ${JSON.stringify(message)}, ${JSON.stringify(detail ?? null)})`,
+    )
+    .catch(() => {});
 }
 
 function getNavigationWebContents(workspaceAppId?: string) {
@@ -622,10 +637,10 @@ class Ipc {
     });
 
     ipc.main.on("workspaceApp.showNotification", (event, notification) => {
-      log.info("[meru:notifications] main received", notification);
+      logWorkspaceAppNotification(event.sender, "main received", notification);
 
       if (!config.get("notifications.allowFromWorkspaceApps")) {
-        log.info("[meru:notifications] dropped, allowFromWorkspaceApps is off");
+        logWorkspaceAppNotification(event.sender, "dropped, allowFromWorkspaceApps is off");
 
         return;
       }
@@ -633,12 +648,16 @@ class Ipc {
       const notifyingWorkspaceApp = WorkspaceApp.tryFromViewWebContents(event.sender);
 
       if (!notifyingWorkspaceApp) {
-        log.info("[meru:notifications] dropped, no workspace app for sender");
+        logWorkspaceAppNotification(event.sender, "dropped, no workspace app for sender");
 
         return;
       }
 
-      log.info("[meru:notifications] Notification.isSupported", Notification.isSupported());
+      logWorkspaceAppNotification(
+        event.sender,
+        "Notification.isSupported",
+        Notification.isSupported(),
+      );
 
       const workspaceAppNotification = createNotification({
         title: notification.title,
@@ -665,21 +684,21 @@ class Ipc {
       });
 
       if (!workspaceAppNotification) {
-        log.info("[meru:notifications] createNotification returned nothing");
+        logWorkspaceAppNotification(event.sender, "createNotification returned nothing");
 
         return;
       }
 
       workspaceAppNotification.on("show", () => {
-        log.info("[meru:notifications] shown");
+        logWorkspaceAppNotification(event.sender, "shown");
       });
 
       workspaceAppNotification.on("failed", (_event, error) => {
-        log.error("[meru:notifications] failed", error);
+        logWorkspaceAppNotification(event.sender, "failed", String(error));
       });
 
       workspaceAppNotification.on("close", () => {
-        log.info("[meru:notifications] closed");
+        logWorkspaceAppNotification(event.sender, "closed");
       });
     });
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -18,8 +18,6 @@ import {
   type MenuItemConstructorOptions,
   nativeImage,
   nativeTheme,
-  Notification,
-  type WebContents,
   session,
   shell,
 } from "electron";
@@ -50,20 +48,6 @@ function clearUndoSendLapseTimeout(browserWindowId: number) {
   }
 
   undoSendLapseTimeouts.delete(browserWindowId);
-}
-
-function logWorkspaceAppNotification(
-  senderWebContents: WebContents,
-  message: string,
-  detail?: unknown,
-) {
-  log.info("[meru:notifications]", message, detail);
-
-  senderWebContents
-    .executeJavaScript(
-      `console.log("[meru:notifications] (main)", ${JSON.stringify(message)}, ${JSON.stringify(detail ?? null)})`,
-    )
-    .catch(() => {});
 }
 
 function getNavigationWebContents(workspaceAppId?: string) {
@@ -637,29 +621,17 @@ class Ipc {
     });
 
     ipc.main.on("workspaceApp.showNotification", (event, notification) => {
-      logWorkspaceAppNotification(event.sender, "main received", notification);
-
       if (!config.get("notifications.allowFromWorkspaceApps")) {
-        logWorkspaceAppNotification(event.sender, "dropped, allowFromWorkspaceApps is off");
-
         return;
       }
 
       const notifyingWorkspaceApp = WorkspaceApp.tryFromViewWebContents(event.sender);
 
       if (!notifyingWorkspaceApp) {
-        logWorkspaceAppNotification(event.sender, "dropped, no workspace app for sender");
-
         return;
       }
 
-      logWorkspaceAppNotification(
-        event.sender,
-        "Notification.isSupported",
-        Notification.isSupported(),
-      );
-
-      const workspaceAppNotification = createNotification({
+      createNotification({
         title: notification.title,
         body: notification.body,
         silent: notification.silent,
@@ -681,24 +653,6 @@ class Ipc {
             accounts.selectAccount(notifyingWorkspaceApp.accountId);
           }
         },
-      });
-
-      if (!workspaceAppNotification) {
-        logWorkspaceAppNotification(event.sender, "createNotification returned nothing");
-
-        return;
-      }
-
-      workspaceAppNotification.on("show", () => {
-        logWorkspaceAppNotification(event.sender, "shown");
-      });
-
-      workspaceAppNotification.on("failed", (_event, error) => {
-        logWorkspaceAppNotification(event.sender, "failed", String(error));
-      });
-
-      workspaceAppNotification.on("close", () => {
-        logWorkspaceAppNotification(event.sender, "closed");
       });
     });
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -18,6 +18,7 @@ import {
   type MenuItemConstructorOptions,
   nativeImage,
   nativeTheme,
+  Notification,
   session,
   shell,
 } from "electron";
@@ -621,17 +622,25 @@ class Ipc {
     });
 
     ipc.main.on("workspaceApp.showNotification", (event, notification) => {
+      log.info("[meru:notifications] main received", notification);
+
       if (!config.get("notifications.allowFromWorkspaceApps")) {
+        log.info("[meru:notifications] dropped, allowFromWorkspaceApps is off");
+
         return;
       }
 
       const notifyingWorkspaceApp = WorkspaceApp.tryFromViewWebContents(event.sender);
 
       if (!notifyingWorkspaceApp) {
+        log.info("[meru:notifications] dropped, no workspace app for sender");
+
         return;
       }
 
-      createNotification({
+      log.info("[meru:notifications] Notification.isSupported", Notification.isSupported());
+
+      const workspaceAppNotification = createNotification({
         title: notification.title,
         body: notification.body,
         silent: notification.silent,
@@ -653,6 +662,24 @@ class Ipc {
             accounts.selectAccount(notifyingWorkspaceApp.accountId);
           }
         },
+      });
+
+      if (!workspaceAppNotification) {
+        log.info("[meru:notifications] createNotification returned nothing");
+
+        return;
+      }
+
+      workspaceAppNotification.on("show", () => {
+        log.info("[meru:notifications] shown");
+      });
+
+      workspaceAppNotification.on("failed", (_event, error) => {
+        log.error("[meru:notifications] failed", error);
+      });
+
+      workspaceAppNotification.on("close", () => {
+        log.info("[meru:notifications] closed");
       });
     });
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -33,7 +33,7 @@ import { DoNotDisturb, doNotDisturb } from "./do-not-disturb";
 import { downloads } from "./downloads";
 import { GMAIL_USER_STYLES_PATH } from "./gmail";
 import { log } from "./lib/log";
-import { createNewEmailNotification } from "./notifications";
+import { createNewEmailNotification, createNotification } from "./notifications";
 import { MAILTO_PROTOCOL } from "./protocol";
 import { appUpdater } from "./updater";
 import { openExternalUrl } from "./url";
@@ -617,6 +617,42 @@ class Ipc {
         title: "Tim from Meru",
         subtitle: "Your Test Notification Request",
         body: "This is a test notification to show how notifications will appear.",
+      });
+    });
+
+    ipc.main.on("workspaceApp.showNotification", (event, notification) => {
+      if (!config.get("notifications.allowFromWorkspaceApps")) {
+        return;
+      }
+
+      const notifyingWorkspaceApp = WorkspaceApp.tryFromViewWebContents(event.sender);
+
+      if (!notifyingWorkspaceApp) {
+        return;
+      }
+
+      createNotification({
+        title: notification.title,
+        body: notification.body,
+        silent: notification.silent,
+        timeoutType: notification.requireInteraction ? "never" : "default",
+        click: () => {
+          if (notifyingWorkspaceApp.isWindowed) {
+            notifyingWorkspaceApp.window.show();
+
+            return;
+          }
+
+          main.show();
+
+          notifyingWorkspaceApp.account.instance.tabs.activateTab(notifyingWorkspaceApp.id);
+
+          if (notifyingWorkspaceApp.account.config.selected) {
+            accounts.refreshSelectedAccountView();
+          } else {
+            accounts.selectAccount(notifyingWorkspaceApp.accountId);
+          }
+        },
       });
     });
 

--- a/packages/preload-workspace-app/index.ts
+++ b/packages/preload-workspace-app/index.ts
@@ -2,6 +2,7 @@ import "@meru/shared/electron-api";
 import "./ipc";
 import { initMailPreload } from "./apps/mail";
 import { initMeetPreload } from "./apps/meet";
+import { initServiceWorkerNotifications } from "./service-worker-notifications";
 
 const appPreloadScripts: Record<string, () => void> = {
   "mail.google.com": initMailPreload,
@@ -12,4 +13,9 @@ const appPreloadScript = appPreloadScripts[window.location.hostname];
 
 if (appPreloadScript) {
   appPreloadScript();
+}
+
+// Gmail notifications are already created natively in the main process, shimming them here would show them twice
+if (window.location.hostname !== "mail.google.com") {
+  initServiceWorkerNotifications();
 }

--- a/packages/preload-workspace-app/service-worker-notifications.ts
+++ b/packages/preload-workspace-app/service-worker-notifications.ts
@@ -9,27 +9,63 @@ declare global {
 }
 
 function patchShowNotification() {
+  console.log(
+    "[meru:notifications] main world reached, bridge is",
+    typeof window.meruShowNotification,
+  );
+
   ServiceWorkerRegistration.prototype.showNotification = function (title, options) {
-    window.meruShowNotification({
-      title,
-      body: options?.body,
-      silent: options?.silent ?? undefined,
-      requireInteraction: options?.requireInteraction,
-    });
+    console.log("[meru:notifications] intercepted", title, options);
+
+    try {
+      window.meruShowNotification({
+        title,
+        body: options?.body,
+        silent: options?.silent ?? undefined,
+        requireInteraction: options?.requireInteraction,
+      });
+
+      console.log("[meru:notifications] handed to bridge");
+    } catch (error) {
+      console.error("[meru:notifications] bridge call threw", error);
+    }
 
     return Promise.resolve();
   };
+
+  console.log("[meru:notifications] prototype patched");
 }
 
 export function initServiceWorkerNotifications() {
-  contextBridge.exposeInMainWorld(
-    "meruShowNotification",
-    (notification: WorkspaceAppNotification) => {
-      ipc.main.send("workspaceApp.showNotification", notification);
-    },
-  );
+  console.log("[meru:notifications] init on", window.location.hostname);
 
-  webFrame.executeJavaScript(`(${patchShowNotification.toString()})()`).catch((error) => {
-    console.error("Failed to patch service worker notifications:", error);
-  });
+  try {
+    contextBridge.exposeInMainWorld(
+      "meruShowNotification",
+      (notification: WorkspaceAppNotification) => {
+        console.log("[meru:notifications] bridge invoked", notification);
+
+        try {
+          ipc.main.send("workspaceApp.showNotification", notification);
+
+          console.log("[meru:notifications] ipc sent");
+        } catch (error) {
+          console.error("[meru:notifications] ipc send threw", error);
+        }
+      },
+    );
+
+    console.log("[meru:notifications] bridge exposed");
+  } catch (error) {
+    console.error("[meru:notifications] exposing bridge threw", error);
+  }
+
+  webFrame
+    .executeJavaScript(`(${patchShowNotification.toString()})()`)
+    .then(() => {
+      console.log("[meru:notifications] injection resolved");
+    })
+    .catch((error) => {
+      console.error("[meru:notifications] injection failed", error);
+    });
 }

--- a/packages/preload-workspace-app/service-worker-notifications.ts
+++ b/packages/preload-workspace-app/service-worker-notifications.ts
@@ -1,35 +1,34 @@
-import { webFrame } from "electron";
+import { ipc } from "@meru/shared/renderer/ipc";
+import type { WorkspaceAppNotification } from "@meru/shared/types";
+import { contextBridge, webFrame } from "electron";
+
+declare global {
+  interface Window {
+    meruShowNotification: (notification: WorkspaceAppNotification) => void;
+  }
+}
 
 function patchShowNotification() {
   ServiceWorkerRegistration.prototype.showNotification = function (title, options) {
-    try {
-      const notification = new Notification(title, {
-        body: options?.body,
-        icon: options?.icon,
-        tag: options?.tag,
-        silent: options?.silent,
-        data: options?.data,
-        requireInteraction: options?.requireInteraction,
-        lang: options?.lang,
-        dir: options?.dir,
-      });
+    window.meruShowNotification({
+      title,
+      body: options?.body,
+      silent: options?.silent ?? undefined,
+      requireInteraction: options?.requireInteraction,
+    });
 
-      notification.onclick = () => {
-        window.focus();
-      };
-
-      notification.onerror = () => {
-        console.error("Failed to show service worker notification:", title);
-      };
-
-      return Promise.resolve();
-    } catch (error) {
-      return Promise.reject(error);
-    }
+    return Promise.resolve();
   };
 }
 
 export function initServiceWorkerNotifications() {
+  contextBridge.exposeInMainWorld(
+    "meruShowNotification",
+    (notification: WorkspaceAppNotification) => {
+      ipc.main.send("workspaceApp.showNotification", notification);
+    },
+  );
+
   webFrame.executeJavaScript(`(${patchShowNotification.toString()})()`).catch((error) => {
     console.error("Failed to patch service worker notifications:", error);
   });

--- a/packages/preload-workspace-app/service-worker-notifications.ts
+++ b/packages/preload-workspace-app/service-worker-notifications.ts
@@ -18,6 +18,10 @@ function patchShowNotification() {
         window.focus();
       };
 
+      notification.onerror = () => {
+        console.error("Failed to show service worker notification:", title);
+      };
+
       return Promise.resolve();
     } catch (error) {
       return Promise.reject(error);

--- a/packages/preload-workspace-app/service-worker-notifications.ts
+++ b/packages/preload-workspace-app/service-worker-notifications.ts
@@ -9,63 +9,27 @@ declare global {
 }
 
 function patchShowNotification() {
-  console.log(
-    "[meru:notifications] main world reached, bridge is",
-    typeof window.meruShowNotification,
-  );
-
   ServiceWorkerRegistration.prototype.showNotification = function (title, options) {
-    console.log("[meru:notifications] intercepted", title, options);
-
-    try {
-      window.meruShowNotification({
-        title,
-        body: options?.body,
-        silent: options?.silent ?? undefined,
-        requireInteraction: options?.requireInteraction,
-      });
-
-      console.log("[meru:notifications] handed to bridge");
-    } catch (error) {
-      console.error("[meru:notifications] bridge call threw", error);
-    }
+    window.meruShowNotification({
+      title,
+      body: options?.body,
+      silent: options?.silent ?? undefined,
+      requireInteraction: options?.requireInteraction,
+    });
 
     return Promise.resolve();
   };
-
-  console.log("[meru:notifications] prototype patched");
 }
 
 export function initServiceWorkerNotifications() {
-  console.log("[meru:notifications] init on", window.location.hostname);
+  contextBridge.exposeInMainWorld(
+    "meruShowNotification",
+    (notification: WorkspaceAppNotification) => {
+      ipc.main.send("workspaceApp.showNotification", notification);
+    },
+  );
 
-  try {
-    contextBridge.exposeInMainWorld(
-      "meruShowNotification",
-      (notification: WorkspaceAppNotification) => {
-        console.log("[meru:notifications] bridge invoked", notification);
-
-        try {
-          ipc.main.send("workspaceApp.showNotification", notification);
-
-          console.log("[meru:notifications] ipc sent");
-        } catch (error) {
-          console.error("[meru:notifications] ipc send threw", error);
-        }
-      },
-    );
-
-    console.log("[meru:notifications] bridge exposed");
-  } catch (error) {
-    console.error("[meru:notifications] exposing bridge threw", error);
-  }
-
-  webFrame
-    .executeJavaScript(`(${patchShowNotification.toString()})()`)
-    .then(() => {
-      console.log("[meru:notifications] injection resolved");
-    })
-    .catch((error) => {
-      console.error("[meru:notifications] injection failed", error);
-    });
+  webFrame.executeJavaScript(`(${patchShowNotification.toString()})()`).catch((error) => {
+    console.error("Failed to patch service worker notifications:", error);
+  });
 }

--- a/packages/preload-workspace-app/service-worker-notifications.ts
+++ b/packages/preload-workspace-app/service-worker-notifications.ts
@@ -1,0 +1,30 @@
+import { webFrame } from "electron";
+
+function patchShowNotification() {
+  ServiceWorkerRegistration.prototype.showNotification = function (title, options) {
+    try {
+      const notification = new Notification(title, {
+        body: options?.body,
+        icon: options?.icon,
+        tag: options?.tag,
+        silent: options?.silent,
+        data: options?.data,
+        requireInteraction: options?.requireInteraction,
+        lang: options?.lang,
+        dir: options?.dir,
+      });
+
+      notification.onclick = () => {
+        window.focus();
+      };
+
+      return Promise.resolve();
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  };
+}
+
+export function initServiceWorkerNotifications() {
+  webFrame.executeJavaScript(`(${patchShowNotification.toString()})()`);
+}

--- a/packages/preload-workspace-app/service-worker-notifications.ts
+++ b/packages/preload-workspace-app/service-worker-notifications.ts
@@ -26,5 +26,7 @@ function patchShowNotification() {
 }
 
 export function initServiceWorkerNotifications() {
-  webFrame.executeJavaScript(`(${patchShowNotification.toString()})()`);
+  webFrame.executeJavaScript(`(${patchShowNotification.toString()})()`).catch((error) => {
+    console.error("Failed to patch service worker notifications:", error);
+  });
 }

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -39,6 +39,13 @@ export type NotificationTime = {
   days?: number[]; // 0=Sun,1=Mon,...,6=Sat; undefined/empty = all days
 };
 
+export type WorkspaceAppNotification = {
+  title: string;
+  body?: string;
+  silent?: boolean;
+  requireInteraction?: boolean;
+};
+
 type GmailHashLocation =
   | "inbox"
   | "starred"
@@ -158,6 +165,7 @@ export type IpcMainEvents =
       "gmail.search": [searchQuery: string];
       "gmail.openUserStyles": [openIn: "editor" | "folder"];
       "workspaceApp.showMenu": [workspaceAppId: string];
+      "workspaceApp.showNotification": [notification: WorkspaceAppNotification];
       "gmail.navigateTo": [hashLocation: GmailHashLocation];
       "gmail.closeComposeWindow": [];
       "gmail.undoMessageSent": [browserWindowId: number];


### PR DESCRIPTION
## Problem

Google Workspace apps (Calendar, Chat, …) don't show web notifications with `new Notification()` — they use `ServiceWorkerRegistration.showNotification()`, the persistent notification API. Electron has never implemented persistent notifications ([electron#13041](https://github.com/electron/electron/issues/13041), open since 2018). In Electron v43.2.0, `shell/browser/notifications/platform_notification_service.h` still declares:

```cpp
void DisplayPersistentNotification(...) override {}
```

with `ReadNextPersistentNotificationId()` carrying the comment `// Electron doesn't support persistent notifications.`

Confirmed by instrumenting `ServiceWorkerRegistration.prototype.showNotification` in a live Google Calendar tab and letting a real event reminder fire: Calendar calls it from page script, the promise resolves, and nothing is ever displayed. So event reminders and Chat messages silently go nowhere, with no error to hint at why.

## Changes

The shim replaces `ServiceWorkerRegistration.prototype.showNotification` and forwards the notification over IPC to the main process, which shows it with Electron's `Notification` via the existing `createNotification` helper in `packages/app/notifications.ts` — the same path Gmail's new-mail and download notifications already use.

- `packages/preload-workspace-app/service-worker-notifications.ts` — exposes `meruShowNotification` with `contextBridge` and installs the prototype patch in the page's main world.
- `packages/app/ipc.ts` — handles `workspaceApp.showNotification`.
- `packages/shared/types.ts` — the `WorkspaceAppNotification` payload and IPC event.

The patch has to run in the page's **main world**: `contextIsolation` is on, so a prototype patched from the preload's isolated world would be invisible to the page. It's installed with `webFrame.executeJavaScript`, which targets `DOMWrapperWorld::kMainWorldId` synchronously. To keep the injected code readable and covered by lint/format/type checks it's written as a normal function and stringified at the call site; it is fully self-contained (globals only), so bundling can't break outer-scope references. Verified against the rolldown output.

The shim runs for every workspace app, not per-host. **`mail.google.com` is deliberately excluded**: Meru already generates Gmail notifications natively in the main process, so shimming there would show them twice.

### Why IPC rather than `new Notification()`

The first version of this branch forwarded to `new Notification()` in the page, which also works. The main process was chosen instead because it puts notification rendering under Meru's own control — the same layer that owns notification sounds, volume and the rest of the notification config — rather than handing the payload to Chromium and losing the ability to shape it.

It also buys behavior the page-level shim could not provide:

- The notification is gated on `notifications.allowFromWorkspaceApps` **explicitly**, in the handler. This is required, not incidental — the IPC path bypasses Electron's permission request handler, which is what enforced that setting before.
- Clicking focuses the window *and* activates the originating tab, selecting its account if it isn't the current one. The page-level shim could only call `window.focus()`.
- `requireInteraction` maps to Electron's `timeoutType: "never"`.

Notifications go through `createNotification`, so they use the system sound, matching download notifications. Meru's configurable notification sound and volume are currently applied only by `createNewEmailNotification`; wiring those up for workspace apps is a deliberate follow-up, not part of this PR.

## Known losses

- **`actions` are dropped.** Google Calendar reminders lose their Snooze button. Electron's `Notification` only supports actions on macOS, and wiring a click back into the service worker's `notificationclick` event is out of scope.
- **`icon` is dropped.** Electron's `Notification` takes a local path or `NativeImage`, not a remote URL, so Calendar's icon would need fetching and converting first. Notifications show Meru's own icon instead.
- **`notificationclick` never fires in the service worker.** Clicking focuses the originating tab rather than opening the specific event.
- **`registration.getNotifications()` is not shimmed.** Pages that enumerate outstanding notifications to update or close them will see an empty list.
- **`tag` no longer replaces an existing notification.** Chromium's tag-based replacement lived in the path this bypasses.
- **Only page-initiated calls are intercepted.** The prototype patch lives in the page's main world, so it catches `registration.showNotification()` from page scripts — the path Calendar uses, confirmed above. A service worker calling `self.registration.showNotification()` from inside its own scope (e.g. from a `push` handler) runs in a realm a preload cannot reach. In practice Electron also has no `PushManager`, so push-driven notifications don't reach the service worker in the first place.
- **`mail.google.com` is excluded** by design, as described above.

`meruShowNotification` is exposed to page JavaScript, so Google's own code could call it directly. That is not a new capability — the page can already show notifications through the Notification API — and everything it can trigger is gated on `notifications.allowFromWorkspaceApps`.

This is independent of #723, which adds a `setPermissionCheckHandler`.

## Test plan

**Testing notifications on macOS.** [Electron's docs](https://www.electronjs.org/docs/latest/tutorial/notifications#macos) require the binary to be code-signed for notification events to emit; unsigned binaries emit a `failed` event instead of showing anything. A `bun dev` build can end up unsigned after `node_modules/electron` is replaced (an Electron version bump, or `postinstall` running `electron-builder install-app-deps` against the bundle), and every notification then fails with `UNErrorDomain error 1` / `UNErrorCodeNotificationsNotAllowed` — including Meru's own **Show Test Notification** button, which is the quickest way to tell this apart from a bug in this PR.

Either ad-hoc sign the dev bundle (repeat after any Electron version change):

```
codesign --force --deep --sign - node_modules/electron/dist/Electron.app
```

or test a `bun run build:mac` bundle. Note also that a dev build runs under Electron's bundle identifier (`com.github.Electron`), not Meru's (`sh.zoid.meru`), so it has its own entry in System Settings → Notifications.

1. Enable **Settings → Notifications → Workspace Apps**, open a Google Calendar tab, and create an event a couple of minutes out with a notification reminder. When the reminder fires, a native OS notification appears with the event title and time. (Before this change, nothing appeared.)
2. Click that notification. Meru is focused and the Calendar tab becomes the active tab. It does **not** navigate to the specific event — expected, per the known losses.
3. Confirm the notification has no Snooze button and shows Meru's icon rather than Calendar's — both expected.
4. Switch to a different tab so Calendar is in the background, and let another reminder fire. The notification still appears and clicking it activates the Calendar tab.
5. Add a second account, open Calendar in it, and let a reminder fire while the *other* account is selected. Clicking the notification switches to the originating account and activates its Calendar tab.
6. Pop Calendar out into its own window and repeat step 1. The reminder still notifies, and clicking focuses that window.
7. Open a Google Chat tab and have someone send you a message. A native notification appears. **Unverified** — only Calendar's notification path was confirmed during investigation. If nothing appears, Chat is likely showing notifications from inside its service worker, which this shim cannot reach (see known losses); check the tab's DevTools console for a patch-install error first.
8. Turn **Workspace Apps** off and repeat step 1. No notification appears — the handler's config check suppresses it. No restart should be needed, since the check runs per notification.
9. Turn it back on and open Gmail. Receiving new mail produces exactly **one** notification, not two, and clicking it still opens the message as before.
10. In DevTools on a Calendar tab, run `navigator.serviceWorker.ready.then((registration) => registration.showNotification("test", { body: "hello" }))`. A notification titled "test" with body "hello" appears and the promise resolves.


