### PR TITLE
show the workspace app name in notification titles

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { IpcEmitter, IpcListener } from "@electron-toolkit/typed-ipc/main";
+import { platform } from "@electron-toolkit/utils";
 import { MAX_RECENT_DOWNLOAD_HISTORY_ITEMS } from "@meru/shared/constants";
 import { getWorkspaceAppUrl } from "@meru/shared/google";
 import { ms } from "@meru/shared/ms";
@@ -631,10 +632,35 @@ class Ipc {
         return;
       }
 
+      const workspaceAppLabel = notifyingWorkspaceApp.app
+        ? workspaceApps[notifyingWorkspaceApp.app].label
+        : undefined;
+
+      const hasMultipleAccounts = accounts.getAccountConfigs().length > 1;
+
+      let notificationTitle = workspaceAppLabel ?? notification.title;
+
+      if (hasMultipleAccounts) {
+        notificationTitle = `[${notifyingWorkspaceApp.account.config.label}] ${notificationTitle}`;
+      }
+
+      let subtitle: string | undefined;
+
+      let body = notification.body;
+
+      if (workspaceAppLabel) {
+        if (platform.isMacOS) {
+          subtitle = notification.title;
+        } else {
+          body = [notification.title, notification.body].filter(Boolean).join("\n");
+        }
+      }
+
       createNotification({
-        title: notification.title,
-        body: notification.body,
-        silent: notification.silent,
+        title: notificationTitle,
+        subtitle,
+        body,
+        silent: notifyingWorkspaceApp.app === "calendar" ? true : notification.silent,
         timeoutType: notification.requireInteraction ? "never" : "default",
         click: () => {
           if (notifyingWorkspaceApp.isWindowed) {


### PR DESCRIPTION
## Problem

Workspace app notifications added in #724 used the page's own notification title verbatim, so a Google Calendar reminder showed up as `Test` — the event name with no indication of which app or account it came from. Gmail's new-mail notifications already solve this: the title names the source (prefixed with the account label when more than one account exists) and the specific content moves to the subtitle.

## Changes

`packages/app/ipc.ts`, in the `workspaceApp.showNotification` handler:

- **Title is the workspace app name**, resolved from `workspaceApps[app].label` — `Calendar`, `Chat`, `Drive` and so on.
- **Account label prefix** when more than one account is configured: `[Work] Calendar`. Matches `createNewEmailNotification`'s format and its `hasMultipleAccounts` gate, so a single-account setup stays uncluttered.
- **The page's title moves to the subtitle**, so a Calendar reminder now reads title `[Work] Calendar`, subtitle `Test`, body `18:00 – 19:00`.
- **Calendar notifications are forced silent.** Google Calendar plays its own notification sound from the page when enabled in Calendar's settings, so leaving the OS notification audible double-plays it.

## Platform behavior

Electron's `subtitle` is macOS-only. On Windows and Linux the page's title would simply be dropped, losing the event name entirely, so on those platforms it's prepended to the body instead:

| | macOS | Windows / Linux |
|---|---|---|
| title | `[Work] Calendar` | `[Work] Calendar` |
| subtitle | `Test` | — |
| body | `18:00 – 19:00` | `Test`<br>`18:00 – 19:00` |

## Notes for review

- **Tabs with no resolved workspace app keep the old shape.** `WorkspaceApp.app` is `undefined` when a tab has been navigated somewhere outside the known Google apps, and there's no sensible app name to show. Those fall back to the page's own title (still account-prefixed when relevant) rather than rendering `[Work] undefined`.
- **The account prefix is gated on multiple accounts**, mirroring Gmail. If you'd rather it always show, that's a one-line change.
- **Only Calendar is forced silent.** Chat and Meet may also play their own sounds; I only have confirmation for Calendar, so I didn't widen it speculatively.
- Notification sound/volume config still isn't applied to workspace app notifications — they use `createNotification`, which plays the system sound like download notifications do. Wiring up Meru's configurable sound remains a separate follow-up, and the forced-silent Calendar case will need to be reconciled with it when that happens.

## Test plan

1. With a single account, let a Google Calendar reminder fire. The notification title reads `Calendar` with no bracket prefix, the subtitle is the event name, and the body is the event time.
2. Add a second account and let a reminder fire from either. The title now reads `[<account label>] Calendar`.
3. Enable notification sounds in Google Calendar's own settings, then let a reminder fire. You hear Calendar's sound exactly once — the OS notification itself is silent.
4. Trigger a notification from a non-Calendar workspace app (e.g. Google Chat). The title is `Chat` (or `[<label>] Chat`), the subtitle is the message title, and the OS notification is *not* forced silent.
5. Click a notification. It still focuses Meru and activates the originating tab, switching account if needed — unchanged from #724.
6. Open a workspace app tab and navigate it to a non-Google page that shows a notification. The title falls back to the page's own notification title rather than showing an app name.
7. On Windows or Linux, repeat step 1. There is no subtitle; the event name appears as the first line of the body, above the time.
8. Confirm Gmail new-mail notifications are unchanged.
