### PR TITLE
show the email summary in notifications on windows and linux

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -709,10 +709,24 @@ export class Gmail {
 
         let body: string | undefined;
 
-        if (platform.isMacOS && config.get("notifications.showSummary")) {
-          body = newMail.summary;
-        } else if (!platform.isMacOS && config.get("notifications.showSubject")) {
-          body = newMail.subject;
+        if (platform.isMacOS) {
+          if (config.get("notifications.showSummary")) {
+            body = newMail.summary;
+          }
+        } else {
+          const bodyLines: string[] = [];
+
+          if (config.get("notifications.showSubject")) {
+            bodyLines.push(newMail.subject);
+          }
+
+          if (config.get("notifications.showSummary")) {
+            bodyLines.push(newMail.summary);
+          }
+
+          if (bodyLines.length) {
+            body = bodyLines.join("\n");
+          }
         }
 
         if (licenseKey.isValid && config.get("verificationCodes.autoCopy")) {

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -33,7 +33,6 @@ import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/comp
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { NOTIFICATION_SOUNDS, playNotificationSound } from "@/lib/notifications";
 import { useConfig, useConfigMutation } from "@/lib/react-query";
-import { platform } from "@/lib/utils";
 
 function hasOverlap(times: NotificationTime[]) {
   return times.some((timeA, index) =>
@@ -163,13 +162,11 @@ export function NotificationsSettings() {
                     description="Display the email subject in notifications."
                     configKey="notifications.showSubject"
                   />
-                  {platform.isMacOS && (
-                    <ConfigSwitchField
-                      label="Show Summary"
-                      description="Display the email summary in notifications."
-                      configKey="notifications.showSummary"
-                    />
-                  )}
+                  <ConfigSwitchField
+                    label="Show Summary"
+                    description="Display the email summary in notifications."
+                    configKey="notifications.showSummary"
+                  />
                   <Field>
                     <FieldLabel className="flex items-center gap-2">
                       Notification Times


### PR DESCRIPTION
## Problem

On Windows and Linux the email summary is never shown in new-mail notifications, and there is no way to find out why.

Electron's `subtitle` is macOS-only, so the notification content was built as:

```ts
if (platform.isMacOS && config.get("notifications.showSummary")) {
  body = newMail.summary;
} else if (!platform.isMacOS && config.get("notifications.showSubject")) {
  body = newMail.subject;
}
```

macOS puts the subject in the subtitle and the summary in the body. Everywhere else the subject takes the body and the summary has nowhere to go — `notifications.showSummary` is simply never read, despite defaulting to `true`. The Settings UI compounds it by wrapping the **Show Summary** switch in `platform.isMacOS`, so a Windows or Linux user sees neither the summary nor a control that would explain its absence.

## Changes

- `packages/app/gmail/index.ts` — on non-macOS the body is now assembled from the enabled fields, subject first, joined with a newline. macOS is unchanged.
- `packages/renderer/routes/settings/notifications.tsx` — **Show Summary** is no longer gated on macOS, so the setting is reachable on every platform. (`platform` became unused in this file and its import was dropped.)

| | macOS | Windows / Linux (before) | Windows / Linux (after) |
|---|---|---|---|
| subtitle | subject | — | — |
| body | summary | subject | subject<br>summary |

Both switches remain independent, so disabling either leaves the other in the body, and disabling both leaves no body at all.

## Notes for review

- **This is a visible change for existing Windows/Linux users.** `showSummary` defaults to `true`, so notifications there will start showing an extra line without anyone changing a setting. That is the intent — the setting was on, it just wasn't honoured — but it is a behavior change on upgrade, and the new switch is how anyone who dislikes it opts out.
- macOS behavior is untouched.
- Assumes the macOS-only gate was an oversight rather than a deliberate platform decision. The config default of `true` on platforms with no way to read or change it is the main evidence.

## Test plan

1. On Windows or Linux with both **Show Subject** and **Show Summary** on, receive a new email. The notification body shows the subject on the first line and the summary on the second.
2. Turn **Show Summary** off and receive another. Only the subject shows.
3. Turn **Show Summary** back on and **Show Subject** off. Only the summary shows.
4. Turn both off. The notification has a title but no body.
5. Open Settings → Notifications on Windows or Linux. The **Show Summary** switch is visible and toggling it takes effect on the next email.
6. On macOS, receive a new email with both switches on. Unchanged: subject in the subtitle, summary in the body.
7. On macOS, turn **Show Summary** off. The subtitle still shows the subject and the body is empty.
