### PR TITLE
scan the full email for verification codes regardless of notification settings

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -730,9 +730,7 @@ export class Gmail {
         }
 
         if (licenseKey.isValid && config.get("verificationCodes.autoCopy")) {
-          const verificationCode = extractVerificationCode(
-            [subtitle, body].filter((text) => typeof text === "string"),
-          );
+          const verificationCode = extractVerificationCode([newMail.subject, newMail.summary]);
 
           if (verificationCode) {
             clipboard.writeText(verificationCode);


### PR DESCRIPTION
> Stacked on #726.

## Problem

Verification-code auto-copy scanned the strings built for *display*, not the email itself:

```ts
const verificationCode = extractVerificationCode(
  [subtitle, body].filter((text) => typeof text === "string"),
);
```

`subtitle` and `body` are shaped by `notifications.showSubject`, `notifications.showSummary` and the platform, so purely cosmetic preferences silently decided what a functional feature could see:

- **Show Subject off, macOS** — `subtitle` is unset, so only the summary is scanned.
- **Show Summary off, macOS** — `body` is unset, so only the subject is scanned.
- **Both off** — nothing is scanned and auto-copy never fires at all.
- **Windows / Linux (before #726)** — `subtitle` is never set and `body` held only the subject, so a code appearing in the summary but not the subject was unreachable.

In every case the feature fails silently: no code is copied and nothing indicates why.

## Changes

`packages/app/gmail/index.ts` — extract from the message fields directly:

```ts
const verificationCode = extractVerificationCode([newMail.subject, newMail.summary]);
```

Both are non-optional `string` on `GmailInboxMessage`, so the `typeof` filter is no longer needed. Detection now behaves identically on every platform and under every combination of notification display settings.

## Notes for review

- **Auto-copy will now fire in cases where it previously stayed silent** — notably with **Show Subject** or **Show Summary** disabled, and on Windows/Linux for codes that only appear in the summary. That is the fix, but it is a behavior change for anyone who had `verificationCodes.autoCopy` on together with reduced notification content.
- `extractVerificationCode`'s confidence heuristics are untouched; it just receives the complete text now. Because the high-confidence pattern check scans the same array, a message whose triggering keyword sits only in the summary can now qualify on platforms where it previously could not — the intended consequence of scanning the whole message.
- The follow-on actions gated behind a detected code (`verificationCodes.autoMarkAsRead`, `verificationCodes.autoDelete`) are unchanged, but they now run in these newly detected cases. Worth a deliberate look, since those mutate the mailbox.
- Display of the notification itself is unchanged — `subtitle` and `body` still drive what is shown.

## Test plan

1. With **Show Subject** and **Show Summary** both on and **Auto Copy** enabled, receive an email whose summary contains a 6-digit code. The code is copied and the confirmation notification appears — unchanged from before.
2. Turn **Show Subject** off and repeat. The code is still copied. (Before this change, on macOS nothing was scanned but the summary; with both off, nothing at all.)
3. Turn both **Show Subject** and **Show Summary** off and repeat. The code is still copied, and the confirmation notification still appears.
4. On Windows or Linux, receive an email whose code appears only in the summary and not the subject. The code is copied.
5. Receive an ordinary email with no code. Nothing is copied and a normal notification appears.
6. Receive an email containing a negative-pattern phrase (e.g. a delivery pick-up code). Nothing is copied, matching the existing heuristic.
7. With **Auto Mark as Read** and **Auto Delete** enabled, repeat step 3 and confirm the message is marked read / deleted as expected now that detection fires.
