### PR TITLE
show the workspace apps launcher on the right with an auto display

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -95,6 +95,7 @@ export const config = new Store<Config>({
     "workspaceApps.openInAppExcludedApps": [],
     "workspaceApps.openBehavior": "tab",
     "workspaceApps.launcherApps": [],
+    "workspaceApps.launcherDisplay": "menu",
     "workspaceApps.showAccountColor": true,
     "workspaceApps.showAccountLabel": true,
     "workspaceApps.persistZoom": true,

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -95,7 +95,7 @@ export const config = new Store<Config>({
     "workspaceApps.openInAppExcludedApps": [],
     "workspaceApps.openBehavior": "tab",
     "workspaceApps.launcherApps": [],
-    "workspaceApps.launcherDisplay": "menu",
+    "workspaceApps.launcherDisplay": "auto",
     "workspaceApps.showAccountColor": true,
     "workspaceApps.showAccountLabel": true,
     "workspaceApps.persistZoom": true,

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -1,7 +1,11 @@
 import { accountColorsMap } from "@meru/shared/accounts";
 import { WEBSITE_URL } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
-import { launcherWorkspaceApps } from "@meru/shared/workspace-apps";
+import {
+  type LauncherWorkspaceApp,
+  launcherWorkspaceApps,
+  type WorkspaceAppsLauncherDisplay,
+} from "@meru/shared/workspace-apps";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import { cn } from "@meru/ui/lib/utils";
@@ -165,6 +169,67 @@ function DoNotDisturb() {
   );
 }
 
+function WorkspaceAppsLauncher({
+  launcherApps,
+  display,
+  disabled,
+}: {
+  launcherApps: LauncherWorkspaceApp[];
+  display: WorkspaceAppsLauncherDisplay;
+  disabled: boolean;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (display === "inline") {
+    return launcherApps.map((app) => (
+      <TitlebarIconButton
+        key={app}
+        title={launcherWorkspaceApps[app]}
+        disabled={disabled}
+        onClick={(event) => {
+          ipc.main.send("workspaceApps.openApp", app, getModifierOpenBehavior(event));
+        }}
+        onAuxClick={(event) => {
+          if (event.button === 1) {
+            ipc.main.send("workspaceApps.openApp", app, "backgroundTab");
+          }
+        }}
+      >
+        <WorkspaceAppIcon app={app} className="size-4" />
+      </TitlebarIconButton>
+    ));
+  }
+
+  return (
+    <TitlebarDropdownMenu
+      title="Workspace Apps"
+      icon={<LayoutGridIcon />}
+      disabled={disabled}
+      isOpen={isOpen}
+      onOpenChange={setIsOpen}
+    >
+      {launcherApps.map((app) => (
+        <TitlebarDropdownMenuItem
+          key={app}
+          title={launcherWorkspaceApps[app]}
+          onClick={(event) => {
+            ipc.main.send("workspaceApps.openApp", app, getModifierOpenBehavior(event));
+          }}
+          onAuxClick={(event) => {
+            if (event.button === 1) {
+              ipc.main.send("workspaceApps.openApp", app, "backgroundTab");
+
+              setIsOpen(false);
+            }
+          }}
+        >
+          <WorkspaceAppIcon app={app} className="size-4" />
+        </TitlebarDropdownMenuItem>
+      ))}
+    </TitlebarDropdownMenu>
+  );
+}
+
 export function AppTitlebar() {
   const accounts = useAccountsStore((state) => state.accounts);
 
@@ -182,8 +247,6 @@ export function AppTitlebar() {
   const dismissAppUpdate = useAppUpdaterStore((state) => state.dismiss);
 
   const { config } = useConfig();
-
-  const [isWorkspaceAppsLauncherOpen, setIsWorkspaceAppsLauncherOpen] = useState(false);
 
   const [isGmailSavedSearchesOpen, setIsGmailSavedSearchesOpen] = useState(false);
 
@@ -328,32 +391,11 @@ export function AppTitlebar() {
           {(shouldShowWorkspaceAppsLauncher || shouldShowUnifiedInboxButton) && (
             <TitlebarButtonGroup>
               {shouldShowWorkspaceAppsLauncher && (
-                <TitlebarDropdownMenu
-                  title="Workspace Apps"
-                  icon={<LayoutGridIcon />}
+                <WorkspaceAppsLauncher
+                  launcherApps={config["workspaceApps.launcherApps"]}
+                  display={config["workspaceApps.launcherDisplay"]}
                   disabled={isUnifiedInboxLocation}
-                  isOpen={isWorkspaceAppsLauncherOpen}
-                  onOpenChange={setIsWorkspaceAppsLauncherOpen}
-                >
-                  {config["workspaceApps.launcherApps"].map((app) => (
-                    <TitlebarDropdownMenuItem
-                      key={app}
-                      title={launcherWorkspaceApps[app]}
-                      onClick={(event) => {
-                        ipc.main.send("workspaceApps.openApp", app, getModifierOpenBehavior(event));
-                      }}
-                      onAuxClick={(event) => {
-                        if (event.button === 1) {
-                          ipc.main.send("workspaceApps.openApp", app, "backgroundTab");
-
-                          setIsWorkspaceAppsLauncherOpen(false);
-                        }
-                      }}
-                    >
-                      <WorkspaceAppIcon app={app} className="size-4" />
-                    </TitlebarDropdownMenuItem>
-                  ))}
-                </TitlebarDropdownMenu>
+                />
               )}
               {shouldShowUnifiedInboxButton && (
                 <Button

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -4,6 +4,7 @@ import { ipc } from "@meru/shared/renderer/ipc";
 import {
   type LauncherWorkspaceApp,
   launcherWorkspaceApps,
+  resolveWorkspaceAppsLauncherDisplay,
   type WorkspaceAppsLauncherDisplay,
 } from "@meru/shared/workspace-apps";
 import { Badge } from "@meru/ui/components/badge";
@@ -180,7 +181,9 @@ function WorkspaceAppsLauncher({
 }) {
   const [isOpen, setIsOpen] = useState(false);
 
-  if (display === "inline") {
+  const resolvedDisplay = resolveWorkspaceAppsLauncherDisplay(display, launcherApps.length);
+
+  if (resolvedDisplay === "inline") {
     return launcherApps.map((app) => (
       <TitlebarIconButton
         key={app}
@@ -204,6 +207,7 @@ function WorkspaceAppsLauncher({
     <TitlebarDropdownMenu
       title="Workspace Apps"
       icon={<LayoutGridIcon />}
+      side="left"
       disabled={disabled}
       isOpen={isOpen}
       onOpenChange={setIsOpen}
@@ -388,28 +392,19 @@ export function AppTitlebar() {
               }}
             />
           </TitlebarButtonGroup>
-          {(shouldShowWorkspaceAppsLauncher || shouldShowUnifiedInboxButton) && (
+          {shouldShowUnifiedInboxButton && (
             <TitlebarButtonGroup>
-              {shouldShowWorkspaceAppsLauncher && (
-                <WorkspaceAppsLauncher
-                  launcherApps={config["workspaceApps.launcherApps"]}
-                  display={config["workspaceApps.launcherDisplay"]}
-                  disabled={isUnifiedInboxLocation}
-                />
-              )}
-              {shouldShowUnifiedInboxButton && (
-                <Button
-                  variant={isUnifiedInboxLocation ? "secondary" : "ghost"}
-                  size="icon"
-                  className="size-7 draggable-none"
-                  onClick={() => {
-                    navigate("/unified-inbox");
-                  }}
-                  title="Unified Inbox"
-                >
-                  <InboxIcon />
-                </Button>
-              )}
+              <Button
+                variant={isUnifiedInboxLocation ? "secondary" : "ghost"}
+                size="icon"
+                className="size-7 draggable-none"
+                onClick={() => {
+                  navigate("/unified-inbox");
+                }}
+                title="Unified Inbox"
+              >
+                <InboxIcon />
+              </Button>
             </TitlebarButtonGroup>
           )}
           {(shouldShowOutOfOfficeButton || accountButtons) && (
@@ -435,6 +430,15 @@ export function AppTitlebar() {
           <div className="flex items-center gap-2">
             <Trial />
             <FindInPage />
+            {shouldShowWorkspaceAppsLauncher && (
+              <TitlebarButtonGroup>
+                <WorkspaceAppsLauncher
+                  launcherApps={config["workspaceApps.launcherApps"]}
+                  display={config["workspaceApps.launcherDisplay"]}
+                  disabled={isUnifiedInboxLocation}
+                />
+              </TitlebarButtonGroup>
+            )}
             {shouldShowSavedSearchesButton && (
               <TitlebarDropdownMenu
                 title="Saved Searches"

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -183,7 +183,7 @@ function WorkspaceAppsLauncher({
 
   const resolvedDisplay = resolveWorkspaceAppsLauncherDisplay(display, launcherApps.length);
 
-  if (resolvedDisplay === "inline") {
+  if (resolvedDisplay === "expanded") {
     return launcherApps.map((app) => (
       <TitlebarIconButton
         key={app}

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -291,7 +291,7 @@ export function WorkspaceAppsSettings() {
           </Field>
           <ConfigSelectField
             label="Launcher Display"
-            description="How launcher apps are shown in the titlebar. Auto shows up to three apps inline as individual buttons and moves to a menu beyond that. Menu always keeps them behind a single button, Inline always shows them as individual buttons."
+            description="How launcher apps are shown in the titlebar. Auto expands up to three apps into individual buttons and collapses beyond that. Collapsed always keeps them behind a single button, Expanded always shows them as individual buttons."
             configKey="workspaceApps.launcherDisplay"
             placeholder="Select display"
             licenseKeyRequired

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -220,7 +220,7 @@ export function WorkspaceAppsSettings() {
                 {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
               </FieldLabel>
               <FieldDescription>
-                Add Workspace Apps to the Workspace Apps launcher in the titlebar on the left.
+                Add Workspace Apps to the Workspace Apps launcher in the titlebar on the right.
               </FieldDescription>
             </FieldContent>
             <div className="flex flex-col gap-4">
@@ -291,7 +291,7 @@ export function WorkspaceAppsSettings() {
           </Field>
           <ConfigSelectField
             label="Launcher Display"
-            description="Show launcher apps in a menu behind a single button or inline as individual buttons in the titlebar."
+            description="How launcher apps are shown in the titlebar. Auto shows up to three apps inline as individual buttons and moves to a menu beyond that. Menu always keeps them behind a single button, Inline always shows them as individual buttons."
             configKey="workspaceApps.launcherDisplay"
             placeholder="Select display"
             licenseKeyRequired

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -7,6 +7,7 @@ import {
   type SupportedWorkspaceApp,
   workspaceAppOpenBehaviors,
   workspaceApps,
+  workspaceAppsLauncherDisplays,
 } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import { ButtonGroup } from "@meru/ui/components/button-group";
@@ -288,6 +289,17 @@ export function WorkspaceAppsSettings() {
               )}
             </div>
           </Field>
+          <ConfigSelectField
+            label="Launcher Display"
+            description="Show launcher apps in a menu behind a single button or inline as individual buttons in the titlebar."
+            configKey="workspaceApps.launcherDisplay"
+            placeholder="Select display"
+            licenseKeyRequired
+            items={Object.entries(workspaceAppsLauncherDisplays).map(([value, label]) => ({
+              value,
+              label,
+            }))}
+          />
         </FieldGroup>
       </SettingsContent>
     </Settings>

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -14,6 +14,7 @@ import type {
   LauncherWorkspaceApp,
   SupportedWorkspaceApp,
   WorkspaceAppOpenBehavior,
+  WorkspaceAppsLauncherDisplay,
 } from "./workspace-apps";
 
 export type DesktopSource = { id: string; name: string; thumbnail: string };
@@ -130,6 +131,7 @@ export type Config = {
   "workspaceApps.openInAppExcludedApps": SupportedWorkspaceApp[];
   "workspaceApps.openBehavior": WorkspaceAppOpenBehavior;
   "workspaceApps.launcherApps": LauncherWorkspaceApp[];
+  "workspaceApps.launcherDisplay": WorkspaceAppsLauncherDisplay;
   "workspaceApps.showAccountColor": boolean;
   "workspaceApps.showAccountLabel": boolean;
   "workspaceApps.persistZoom": boolean;

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -49,6 +49,13 @@ export const launcherWorkspaceApps = Object.fromEntries(
     .map(([workspaceApp, workspaceAppDefinition]) => [workspaceApp, workspaceAppDefinition.label]),
 ) as Record<LauncherWorkspaceApp, string>;
 
+export const workspaceAppsLauncherDisplays = {
+  menu: "Menu",
+  inline: "Inline",
+} as const;
+
+export type WorkspaceAppsLauncherDisplay = keyof typeof workspaceAppsLauncherDisplays;
+
 export const workspaceAppOpenBehaviors = {
   tab: "Tab",
   newWindow: "New Window",

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -49,12 +49,12 @@ export const launcherWorkspaceApps = Object.fromEntries(
     .map(([workspaceApp, workspaceAppDefinition]) => [workspaceApp, workspaceAppDefinition.label]),
 ) as Record<LauncherWorkspaceApp, string>;
 
-const LAUNCHER_INLINE_APPS_THRESHOLD = 3;
+const LAUNCHER_EXPANDED_APPS_THRESHOLD = 3;
 
 export const workspaceAppsLauncherDisplays = {
   auto: "Auto",
-  menu: "Menu",
-  inline: "Inline",
+  collapsed: "Collapsed",
+  expanded: "Expanded",
 } as const;
 
 export type WorkspaceAppsLauncherDisplay = keyof typeof workspaceAppsLauncherDisplays;
@@ -67,7 +67,7 @@ export function resolveWorkspaceAppsLauncherDisplay(
     return launcherDisplay;
   }
 
-  return launcherAppCount > LAUNCHER_INLINE_APPS_THRESHOLD ? "menu" : "inline";
+  return launcherAppCount > LAUNCHER_EXPANDED_APPS_THRESHOLD ? "collapsed" : "expanded";
 }
 
 export const workspaceAppOpenBehaviors = {

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -49,12 +49,26 @@ export const launcherWorkspaceApps = Object.fromEntries(
     .map(([workspaceApp, workspaceAppDefinition]) => [workspaceApp, workspaceAppDefinition.label]),
 ) as Record<LauncherWorkspaceApp, string>;
 
+const LAUNCHER_INLINE_APPS_THRESHOLD = 3;
+
 export const workspaceAppsLauncherDisplays = {
+  auto: "Auto",
   menu: "Menu",
   inline: "Inline",
 } as const;
 
 export type WorkspaceAppsLauncherDisplay = keyof typeof workspaceAppsLauncherDisplays;
+
+export function resolveWorkspaceAppsLauncherDisplay(
+  launcherDisplay: WorkspaceAppsLauncherDisplay,
+  launcherAppCount: number,
+): Exclude<WorkspaceAppsLauncherDisplay, "auto"> {
+  if (launcherDisplay !== "auto") {
+    return launcherDisplay;
+  }
+
+  return launcherAppCount > LAUNCHER_INLINE_APPS_THRESHOLD ? "menu" : "inline";
+}
 
 export const workspaceAppOpenBehaviors = {
   tab: "Tab",


### PR DESCRIPTION
3.58.0 moved the Workspace Apps launcher to the left of the titlebar and folded every launcher app behind one menu button. Feedback since then: for small launchers that is an extra click for nothing, and the position change broke the muscle memory of everyone who used the launcher before 3.58.

This branch settles both: the launcher goes back to the right, and how it renders adapts to how many apps are in it.

## Changes

- The launcher renders in the right titlebar cluster, leftmost within it — before Saved Searches, or before Downloads when there are no saved searches. Its menu opens with `side="left"` to match. The position is **not** configurable; #730, which added an option for it, is closed as superseded.
- New `workspaceApps.launcherDisplay` config key: `auto` (default), `collapsed`, `expanded`.
  - `auto` expands into individual buttons at three launcher apps or fewer and collapses behind one button beyond that.
  - `collapsed` and `expanded` pin it either way.
- `Settings… → Workspace Apps → Launcher Display` exposes it; the Launcher Apps description now says the launcher sits on the right.

## Risks and omissions

- `launcherDisplay` is a new key with no migration, so every existing user lands on `auto`. Anyone who wants the menu with three or fewer apps has to opt in — acceptable, since the shipped 3.58 behaviour was itself the thing being corrected.
- `expanded` forced with a large launcher renders one titlebar button per app and can crowd the right cluster. No cap is enforced; `auto` is what keeps this from happening by default.
- The three-app threshold is a judgement call, not a measured one. It is a module-private constant in `packages/shared/workspace-apps.ts` and cheap to move.
- Not verified: the app was not run or screenshotted for this branch. Types, lint and format pass.

## Test plan

1. With no license key, open the titlebar — no launcher, as before.
2. With a valid license key and an empty launcher, open the titlebar — still no launcher.
3. Add two apps in `Settings… → Workspace Apps → Launcher Apps`, leave Launcher Display on `Auto` → both apps render as individual icon buttons on the right of the titlebar, immediately left of Saved Searches (or of Downloads with no saved searches).
4. Add two more apps (four total) → the buttons collapse into a single grid-icon button; clicking it opens the app row, which expands to the left rather than off the right edge of the window.
5. Set Launcher Display to `Collapsed` with two apps → stays a single button. Set it to `Expanded` with four apps → four individual buttons.
6. Click a launcher app → it opens per the current mode. Middle-click one → background tab. Hold Cmd/Ctrl (background tab) and Shift (new window) while clicking → same behaviour when expanded and collapsed.
7. Navigate to the Unified Inbox → the launcher is disabled in both displays, and re-enables on returning to the account view.
8. Restart the app → Launcher Display persists.
