### PR TITLE
add an option to position the workspace apps launcher on the right

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -96,6 +96,7 @@ export const config = new Store<Config>({
     "workspaceApps.openBehavior": "tab",
     "workspaceApps.launcherApps": [],
     "workspaceApps.launcherDisplay": "menu",
+    "workspaceApps.launcherPosition": "left",
     "workspaceApps.showAccountColor": true,
     "workspaceApps.showAccountLabel": true,
     "workspaceApps.persistZoom": true,

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -95,6 +95,7 @@ export const config = new Store<Config>({
     "workspaceApps.openInAppExcludedApps": [],
     "workspaceApps.openBehavior": "tab",
     "workspaceApps.launcherApps": [],
+    "workspaceApps.launcherDisplay": "menu",
     "workspaceApps.showAccountColor": true,
     "workspaceApps.showAccountLabel": true,
     "workspaceApps.persistZoom": true,

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -1,7 +1,11 @@
 import { accountColorsMap } from "@meru/shared/accounts";
 import { WEBSITE_URL } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
-import { launcherWorkspaceApps } from "@meru/shared/workspace-apps";
+import {
+  type LauncherWorkspaceApp,
+  launcherWorkspaceApps,
+  type WorkspaceAppsLauncherDisplay,
+} from "@meru/shared/workspace-apps";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import { cn } from "@meru/ui/lib/utils";
@@ -165,6 +169,67 @@ function DoNotDisturb() {
   );
 }
 
+function WorkspaceAppsLauncher({
+  launcherApps,
+  display,
+  disabled,
+}: {
+  launcherApps: LauncherWorkspaceApp[];
+  display: WorkspaceAppsLauncherDisplay;
+  disabled: boolean;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (display === "inline") {
+    return launcherApps.map((app) => (
+      <TitlebarIconButton
+        key={app}
+        title={launcherWorkspaceApps[app]}
+        disabled={disabled}
+        onClick={(event) => {
+          ipc.main.send("workspaceApps.openApp", app, getModifierOpenBehavior(event));
+        }}
+        onAuxClick={(event) => {
+          if (event.button === 1) {
+            ipc.main.send("workspaceApps.openApp", app, "backgroundTab");
+          }
+        }}
+      >
+        <WorkspaceAppIcon app={app} className="size-4" />
+      </TitlebarIconButton>
+    ));
+  }
+
+  return (
+    <TitlebarDropdownMenu
+      title="Workspace Apps"
+      icon={<LayoutGridIcon />}
+      disabled={disabled}
+      isOpen={isOpen}
+      onOpenChange={setIsOpen}
+    >
+      {launcherApps.map((app) => (
+        <TitlebarDropdownMenuItem
+          key={app}
+          title={launcherWorkspaceApps[app]}
+          onClick={(event) => {
+            ipc.main.send("workspaceApps.openApp", app, getModifierOpenBehavior(event));
+          }}
+          onAuxClick={(event) => {
+            if (event.button === 1) {
+              ipc.main.send("workspaceApps.openApp", app, "backgroundTab");
+
+              setIsOpen(false);
+            }
+          }}
+        >
+          <WorkspaceAppIcon app={app} className="size-4" />
+        </TitlebarDropdownMenuItem>
+      ))}
+    </TitlebarDropdownMenu>
+  );
+}
+
 export function AppTitlebar() {
   const accounts = useAccountsStore((state) => state.accounts);
 
@@ -182,8 +247,6 @@ export function AppTitlebar() {
   const dismissAppUpdate = useAppUpdaterStore((state) => state.dismiss);
 
   const { config } = useConfig();
-
-  const [isWorkspaceAppsLauncherOpen, setIsWorkspaceAppsLauncherOpen] = useState(false);
 
   const [isGmailSavedSearchesOpen, setIsGmailSavedSearchesOpen] = useState(false);
 
@@ -328,32 +391,11 @@ export function AppTitlebar() {
           {(shouldShowWorkspaceAppsLauncher || shouldShowUnifiedInboxButton) && (
             <TitlebarButtonGroup>
               {shouldShowWorkspaceAppsLauncher && (
-                <TitlebarDropdownMenu
-                  title="Workspace Apps"
-                  icon={<LayoutGridIcon />}
+                <WorkspaceAppsLauncher
+                  launcherApps={config["workspaceApps.launcherApps"]}
+                  display={config["workspaceApps.launcherDisplay"]}
                   disabled={isUnifiedInboxLocation}
-                  isOpen={isWorkspaceAppsLauncherOpen}
-                  onOpenChange={setIsWorkspaceAppsLauncherOpen}
-                >
-                  {config["workspaceApps.launcherApps"].map((app) => (
-                    <TitlebarDropdownMenuItem
-                      key={app}
-                      title={launcherWorkspaceApps[app]}
-                      onClick={(event) => {
-                        ipc.main.send("workspaceApps.openApp", app, getModifierOpenBehavior(event));
-                      }}
-                      onAuxClick={(event) => {
-                        if (event.button === 1) {
-                          ipc.main.send("workspaceApps.openApp", app, "backgroundTab");
-
-                          setIsWorkspaceAppsLauncherOpen(false);
-                        }
-                      }}
-                    >
-                      <WorkspaceAppIcon app={app} className="size-4" />
-                    </TitlebarDropdownMenuItem>
-                  ))}
-                </TitlebarDropdownMenu>
+                />
               )}
               {shouldShowUnifiedInboxButton && (
                 <Button

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -5,6 +5,7 @@ import {
   type LauncherWorkspaceApp,
   launcherWorkspaceApps,
   type WorkspaceAppsLauncherDisplay,
+  type WorkspaceAppsLauncherPosition,
 } from "@meru/shared/workspace-apps";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
@@ -172,10 +173,12 @@ function DoNotDisturb() {
 function WorkspaceAppsLauncher({
   launcherApps,
   display,
+  position,
   disabled,
 }: {
   launcherApps: LauncherWorkspaceApp[];
   display: WorkspaceAppsLauncherDisplay;
+  position: WorkspaceAppsLauncherPosition;
   disabled: boolean;
 }) {
   const [isOpen, setIsOpen] = useState(false);
@@ -204,6 +207,7 @@ function WorkspaceAppsLauncher({
     <TitlebarDropdownMenu
       title="Workspace Apps"
       icon={<LayoutGridIcon />}
+      side={position === "right" ? "left" : "right"}
       disabled={disabled}
       isOpen={isOpen}
       onOpenChange={setIsOpen}
@@ -271,8 +275,16 @@ export function AppTitlebar() {
 
   const isUnifiedInboxLocation = location === "/unified-inbox";
 
+  const launcherPosition = config["workspaceApps.launcherPosition"];
+
   const shouldShowWorkspaceAppsLauncher =
     isLicenseKeyValid && config["workspaceApps.launcherApps"].length > 0;
+
+  const shouldShowWorkspaceAppsLauncherOnLeft =
+    shouldShowWorkspaceAppsLauncher && launcherPosition === "left";
+
+  const shouldShowWorkspaceAppsLauncherOnRight =
+    shouldShowWorkspaceAppsLauncher && launcherPosition === "right";
 
   const shouldShowUnifiedInboxButton =
     isLicenseKeyValid && config["unifiedInbox.enabled"] && accounts.length > 1;
@@ -365,6 +377,15 @@ export function AppTitlebar() {
 
     const accountButtons = renderAccounts();
 
+    const workspaceAppsLauncher = (
+      <WorkspaceAppsLauncher
+        launcherApps={config["workspaceApps.launcherApps"]}
+        display={config["workspaceApps.launcherDisplay"]}
+        position={launcherPosition}
+        disabled={isUnifiedInboxLocation}
+      />
+    );
+
     return (
       <>
         <TitlebarLeft>
@@ -388,15 +409,9 @@ export function AppTitlebar() {
               }}
             />
           </TitlebarButtonGroup>
-          {(shouldShowWorkspaceAppsLauncher || shouldShowUnifiedInboxButton) && (
+          {(shouldShowWorkspaceAppsLauncherOnLeft || shouldShowUnifiedInboxButton) && (
             <TitlebarButtonGroup>
-              {shouldShowWorkspaceAppsLauncher && (
-                <WorkspaceAppsLauncher
-                  launcherApps={config["workspaceApps.launcherApps"]}
-                  display={config["workspaceApps.launcherDisplay"]}
-                  disabled={isUnifiedInboxLocation}
-                />
-              )}
+              {shouldShowWorkspaceAppsLauncherOnLeft && workspaceAppsLauncher}
               {shouldShowUnifiedInboxButton && (
                 <Button
                   variant={isUnifiedInboxLocation ? "secondary" : "ghost"}
@@ -435,6 +450,9 @@ export function AppTitlebar() {
           <div className="flex items-center gap-2">
             <Trial />
             <FindInPage />
+            {shouldShowWorkspaceAppsLauncherOnRight && (
+              <TitlebarButtonGroup>{workspaceAppsLauncher}</TitlebarButtonGroup>
+            )}
             {shouldShowSavedSearchesButton && (
               <TitlebarDropdownMenu
                 title="Saved Searches"

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -8,6 +8,7 @@ import {
   workspaceAppOpenBehaviors,
   workspaceApps,
   workspaceAppsLauncherDisplays,
+  workspaceAppsLauncherPositions,
 } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import { ButtonGroup } from "@meru/ui/components/button-group";
@@ -296,6 +297,17 @@ export function WorkspaceAppsSettings() {
             placeholder="Select display"
             licenseKeyRequired
             items={Object.entries(workspaceAppsLauncherDisplays).map(([value, label]) => ({
+              value,
+              label,
+            }))}
+          />
+          <ConfigSelectField
+            label="Launcher Position"
+            description="Show the launcher on the left or right side of the titlebar."
+            configKey="workspaceApps.launcherPosition"
+            placeholder="Select position"
+            licenseKeyRequired
+            items={Object.entries(workspaceAppsLauncherPositions).map(([value, label]) => ({
               value,
               label,
             }))}

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -7,6 +7,7 @@ import {
   type SupportedWorkspaceApp,
   workspaceAppOpenBehaviors,
   workspaceApps,
+  workspaceAppsLauncherDisplays,
 } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import { ButtonGroup } from "@meru/ui/components/button-group";
@@ -288,6 +289,17 @@ export function WorkspaceAppsSettings() {
               )}
             </div>
           </Field>
+          <ConfigSelectField
+            label="Launcher Display"
+            description="Show launcher apps in a menu behind a single button or inline as individual buttons in the titlebar."
+            configKey="workspaceApps.launcherDisplay"
+            placeholder="Select display"
+            licenseKeyRequired
+            items={Object.entries(workspaceAppsLauncherDisplays).map(([value, label]) => ({
+              value,
+              label,
+            }))}
+          />
         </FieldGroup>
       </SettingsContent>
     </Settings>

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -14,6 +14,7 @@ import type {
   LauncherWorkspaceApp,
   SupportedWorkspaceApp,
   WorkspaceAppOpenBehavior,
+  WorkspaceAppsLauncherDisplay,
 } from "./workspace-apps";
 
 export type DesktopSource = { id: string; name: string; thumbnail: string };
@@ -130,6 +131,7 @@ export type Config = {
   "workspaceApps.openInAppExcludedApps": SupportedWorkspaceApp[];
   "workspaceApps.openBehavior": WorkspaceAppOpenBehavior;
   "workspaceApps.launcherApps": LauncherWorkspaceApp[];
+  "workspaceApps.launcherDisplay": WorkspaceAppsLauncherDisplay;
   "workspaceApps.showAccountColor": boolean;
   "workspaceApps.showAccountLabel": boolean;
   "workspaceApps.persistZoom": boolean;

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -15,6 +15,7 @@ import type {
   SupportedWorkspaceApp,
   WorkspaceAppOpenBehavior,
   WorkspaceAppsLauncherDisplay,
+  WorkspaceAppsLauncherPosition,
 } from "./workspace-apps";
 
 export type DesktopSource = { id: string; name: string; thumbnail: string };
@@ -132,6 +133,7 @@ export type Config = {
   "workspaceApps.openBehavior": WorkspaceAppOpenBehavior;
   "workspaceApps.launcherApps": LauncherWorkspaceApp[];
   "workspaceApps.launcherDisplay": WorkspaceAppsLauncherDisplay;
+  "workspaceApps.launcherPosition": WorkspaceAppsLauncherPosition;
   "workspaceApps.showAccountColor": boolean;
   "workspaceApps.showAccountLabel": boolean;
   "workspaceApps.persistZoom": boolean;

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -49,6 +49,13 @@ export const launcherWorkspaceApps = Object.fromEntries(
     .map(([workspaceApp, workspaceAppDefinition]) => [workspaceApp, workspaceAppDefinition.label]),
 ) as Record<LauncherWorkspaceApp, string>;
 
+export const workspaceAppsLauncherDisplays = {
+  menu: "Menu",
+  inline: "Inline",
+} as const;
+
+export type WorkspaceAppsLauncherDisplay = keyof typeof workspaceAppsLauncherDisplays;
+
 export const workspaceAppOpenBehaviors = {
   tab: "Tab",
   newWindow: "New Window",

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -56,6 +56,13 @@ export const workspaceAppsLauncherDisplays = {
 
 export type WorkspaceAppsLauncherDisplay = keyof typeof workspaceAppsLauncherDisplays;
 
+export const workspaceAppsLauncherPositions = {
+  left: "Left",
+  right: "Right",
+} as const;
+
+export type WorkspaceAppsLauncherPosition = keyof typeof workspaceAppsLauncherPositions;
+
 export const workspaceAppOpenBehaviors = {
   tab: "Tab",
   newWindow: "New Window",


### PR DESCRIPTION
The Workspace Apps launcher is fixed to the left side of the titlebar. Before it was grouped with the Unified Inbox button, it lived in the right-hand cluster, which some users prefer.

Stacked on #729 (Launcher Display) — review that one first.

## Changes

- New config key `workspaceApps.launcherPosition` (`"left"` | `"right"`), defaulting to `"left"` so existing behavior is unchanged.
- New **Launcher Position** select in Settings → Workspace Apps, below Launcher Display.
- `app-titlebar.tsx`: the launcher element is built once and rendered either in the existing left button group (next to Unified Inbox) or in the right-hand cluster, immediately before Saved Searches — so it sits next to Saved Searches when those exist and next to the downloads button when they don't. Its dropdown flips to `side="left"` on the right so it opens inward.
- Only the launcher moves. The Unified Inbox button stays on the left, and the left button group no longer renders at all when the launcher is on the right and Unified Inbox is hidden.

Both display modes (menu and inline) work in either position.

## Test plan

1. With a valid license and apps in Launcher Apps, confirm the launcher renders on the left by default, grouped with the Unified Inbox button.
2. Set **Launcher Position** to *Right* → the launcher moves into the right cluster, immediately left of the Saved Searches button.
3. With no saved searches configured → on Right, the launcher sits immediately left of the downloads button instead.
4. On Right with **Launcher Display** = *Menu*, open the menu → it opens toward the left (inward), not clipped at the window edge.
5. On Right with **Launcher Display** = *Inline* → all app icons render in the right cluster, spaced like the other titlebar icon buttons, and clicking/middle-clicking behaves as on the left.
6. On Right with Unified Inbox enabled and 2+ accounts → the Unified Inbox button stays on the left; no empty group or stray gap is left where the launcher was.
7. On Right with Unified Inbox disabled (or a single account) → the left group disappears entirely; navigation controls and account buttons keep their spacing.
8. Switch to the unified inbox → the launcher is disabled in both positions.
9. Set Right, restart the app → the setting persists.
