### PR TITLE
hide the tab strip in new windows mode

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -48,7 +48,7 @@ class Accounts {
       accounts.updateAllViewBounds();
     });
 
-    config.onDidChange("workspaceApps.openBehavior", () => {
+    config.onDidChange("workspaceApps.mode", () => {
       accounts.updateAllViewBounds();
     });
 
@@ -110,7 +110,7 @@ class Accounts {
     return getVerticalTabsWidth(
       getVisibleVerticalTabs(
         this.getSelectedAccount().instance.tabs.serialize(),
-        config.get("workspaceApps.openBehavior"),
+        config.get("workspaceApps.mode"),
       ),
       config.get("verticalTabs.width"),
     );

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { platform } from "@electron-toolkit/utils";
 import type { AccountConfig } from "@meru/shared/schemas";
-import { getVerticalTabsWidth } from "@meru/shared/tabs";
+import { getVerticalTabsWidth, getVisibleVerticalTabs } from "@meru/shared/tabs";
 import { Account } from "./account";
 import { config } from "./config";
 import { ipc } from "./ipc";
@@ -45,6 +45,10 @@ class Accounts {
     });
 
     config.onDidChange("verticalTabs.width", () => {
+      accounts.updateAllViewBounds();
+    });
+
+    config.onDidChange("workspaceApps.openBehavior", () => {
       accounts.updateAllViewBounds();
     });
 
@@ -104,7 +108,10 @@ class Accounts {
 
   getVerticalTabsWidth() {
     return getVerticalTabsWidth(
-      this.getSelectedAccount().instance.tabs.serialize(),
+      getVisibleVerticalTabs(
+        this.getSelectedAccount().instance.tabs.serialize(),
+        config.get("workspaceApps.openBehavior"),
+      ),
       config.get("verticalTabs.width"),
     );
   }

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -221,8 +221,10 @@ class Ipc {
     ipc.main.on("workspaceApp.showMenu", (_event, workspaceAppId) => {
       const workspaceApp = WorkspaceApp.fromId(workspaceAppId);
 
+      const isWindowsMode = config.get("workspaceApps.mode") === "windows";
+
       Menu.buildFromTemplate([
-        ...(workspaceApp.isPopup
+        ...(workspaceApp.isPopup || isWindowsMode
           ? []
           : [
               {
@@ -311,19 +313,31 @@ class Ipc {
         .slice(contextTabIndex + 1)
         .some((accountTab) => accountTab.persistence !== "pinned" && !accountTab.dormant);
 
+      const isWindowsMode = config.get("workspaceApps.mode") === "windows";
+
+      const openWorkspaceAppUrl = (url: string) => {
+        if (isWindowsMode) {
+          account.instance.tabs.openWindowedTab(url);
+
+          return;
+        }
+
+        const workspaceApp = account.instance.tabs.openTab(url);
+
+        account.instance.tabs.activateTab(workspaceApp.id);
+
+        if (account.config.selected) {
+          accounts.refreshSelectedAccountView();
+        }
+      };
+
       Menu.buildFromTemplate([
         ...(tabApp && !workspaceApps[tabApp].singleInstance && !workspaceApps[tabApp].popupOnly
           ? [
               {
-                label: `New ${workspaceApps[tabApp].label} Tab`,
+                label: `New ${workspaceApps[tabApp].label} ${isWindowsMode ? "Window" : "Tab"}`,
                 click: () => {
-                  const workspaceApp = account.instance.tabs.openTab(getWorkspaceAppUrl(tabApp));
-
-                  account.instance.tabs.activateTab(workspaceApp.id);
-
-                  if (account.config.selected) {
-                    accounts.refreshSelectedAccountView();
-                  }
+                  openWorkspaceAppUrl(getWorkspaceAppUrl(tabApp));
                 },
               },
             ]
@@ -346,13 +360,7 @@ class Ipc {
             const duplicatedTabUrl =
               !currentTabUrl && tabApp ? getWorkspaceAppUrl(tabApp) : currentTabUrl;
 
-            const workspaceApp = account.instance.tabs.openTab(duplicatedTabUrl);
-
-            account.instance.tabs.activateTab(workspaceApp.id);
-
-            if (account.config.selected) {
-              accounts.refreshSelectedAccountView();
-            }
+            openWorkspaceAppUrl(duplicatedTabUrl);
           },
         },
         ...(tab instanceof WorkspaceApp && tab.isWindowed

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -7,7 +7,7 @@ import { accounts } from "./accounts";
 import type { Gmail } from "./gmail";
 import { main } from "./main";
 import { appMenu } from "./menu";
-import { WorkspaceApp } from "./workspace-app";
+import { resolveWorkspaceAppOpenBehavior, WorkspaceApp } from "./workspace-app";
 
 const MAX_RECENTLY_CLOSED_TAB_URLS = 20;
 
@@ -373,6 +373,10 @@ export class Tabs {
 
     if (!reopenedTabUrl) {
       return;
+    }
+
+    if (resolveWorkspaceAppOpenBehavior() === "newWindow") {
+      return this.openWindowedTab(reopenedTabUrl);
     }
 
     const workspaceApp = this.openTab(reopenedTabUrl);

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -4,6 +4,7 @@ import { getTabSection, GMAIL_TAB_ID, type TabState, tabSections } from "@meru/s
 import type { SupportedWorkspaceApp } from "@meru/shared/workspace-apps";
 import type { WebContentsView } from "electron";
 import { accounts } from "./accounts";
+import { config } from "./config";
 import type { Gmail } from "./gmail";
 import { main } from "./main";
 import { appMenu } from "./menu";
@@ -234,7 +235,7 @@ export class Tabs {
       url: dormantTab.url,
       persistence: dormantTab.persistence,
       loadOnLaunch: dormantTab.loadOnLaunch,
-      asWindow: dormantTab.windowed,
+      asWindow: dormantTab.windowed || config.get("workspaceApps.mode") === "windows",
       app: dormantTab.app,
       zoomFactor: dormantTab.zoomFactor,
     });
@@ -275,7 +276,11 @@ export class Tabs {
   }
 
   private activateAdjacentTab(direction: "next" | "previous") {
-    const cyclableTabs = this.tabs.filter((tab) => !isWindowedTab(tab));
+    const isWindowsMode = config.get("workspaceApps.mode") === "windows";
+
+    const cyclableTabs = this.tabs.filter(
+      (tab) => !isWindowedTab(tab) && !(isWindowsMode && tab.dormant),
+    );
 
     const activeTabIndex = cyclableTabs.findIndex((tab) => tab.id === this.activeTabId);
 

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -43,6 +43,7 @@ export type Tab = {
   title: string;
   persistence: TabPersistence | null;
   dormant: boolean;
+  loadOnLaunch?: boolean;
   isLoading: boolean;
   navigationHistory: { canGoBack: boolean; canGoForward: boolean };
   view?: WebContentsView;
@@ -236,6 +237,7 @@ export class Tabs {
       persistence: dormantTab.persistence,
       loadOnLaunch: dormantTab.loadOnLaunch,
       asWindow: dormantTab.windowed || config.get("workspaceApps.mode") === "windows",
+      savedAsWindow: dormantTab.windowed,
       app: dormantTab.app,
       zoomFactor: dormantTab.zoomFactor,
     });
@@ -344,7 +346,7 @@ export class Tabs {
           title: savedWorkspaceApp.title,
           persistence: savedWorkspaceApp.persistence,
           loadOnLaunch: savedWorkspaceApp.loadOnLaunch,
-          windowed: savedWorkspaceApp.isWindowed,
+          windowed: savedWorkspaceApp.opensAsWindow,
         },
         savedWorkspaceApp.zoomFactor,
       ),
@@ -513,7 +515,7 @@ export class Tabs {
           title: tab.title,
           persistence: tab.persistence,
           loadOnLaunch: tab.loadOnLaunch,
-          windowed: tab.isWindowed,
+          windowed: tab.opensAsWindow,
         });
       } else if (tab instanceof DormantTab) {
         savedTabs.push({
@@ -546,6 +548,7 @@ export class Tabs {
       persistence: tab.persistence,
       dormant: tab.dormant,
       windowed: isWindowedTab(tab),
+      loadOnLaunch: Boolean(tab.loadOnLaunch),
       loading: tab.isLoading,
       navigationHistory: tab.navigationHistory,
       active: tab.id === this.activeTabId,

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -84,6 +84,7 @@ type WorkspaceAppOptions = {
   window?: BrowserWindowConstructorOptions;
   view?: WebContentsViewConstructorOptions;
   asWindow?: boolean;
+  savedAsWindow?: boolean;
   persistence?: TabPersistence | null;
   loadOnLaunch?: boolean;
   app?: SupportedWorkspaceApp;
@@ -381,6 +382,14 @@ export class WorkspaceApp {
 
   loadOnLaunch = false;
 
+  /**
+   * Whether this app should be restored in its own window, as opposed to
+   * whether it currently has one. The two only differ in `windows` mode, where
+   * every app is windowed because the mode says so rather than because the user
+   * asked — persisting `isWindowed` there would rewrite the user's choice.
+   */
+  opensAsWindow: boolean;
+
   private powerSaveBlockerId: number | undefined;
 
   private viewDestroyed = false;
@@ -393,6 +402,7 @@ export class WorkspaceApp {
     window,
     view,
     asWindow,
+    savedAsWindow,
     persistence,
     loadOnLaunch,
     app,
@@ -402,6 +412,8 @@ export class WorkspaceApp {
     this.app = app ?? getWorkspaceAppFromUrl(url);
     this.persistence = persistence ?? null;
     this.loadOnLaunch = Boolean(loadOnLaunch);
+    this.opensAsWindow =
+      savedAsWindow ?? (Boolean(asWindow) && config.get("workspaceApps.mode") !== "windows");
 
     if (asWindow) {
       this._window = this.createBrowserWindow(window);
@@ -624,6 +636,8 @@ export class WorkspaceApp {
   }
 
   detachToWindow() {
+    this.opensAsWindow = true;
+
     main.window.contentView.removeChildView(this.view);
 
     this._window = this.createBrowserWindow();
@@ -660,6 +674,8 @@ export class WorkspaceApp {
   }
 
   adoptIntoTabs() {
+    this.opensAsWindow = false;
+
     const discardedWindow = this.window;
 
     discardedWindow.off("resize", this.updateViewBounds);

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -2,7 +2,7 @@ import type { GmailInboxMessage } from "@meru/shared/gmail";
 import { ms } from "@meru/shared/ms";
 import { ipc } from "@meru/shared/renderer/ipc";
 import type { AccountConfig } from "@meru/shared/schemas";
-import { getVerticalTabsWidth } from "@meru/shared/tabs";
+import { getVerticalTabsWidth, getVisibleVerticalTabs } from "@meru/shared/tabs";
 import { useEffect, useRef, useState } from "react";
 import { useConfig } from "./react-query";
 import { useAccountsStore, useTabsStore, useTrialStore } from "./stores";
@@ -57,9 +57,11 @@ export function useVerticalTabs() {
 
   const selectedAccount = accounts.find((account) => account.config.selected);
 
-  const tabs =
+  const tabs = getVisibleVerticalTabs(
     accountsTabs.find((accountTabs) => accountTabs.accountId === selectedAccount?.config.id)
-      ?.tabs ?? [];
+      ?.tabs ?? [],
+    config?.["workspaceApps.mode"] ?? "tabs",
+  );
 
   const width = getVerticalTabsWidth(tabs, config?.["verticalTabs.width"] ?? "auto");
 

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -93,6 +93,10 @@ export function WorkspaceAppsSettings() {
     accountTabs.tabs.some((tab) => tab.id !== GMAIL_TAB_ID && !tab.dormant && !tab.windowed),
   );
 
+  const hasLoadOnLaunchWorkspaceApps = accountsTabs.some((accountTabs) =>
+    accountTabs.tabs.some((tab) => tab.loadOnLaunch),
+  );
+
   if (!config) {
     return;
   }
@@ -154,10 +158,18 @@ export function WorkspaceAppsSettings() {
                   label,
                 }))}
                 confirmation={{
-                  when: (mode) => mode === "windows" && hasOpenWorkspaceAppTabs,
+                  when: (mode) =>
+                    mode === "windows" && (hasOpenWorkspaceAppTabs || hasLoadOnLaunchWorkspaceApps),
                   title: "Switch to New Windows?",
-                  description:
-                    "Workspace Apps will open in their own window from now on. The tabs you already have open stay as they are, and the tab strip hides once you have closed them, or after a restart.",
+                  description: (
+                    <>
+                      Workspace Apps will open in their own window from now on.
+                      {hasOpenWorkspaceAppTabs &&
+                        " The tabs you already have open stay as they are, and the tab strip hides once you have closed them, or after a restart."}
+                      {hasLoadOnLaunchWorkspaceApps &&
+                        " Pinned apps set to load on launch will open as windows the next time you start Meru."}
+                    </>
+                  ),
                   confirmLabel: "Switch to New Windows",
                 }}
               />

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -19,6 +19,7 @@ export type TabState = {
   persistence: TabPersistence | null;
   dormant: boolean;
   windowed: boolean;
+  loadOnLaunch: boolean;
   loading: boolean;
   navigationHistory: { canGoBack: boolean; canGoForward: boolean };
   active: boolean;

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -1,6 +1,6 @@
 import { VERTICAL_TABS_NARROW_WIDTH, VERTICAL_TABS_WIDE_WIDTH } from "./constants";
 import type { AccountConfig, TabPersistence } from "./schemas";
-import type { SupportedWorkspaceApp } from "./workspace-apps";
+import type { SupportedWorkspaceApp, WorkspaceAppOpenBehavior } from "./workspace-apps";
 
 export const GMAIL_TAB_ID = "gmail";
 
@@ -43,6 +43,17 @@ export function getTabSection(tab: Pick<TabState, "id" | "persistence" | "dorman
   }
 
   return "normal";
+}
+
+export function getVisibleVerticalTabs<VerticalTab extends Pick<TabState, "windowed">>(
+  tabs: VerticalTab[],
+  workspaceAppsOpenBehavior: WorkspaceAppOpenBehavior,
+) {
+  if (workspaceAppsOpenBehavior !== "newWindow") {
+    return tabs;
+  }
+
+  return tabs.filter((tab) => !tab.windowed);
 }
 
 export function getVerticalTabsWidth(

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -1,6 +1,6 @@
 import { VERTICAL_TABS_NARROW_WIDTH, VERTICAL_TABS_WIDE_WIDTH } from "./constants";
 import type { AccountConfig, TabPersistence } from "./schemas";
-import type { SupportedWorkspaceApp, WorkspaceAppOpenBehavior } from "./workspace-apps";
+import type { SupportedWorkspaceApp, WorkspaceAppsMode } from "./workspace-apps";
 
 export const GMAIL_TAB_ID = "gmail";
 
@@ -45,15 +45,20 @@ export function getTabSection(tab: Pick<TabState, "id" | "persistence" | "dorman
   return "normal";
 }
 
-export function getVisibleVerticalTabs<VerticalTab extends Pick<TabState, "windowed">>(
+/**
+ * In `windows` mode the strip only shows tabs that live in the main window:
+ * windowed apps have a window of their own, and dormant entries would open as
+ * one. Everything filtered out here stays saved and comes back in `tabs` mode.
+ */
+export function getVisibleVerticalTabs<VerticalTab extends Pick<TabState, "dormant" | "windowed">>(
   tabs: VerticalTab[],
-  workspaceAppsOpenBehavior: WorkspaceAppOpenBehavior,
+  workspaceAppsMode: WorkspaceAppsMode,
 ) {
-  if (workspaceAppsOpenBehavior !== "newWindow") {
+  if (workspaceAppsMode === "tabs") {
     return tabs;
   }
 
-  return tabs.filter((tab) => !tab.windowed);
+  return tabs.filter((tab) => !tab.dormant && !tab.windowed);
 }
 
 export function getVerticalTabsWidth(


### PR DESCRIPTION
Stacked on #734, which turns `New Window` from an open behaviour into the `New Windows` mode. This branch makes the tab strip honour that mode: in `New Windows` there is no strip.

The rule the strip now follows is a single invariant — **it shows exactly the tabs whose content lives in the main window.** In `Tabs` mode that is every tab, unchanged. In `New Windows` mode windowed apps are excluded (their content is in their own window) and dormant entries are excluded (opening one would produce a window, not a tab), which leaves Gmail and the strip collapses to nothing.

## Changes

- `getVisibleVerticalTabs` in `packages/shared/tabs.ts` filters on the mode, and both the renderer strip and the main-process view bounds go through it, so the painted strip and the space reserved for it cannot disagree.
- `Accounts.init` gets a `workspaceApps.mode` listener that re-runs view bounds, next to the existing `verticalTabs.width` one.
- A dormant entry materialises as a window in `New Windows` mode even if it was saved as a tab, so `Load on Launch` entries survive a mode switch instead of restoring into a strip that is not there.
- `WorkspaceApp` gained `opensAsWindow` — what an entry should be *restored* as, as opposed to whether it currently has a window. Both are the same in `Tabs` mode, but not here: every app is windowed because the mode says so, and persisting `isWindowed` would rewrite the user's own choice. Only `Move to New Window` and `Move to Tab` change it, and both already save. Without this, a pinned tab that ran once in `New Windows` mode comes back as a window in `Tabs` mode forever, silently.
- #734's switch confirmation now also fires when any account has `Load on Launch` entries — not just open tabs — and says they will open as windows next launch. `TabState` carries `loadOnLaunch` so the renderer can tell.
- `Ctrl`+`Tab` cycling skips dormant entries in `New Windows` mode — otherwise it would materialise a window for an entry the user cannot see.
- `Reopen Closed Tab` reopens as a window in that mode.
- Menu actions that only make sense with a strip follow the mode too: the workspace app window menu drops `Move to Tab`, and the tab context menu's `New … Tab` becomes `New … Window` while `Duplicate` opens a window. Both were still creating embedded tabs in a mode that has none — reachable via a leftover tab's context menu.

## What is deliberately left alone

Embedded tabs that were already open when the mode is switched **stay open and stay in the strip** until they are closed. Nothing is stranded and no windows are spawned by flipping a setting; the strip disappears on its own once they are gone or after a restart. The confirmation at the moment of the switch says exactly that.

## Risks and omissions

- **Bookmarked entries have no entry point while the strip is hidden.** They are saved URLs with no representation outside the strip, so in `New Windows` mode they are unreachable — preserved, not deleted, and back as soon as you return to `Tabs`. Bookmarks are getting a titlebar entry point of their own, which closes this properly; it is noted in #739 and is not in this branch.
- Drag-reorder still sends a section index computed over *visible* tabs while the main process splices over the full section. A hidden pinned entry can therefore shift a drop by one position. Pre-existing, and now reachable in one more configuration.
- A pinned entry that is invisible in `New Windows` mode still counts toward the saved tabs written on quit — intended (it comes back in `Tabs` mode), but it does mean the config holds entries the UI never shows.
- Not verified: the app was not run for this branch. Types, lint, format and `bun test` (120 pass) are green.

## Test plan

1. In `Tabs` mode with several tabs open, pinned and bookmarked entries present → the strip looks and behaves exactly as before.
2. Switch to `New Windows` with only Gmail open → the strip disappears and the Gmail view expands to the full window width, with no leftover gap on the left.
3. Open three apps from the launcher in `New Windows` mode → three windows, no strip.
4. Switch to `New Windows` with two workspace app tabs open → the toast from #734 appears, both tabs stay in the strip, and the strip disappears after closing the second one.
5. In `Tabs` mode, pin an app and enable `Load on Launch`, then switch to `New Windows` and restart → the app comes back as a window, and the strip stays hidden.
6. Do the same but restart in `Tabs` mode → it comes back as a tab, pinned, exactly as before.
7. In `New Windows` mode press `Ctrl`+`Tab` repeatedly with a pinned dormant entry saved → focus stays on Gmail; no window is spawned.
8. In `New Windows` mode close a windowed app and press `Cmd`/`Ctrl`+`Shift`+`T` → it reopens as a window.
9. Resize the main window in `New Windows` mode → the Gmail view keeps filling the full width.
10. **The flag that used to be rewritten:** in `Tabs` mode pin an app *as a tab* with `Load on Launch`, switch to `New Windows`, restart (it opens as a window), quit, switch back to `Tabs`, restart → it comes back as a **tab**, not a window.
11. The same round trip with an app you pinned after `Move to New Window` → it comes back as a **window** in `Tabs` mode, because that time you asked for one.
12. In `New Windows` mode, open an app from the launcher, check `Load on Launch`, then switch to `Tabs` and restart → it comes back as a tab.
13. With `Load on Launch` entries but no open tabs, switch to `New Windows` → the confirmation appears and mentions the launch behaviour. With neither, it does not appear at all.
14. In `New Windows` mode, open an app window → its More Options menu has no `Move to Tab`. Switch to `Tabs` → the entry is back.
15. In `New Windows` mode with a leftover tab in the strip, right-click it → `New … Window` rather than `New … Tab`, and both it and `Duplicate` open windows, leaving the strip as it was.
