### PR TITLE
replace the workspace apps open behavior with a mode setting

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -93,7 +93,7 @@ export const config = new Store<Config>({
     "trial.expired": false,
     "workspaceApps.openInApp": true,
     "workspaceApps.openInAppExcludedApps": [],
-    "workspaceApps.openBehavior": "tab",
+    "workspaceApps.mode": "tabs",
     "workspaceApps.launcherApps": [],
     "workspaceApps.launcherDisplay": "auto",
     "workspaceApps.showAccountColor": true,
@@ -393,6 +393,17 @@ export const config = new Store<Config>({
 
       // @ts-expect-error
       store.delete("gmail.fullDarkTheme");
+    },
+    ">3.58.0": (store) => {
+      // @ts-expect-error: `workspaceApps.openBehavior` is now 'workspaceApps.mode'
+      const openBehavior = store.get("workspaceApps.openBehavior");
+
+      if (typeof openBehavior === "string") {
+        store.set("workspaceApps.mode", openBehavior === "newWindow" ? "windows" : "tabs");
+      }
+
+      // @ts-expect-error
+      store.delete("workspaceApps.openBehavior");
     },
   },
 });

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -29,7 +29,7 @@ import { licenseKey } from "@/license-key";
 import { main } from "@/main";
 import { appMenu } from "@/menu";
 import { DormantTab } from "@/tabs";
-import { WorkspaceApp } from "@/workspace-app";
+import { resolveWorkspaceAppOpenBehavior, WorkspaceApp } from "@/workspace-app";
 import { DoNotDisturb, doNotDisturb } from "./do-not-disturb";
 import { downloads } from "./downloads";
 import { GMAIL_USER_STYLES_PATH } from "./gmail";
@@ -687,7 +687,7 @@ class Ipc {
         return;
       }
 
-      const openBehavior = modifierOpenBehavior ?? config.get("workspaceApps.openBehavior");
+      const openBehavior = resolveWorkspaceAppOpenBehavior(modifierOpenBehavior);
 
       const selectedAccount = accounts.getSelectedAccount();
 

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -68,6 +68,16 @@ function getWorkspaceAppFromUrl(url: string) {
   return workspaceAppsBySubdomain.get(workspaceAppSubdomain);
 }
 
+export function resolveWorkspaceAppOpenBehavior(
+  requestedOpenBehavior?: WorkspaceAppOpenBehavior,
+): WorkspaceAppOpenBehavior {
+  if (config.get("workspaceApps.mode") === "windows") {
+    return "newWindow";
+  }
+
+  return requestedOpenBehavior ?? "tab";
+}
+
 type WorkspaceAppOptions = {
   accountId: AccountConfig["id"];
   url: string;
@@ -244,12 +254,14 @@ export class WorkspaceApp {
         return { action: "deny" };
       }
 
-      const openBehavior: WorkspaceAppOpenBehavior =
+      const requestedOpenBehavior =
         disposition === "new-window"
           ? "newWindow"
           : disposition === "background-tab"
             ? "backgroundTab"
-            : config.get("workspaceApps.openBehavior");
+            : undefined;
+
+      const openBehavior = resolveWorkspaceAppOpenBehavior(requestedOpenBehavior);
 
       const account = accounts.getAccount(accountId);
 

--- a/packages/renderer/components/config-select-field.tsx
+++ b/packages/renderer/components/config-select-field.tsx
@@ -1,4 +1,14 @@
 import type { Config } from "@meru/shared/types";
+import { Button } from "@meru/ui/components/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@meru/ui/components/dialog";
 import { Field, FieldContent, FieldDescription, FieldLabel } from "@meru/ui/components/field";
 import {
   Select,
@@ -7,7 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@meru/ui/components/select";
-import type { ReactNode } from "react";
+import { type ReactNode, useState } from "react";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useConfig, useConfigMutation } from "@/lib/react-query";
 import { restartRequiredToast } from "@/lib/toast";
@@ -22,7 +32,7 @@ export function ConfigSelectField({
   licenseKeyRequired,
   disabled,
   restartRequired,
-  onValueChanged,
+  confirmation,
 }: {
   configKey: keyof Config;
   label: string;
@@ -32,7 +42,17 @@ export function ConfigSelectField({
   licenseKeyRequired?: boolean;
   disabled?: boolean;
   restartRequired?: boolean;
-  onValueChanged?: (value: string) => void;
+  /**
+   * Holds the value back until the user confirms it. The field keeps rendering
+   * the value from config while the dialog is open, so cancelling needs no
+   * reverting — nothing was written.
+   */
+  confirmation?: {
+    when: (value: string) => boolean;
+    title: string;
+    description: ReactNode;
+    confirmLabel: string;
+  };
 }) {
   const { config } = useConfig();
 
@@ -46,6 +66,8 @@ export function ConfigSelectField({
 
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
+  const [confirmableValue, setConfirmableValue] = useState<string | null>(null);
+
   if (!config) {
     return;
   }
@@ -57,6 +79,12 @@ export function ConfigSelectField({
   }
 
   const isDisabled = disabled || (licenseKeyRequired && !isLicenseKeyValid);
+
+  const setValue = (newValue: string) => {
+    configMutation.mutate({
+      [configKey]: newValue,
+    });
+  };
 
   return (
     <Field>
@@ -71,18 +99,17 @@ export function ConfigSelectField({
         items={items}
         value={value}
         onValueChange={(newValue) => {
-          if (newValue) {
-            configMutation.mutate(
-              {
-                [configKey]: newValue,
-              },
-              {
-                onSuccess: () => {
-                  onValueChanged?.(newValue);
-                },
-              },
-            );
+          if (!newValue) {
+            return;
           }
+
+          if (confirmation?.when(newValue)) {
+            setConfirmableValue(newValue);
+
+            return;
+          }
+
+          setValue(newValue);
         }}
         disabled={isDisabled}
       >
@@ -97,6 +124,37 @@ export function ConfigSelectField({
           ))}
         </SelectContent>
       </Select>
+      {confirmation && (
+        <Dialog
+          open={confirmableValue !== null}
+          onOpenChange={(isOpen) => {
+            if (!isOpen) {
+              setConfirmableValue(null);
+            }
+          }}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{confirmation.title}</DialogTitle>
+            </DialogHeader>
+            <DialogDescription>{confirmation.description}</DialogDescription>
+            <DialogFooter>
+              <DialogClose render={<Button variant="outline">Cancel</Button>} />
+              <Button
+                onClick={() => {
+                  if (confirmableValue) {
+                    setValue(confirmableValue);
+                  }
+
+                  setConfirmableValue(null);
+                }}
+              >
+                {confirmation.confirmLabel}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
     </Field>
   );
 }

--- a/packages/renderer/components/config-select-field.tsx
+++ b/packages/renderer/components/config-select-field.tsx
@@ -22,6 +22,7 @@ export function ConfigSelectField({
   licenseKeyRequired,
   disabled,
   restartRequired,
+  onValueChanged,
 }: {
   configKey: keyof Config;
   label: string;
@@ -31,6 +32,7 @@ export function ConfigSelectField({
   licenseKeyRequired?: boolean;
   disabled?: boolean;
   restartRequired?: boolean;
+  onValueChanged?: (value: string) => void;
 }) {
   const { config } = useConfig();
 
@@ -70,9 +72,16 @@ export function ConfigSelectField({
         value={value}
         onValueChange={(newValue) => {
           if (newValue) {
-            configMutation.mutate({
-              [configKey]: newValue,
-            });
+            configMutation.mutate(
+              {
+                [configKey]: newValue,
+              },
+              {
+                onSuccess: () => {
+                  onValueChanged?.(newValue);
+                },
+              },
+            );
           }
         }}
         disabled={isDisabled}

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -1,13 +1,14 @@
 import { move } from "@dnd-kit/helpers";
 import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
+import { GMAIL_TAB_ID } from "@meru/shared/tabs";
 import {
   type LauncherWorkspaceApp,
   launcherWorkspaceApps,
   type SupportedWorkspaceApp,
-  workspaceAppOpenBehaviors,
   workspaceApps,
   workspaceAppsLauncherDisplays,
+  workspaceAppsModes,
 } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import { ButtonGroup } from "@meru/ui/components/button-group";
@@ -27,6 +28,7 @@ import {
 } from "@meru/ui/components/field";
 import { Kbd } from "@meru/ui/components/kbd";
 import { ChevronDownIcon, GripVerticalIcon, PlusIcon, XIcon } from "lucide-react";
+import { toast } from "sonner";
 import type { Entries } from "type-fest";
 import { ConfigSelectField } from "@/components/config-select-field";
 import { ConfigSwitchField } from "@/components/config-switch-field";
@@ -36,6 +38,7 @@ import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/comp
 import { WorkspaceAppIcon } from "@/components/workspace-app-icon";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useConfig, useConfigMutation } from "@/lib/react-query";
+import { useTabsStore } from "@/lib/stores";
 import { platform } from "@/lib/utils";
 
 function SortableLauncherAppItem({
@@ -85,6 +88,12 @@ export function WorkspaceAppsSettings() {
 
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
+  const accountsTabs = useTabsStore((state) => state.accountsTabs);
+
+  const hasOpenWorkspaceAppTabs = accountsTabs.some((accountTabs) =>
+    accountTabs.tabs.some((tab) => tab.id !== GMAIL_TAB_ID && !tab.dormant && !tab.windowed),
+  );
+
   if (!config) {
     return;
   }
@@ -129,22 +138,32 @@ export function WorkspaceAppsSettings() {
           {config["workspaceApps.openInApp"] && (
             <>
               <ConfigSelectField
-                label="Open Behavior"
+                label="Mode"
                 description={
                   <>
-                    How Workspace Apps open: as a tab in the main window (default), in a new window,
-                    or as a background tab. Hold <Kbd>{platform.isMacOS ? "Cmd" : "Ctrl"}</Kbd> to
-                    always open as a background tab or <Kbd>Shift</Kbd> to always open in a new
-                    window.
+                    How Workspace Apps open: as tabs in the main window (default), or each in its
+                    own window with no tab strip. In Tabs, hold{" "}
+                    <Kbd>{platform.isMacOS ? "Cmd" : "Ctrl"}</Kbd> to open a background tab or{" "}
+                    <Kbd>Shift</Kbd> to open a new window.
                   </>
                 }
-                configKey="workspaceApps.openBehavior"
-                placeholder="Select behavior"
+                configKey="workspaceApps.mode"
+                placeholder="Select mode"
                 licenseKeyRequired
-                items={Object.entries(workspaceAppOpenBehaviors).map(([value, label]) => ({
+                items={Object.entries(workspaceAppsModes).map(([value, label]) => ({
                   value,
                   label,
                 }))}
+                onValueChanged={(mode) => {
+                  if (mode !== "windows" || !hasOpenWorkspaceAppTabs) {
+                    return;
+                  }
+
+                  toast.info("Workspace Apps now open in their own window", {
+                    description:
+                      "Your open tabs stay as they are — the tab strip hides once you close them or restart Meru.",
+                  });
+                }}
               />
               <Field>
                 <FieldContent>

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -13,14 +13,6 @@ import {
 import { Button } from "@meru/ui/components/button";
 import { ButtonGroup } from "@meru/ui/components/button-group";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@meru/ui/components/dialog";
-import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
@@ -36,7 +28,6 @@ import {
 } from "@meru/ui/components/field";
 import { Kbd } from "@meru/ui/components/kbd";
 import { ChevronDownIcon, GripVerticalIcon, PlusIcon, XIcon } from "lucide-react";
-import { useState } from "react";
 import type { Entries } from "type-fest";
 import { ConfigSelectField } from "@/components/config-select-field";
 import { ConfigSwitchField } from "@/components/config-switch-field";
@@ -102,8 +93,6 @@ export function WorkspaceAppsSettings() {
     accountTabs.tabs.some((tab) => tab.id !== GMAIL_TAB_ID && !tab.dormant && !tab.windowed),
   );
 
-  const [isWindowsModeDialogOpen, setIsWindowsModeDialogOpen] = useState(false);
-
   if (!config) {
     return;
   }
@@ -164,12 +153,12 @@ export function WorkspaceAppsSettings() {
                   value,
                   label,
                 }))}
-                onValueChanged={(mode) => {
-                  if (mode !== "windows" || !hasOpenWorkspaceAppTabs) {
-                    return;
-                  }
-
-                  setIsWindowsModeDialogOpen(true);
+                confirmation={{
+                  when: (mode) => mode === "windows" && hasOpenWorkspaceAppTabs,
+                  title: "Switch to New Windows?",
+                  description:
+                    "Workspace Apps will open in their own window from now on. The tabs you already have open stay as they are, and the tab strip hides once you have closed them, or after a restart.",
+                  confirmLabel: "Switch to New Windows",
                 }}
               />
               <Field>
@@ -328,18 +317,6 @@ export function WorkspaceAppsSettings() {
           />
         </FieldGroup>
       </SettingsContent>
-      <Dialog open={isWindowsModeDialogOpen} onOpenChange={setIsWindowsModeDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Workspace Apps now open in their own window</DialogTitle>
-          </DialogHeader>
-          <DialogDescription>
-            Your open tabs stay as they are. The tab strip hides once you have closed them, or after
-            a restart.
-          </DialogDescription>
-          <DialogFooter showCloseButton />
-        </DialogContent>
-      </Dialog>
     </Settings>
   );
 }

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -13,6 +13,14 @@ import {
 import { Button } from "@meru/ui/components/button";
 import { ButtonGroup } from "@meru/ui/components/button-group";
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@meru/ui/components/dialog";
+import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
@@ -28,7 +36,7 @@ import {
 } from "@meru/ui/components/field";
 import { Kbd } from "@meru/ui/components/kbd";
 import { ChevronDownIcon, GripVerticalIcon, PlusIcon, XIcon } from "lucide-react";
-import { toast } from "sonner";
+import { useState } from "react";
 import type { Entries } from "type-fest";
 import { ConfigSelectField } from "@/components/config-select-field";
 import { ConfigSwitchField } from "@/components/config-switch-field";
@@ -93,6 +101,8 @@ export function WorkspaceAppsSettings() {
   const hasOpenWorkspaceAppTabs = accountsTabs.some((accountTabs) =>
     accountTabs.tabs.some((tab) => tab.id !== GMAIL_TAB_ID && !tab.dormant && !tab.windowed),
   );
+
+  const [isWindowsModeDialogOpen, setIsWindowsModeDialogOpen] = useState(false);
 
   if (!config) {
     return;
@@ -159,10 +169,7 @@ export function WorkspaceAppsSettings() {
                     return;
                   }
 
-                  toast.info("Workspace Apps now open in their own window", {
-                    description:
-                      "Your open tabs stay as they are — the tab strip hides once you close them or restart Meru.",
-                  });
+                  setIsWindowsModeDialogOpen(true);
                 }}
               />
               <Field>
@@ -321,6 +328,18 @@ export function WorkspaceAppsSettings() {
           />
         </FieldGroup>
       </SettingsContent>
+      <Dialog open={isWindowsModeDialogOpen} onOpenChange={setIsWindowsModeDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Workspace Apps now open in their own window</DialogTitle>
+          </DialogHeader>
+          <DialogDescription>
+            Your open tabs stay as they are. The tab strip hides once you have closed them, or after
+            a restart.
+          </DialogDescription>
+          <DialogFooter showCloseButton />
+        </DialogContent>
+      </Dialog>
     </Settings>
   );
 }

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -15,6 +15,7 @@ import type {
   SupportedWorkspaceApp,
   WorkspaceAppOpenBehavior,
   WorkspaceAppsLauncherDisplay,
+  WorkspaceAppsMode,
 } from "./workspace-apps";
 
 export type DesktopSource = { id: string; name: string; thumbnail: string };
@@ -129,7 +130,7 @@ export type Config = {
   "trial.expired": boolean;
   "workspaceApps.openInApp": boolean;
   "workspaceApps.openInAppExcludedApps": SupportedWorkspaceApp[];
-  "workspaceApps.openBehavior": WorkspaceAppOpenBehavior;
+  "workspaceApps.mode": WorkspaceAppsMode;
   "workspaceApps.launcherApps": LauncherWorkspaceApp[];
   "workspaceApps.launcherDisplay": WorkspaceAppsLauncherDisplay;
   "workspaceApps.showAccountColor": boolean;

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -70,10 +70,15 @@ export function resolveWorkspaceAppsLauncherDisplay(
   return launcherAppCount > LAUNCHER_EXPANDED_APPS_THRESHOLD ? "collapsed" : "expanded";
 }
 
-export const workspaceAppOpenBehaviors = {
-  tab: "Tab",
-  newWindow: "New Window",
-  backgroundTab: "Background Tab",
+export const workspaceAppsModes = {
+  tabs: "Tabs",
+  windows: "New Windows",
 } as const;
 
-export type WorkspaceAppOpenBehavior = keyof typeof workspaceAppOpenBehaviors;
+export type WorkspaceAppsMode = keyof typeof workspaceAppsModes;
+
+/**
+ * How a single Workspace App ends up being opened. Resolved per click from the
+ * configured mode and the held modifier keys — never stored in the config.
+ */
+export type WorkspaceAppOpenBehavior = "tab" | "backgroundTab" | "newWindow";


### PR DESCRIPTION
`workspaceApps.openBehavior` conflated two different things under one name and one type: the preference a user stores (`Tab` / `Background Tab` / `New Window`) and the target a single click resolves to after modifiers and Electron dispositions are applied. That overlap gets actively dangerous now that `New Window` is becoming a mode that hides the tab strip — the stored value and the resolved value stop having the same legal set.

`Background Tab` also does not belong in a settings dropdown. No browser offers it as a default; it is a modifier gesture, and Meru already has it (Cmd/Ctrl+click).

## Changes

- `workspaceApps.openBehavior` → **`workspaceApps.mode`**, with two values: `tabs` (default) and `windows`, labelled **Tabs** and **New Windows**. `Settings… → Workspace Apps → Open Behavior` becomes `Mode`.
- `WorkspaceAppOpenBehavior` stays three-valued but is now purely a resolved-per-click type, documented as such, and no longer backs a config key. Its label record is gone with the dropdown that used it.
- New `resolveWorkspaceAppOpenBehavior()` in `packages/app/workspace-app.ts` is the single place mode and request meet: in `windows` mode everything resolves to `newWindow`, otherwise the requested behaviour wins and `tab` is the fallback. Both call sites (the window-open handler and the `workspaceApps.openApp` IPC) go through it.
- Migration `>3.58.0` maps a stored `newWindow` to `windows` and everything else — including `backgroundTab` — to `tabs`, then deletes the old key.
- Switching to New Windows while workspace app tabs are open now **asks first**, explaining that the open tabs are left alone and the strip hides once they are closed or the app restarts. It went toast → after-the-fact dialog → confirmation: a toast read too fast to finish, and a dialog that only informs is worse than one that asks, since the change has already happened by the time it is read.
- `ConfigSelectField` gained a declarative `confirmation` prop (`when` / `title` / `description` / `confirmLabel`) that holds the value back until confirmed, in the same spirit as its existing `restartRequired`. Cancelling needs no reverting: the field renders from config, so a value that was never written simply never appears.
- Going back to Tabs never asks. Windows stay windows, saved entries reappear, nothing is lost.

## Risks and omissions

- **Anyone who set `Background Tab` as their default loses that preference** and lands on `Tabs`. Cmd/Ctrl+click still opens background tabs on demand. This is deliberate, and the release notes will call it out.
- The migration reads the old value with `@ts-expect-error` like every other migration in that file; if a config somehow holds an unexpected string it falls through to `tabs`, which is the safe direction.
- The "are any tabs open" check reads the renderer tab store, which is populated by broadcasts rather than an initial fetch — the same data the strip renders from, so the two cannot disagree. In practice every account's Gmail view broadcasts on load long before settings can be reached, but a renderer that had somehow never received a `tabs.changed` broadcast would switch without asking.
- The check spans **all** accounts, not the selected one, so a switch is confirmed whenever any account has tabs open. That is deliberate — the mode is global — but the dialog does not name which account they are in.
- Pinned and bookmarked entries are not part of the trigger. They are hidden rather than lost while in New Windows mode, and are getting a titlebar entry point of their own (noted in #739), so warning about them now would describe a state that is on its way out.
- Nothing in this branch changes what the tab strip renders — `windows` mode still shows windowed tabs in the strip. Hiding it is the next branch (#732 reworked).
- Not verified: the app was not run for this branch. Types, lint, format and `bun test` (120 pass) are green.

## Test plan

1. Fresh config: `Settings… → Workspace Apps → Mode` shows **Tabs** selected, with **New Windows** as the only other option.
2. Existing config with Open Behavior set to `Tab` → after upgrading, Mode reads **Tabs**. Set to `New Window` → Mode reads **New Windows**. Set to `Background Tab` → Mode reads **Tabs**.
3. Inspect the config file after any of those: `workspaceApps.openBehavior` is gone, `workspaceApps.mode` is present.
4. In **Tabs** mode, click a launcher app → foreground tab. Cmd/Ctrl+click → background tab. Shift+click → new window. Middle-click → background tab.
5. In **New Windows** mode, repeat all four gestures → every one of them opens a window; no new tabs appear.
6. In **New Windows** mode, click a link inside a workspace app that opens a Google app (and one that Electron reports as `background-tab`) → both open as windows.
7. With at least one workspace app tab open, pick **New Windows** → a confirmation appears and the dropdown still reads **Tabs** behind it. Cancel it (button, Esc, and click-outside, each once) → the config is untouched and apps still open as tabs. Pick it again and confirm → the mode changes.
8. With only Gmail open, pick **New Windows** → no dialog, the change applies immediately. Switch back to **Tabs** with windows open → no dialog either.
9. With two accounts where only the second has tabs open, on the first account pick **New Windows** → it still asks.
10. Turn `Open in App` off → the Mode field disappears with the rest of that group, as before.
