### PR TITLE
add load on launch to the workspace app window menu

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -223,6 +223,8 @@ class Ipc {
 
       const isWindowsMode = config.get("workspaceApps.mode") === "windows";
 
+      const isSavableWorkspaceApp = !workspaceApp.isPopup && Boolean(workspaceApp.app);
+
       Menu.buildFromTemplate([
         ...(workspaceApp.isPopup || isWindowsMode
           ? []
@@ -237,6 +239,31 @@ class Ipc {
                 type: "separator" as const,
               },
             ]),
+        ...(isSavableWorkspaceApp
+          ? [
+              {
+                label: "Load on Launch",
+                type: "checkbox" as const,
+                checked: workspaceApp.persistence === "pinned" && workspaceApp.loadOnLaunch,
+                click: () => {
+                  if (workspaceApp.loadOnLaunch) {
+                    workspaceApp.loadOnLaunch = false;
+
+                    accounts.saveTabs();
+
+                    return;
+                  }
+
+                  workspaceApp.loadOnLaunch = true;
+
+                  workspaceApp.account.instance.tabs.setTabPersistence(workspaceApp.id, "pinned");
+                },
+              },
+              {
+                type: "separator" as const,
+              },
+            ]
+          : []),
         {
           label: "Copy Link",
           click: () => {


### PR DESCRIPTION
Stacked on #732, which hides the tab strip in `New Windows` mode. That removes the only place `Load on Launch` could be reached — it lives in the pinned tab's context menu in the strip — so in `New Windows` mode there is no way to say "bring this app back when Meru starts".

The persistence itself already works for windows: a workspace app window *is* a tab in the model, saves `windowed: true`, and #732 restores such an entry as a window. Only the affordance was missing.

## Changes

- `Load on Launch` checkbox in a Workspace App window's More Options menu, above `Copy Link`.
- Checking it pins the app and sets the flag in one step; unchecking clears only the flag and leaves the pin.
- Shown only for windows that can actually be saved: not popups (they are not tabs at all) and only with a recognised app, since saved tabs without one are dropped when serialising.

Wording matches the existing strip entry — same flag, same name in both places.

## Risks and omissions

- **Unchecking leaves the app pinned.** In `Tabs` mode that is visible and manageable in the strip; in `New Windows` mode it becomes a saved entry with no UI, which resurfaces as a pinned tab if the user switches back to `Tabs`. The alternative — unpinning on uncheck — would silently discard a pin the user set deliberately in `Tabs` mode, which is worse. Documented, not hidden.
- Checking it on a **bookmarked** window converts it to pinned, because `Load on Launch` only exists for pinned entries in the model. Consistent with the strip, but it is a persistence change the menu does not spell out.
- No feedback is shown when toggling — the checkbox state on the next open is the only confirmation. Consistent with the strip's entry.
- Not verified: the app was not run for this branch. Types, lint and format are green.

## Test plan

1. In `New Windows` mode, open Calendar from the launcher → its More Options menu shows an unchecked `Load on Launch`.
2. Check it, quit, relaunch → Calendar comes back as a window on start. Its menu shows the box checked.
3. Uncheck it, quit, relaunch → Calendar does not come back. Switch to `Tabs` mode → it is there as a pinned tab (the pin survived).
4. In `Tabs` mode, move a tab to its own window, check `Load on Launch` there → the tab appears pinned in the strip with a window badge, and its strip context menu shows `Load on Launch` checked. The two menus agree.
5. Quit and relaunch from that state → it comes back as a window, pinned.
6. Open a PDF from Gmail (a popup window) → its menu has no `Load on Launch` entry, and no `Move to Tab` either, as before.
7. Open a non-Google page that lands in a workspace app window → no `Load on Launch` entry.
8. With two accounts, check `Load on Launch` on a window belonging to the second account, relaunch → it restores under that account only.
