### PR TITLE
move the workspace apps launcher into the tab strip

### DIFF
--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -1,12 +1,6 @@
 import { accountColorsMap } from "@meru/shared/accounts";
 import { WEBSITE_URL } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
-import {
-  type LauncherWorkspaceApp,
-  launcherWorkspaceApps,
-  resolveWorkspaceAppsLauncherDisplay,
-  type WorkspaceAppsLauncherDisplay,
-} from "@meru/shared/workspace-apps";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import { cn } from "@meru/ui/lib/utils";
@@ -16,7 +10,6 @@ import {
   DownloadIcon,
   EllipsisVerticalIcon,
   InboxIcon,
-  LayoutGridIcon,
   MailSearchIcon,
   MoonIcon,
   SparklesIcon,
@@ -36,15 +29,13 @@ import {
   TitlebarTitle,
 } from "@/components/titlebar";
 import { UnreadCountBadge } from "@/components/unread-count-badge";
-import { WorkspaceAppIcon } from "@/components/workspace-app-icon";
-import { useIsLicenseKeyValid } from "@/lib/hooks";
+import { WorkspaceAppsLauncher } from "@/components/workspace-apps-launcher";
+import { useIsLicenseKeyValid, useVerticalTabs } from "@/lib/hooks";
 import { useConfig } from "@/lib/react-query";
-import { getModifierOpenBehavior } from "@/lib/workspace-apps";
 import {
   useAccountsStore,
   useAppUpdaterStore,
   useFindInPageStore,
-  useTabsStore,
   useTrialStore,
 } from "../lib/stores";
 
@@ -170,80 +161,12 @@ function DoNotDisturb() {
   );
 }
 
-function WorkspaceAppsLauncher({
-  launcherApps,
-  display,
-  disabled,
-}: {
-  launcherApps: LauncherWorkspaceApp[];
-  display: WorkspaceAppsLauncherDisplay;
-  disabled: boolean;
-}) {
-  const [isOpen, setIsOpen] = useState(false);
-
-  const resolvedDisplay = resolveWorkspaceAppsLauncherDisplay(display, launcherApps.length);
-
-  if (resolvedDisplay === "expanded") {
-    return launcherApps.map((app) => (
-      <TitlebarIconButton
-        key={app}
-        title={launcherWorkspaceApps[app]}
-        disabled={disabled}
-        onClick={(event) => {
-          ipc.main.send("workspaceApps.openApp", app, getModifierOpenBehavior(event));
-        }}
-        onAuxClick={(event) => {
-          if (event.button === 1) {
-            ipc.main.send("workspaceApps.openApp", app, "backgroundTab");
-          }
-        }}
-      >
-        <WorkspaceAppIcon app={app} className="size-4" />
-      </TitlebarIconButton>
-    ));
-  }
-
-  return (
-    <TitlebarDropdownMenu
-      title="Workspace Apps"
-      icon={<LayoutGridIcon />}
-      side="left"
-      disabled={disabled}
-      isOpen={isOpen}
-      onOpenChange={setIsOpen}
-    >
-      {launcherApps.map((app) => (
-        <TitlebarDropdownMenuItem
-          key={app}
-          title={launcherWorkspaceApps[app]}
-          onClick={(event) => {
-            ipc.main.send("workspaceApps.openApp", app, getModifierOpenBehavior(event));
-          }}
-          onAuxClick={(event) => {
-            if (event.button === 1) {
-              ipc.main.send("workspaceApps.openApp", app, "backgroundTab");
-
-              setIsOpen(false);
-            }
-          }}
-        >
-          <WorkspaceAppIcon app={app} className="size-4" />
-        </TitlebarDropdownMenuItem>
-      ))}
-    </TitlebarDropdownMenu>
-  );
-}
-
 export function AppTitlebar() {
   const accounts = useAccountsStore((state) => state.accounts);
 
-  const selectedAccount = accounts.find((account) => account.config.selected);
+  const { tabs: selectedAccountTabs, width: verticalTabsWidth } = useVerticalTabs();
 
-  const accountsTabs = useTabsStore((state) => state.accountsTabs);
-
-  const activeTab = accountsTabs
-    .find((accountTabs) => accountTabs.accountId === selectedAccount?.config.id)
-    ?.tabs.find((tab) => tab.active);
+  const activeTab = selectedAccountTabs.find((tab) => tab.active);
 
   const [location] = useLocation();
 
@@ -275,8 +198,10 @@ export function AppTitlebar() {
 
   const isUnifiedInboxLocation = location === "/unified-inbox";
 
+  // The vertical tabs strip hosts the launcher whenever it is there, so that
+  // opening another app stays in the same place as switching between them.
   const shouldShowWorkspaceAppsLauncher =
-    isLicenseKeyValid && config["workspaceApps.launcherApps"].length > 0;
+    isLicenseKeyValid && config["workspaceApps.launcherApps"].length > 0 && verticalTabsWidth === 0;
 
   const shouldShowUnifiedInboxButton =
     isLicenseKeyValid && config["unifiedInbox.enabled"] && accounts.length > 1;
@@ -435,6 +360,7 @@ export function AppTitlebar() {
                 <WorkspaceAppsLauncher
                   launcherApps={config["workspaceApps.launcherApps"]}
                   display={config["workspaceApps.launcherDisplay"]}
+                  presentation="titlebar"
                   disabled={isUnifiedInboxLocation}
                 />
               </TitlebarButtonGroup>

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -29,8 +29,11 @@ import {
   TitlebarTitle,
 } from "@/components/titlebar";
 import { UnreadCountBadge } from "@/components/unread-count-badge";
-import { WorkspaceAppsLauncher } from "@/components/workspace-apps-launcher";
-import { useIsLicenseKeyValid, useVerticalTabs } from "@/lib/hooks";
+import {
+  WORKSPACE_APPS_LAUNCHER_FADE_DURATION,
+  WorkspaceAppsLauncher,
+} from "@/components/workspace-apps-launcher";
+import { useDelayedUnmount, useIsLicenseKeyValid, useVerticalTabs } from "@/lib/hooks";
 import { useConfig } from "@/lib/react-query";
 import {
   useAccountsStore,
@@ -181,6 +184,18 @@ export function AppTitlebar() {
 
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
+  // The vertical tabs strip hosts the launcher whenever it is there, so that
+  // opening another app stays in the same place as switching between them.
+  const isWorkspaceAppsLauncherVisible =
+    isLicenseKeyValid &&
+    Boolean(config?.["workspaceApps.launcherApps"].length) &&
+    verticalTabsWidth === 0;
+
+  const shouldRenderWorkspaceAppsLauncher = useDelayedUnmount(
+    isWorkspaceAppsLauncherVisible,
+    WORKSPACE_APPS_LAUNCHER_FADE_DURATION,
+  );
+
   if (location.startsWith("/settings/")) {
     return (
       <Titlebar>
@@ -197,11 +212,6 @@ export function AppTitlebar() {
   const isAccountLocation = location === "/";
 
   const isUnifiedInboxLocation = location === "/unified-inbox";
-
-  // The vertical tabs strip hosts the launcher whenever it is there, so that
-  // opening another app stays in the same place as switching between them.
-  const shouldShowWorkspaceAppsLauncher =
-    isLicenseKeyValid && config["workspaceApps.launcherApps"].length > 0 && verticalTabsWidth === 0;
 
   const shouldShowUnifiedInboxButton =
     isLicenseKeyValid && config["unifiedInbox.enabled"] && accounts.length > 1;
@@ -355,8 +365,15 @@ export function AppTitlebar() {
           <div className="flex items-center gap-2">
             <Trial />
             <FindInPage />
-            {shouldShowWorkspaceAppsLauncher && (
-              <TitlebarButtonGroup>
+            {shouldRenderWorkspaceAppsLauncher && (
+              <TitlebarButtonGroup
+                className={cn(
+                  "duration-150",
+                  isWorkspaceAppsLauncherVisible
+                    ? "animate-in fade-in-0"
+                    : "animate-out fade-out-0 fill-mode-forwards",
+                )}
+              >
                 <WorkspaceAppsLauncher
                   launcherApps={config["workspaceApps.launcherApps"]}
                   display={config["workspaceApps.launcherDisplay"]}

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -30,10 +30,10 @@ import {
 } from "@/components/titlebar";
 import { UnreadCountBadge } from "@/components/unread-count-badge";
 import {
-  WORKSPACE_APPS_LAUNCHER_FADE_DURATION,
+  WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME,
   WorkspaceAppsLauncher,
 } from "@/components/workspace-apps-launcher";
-import { useDelayedUnmount, useIsLicenseKeyValid, useVerticalTabs } from "@/lib/hooks";
+import { useIsLicenseKeyValid, useVerticalTabs } from "@/lib/hooks";
 import { useConfig } from "@/lib/react-query";
 import {
   useAccountsStore,
@@ -184,18 +184,6 @@ export function AppTitlebar() {
 
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
-  // The vertical tabs strip hosts the launcher whenever it is there, so that
-  // opening another app stays in the same place as switching between them.
-  const isWorkspaceAppsLauncherVisible =
-    isLicenseKeyValid &&
-    Boolean(config?.["workspaceApps.launcherApps"].length) &&
-    verticalTabsWidth === 0;
-
-  const shouldRenderWorkspaceAppsLauncher = useDelayedUnmount(
-    isWorkspaceAppsLauncherVisible,
-    WORKSPACE_APPS_LAUNCHER_FADE_DURATION,
-  );
-
   if (location.startsWith("/settings/")) {
     return (
       <Titlebar>
@@ -212,6 +200,13 @@ export function AppTitlebar() {
   const isAccountLocation = location === "/";
 
   const isUnifiedInboxLocation = location === "/unified-inbox";
+
+  const shouldShowWorkspaceAppsLauncher =
+    isLicenseKeyValid && config["workspaceApps.launcherApps"].length > 0;
+
+  // The vertical tabs strip hosts the launcher whenever it is there, so that
+  // opening another app stays in the same place as switching between them.
+  const isWorkspaceAppsLauncherHostedByVerticalTabs = verticalTabsWidth > 0;
 
   const shouldShowUnifiedInboxButton =
     isLicenseKeyValid && config["unifiedInbox.enabled"] && accounts.length > 1;
@@ -365,13 +360,11 @@ export function AppTitlebar() {
           <div className="flex items-center gap-2">
             <Trial />
             <FindInPage />
-            {shouldRenderWorkspaceAppsLauncher && (
+            {shouldShowWorkspaceAppsLauncher && (
               <TitlebarButtonGroup
                 className={cn(
-                  "duration-150",
-                  isWorkspaceAppsLauncherVisible
-                    ? "animate-in fade-in-0"
-                    : "animate-out fade-out-0 fill-mode-forwards",
+                  WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME,
+                  isWorkspaceAppsLauncherHostedByVerticalTabs && "hidden opacity-0",
                 )}
               >
                 <WorkspaceAppsLauncher

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -370,7 +370,6 @@ export function AppTitlebar() {
                 <WorkspaceAppsLauncher
                   launcherApps={config["workspaceApps.launcherApps"]}
                   display={config["workspaceApps.launcherDisplay"]}
-                  presentation="titlebar"
                   disabled={isUnifiedInboxLocation}
                 />
               </TitlebarButtonGroup>

--- a/packages/renderer/components/titlebar.tsx
+++ b/packages/renderer/components/titlebar.tsx
@@ -9,7 +9,8 @@ import {
 } from "@meru/ui/components/dropdown-menu";
 import { cn } from "@meru/ui/lib/utils";
 import { ArrowLeftIcon, ArrowRightIcon, LoaderCircleIcon, RotateCwIcon, XIcon } from "lucide-react";
-import { type ComponentProps, type ReactNode, useEffect, useState } from "react";
+import { type ComponentProps, type ReactNode, useState } from "react";
+import { useCloseOnWindowBlur } from "@/lib/hooks";
 
 export function Titlebar({ children }: { children: ReactNode }) {
   return (
@@ -84,21 +85,9 @@ export function TitlebarDropdownMenu({
   onOpenChange: (isOpen: boolean) => void;
   children: ReactNode;
 }) {
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    const handleWindowBlur = () => {
-      onOpenChange(false);
-    };
-
-    window.addEventListener("blur", handleWindowBlur);
-
-    return () => {
-      window.removeEventListener("blur", handleWindowBlur);
-    };
-  }, [isOpen, onOpenChange]);
+  useCloseOnWindowBlur(isOpen, () => {
+    onOpenChange(false);
+  });
 
   return (
     <DropdownMenu open={isOpen} onOpenChange={onOpenChange} orientation="horizontal">

--- a/packages/renderer/components/titlebar.tsx
+++ b/packages/renderer/components/titlebar.tsx
@@ -39,8 +39,14 @@ export function TitlebarRight({ children }: { children: ReactNode }) {
   return <div className="flex items-center gap-2">{children}</div>;
 }
 
-export function TitlebarButtonGroup({ children }: { children: ReactNode }) {
-  return <div className="flex items-center gap-1">{children}</div>;
+export function TitlebarButtonGroup({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return <div className={cn("flex items-center gap-1", className)}>{children}</div>;
 }
 
 export function TitlebarPageTitle({ children }: { children: string }) {

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -5,12 +5,7 @@ import { useSortable } from "@dnd-kit/react/sortable";
 import { VERTICAL_TABS_WIDE_WIDTH } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
 import type { AccountConfig } from "@meru/shared/schemas";
-import {
-  GMAIL_TAB_ID,
-  getTabSection,
-  getVerticalTabsWidth,
-  type TabState,
-} from "@meru/shared/tabs";
+import { GMAIL_TAB_ID, getTabSection, type TabState } from "@meru/shared/tabs";
 import { workspaceApps } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import { cn } from "@meru/ui/lib/utils";
@@ -18,9 +13,10 @@ import { AppWindowIcon, BookmarkIcon, CircleAlertIcon, GlobeIcon, XIcon } from "
 import type { Ref } from "react";
 import { UnreadCountBadge } from "@/components/unread-count-badge";
 import { WorkspaceAppIcon } from "@/components/workspace-app-icon";
+import { WorkspaceAppsLauncher } from "@/components/workspace-apps-launcher";
+import { useIsLicenseKeyValid, useVerticalTabs } from "@/lib/hooks";
 import { useConfig } from "@/lib/react-query";
 import { getModifierOpenBehavior } from "@/lib/workspace-apps";
-import { useAccountsStore, useTabsStore } from "../lib/stores";
 
 const verticalTabsPlugins = defaultPreset.plugins.filter((plugin) => plugin !== Accessibility);
 
@@ -233,36 +229,33 @@ function SortableVerticalTab({
 }
 
 export function VerticalTabs() {
-  const accounts = useAccountsStore((state) => state.accounts);
-  const accountsTabs = useTabsStore((state) => state.accountsTabs);
-
   const { config } = useConfig();
 
-  const selectedAccount = accounts.find((account) => account.config.selected);
+  const isLicenseKeyValid = useIsLicenseKeyValid();
 
-  const selectedAccountTabs = accountsTabs.find(
-    (accountTabs) => accountTabs.accountId === selectedAccount?.config.id,
-  );
+  const {
+    selectedAccount,
+    tabs: selectedAccountTabs,
+    width: verticalTabsWidth,
+  } = useVerticalTabs();
 
-  const verticalTabsWidth = selectedAccountTabs
-    ? getVerticalTabsWidth(selectedAccountTabs.tabs, config?.["verticalTabs.width"] ?? "auto")
-    : 0;
-
-  if (!selectedAccount || !selectedAccountTabs || verticalTabsWidth === 0) {
+  if (!selectedAccount || verticalTabsWidth === 0) {
     return;
   }
 
   const isWide = verticalTabsWidth === VERTICAL_TABS_WIDE_WIDTH;
 
-  const pinnedSectionTabs = selectedAccountTabs.tabs.filter(
-    (tab) => getTabSection(tab) === "pinned",
-  );
+  const pinnedSectionTabs = selectedAccountTabs.filter((tab) => getTabSection(tab) === "pinned");
 
-  const normalTabs = selectedAccountTabs.tabs.filter((tab) => getTabSection(tab) === "normal");
+  const normalTabs = selectedAccountTabs.filter((tab) => getTabSection(tab) === "normal");
 
-  const bookmarkedTabs = selectedAccountTabs.tabs.filter(
-    (tab) => getTabSection(tab) === "bookmarks",
-  );
+  const bookmarkedTabs = selectedAccountTabs.filter((tab) => getTabSection(tab) === "bookmarks");
+
+  const launcherApps = config?.["workspaceApps.launcherApps"] ?? [];
+
+  const launcherDisplay = config?.["workspaceApps.launcherDisplay"] ?? "auto";
+
+  const shouldShowWorkspaceAppsLauncher = isLicenseKeyValid && launcherApps.length > 0;
 
   const gmailTabStatus = {
     attentionRequired: selectedAccount.gmail.attentionRequired,
@@ -353,6 +346,20 @@ export function VerticalTabs() {
           />
         ))}
       </DragDropProvider>
+      {shouldShowWorkspaceAppsLauncher && (
+        <div
+          className={cn(
+            "mt-auto flex border-t pt-2",
+            isWide ? "flex-row flex-wrap justify-center gap-1" : "flex-col gap-2",
+          )}
+        >
+          <WorkspaceAppsLauncher
+            launcherApps={launcherApps}
+            display={launcherDisplay}
+            presentation="verticalTabs"
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -14,8 +14,8 @@ import type { Ref } from "react";
 import { UnreadCountBadge } from "@/components/unread-count-badge";
 import { WorkspaceAppIcon } from "@/components/workspace-app-icon";
 import {
+  VerticalTabsWorkspaceAppsLauncher,
   WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME,
-  WorkspaceAppsLauncher,
 } from "@/components/workspace-apps-launcher";
 import { useIsLicenseKeyValid, useVerticalTabs } from "@/lib/hooks";
 import { useConfig } from "@/lib/react-query";
@@ -256,8 +256,6 @@ export function VerticalTabs() {
 
   const launcherApps = config?.["workspaceApps.launcherApps"] ?? [];
 
-  const launcherDisplay = config?.["workspaceApps.launcherDisplay"] ?? "auto";
-
   const shouldShowWorkspaceAppsLauncher = isLicenseKeyValid && launcherApps.length > 0;
 
   const gmailTabStatus = {
@@ -350,18 +348,8 @@ export function VerticalTabs() {
         ))}
       </DragDropProvider>
       {shouldShowWorkspaceAppsLauncher && (
-        <div
-          className={cn(
-            "mt-auto flex border-t pt-2",
-            WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME,
-            isWide ? "flex-row flex-wrap justify-center gap-1" : "flex-col gap-2",
-          )}
-        >
-          <WorkspaceAppsLauncher
-            launcherApps={launcherApps}
-            display={launcherDisplay}
-            presentation="verticalTabs"
-          />
+        <div className={cn(WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME, isWide && "w-full")}>
+          <VerticalTabsWorkspaceAppsLauncher launcherApps={launcherApps} isWide={isWide} />
         </div>
       )}
     </div>

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -13,7 +13,10 @@ import { AppWindowIcon, BookmarkIcon, CircleAlertIcon, GlobeIcon, XIcon } from "
 import type { Ref } from "react";
 import { UnreadCountBadge } from "@/components/unread-count-badge";
 import { WorkspaceAppIcon } from "@/components/workspace-app-icon";
-import { WorkspaceAppsLauncher } from "@/components/workspace-apps-launcher";
+import {
+  WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME,
+  WorkspaceAppsLauncher,
+} from "@/components/workspace-apps-launcher";
 import { useIsLicenseKeyValid, useVerticalTabs } from "@/lib/hooks";
 import { useConfig } from "@/lib/react-query";
 import { getModifierOpenBehavior } from "@/lib/workspace-apps";
@@ -349,7 +352,8 @@ export function VerticalTabs() {
       {shouldShowWorkspaceAppsLauncher && (
         <div
           className={cn(
-            "mt-auto flex animate-in border-t pt-2 duration-150 fade-in-0",
+            "mt-auto flex border-t pt-2",
+            WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME,
             isWide ? "flex-row flex-wrap justify-center gap-1" : "flex-col gap-2",
           )}
         >

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -349,7 +349,7 @@ export function VerticalTabs() {
       {shouldShowWorkspaceAppsLauncher && (
         <div
           className={cn(
-            "mt-auto flex border-t pt-2",
+            "mt-auto flex animate-in border-t pt-2 duration-150 fade-in-0",
             isWide ? "flex-row flex-wrap justify-center gap-1" : "flex-col gap-2",
           )}
         >

--- a/packages/renderer/components/workspace-apps-launcher.tsx
+++ b/packages/renderer/components/workspace-apps-launcher.tsx
@@ -1,3 +1,4 @@
+import { ms } from "@meru/shared/ms";
 import { ipc } from "@meru/shared/renderer/ipc";
 import {
   type LauncherWorkspaceApp,
@@ -23,6 +24,12 @@ import {
 import { WorkspaceAppIcon } from "@/components/workspace-app-icon";
 import { useCloseOnWindowBlur } from "@/lib/hooks";
 import { getModifierOpenBehavior } from "@/lib/workspace-apps";
+
+/**
+ * Matches the `duration-150` on the fade classes its hosts render it with, so
+ * the launcher stays mounted for as long as its fade-out takes.
+ */
+export const WORKSPACE_APPS_LAUNCHER_FADE_DURATION = ms("150ms");
 
 export function WorkspaceAppsLauncher({
   launcherApps,
@@ -59,7 +66,7 @@ export function WorkspaceAppsLauncher({
     },
   });
 
-  if (resolvedDisplay === "inline") {
+  if (resolvedDisplay === "expanded") {
     return launcherApps.map((app) =>
       presentation === "titlebar" ? (
         <TitlebarIconButton key={app} disabled={disabled} {...getLauncherAppProps(app)}>

--- a/packages/renderer/components/workspace-apps-launcher.tsx
+++ b/packages/renderer/components/workspace-apps-launcher.tsx
@@ -1,4 +1,3 @@
-import { ms } from "@meru/shared/ms";
 import { ipc } from "@meru/shared/renderer/ipc";
 import {
   type LauncherWorkspaceApp,
@@ -26,10 +25,13 @@ import { useCloseOnWindowBlur } from "@/lib/hooks";
 import { getModifierOpenBehavior } from "@/lib/workspace-apps";
 
 /**
- * Matches the `duration-150` on the fade classes its hosts render it with, so
- * the launcher stays mounted for as long as its fade-out takes.
+ * Fades the launcher in when it takes over a host and out when it hands over,
+ * without either host having to keep it mounted: `transition-discrete` holds
+ * the `display` flip until the fade has played, and `starting:` supplies the
+ * transparent state it fades in from.
  */
-export const WORKSPACE_APPS_LAUNCHER_FADE_DURATION = ms("150ms");
+export const WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME =
+  "transition-[opacity,display] transition-discrete duration-150 starting:opacity-0";
 
 export function WorkspaceAppsLauncher({
   launcherApps,

--- a/packages/renderer/components/workspace-apps-launcher.tsx
+++ b/packages/renderer/components/workspace-apps-launcher.tsx
@@ -118,7 +118,7 @@ export function VerticalTabsWorkspaceAppsLauncher({
           <Button
             variant="ghost"
             size={isWide ? "sm" : "icon"}
-            className={cn("opacity-50 hover:opacity-100", isWide && "w-full justify-start")}
+            className={cn("text-muted-foreground", isWide && "w-full justify-start")}
             title="New Tab"
           >
             <PlusIcon />

--- a/packages/renderer/components/workspace-apps-launcher.tsx
+++ b/packages/renderer/components/workspace-apps-launcher.tsx
@@ -128,16 +128,22 @@ export function VerticalTabsWorkspaceAppsLauncher({
       />
       <DropdownMenuBackdrop />
       {/* Opens upward at trigger width so it stays inside the strip — anything
-          wider would be painted over by the workspace app view next to it. */}
+          wider would be painted over by the workspace app view next to it.
+          That leaves room for app names only in the wide strip. */}
       <DropdownMenuContent
         side="top"
         align="center"
         collisionPadding={0}
-        className="flex w-auto min-w-0 flex-col gap-1 p-0.5"
+        className={cn("flex flex-col gap-1 p-0.5", !isWide && "w-auto min-w-0")}
       >
         {launcherApps.map((app) => (
-          <DropdownMenuItem key={app} className="justify-center" {...getLauncherAppProps(app)}>
+          <DropdownMenuItem
+            key={app}
+            className={cn(!isWide && "justify-center")}
+            {...getLauncherAppProps(app)}
+          >
             <WorkspaceAppIcon app={app} className="size-4" />
+            {isWide && launcherWorkspaceApps[app]}
           </DropdownMenuItem>
         ))}
       </DropdownMenuContent>

--- a/packages/renderer/components/workspace-apps-launcher.tsx
+++ b/packages/renderer/components/workspace-apps-launcher.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@meru/ui/components/dropdown-menu";
+import { cn } from "@meru/ui/lib/utils";
 import { LayoutGridIcon } from "lucide-react";
 import { type MouseEvent, useState } from "react";
 import {
@@ -33,24 +34,12 @@ import { getModifierOpenBehavior } from "@/lib/workspace-apps";
 export const WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME =
   "transition-[opacity,display] transition-discrete duration-150 starting:opacity-0";
 
-export function WorkspaceAppsLauncher({
-  launcherApps,
-  display,
-  presentation,
-  disabled,
-}: {
-  launcherApps: LauncherWorkspaceApp[];
-  display: WorkspaceAppsLauncherDisplay;
-  presentation: "titlebar" | "verticalTabs";
-  disabled?: boolean;
-}) {
+function useLauncherApps() {
   const [isOpen, setIsOpen] = useState(false);
 
   useCloseOnWindowBlur(isOpen, () => {
     setIsOpen(false);
   });
-
-  const resolvedDisplay = resolveWorkspaceAppsLauncherDisplay(display, launcherApps.length);
 
   const getLauncherAppProps = (app: LauncherWorkspaceApp) => ({
     title: launcherWorkspaceApps[app],
@@ -68,44 +57,70 @@ export function WorkspaceAppsLauncher({
     },
   });
 
-  if (resolvedDisplay === "expanded") {
-    return launcherApps.map((app) =>
-      presentation === "titlebar" ? (
-        <TitlebarIconButton key={app} disabled={disabled} {...getLauncherAppProps(app)}>
-          <WorkspaceAppIcon app={app} className="size-4" />
-        </TitlebarIconButton>
-      ) : (
-        <Button key={app} variant="ghost" size="icon" {...getLauncherAppProps(app)}>
-          <WorkspaceAppIcon app={app} className="size-4" />
-        </Button>
-      ),
-    );
+  return { isOpen, setIsOpen, getLauncherAppProps };
+}
+
+export function WorkspaceAppsLauncher({
+  launcherApps,
+  display,
+  disabled,
+}: {
+  launcherApps: LauncherWorkspaceApp[];
+  display: WorkspaceAppsLauncherDisplay;
+  disabled?: boolean;
+}) {
+  const { isOpen, setIsOpen, getLauncherAppProps } = useLauncherApps();
+
+  if (resolveWorkspaceAppsLauncherDisplay(display, launcherApps.length) === "expanded") {
+    return launcherApps.map((app) => (
+      <TitlebarIconButton key={app} disabled={disabled} {...getLauncherAppProps(app)}>
+        <WorkspaceAppIcon app={app} className="size-4" />
+      </TitlebarIconButton>
+    ));
   }
 
-  if (presentation === "titlebar") {
-    return (
-      <TitlebarDropdownMenu
-        title="Workspace Apps"
-        icon={<LayoutGridIcon />}
-        side="left"
-        disabled={disabled}
-        isOpen={isOpen}
-        onOpenChange={setIsOpen}
-      >
-        {launcherApps.map((app) => (
-          <TitlebarDropdownMenuItem key={app} {...getLauncherAppProps(app)}>
-            <WorkspaceAppIcon app={app} className="size-4" />
-          </TitlebarDropdownMenuItem>
-        ))}
-      </TitlebarDropdownMenu>
-    );
-  }
+  return (
+    <TitlebarDropdownMenu
+      title="Workspace Apps"
+      icon={<LayoutGridIcon />}
+      side="left"
+      disabled={disabled}
+      isOpen={isOpen}
+      onOpenChange={setIsOpen}
+    >
+      {launcherApps.map((app) => (
+        <TitlebarDropdownMenuItem key={app} {...getLauncherAppProps(app)}>
+          <WorkspaceAppIcon app={app} className="size-4" />
+        </TitlebarDropdownMenuItem>
+      ))}
+    </TitlebarDropdownMenu>
+  );
+}
+
+/**
+ * Always a single button: the strip is a column of app icons already, so
+ * launcher apps laid out inline there would read as tabs rather than as a way
+ * to open one. The display setting stays a titlebar concern.
+ */
+export function VerticalTabsWorkspaceAppsLauncher({
+  launcherApps,
+  isWide,
+}: {
+  launcherApps: LauncherWorkspaceApp[];
+  isWide: boolean;
+}) {
+  const { isOpen, setIsOpen, getLauncherAppProps } = useLauncherApps();
 
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenuTrigger
         render={
-          <Button variant="ghost" size="icon" title="Workspace Apps">
+          <Button
+            variant="ghost"
+            size="icon"
+            className={cn(isWide && "w-full")}
+            title="Workspace Apps"
+          >
             <LayoutGridIcon />
           </Button>
         }

--- a/packages/renderer/components/workspace-apps-launcher.tsx
+++ b/packages/renderer/components/workspace-apps-launcher.tsx
@@ -14,7 +14,7 @@ import {
   DropdownMenuTrigger,
 } from "@meru/ui/components/dropdown-menu";
 import { cn } from "@meru/ui/lib/utils";
-import { LayoutGridIcon } from "lucide-react";
+import { LayoutGridIcon, PlusIcon } from "lucide-react";
 import { type MouseEvent, useState } from "react";
 import {
   TitlebarDropdownMenu,
@@ -117,11 +117,12 @@ export function VerticalTabsWorkspaceAppsLauncher({
         render={
           <Button
             variant="ghost"
-            size="icon"
-            className={cn(isWide && "w-full")}
-            title="Workspace Apps"
+            size={isWide ? "sm" : "icon"}
+            className={cn("opacity-50 hover:opacity-100", isWide && "w-full justify-start")}
+            title="New Tab"
           >
-            <LayoutGridIcon />
+            <PlusIcon />
+            {isWide && "New Tab"}
           </Button>
         }
       />

--- a/packages/renderer/components/workspace-apps-launcher.tsx
+++ b/packages/renderer/components/workspace-apps-launcher.tsx
@@ -1,0 +1,121 @@
+import { ipc } from "@meru/shared/renderer/ipc";
+import {
+  type LauncherWorkspaceApp,
+  launcherWorkspaceApps,
+  resolveWorkspaceAppsLauncherDisplay,
+  type WorkspaceAppsLauncherDisplay,
+} from "@meru/shared/workspace-apps";
+import { Button } from "@meru/ui/components/button";
+import {
+  DropdownMenu,
+  DropdownMenuBackdrop,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@meru/ui/components/dropdown-menu";
+import { LayoutGridIcon } from "lucide-react";
+import { type MouseEvent, useState } from "react";
+import {
+  TitlebarDropdownMenu,
+  TitlebarDropdownMenuItem,
+  TitlebarIconButton,
+} from "@/components/titlebar";
+import { WorkspaceAppIcon } from "@/components/workspace-app-icon";
+import { useCloseOnWindowBlur } from "@/lib/hooks";
+import { getModifierOpenBehavior } from "@/lib/workspace-apps";
+
+export function WorkspaceAppsLauncher({
+  launcherApps,
+  display,
+  presentation,
+  disabled,
+}: {
+  launcherApps: LauncherWorkspaceApp[];
+  display: WorkspaceAppsLauncherDisplay;
+  presentation: "titlebar" | "verticalTabs";
+  disabled?: boolean;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useCloseOnWindowBlur(isOpen, () => {
+    setIsOpen(false);
+  });
+
+  const resolvedDisplay = resolveWorkspaceAppsLauncherDisplay(display, launcherApps.length);
+
+  const getLauncherAppProps = (app: LauncherWorkspaceApp) => ({
+    title: launcherWorkspaceApps[app],
+    onClick: (event: MouseEvent) => {
+      ipc.main.send("workspaceApps.openApp", app, getModifierOpenBehavior(event));
+
+      setIsOpen(false);
+    },
+    onAuxClick: (event: MouseEvent) => {
+      if (event.button === 1) {
+        ipc.main.send("workspaceApps.openApp", app, "backgroundTab");
+
+        setIsOpen(false);
+      }
+    },
+  });
+
+  if (resolvedDisplay === "inline") {
+    return launcherApps.map((app) =>
+      presentation === "titlebar" ? (
+        <TitlebarIconButton key={app} disabled={disabled} {...getLauncherAppProps(app)}>
+          <WorkspaceAppIcon app={app} className="size-4" />
+        </TitlebarIconButton>
+      ) : (
+        <Button key={app} variant="ghost" size="icon" {...getLauncherAppProps(app)}>
+          <WorkspaceAppIcon app={app} className="size-4" />
+        </Button>
+      ),
+    );
+  }
+
+  if (presentation === "titlebar") {
+    return (
+      <TitlebarDropdownMenu
+        title="Workspace Apps"
+        icon={<LayoutGridIcon />}
+        side="left"
+        disabled={disabled}
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+      >
+        {launcherApps.map((app) => (
+          <TitlebarDropdownMenuItem key={app} {...getLauncherAppProps(app)}>
+            <WorkspaceAppIcon app={app} className="size-4" />
+          </TitlebarDropdownMenuItem>
+        ))}
+      </TitlebarDropdownMenu>
+    );
+  }
+
+  return (
+    <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+      <DropdownMenuTrigger
+        render={
+          <Button variant="ghost" size="icon" title="Workspace Apps">
+            <LayoutGridIcon />
+          </Button>
+        }
+      />
+      <DropdownMenuBackdrop />
+      {/* Opens upward at trigger width so it stays inside the strip — anything
+          wider would be painted over by the workspace app view next to it. */}
+      <DropdownMenuContent
+        side="top"
+        align="center"
+        collisionPadding={0}
+        className="flex w-auto min-w-0 flex-col gap-1 p-0.5"
+      >
+        {launcherApps.map((app) => (
+          <DropdownMenuItem key={app} className="justify-center" {...getLauncherAppProps(app)}>
+            <WorkspaceAppIcon app={app} className="size-4" />
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -2,9 +2,10 @@ import type { GmailInboxMessage } from "@meru/shared/gmail";
 import { ms } from "@meru/shared/ms";
 import { ipc } from "@meru/shared/renderer/ipc";
 import type { AccountConfig } from "@meru/shared/schemas";
+import { getVerticalTabsWidth } from "@meru/shared/tabs";
 import { useEffect, useRef, useState } from "react";
 import { useConfig } from "./react-query";
-import { useAccountsStore, useTrialStore } from "./stores";
+import { useAccountsStore, useTabsStore, useTrialStore } from "./stores";
 
 export function useMouseAccountSwitching() {
   useEffect(() => {
@@ -22,6 +23,47 @@ export function useMouseAccountSwitching() {
       document.removeEventListener("mousedown", handleMouseBackAndForward);
     };
   }, []);
+}
+
+export function useCloseOnWindowBlur(isOpen: boolean, onClose: () => void) {
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handleWindowBlur = () => {
+      onClose();
+    };
+
+    window.addEventListener("blur", handleWindowBlur);
+
+    return () => {
+      window.removeEventListener("blur", handleWindowBlur);
+    };
+  }, [isOpen, onClose]);
+}
+
+/**
+ * The tabs the vertical tabs strip renders and the width it takes up. The
+ * titlebar reads it too, to know whether the strip is there to host the
+ * Workspace Apps launcher.
+ */
+export function useVerticalTabs() {
+  const accounts = useAccountsStore((state) => state.accounts);
+
+  const accountsTabs = useTabsStore((state) => state.accountsTabs);
+
+  const { config } = useConfig();
+
+  const selectedAccount = accounts.find((account) => account.config.selected);
+
+  const tabs =
+    accountsTabs.find((accountTabs) => accountTabs.accountId === selectedAccount?.config.id)
+      ?.tabs ?? [];
+
+  const width = getVerticalTabsWidth(tabs, config?.["verticalTabs.width"] ?? "auto");
+
+  return { selectedAccount, tabs, width };
 }
 
 export function useIsLicenseKeyValid() {

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -25,33 +25,6 @@ export function useMouseAccountSwitching() {
   }, []);
 }
 
-/**
- * Keeps content mounted for `duration` after it turns invisible, so it can play
- * a fade-out before leaving the DOM. Keep `duration` in step with the animation
- * duration on the element itself.
- */
-export function useDelayedUnmount(isVisible: boolean, duration: number) {
-  const [isMounted, setIsMounted] = useState(isVisible);
-
-  useEffect(() => {
-    if (isVisible) {
-      setIsMounted(true);
-
-      return;
-    }
-
-    const unmountTimeout = setTimeout(() => {
-      setIsMounted(false);
-    }, duration);
-
-    return () => {
-      clearTimeout(unmountTimeout);
-    };
-  }, [isVisible, duration]);
-
-  return isMounted;
-}
-
 export function useCloseOnWindowBlur(isOpen: boolean, onClose: () => void) {
   useEffect(() => {
     if (!isOpen) {

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -25,6 +25,33 @@ export function useMouseAccountSwitching() {
   }, []);
 }
 
+/**
+ * Keeps content mounted for `duration` after it turns invisible, so it can play
+ * a fade-out before leaving the DOM. Keep `duration` in step with the animation
+ * duration on the element itself.
+ */
+export function useDelayedUnmount(isVisible: boolean, duration: number) {
+  const [isMounted, setIsMounted] = useState(isVisible);
+
+  useEffect(() => {
+    if (isVisible) {
+      setIsMounted(true);
+
+      return;
+    }
+
+    const unmountTimeout = setTimeout(() => {
+      setIsMounted(false);
+    }, duration);
+
+    return () => {
+      clearTimeout(unmountTimeout);
+    };
+  }, [isVisible, duration]);
+
+  return isMounted;
+}
+
 export function useCloseOnWindowBlur(isOpen: boolean, onClose: () => void) {
   useEffect(() => {
     if (!isOpen) {


### PR DESCRIPTION
Depends on #740, now merged: keeping a hidden launcher in the titlebar exposed a latent bug in the Workspace App icons, where Drive rendered blank and Meet rendered as a dot. Rebased onto it, so this diff is the launcher change alone.

Feedback from users running with tabs open: once apps live in the tab strip on the left, they look for the way to open another app *there*, not across the window in the titlebar. Switching between apps and opening one should be the same place.

## Changes

- The launcher moves into the vertical tabs strip whenever the strip is visible, and stays in the titlebar when it is not. One predicate decides it — the strip's own width — so the two hosts cannot both render it or both skip it.
- `useVerticalTabs` in `packages/renderer/lib/hooks.ts` is that shared source: it returns the selected account, its tabs and the strip width, and both `VerticalTabs` and `AppTitlebar` read it instead of each deriving the same thing from the stores.
- The launcher moves out of `app-titlebar.tsx` into its own component file, as two components over a shared `useLauncherApps` hook: `WorkspaceAppsLauncher` for the titlebar, which honours the display setting, and `VerticalTabsWorkspaceAppsLauncher` for the strip, which is **always one button**: a muted `+ New Tab` spanning the strip width, left aligned, in the wide strip, and a `+` icon in the narrow one. The strip is a column of app icons already, so launcher apps laid out inline there would read as tabs rather than as a way to open one; the display setting stays a titlebar concern.
- In the strip it sits directly below the tabs, in flow, rather than pinned to the bottom edge.
- Handing over is a 150ms cross-fade rather than a jump cut, in CSS alone: `transition-discrete` (`transition-behavior: allow-discrete`) holds the `display` flip until the fade has played, and `starting:opacity-0` (`@starting-style`) supplies the transparent state it fades in from. No timer, no mount bookkeeping, and the element leaves the layout the moment it is gone. Both hosts share one class string, `WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME`.
- In the strip the menu opens **upward at trigger width**. Anything wider would extend past the strip and be painted over by the workspace app view beside it. In the wide strip that width is the strip itself, so the menu spans it and lists each app by icon **and name**; in the narrow strip only the icons fit.
- The close-on-window-blur effect that `TitlebarDropdownMenu` had inline is now `useCloseOnWindowBlur`, shared by both menus.

## Risks and omissions

- **The launcher still crosses the window** the first time a tab opens, and back when the last one closes. The cross-fade softens the handover, but it does not shorten the distance, and only use will tell whether 150ms is the right length.
- The strip's launcher only fades **in**. It is unmounted with the strip rather than hidden by it, so no exit transition can run; the strip itself still disappears instantly, which is the strip's own affair.
- The titlebar launcher now stays in the DOM permanently (hidden) while the strip hosts it. Inert, but its menu state lives on across a handover.
- The `hidden` class has to beat `flex` on the same element. It does — Tailwind emits `.hidden` after `.flex`, verified against the installed 4.2.2 by compiling the exact class list — but it is a cascade-order dependency rather than an explicit one.
- The strip button carries no separator from the tabs above it, so with several tabs open the grid icon is one more icon in the column. It is a different glyph from any app icon, which is what distinguishes it.
- `Expanded` therefore has no effect while the strip hosts the launcher. The setting's description already scopes itself to the titlebar, but someone who sets `Expanded` and then opens a tab sees the setting stop applying.
- On the Unified Inbox and Download History routes the strip is not rendered, so with tabs open the launcher is in neither place. Previously it was in the titlebar there but disabled. Not obviously worse, but it is a behaviour change.
- The strip menu's backdrop only covers renderer-owned area, so a click on the workspace app view does not close it; window blur does. Same as the titlebar menu today.
- `useCloseOnWindowBlur` lives in `lib/hooks.ts`, which pulls the store modules into every window that renders a titlebar, including workspace app windows. Their side effects are only IPC listener registrations, so this is inert, but it is a wider import than the hook needs.
- Not verified: the app was not run for this branch. Types, lint and format are green.

## Test plan

1. With a valid license, two launcher apps and only Gmail open → the launcher is in the titlebar on the right, expanded.
2. Open one app as a tab → the titlebar launcher fades out as the strip's fades in directly below the tabs. Neither one blinks out or pops in, and the rest of the titlebar's right cluster closes the gap as the fade finishes rather than after it.
3. Close that tab → the strip goes away and the titlebar launcher fades back in.
4. Open and close a tab several times in quick succession → the launcher settles in the right host every time, with no leftover copy in the titlebar.
5. With a tab open, in the wide strip → a muted, left-aligned `+ New Tab` spanning the strip width, sitting directly under the last tab, and picking up full-strength text on hover and while its menu is open. In the narrow strip → a `+` icon button in the same place. Clicking it opens the app list *upward*, fully inside the strip, not clipped or painted over by the page next to it — spanning the button's width with names beside the icons when wide, icons only when narrow.
6. Open several tabs until the strip fills → the launcher button stays directly below the last tab rather than at the bottom edge, and the menu still opens fully inside the strip in both widths.
7. With Display set to `Expanded` and four apps, open a tab → the titlebar shows four buttons, the strip still shows one. Close the tab → the titlebar's four come back.
8. From the strip launcher: click → foreground tab; Cmd/Ctrl+click → background tab; Shift+click → new window; middle-click → background tab. The menu closes after each.
9. Open the strip launcher menu, then click into the Gmail page, then switch to another app entirely → the menu is closed when you come back.
10. In `New Windows` mode (once #732 lands) the strip is hidden, so the launcher stays in the titlebar with apps open.
11. With no license key or an empty launcher → no launcher in either host, and the strip otherwise unchanged.
