### PR TITLE
keep windowed apps out of the tab strip

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,7 @@ The planning notes for this feature lived in machine-local files; this section i
 
 ### 3. Strip polish memos (2026-08-05)
 
-- List **all** of an account's workspace-app windows in the strip with the window indicator, not just detached tabs (decided 2026-08-05 when scoping the persistent-tab rework of the detach PR; needs a design pass for edge cases like PDF-viewer popups and `alwaysOpenAsWindow` apps). Concrete missing case: apps opened directly as a window (Shift+click in the "+" menu) never appear in the strip but should.
+- ~~List **all** of an account's workspace-app windows in the strip with the window indicator, not just detached tabs.~~ **Reversed 2026-08-09:** the strip now shows only tabs that live in the main window, and windowed apps are represented by their window alone — the window indicator and its badge are gone. Any future work here starts from "windows are not in the strip", not from listing more of them.
 
 ### Wording conventions
 

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -9,7 +9,7 @@ import { GMAIL_TAB_ID, getTabSection, type TabState } from "@meru/shared/tabs";
 import { workspaceApps } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import { cn } from "@meru/ui/lib/utils";
-import { AppWindowIcon, BookmarkIcon, CircleAlertIcon, GlobeIcon, XIcon } from "lucide-react";
+import { BookmarkIcon, CircleAlertIcon, GlobeIcon, XIcon } from "lucide-react";
 import type { Ref } from "react";
 import { UnreadCountBadge } from "@/components/unread-count-badge";
 import { WorkspaceAppIcon } from "@/components/workspace-app-icon";
@@ -63,19 +63,6 @@ function TabIcon({ tab }: { tab: TabState }) {
   }
 
   return <GlobeIcon />;
-}
-
-function WindowedTabBadge({ className }: { className?: string }) {
-  return (
-    <div
-      className={cn(
-        "absolute flex size-4 items-center justify-center rounded-full bg-secondary text-secondary-foreground",
-        className,
-      )}
-    >
-      <AppWindowIcon className="size-2.5" />
-    </div>
-  );
 }
 
 type GmailTabStatus = {
@@ -166,14 +153,10 @@ function VerticalTab({
             {tab.title}
           </span>
         )}
-        {isWideRow && tab.windowed && (
-          <AppWindowIcon className="size-3 shrink-0 text-muted-foreground" />
-        )}
         {isWideRow && tab.persistence === "bookmarked" && (
           <BookmarkIcon className="size-3 shrink-0 text-muted-foreground" />
         )}
       </Button>
-      {!isWideRow && tab.windowed && <WindowedTabBadge className="-right-1 -bottom-1" />}
       {gmailStatus && <GmailTabStatusBadge {...gmailStatus} />}
       {isCloseable && (
         <Button

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -47,19 +47,16 @@ export function getTabSection(tab: Pick<TabState, "id" | "persistence" | "dorman
 }
 
 /**
- * In `windows` mode the strip only shows tabs that live in the main window:
- * windowed apps have a window of their own, and dormant entries would open as
- * one. Everything filtered out here stays saved and comes back in `tabs` mode.
+ * The strip shows the tabs that live in the main window. An app in its own
+ * window is represented by that window, not by a row here, and in `windows`
+ * mode dormant entries are left out too because opening one produces a window
+ * rather than a tab. Everything filtered out stays saved either way.
  */
 export function getVisibleVerticalTabs<VerticalTab extends Pick<TabState, "dormant" | "windowed">>(
   tabs: VerticalTab[],
   workspaceAppsMode: WorkspaceAppsMode,
 ) {
-  if (workspaceAppsMode === "tabs") {
-    return tabs;
-  }
-
-  return tabs.filter((tab) => !tab.dormant && !tab.windowed);
+  return tabs.filter((tab) => !tab.windowed && (workspaceAppsMode === "tabs" || !tab.dormant));
 }
 
 export function getVerticalTabsWidth(


### PR DESCRIPTION
An app open in its own window was still occupying a row in the tab strip, with a window badge on it, in `Tabs` mode. `New Windows` mode already filtered those out — this makes the rule the same in both modes.

The strip now shows exactly the tabs whose content lives in the main window. A window represents itself.

## Changes

- `getVisibleVerticalTabs` filters windowed tabs in both modes. Only the dormant part stays mode-dependent: dormant entries show in `Tabs` mode, where opening one produces a tab, and are left out in `New Windows` mode, where it would produce a window.
- The window badge on narrow tabs and the window icon on wide rows are gone with the rows they annotated, along with the `WindowedTabBadge` component.
- The 2026-08-05 memo in `TODO.md` that wanted *more* windows listed in the strip is struck through and marked reversed, so a future session doesn't implement the opposite from a stale note.

## Risks and omissions

- **Clicking a strip row was a way to focus a detached window.** That affordance is gone; those windows are now reachable through the OS window switcher, the dock, or a notification. Nothing else changes — `activateTab` still focuses the window when a notification opens one.
- Detaching a tab with `Move to New Window` now makes its row disappear rather than dim into a badge. Getting it back is `Move to Tab` in that window's own menu, which is where it already lived.
- A pinned or bookmarked entry that is open as a window shows nothing in the strip while it runs, then reappears as a dormant row once closed. Correct under the new rule, but it does mean a pinned row can vanish and return without the user touching it.
- An account whose only workspace apps are windows now collapses the strip entirely, since the width is derived from the same filtered list.
- Not verified: the app was not run here. Types, lint, format and `bun test` (120 pass) are green.

## Test plan

1. In `Tabs` mode with two tabs open, `Move to New Window` on one → its row leaves the strip immediately and the remaining tabs close the gap. No badge anywhere.
2. In that window, `Move to Tab` → it returns to the strip as an ordinary row and is selected.
3. Shift+click a launcher app in `Tabs` mode → a window opens and the strip is untouched.
4. With Gmail plus one detached window and nothing else → the strip disappears, and the Gmail view fills the window with no leftover gap.
5. Pin a tab, detach it to a window, quit and relaunch → it restores as a window (its saved intent) and the strip shows only Gmail; close the window → the pinned row reappears, dimmed.
6. Click a notification from a workspace app that is open as a window → its window comes forward, as before.
7. In `New Windows` mode → unchanged from what #732 shipped.
8. Wide and narrow strip widths both → no stray spacing where the badge used to sit.
