### PR TITLE
add a setting for listing windowed apps in the tab strip

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,7 @@ The planning notes for this feature lived in machine-local files; this section i
 
 ### 3. Strip polish memos (2026-08-05)
 
-- List **all** of an account's workspace-app windows in the strip with the window indicator, not just detached tabs (decided 2026-08-05 when scoping the persistent-tab rework of the detach PR; needs a design pass for edge cases like PDF-viewer popups and `alwaysOpenAsWindow` apps). Concrete missing case: apps opened directly as a window (Shift+click in the "+" menu) never appear in the strip but should.
+- List **all** of an account's workspace-app windows in the strip with the window indicator, not just detached tabs (decided 2026-08-05 when scoping the persistent-tab rework of the detach PR). **Mostly done as of 2026-08-09:** apps opened straight into a window are pushed onto the tabs list, so they show like any other windowed entry, and `Settings… → Appearance → Vertical Tabs → Show Windows` turns the whole listing off for anyone who wants the strip to mean tabs only. Still outside the list: popups such as the PDF viewer, which are never tabs. Whether they belong there needs the design pass the original note asked for.
 
 ### Wording conventions
 

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -48,6 +48,10 @@ class Accounts {
       accounts.updateAllViewBounds();
     });
 
+    config.onDidChange("verticalTabs.showWindows", () => {
+      accounts.updateAllViewBounds();
+    });
+
     config.onDidChange("workspaceApps.mode", () => {
       accounts.updateAllViewBounds();
     });
@@ -108,10 +112,10 @@ class Accounts {
 
   getVerticalTabsWidth() {
     return getVerticalTabsWidth(
-      getVisibleVerticalTabs(
-        this.getSelectedAccount().instance.tabs.serialize(),
-        config.get("workspaceApps.mode"),
-      ),
+      getVisibleVerticalTabs(this.getSelectedAccount().instance.tabs.serialize(), {
+        workspaceAppsMode: config.get("workspaceApps.mode"),
+        showWindows: config.get("verticalTabs.showWindows"),
+      }),
       config.get("verticalTabs.width"),
     );
   }

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -111,6 +111,7 @@ export const config = new Store<Config>({
     "unifiedInbox.showSenderIcons": true,
     "unifiedInbox.rowsPerPage": 10,
     "spellchecker.languages": [],
+    "verticalTabs.showWindows": true,
     "verticalTabs.width": "auto",
   },
   migrations: {

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -60,7 +60,10 @@ export function useVerticalTabs() {
   const tabs = getVisibleVerticalTabs(
     accountsTabs.find((accountTabs) => accountTabs.accountId === selectedAccount?.config.id)
       ?.tabs ?? [],
-    config?.["workspaceApps.mode"] ?? "tabs",
+    {
+      workspaceAppsMode: config?.["workspaceApps.mode"] ?? "tabs",
+      showWindows: config?.["verticalTabs.showWindows"] ?? true,
+    },
   );
 
   const width = getVerticalTabsWidth(tabs, config?.["verticalTabs.width"] ?? "auto");

--- a/packages/renderer/routes/settings/appearance.tsx
+++ b/packages/renderer/routes/settings/appearance.tsx
@@ -172,6 +172,12 @@ export function AppearanceSettings() {
           <FieldSeparator />
           <FieldSet>
             <FieldLegend>Vertical Tabs</FieldLegend>
+            <ConfigSwitchField
+              label="Show Windows"
+              description="List Workspace Apps that are open in their own window alongside the tabs, so the sidebar is an overview of everything open. Click one to bring its window forward. Has no effect in the New Windows mode, where the sidebar is hidden."
+              configKey="verticalTabs.showWindows"
+              licenseKeyRequired
+            />
             <ConfigSelectField
               label="Width"
               description="How wide the vertical tabs sidebar is. Auto switches between narrow and wide automatically based on the open tabs."

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -47,19 +47,23 @@ export function getTabSection(tab: Pick<TabState, "id" | "persistence" | "dorman
 }
 
 /**
- * In `windows` mode the strip only shows tabs that live in the main window:
+ * `windows` mode leaves the strip with only what lives in the main window:
  * windowed apps have a window of their own, and dormant entries would open as
- * one. Everything filtered out here stays saved and comes back in `tabs` mode.
+ * one. In `tabs` mode windowed apps are listed alongside the tabs unless the
+ * user turns that off. Everything filtered out here stays saved either way.
  */
 export function getVisibleVerticalTabs<VerticalTab extends Pick<TabState, "dormant" | "windowed">>(
   tabs: VerticalTab[],
-  workspaceAppsMode: WorkspaceAppsMode,
+  {
+    workspaceAppsMode,
+    showWindows,
+  }: { workspaceAppsMode: WorkspaceAppsMode; showWindows: boolean },
 ) {
-  if (workspaceAppsMode === "tabs") {
-    return tabs;
+  if (workspaceAppsMode === "windows") {
+    return tabs.filter((tab) => !tab.dormant && !tab.windowed);
   }
 
-  return tabs.filter((tab) => !tab.dormant && !tab.windowed);
+  return showWindows ? tabs : tabs.filter((tab) => !tab.windowed);
 }
 
 export function getVerticalTabsWidth(

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -148,6 +148,7 @@ export type Config = {
   "unifiedInbox.showSenderIcons": boolean;
   "unifiedInbox.rowsPerPage": number;
   "spellchecker.languages": string[];
+  "verticalTabs.showWindows": boolean;
   "verticalTabs.width": VerticalTabsWidth;
 };
 


### PR DESCRIPTION
Supersedes #741, which hid windowed apps from the strip outright. Listing them is genuinely useful — Meru is one of the few apps where the same thing can be a tab or a window, so the sidebar doubles as an overview of everything open for the account, and clicking a row brings its window forward. But wanting the strip to mean *tabs* is just as reasonable, so this makes it a choice instead of a verdict.

## Changes

- New `verticalTabs.showWindows`, **on by default**, so nothing changes for anyone who does not go looking. `Settings… → Appearance → Vertical Tabs → Show Windows`.
- `getVisibleVerticalTabs` takes its two inputs as a named object now that there are two — `{ workspaceAppsMode, showWindows }` — and both the renderer strip and the main-process view bounds pass the same pair, so the painted strip and the reserved width cannot disagree.
- A `verticalTabs.showWindows` listener re-runs view bounds, next to the existing `verticalTabs.width` one.
- The 2026-08-05 `TODO.md` memo asking for all windows to be listed is marked mostly done: apps opened straight into a window already appear, and this setting governs the listing. Popups such as the PDF viewer are still never tabs and so still absent — left to the design pass that note asked for.

## Deliberate: New Windows mode ignores the setting

In `New Windows` mode the strip stays hidden whether or not `Show Windows` is on. Otherwise the mode's defining behaviour would become conditional on an unrelated switch, and #734's switch confirmation — which promises the strip hides — would be lying to anyone with the setting on.

The reading that makes this consistent rather than arbitrary: the setting lists windows *alongside tabs*, and that mode has no tabs to list them alongside. If you would rather have an overview strip in that mode too, it is one condition in `getVisibleVerticalTabs`, but it changes what New Windows mode means.

## Risks and omissions

- Turning it off leaves a detached window reachable only through the OS window switcher, the dock, or a notification. `Move to Tab` in the window's own menu still brings it back.
- With it off, an account whose only workspace apps are windows collapses the strip entirely, since the width comes from the same filtered list.
- A pinned entry that is open as a window disappears from the strip while it runs and returns as a dormant row once closed. Only visible with the setting off, and correct under that rule, but a row does move without the user touching it.
- The setting is `licenseKeyRequired` like the rest of that group; without a license the strip is not reachable anyway.
- Not verified: the app was not run here. Types, lint, format and `bun test` (120 pass) are green.

## Test plan

1. Fresh config → `Show Windows` is on, and a detached window still appears in the strip with its window badge exactly as before this branch.
2. Turn it off with a detached window open → the row disappears immediately and the remaining tabs close the gap, with no restart.
3. Turn it back on → the row returns, and the Gmail view resizes to match in both directions without a stale gap on the left.
4. With it off and Gmail plus one window as the only entries → the strip disappears entirely; turn it on → the strip comes back at the right width.
5. With it on, click a windowed row → its window comes forward rather than anything happening in the main window.
6. Shift+click a launcher app with it on → the new window appears in the strip; with it off, the strip is untouched.
7. Switch to `New Windows` mode with `Show Windows` on → the strip is still hidden, and the apps you open are windows only.
8. Open a PDF from Gmail → its popup window appears in neither state, as before.
9. Both strip widths, setting on → badges and window icons render as they did before this branch.
