### PR TITLE
move the vertical tabs settings to workspace apps

### DIFF
--- a/packages/renderer/routes/settings/appearance.tsx
+++ b/packages/renderer/routes/settings/appearance.tsx
@@ -1,5 +1,4 @@
 import { ipc } from "@meru/shared/renderer/ipc";
-import { verticalTabsWidths } from "@meru/shared/tabs";
 import {
   Field,
   FieldContent,
@@ -167,27 +166,6 @@ export function AppearanceSettings() {
               description="Hide all unread badges if disabled regardless of individual account settings."
               configKey="accounts.unreadBadge"
               restartRequired
-            />
-          </FieldSet>
-          <FieldSeparator />
-          <FieldSet>
-            <FieldLegend>Vertical Tabs</FieldLegend>
-            <ConfigSwitchField
-              label="Show Windows"
-              description="List Workspace Apps that are open in their own window alongside the tabs, so the sidebar is an overview of everything open. Click one to bring its window forward. Has no effect in the New Windows mode, where the sidebar is hidden."
-              configKey="verticalTabs.showWindows"
-              licenseKeyRequired
-            />
-            <ConfigSelectField
-              label="Width"
-              description="How wide the vertical tabs sidebar is. Auto switches between narrow and wide automatically based on the open tabs."
-              configKey="verticalTabs.width"
-              placeholder="Select width"
-              licenseKeyRequired
-              items={Object.entries(verticalTabsWidths).map(([value, label]) => ({
-                value,
-                label,
-              }))}
             />
           </FieldSet>
           <FieldSeparator />

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -1,7 +1,7 @@
 import { move } from "@dnd-kit/helpers";
 import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
-import { GMAIL_TAB_ID } from "@meru/shared/tabs";
+import { GMAIL_TAB_ID, verticalTabsWidths } from "@meru/shared/tabs";
 import {
   type LauncherWorkspaceApp,
   launcherWorkspaceApps,
@@ -24,7 +24,9 @@ import {
   FieldDescription,
   FieldGroup,
   FieldLabel,
+  FieldLegend,
   FieldSeparator,
+  FieldSet,
 } from "@meru/ui/components/field";
 import { Kbd } from "@meru/ui/components/kbd";
 import { ChevronDownIcon, GripVerticalIcon, PlusIcon, XIcon } from "lucide-react";
@@ -218,6 +220,31 @@ export function WorkspaceAppsSettings() {
                   </DropdownMenuContent>
                 </DropdownMenu>
               </Field>
+            </>
+          )}
+          {config["workspaceApps.mode"] === "tabs" && (
+            <>
+              <FieldSeparator />
+              <FieldSet>
+                <FieldLegend>Vertical Tabs</FieldLegend>
+                <ConfigSwitchField
+                  label="Show Windows"
+                  description="List Workspace Apps that are open in their own window alongside the tabs, so the sidebar is an overview of everything open. Click one to bring its window forward."
+                  configKey="verticalTabs.showWindows"
+                  licenseKeyRequired
+                />
+                <ConfigSelectField
+                  label="Width"
+                  description="How wide the vertical tabs sidebar is. Auto switches between narrow and wide automatically based on the open tabs."
+                  configKey="verticalTabs.width"
+                  placeholder="Select width"
+                  licenseKeyRequired
+                  items={Object.entries(verticalTabsWidths).map(([value, label]) => ({
+                    value,
+                    label,
+                  }))}
+                />
+              </FieldSet>
             </>
           )}
           <FieldSeparator />


### PR DESCRIPTION
The vertical tabs sidebar only exists because Workspace Apps open as tabs, so its settings belong next to the Mode switch that decides that — not in Appearance, a page away from the thing they describe. And in `New Windows` mode there is no sidebar at all, so both settings were configuring something the user could not see.

## Changes

- `Show Windows` and `Width` move from `Settings… → Appearance → Vertical Tabs` to `Settings… → Workspace Apps`, in a `Vertical Tabs` field set directly below Mode and Excluded Apps. Same keys, same values — nothing to migrate.
- The group only renders while Mode is `Tabs`. Switching to `New Windows` takes it away, and switching back brings it straight back with the values intact.
- `Show Windows` loses its trailing "Has no effect in the New Windows mode, where the sidebar is hidden" — the field is now absent in that mode, so the sentence has nothing left to warn about.

## Risks and omissions

- **The gate is Mode alone, not `Open in App`.** Even with `Open in App` off — and with #744, which stops the launcher ignoring it — the sidebar can still appear, from tabs opened before the setting was turned off and from pinned entries restored at startup. Gating on `Open in App` too would hide settings that still apply to what is on screen.
- Anyone who knows these settings from Appearance has to find them again. They are one page away, under the feature they belong to, and Appearance keeps no stub pointing at them.
- The field set is the first on the Workspace Apps page, which is otherwise a flat list of fields; it carries a legend so `Width` is unambiguous there. Slight inconsistency in service of clarity.
- Not verified: the app was not run here. Types, lint, format and `bun test` (120 pass) are green.

## Test plan

1. `Settings… → Appearance` → the Vertical Tabs section is gone, and the sections around it (Accounts, dock/menu bar icons, Window) are unchanged with no double separator where it used to be.
2. `Settings… → Workspace Apps` with Mode on `Tabs` → a Vertical Tabs group sits below Excluded Apps with `Show Windows` and `Width`.
3. Change `Width` there → the sidebar resizes immediately, as it did from Appearance.
4. Toggle `Show Windows` with a detached window open → its row appears and disappears, and the view resizes to match.
5. Switch Mode to `New Windows` → the group disappears. Switch back to `Tabs` → it returns with both values as they were.
6. Turn `Open in App` off with Mode on `Tabs` → the group stays visible, and a launcher app still opens as a tab and still obeys `Width`.
7. Without a license key → both fields show the Pro badge and are disabled, as before the move.
