### PR TITLE
open launcher apps in the browser when open in app is off

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -722,6 +722,21 @@ class Ipc {
         return;
       }
 
+      // `Open in App` and its exclusions govern every way an app opens, links
+      // and launcher alike — otherwise the launcher would be the one path that
+      // ignores the setting.
+      if (
+        !config.get("workspaceApps.openInApp") ||
+        config.get("workspaceApps.openInAppExcludedApps").includes(app)
+      ) {
+        openExternalUrl(getWorkspaceAppUrl(app), {
+          skipTrustedHostCheck: true,
+          focusBrowser: modifierOpenBehavior !== "backgroundTab",
+        });
+
+        return;
+      }
+
       const openBehavior = resolveWorkspaceAppOpenBehavior(modifierOpenBehavior);
 
       const selectedAccount = accounts.getSelectedAccount();


### PR DESCRIPTION
`Settings… → Workspace Apps → Open in App` reads as the switch for how Workspace Apps open, but only the link path honoured it. `workspaceApps.openApp` — the launcher, and the modifier gestures on a strip tab that open a second instance — went straight to `openTab` / `openWindowedTab` and ignored both the switch and the Excluded Apps list. Turning `Open in App` off left the launcher opening tabs anyway.

## Changes

- The `workspaceApps.openApp` handler now checks `workspaceApps.openInApp` and `workspaceApps.openInAppExcludedApps` before opening anything, and falls through to `openExternalUrl` when either says no.
- `skipTrustedHostCheck` is set, matching how the link path treats a recognised Workspace App, so the external-link confirmation does not fire for Google's own domains.
- Cmd/Ctrl+click still means "don't take me there": it maps to `focusBrowser: false`, the same way a `background-tab` disposition does on the link path.

## Risks and omissions

- **Behaviour change for anyone with `Open in App` off and launcher apps configured.** Clicking a launcher app now opens the browser instead of a tab. That is the setting doing what it says, but it will be a surprise to someone who had grown used to the launcher as the exception.
- A launcher app on the Excluded Apps list now opens externally too. Also correct per that field's description ("open in the external browser instead of the app"), also a change.
- The launcher is deliberately still shown with `Open in App` off. It remains a working set of shortcuts to your Google apps, they just land in the browser.
- Not fixed here, and still inconsistent: `loadLaunchTabs` restores saved tabs on startup without consulting `Open in App`, so a pinned `Load on Launch` app still opens in the app. Arguably right — it is a saved in-app tab rather than a new open — but it is the same question and this branch does not settle it.
- Also untouched: `New … Tab` and `Duplicate` in the tab context menu still open in the app. They act on a tab that is already there, so the setting reads as being about *new* opens, not about duplicating something in front of you.
- Not verified: the app was not run here. Types, lint, format and `bun test` (120 pass) are green.

## Test plan

1. `Open in App` on, click a launcher app → opens as a tab, exactly as before.
2. Turn `Open in App` off, click a launcher app → the app opens in the default browser and no tab appears.
3. With it off, Cmd/Ctrl+click a launcher app → the browser opens the app without taking focus from Meru.
4. With it off, Shift+click a launcher app → still the browser; no Meru window appears.
5. With it on, add an app to Excluded Apps and click it in the launcher → the browser. Remove it from the list → a tab again.
6. With it off and `externalLinks.confirm` on, click a launcher app → it opens without the "open this external link?" dialog, since it is a Google domain.
7. With it off, middle-click a strip tab's icon for an app that allows a second instance → the browser, not a background tab.
8. Without a license key → the launcher is not rendered at all, as before.
