### PR TITLE
make open in app govern every way a workspace app opens

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -29,7 +29,12 @@ import { licenseKey } from "@/license-key";
 import { main } from "@/main";
 import { appMenu } from "@/menu";
 import { DormantTab } from "@/tabs";
-import { resolveWorkspaceAppOpenBehavior, WorkspaceApp } from "@/workspace-app";
+import {
+  canOpenWorkspaceAppInApp,
+  getWorkspaceAppFromUrl,
+  resolveWorkspaceAppOpenBehavior,
+  WorkspaceApp,
+} from "@/workspace-app";
 import { DoNotDisturb, doNotDisturb } from "./do-not-disturb";
 import { downloads } from "./downloads";
 import { GMAIL_USER_STYLES_PATH } from "./gmail";
@@ -343,6 +348,12 @@ class Ipc {
       const isWindowsMode = config.get("workspaceApps.mode") === "windows";
 
       const openWorkspaceAppUrl = (url: string) => {
+        if (!canOpenWorkspaceAppInApp(getWorkspaceAppFromUrl(url))) {
+          openExternalUrl(url, { skipTrustedHostCheck: true });
+
+          return;
+        }
+
         if (isWindowsMode) {
           account.instance.tabs.openWindowedTab(url);
 
@@ -722,13 +733,7 @@ class Ipc {
         return;
       }
 
-      // `Open in App` and its exclusions govern every way an app opens, links
-      // and launcher alike — otherwise the launcher would be the one path that
-      // ignores the setting.
-      if (
-        !config.get("workspaceApps.openInApp") ||
-        config.get("workspaceApps.openInAppExcludedApps").includes(app)
-      ) {
+      if (!canOpenWorkspaceAppInApp(app)) {
         openExternalUrl(getWorkspaceAppUrl(app), {
           skipTrustedHostCheck: true,
           focusBrowser: modifierOpenBehavior !== "backgroundTab",

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -8,6 +8,7 @@ import { config } from "./config";
 import type { Gmail } from "./gmail";
 import { main } from "./main";
 import { appMenu } from "./menu";
+import { openExternalUrl } from "./url";
 import { resolveWorkspaceAppOpenBehavior, WorkspaceApp } from "./workspace-app";
 
 const MAX_RECENTLY_CLOSED_TAB_URLS = 20;
@@ -26,6 +27,13 @@ export function registerTabBroadcasts(view: WebContentsView) {
 
 export function isWindowedTab(tab: Tab) {
   return tab instanceof WorkspaceApp && tab.isWindowed;
+}
+
+function canOpenWorkspaceAppInApp(app: SupportedWorkspaceApp) {
+  return (
+    config.get("workspaceApps.openInApp") &&
+    !config.get("workspaceApps.openInAppExcludedApps").includes(app)
+  );
 }
 
 type SavedWorkspaceApp = WorkspaceApp & {
@@ -214,6 +222,12 @@ export class Tabs {
     }
 
     if (activatedTab instanceof DormantTab) {
+      if (!canOpenWorkspaceAppInApp(activatedTab.app)) {
+        openExternalUrl(activatedTab.url, { skipTrustedHostCheck: true });
+
+        return;
+      }
+
       const materializedTab = this.materializeDormantTab(activatedTab);
 
       if (!materializedTab.isWindowed) {
@@ -255,7 +269,7 @@ export class Tabs {
 
   loadLaunchTabs() {
     for (const tab of this.tabs.slice()) {
-      if (tab instanceof DormantTab && tab.loadOnLaunch) {
+      if (tab instanceof DormantTab && tab.loadOnLaunch && canOpenWorkspaceAppInApp(tab.app)) {
         this.materializeDormantTab(tab);
       }
     }

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -9,7 +9,12 @@ import type { Gmail } from "./gmail";
 import { main } from "./main";
 import { appMenu } from "./menu";
 import { openExternalUrl } from "./url";
-import { resolveWorkspaceAppOpenBehavior, WorkspaceApp } from "./workspace-app";
+import {
+  canOpenWorkspaceAppInApp,
+  getWorkspaceAppFromUrl,
+  resolveWorkspaceAppOpenBehavior,
+  WorkspaceApp,
+} from "./workspace-app";
 
 const MAX_RECENTLY_CLOSED_TAB_URLS = 20;
 
@@ -27,13 +32,6 @@ export function registerTabBroadcasts(view: WebContentsView) {
 
 export function isWindowedTab(tab: Tab) {
   return tab instanceof WorkspaceApp && tab.isWindowed;
-}
-
-function canOpenWorkspaceAppInApp(app: SupportedWorkspaceApp) {
-  return (
-    config.get("workspaceApps.openInApp") &&
-    !config.get("workspaceApps.openInAppExcludedApps").includes(app)
-  );
 }
 
 type SavedWorkspaceApp = WorkspaceApp & {
@@ -393,6 +391,12 @@ export class Tabs {
     const reopenedTabUrl = this.recentlyClosedTabUrls.pop();
 
     if (!reopenedTabUrl) {
+      return;
+    }
+
+    if (!canOpenWorkspaceAppInApp(getWorkspaceAppFromUrl(reopenedTabUrl))) {
+      openExternalUrl(reopenedTabUrl, { skipTrustedHostCheck: true });
+
       return;
     }
 

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -58,7 +58,7 @@ const SUPPORTED_WORKSPACE_APPS_URL_REGEXP = new RegExp(
   `(${Array.from(workspaceAppsBySubdomain.keys()).join("|")})(?:\\.usercontent)?\\.google\\.com`,
 );
 
-function getWorkspaceAppFromUrl(url: string) {
+export function getWorkspaceAppFromUrl(url: string) {
   const workspaceAppSubdomain = url.match(SUPPORTED_WORKSPACE_APPS_URL_REGEXP)?.[1];
 
   if (!workspaceAppSubdomain) {
@@ -66,6 +66,20 @@ function getWorkspaceAppFromUrl(url: string) {
   }
 
   return workspaceAppsBySubdomain.get(workspaceAppSubdomain);
+}
+
+/**
+ * Whether an app may open inside Meru at all. `Open in App` and its exclusions
+ * govern every way one opens — links, launcher, restoring a saved tab — so this
+ * is the single place that answers it. An unrecognised URL only has the switch
+ * to go on.
+ */
+export function canOpenWorkspaceAppInApp(app: SupportedWorkspaceApp | undefined) {
+  if (!config.get("workspaceApps.openInApp")) {
+    return false;
+  }
+
+  return !app || !config.get("workspaceApps.openInAppExcludedApps").includes(app);
 }
 
 export function resolveWorkspaceAppOpenBehavior(
@@ -245,8 +259,7 @@ export class WorkspaceApp {
       licenseKey.isValid &&
       matchedSupportedWorkspaceApp &&
       !workspaceApps[matchedSupportedWorkspaceApp].singleInstance &&
-      config.get("workspaceApps.openInApp") &&
-      !config.get("workspaceApps.openInAppExcludedApps").includes(matchedSupportedWorkspaceApp);
+      canOpenWorkspaceAppInApp(matchedSupportedWorkspaceApp);
 
     if (isWorkspaceAppEnabledToOpenInApp) {
       if (workspaceApps[matchedSupportedWorkspaceApp].popupOnly) {

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -139,6 +139,7 @@ export function WorkspaceAppsSettings() {
             description="Open Workspace Apps in app instead of external browser."
             configKey="workspaceApps.openInApp"
             licenseKeyRequired
+            restartRequired
           />
           {config["workspaceApps.openInApp"] && (
             <>


### PR DESCRIPTION
Follows #744, which made the launcher honour `Open in App`. Restoring a saved tab was the other path that ignored it: `loadLaunchTabs` materialised every `Load on Launch` entry at startup no matter what the setting said, so turning `Open in App` off still left Meru opening Workspace Apps in app on every start.

## Changes

Three commits, meant to be read in order.

**Saved tabs follow the setting**

- One `canOpenWorkspaceAppInApp(app)` helper answers "may this app open inside Meru?" from `workspaceApps.openInApp` plus the Excluded Apps list, so the rule has a single definition rather than being spelled out per call site.
- `loadLaunchTabs` skips entries it says no to. They stay dormant instead of opening — a startup that spawned browser tabs would be worse than one that opens nothing.
- Clicking a dormant entry — the strip row, or `Open` in its context menu — opens its saved URL in the browser instead of materialising it.

**Every in-app open goes through that one check**

- The helper moves to `workspace-app.ts`, beside `resolveWorkspaceAppOpenBehavior`, and takes `SupportedWorkspaceApp | undefined` so a URL that resolves to no known app falls back to the switch alone. `getWorkspaceAppFromUrl` is exported for that.
- `reopenClosedTab` uses it, so <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd> and the strip's `Reopen Closed Tab` open the browser rather than restoring a tab.
- `New … Tab` and `Duplicate` in a tab's context menu use it too — reachable whenever saved entries keep the strip on screen, which is why the restart alone does not cover them.
- The window-open handler's inline copy of the same condition and the launcher's from #744 both collapse into the helper.

**The setting asks for a restart**

- `Open in App` is now `restartRequired`. Turning it off mid-session genuinely leaves a mixed state — tabs that are already open stay open, and their menus keep working — so the toast says so rather than the UI pretending the change is complete.

## What is left in app on purpose

PDF viewer popups from Gmail attachments and Gmail's own compose and pop-out windows still open in app. They are mail content rather than Workspace Apps, and those URLs are session-bound — sending them to the browser would likely land on a login page instead of the attachment.

## Risks and omissions

- **A `Load on Launch` app stops appearing at startup** once `Open in App` is off. That is the point, but for someone who had both set it is a visible change with no notice at the moment it happens — the setting is in Settings, the effect shows up on the next launch.
- Excluded apps are treated the same way, so an excluded app with a saved entry no longer restores in app either. Consistent with #744 and with that field's description, and also unannounced.
- Entries stay dormant and visible in the strip rather than disappearing, so nothing is lost — but a dormant row that always opens the browser looks the same as one that opens a tab. There is no marker distinguishing them.
- The restart prompt is advisory. Nothing stops someone carrying on in the mixed state, where the launcher and links already obey the new value while open tabs do not.
- Not verified: the app was not run here. Types, lint, format and `bun test` (120 pass) are green.

## Test plan

1. `Open in App` on, pin an app with `Load on Launch`, restart → it opens in app, as before.
2. Turn `Open in App` off, restart → it does not open, no browser window appears at startup, and its dormant row is still in the strip.
3. Click that dormant row → the app opens in the default browser at its saved URL, and no tab is created.
4. Right-click it and choose `Open` → the same.
5. Turn `Open in App` back on, click the row → it materialises as a tab again, and restarts restore it in app.
6. With `Open in App` on, add an app with a saved entry to Excluded Apps, restart → it does not open in app; clicking its row opens the browser.
7. With a bookmarked entry (not pinned) and `Open in App` off → clicking it opens the browser; the bookmark stays in the strip.
8. Gmail is unaffected in every case above — it is not a saved entry and always loads.
9. Toggle `Open in App` → the restart toast appears, with `Restart Now` working.
10. With it off, close a tab that was open from before and press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>T</kbd> → the browser opens it; the strip's `Reopen Closed Tab` does the same.
11. With it off and a pinned entry in the strip, right-click it → `New … Tab` and `Duplicate` open the browser, and no tab is created.
12. With it on, all three of those behave exactly as before.
13. Open a PDF attachment from Gmail with the setting off → it still opens in its own window in app.
