### PR TITLE
extract the titlebar popup out of downloads

### DIFF
--- a/packages/app/downloads.ts
+++ b/packages/app/downloads.ts
@@ -1,15 +1,15 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { platform } from "@electron-toolkit/utils";
-import { APP_TITLEBAR_HEIGHT, BASE_SPACING } from "@meru/shared/constants";
+import { BASE_SPACING } from "@meru/shared/constants";
 import { ms } from "@meru/shared/ms";
 import type { DownloadItem } from "@meru/shared/types";
-import { BrowserWindow, shell, WebContentsView } from "electron";
+import { shell } from "electron";
 import electronDl from "electron-dl";
 import { config } from "@/config";
 import { createNotification } from "@/notifications";
 import { fileExists } from "./lib/fs";
-import { getPreloadPath, loadRenderer } from "./lib/window";
+import { TitlebarPopup } from "./lib/titlebar-popup";
 
 const FILE_MANAGER_NAME = platform.isMacOS
   ? "Finder"
@@ -18,11 +18,11 @@ const FILE_MANAGER_NAME = platform.isMacOS
     : "your file manager";
 
 class Downloads {
-  recentDownloadHistoryView: WebContentsView | null = null;
-
-  recentDownloadHistoryParentWindow: BrowserWindow | null = null;
-
-  downloadHistoryPopupOnBlurEnabled = false;
+  recentDownloadHistoryPopup = new TitlebarPopup({
+    page: "recent-download-history",
+    width: BASE_SPACING * 48,
+    height: BASE_SPACING * 44,
+  });
 
   addDownloadHistoryItem({ fileName, filePath, createdAt, exists }: Omit<DownloadItem, "id">) {
     const item = {
@@ -117,85 +117,6 @@ class Downloads {
     cleanupDownloadsHistory();
 
     setInterval(cleanupDownloadsHistory, ms("24h"));
-  }
-
-  setRecentDownloadHistoryPopupBounds = () => {
-    if (!this.recentDownloadHistoryView || !this.recentDownloadHistoryParentWindow) {
-      return;
-    }
-
-    const width = BASE_SPACING * 48;
-
-    const parentWindowBounds = platform.isWindows
-      ? this.recentDownloadHistoryParentWindow.getContentBounds()
-      : this.recentDownloadHistoryParentWindow.getBounds();
-
-    this.recentDownloadHistoryView.setBounds({
-      x: parentWindowBounds.width - width - BASE_SPACING,
-      y: APP_TITLEBAR_HEIGHT + BASE_SPACING,
-      width,
-      height: BASE_SPACING * 44,
-    });
-  };
-
-  closeRecentDownloadHistoryPopup = () => {
-    if (this.recentDownloadHistoryView && this.recentDownloadHistoryParentWindow) {
-      this.recentDownloadHistoryView.webContents.removeAllListeners();
-
-      this.recentDownloadHistoryView.webContents.close();
-
-      this.recentDownloadHistoryParentWindow.contentView.removeChildView(
-        this.recentDownloadHistoryView,
-      );
-
-      this.recentDownloadHistoryParentWindow.removeListener(
-        "resize",
-        this.setRecentDownloadHistoryPopupBounds,
-      );
-
-      this.recentDownloadHistoryView = null;
-      this.recentDownloadHistoryParentWindow = null;
-    }
-  };
-
-  toggleRecentDownloadHistoryPopup(parentWindow: BrowserWindow) {
-    if (this.recentDownloadHistoryView) {
-      const wasSameWindow = this.recentDownloadHistoryParentWindow === parentWindow;
-
-      this.closeRecentDownloadHistoryPopup();
-
-      if (wasSameWindow) {
-        return false;
-      }
-    }
-
-    this.recentDownloadHistoryView = new WebContentsView({
-      webPreferences: {
-        preload: getPreloadPath("renderer"),
-      },
-    });
-
-    this.recentDownloadHistoryParentWindow = parentWindow;
-
-    loadRenderer(this.recentDownloadHistoryView, {
-      page: "recent-download-history",
-    });
-
-    parentWindow.contentView.addChildView(this.recentDownloadHistoryView);
-
-    this.setRecentDownloadHistoryPopupBounds();
-
-    this.recentDownloadHistoryView.webContents.once("blur", () => {
-      if (this.downloadHistoryPopupOnBlurEnabled) {
-        this.closeRecentDownloadHistoryPopup();
-      }
-    });
-
-    parentWindow.on("resize", this.setRecentDownloadHistoryPopupBounds);
-
-    this.recentDownloadHistoryView.setBorderRadius(BASE_SPACING * 2);
-
-    return true;
   }
 
   async checkDownloadHistoryItems(limit?: number) {

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -76,9 +76,12 @@ class Ipc {
     config.onDidAnyChange(() => {
       ipc.renderer.send(main.window.webContents, "config.configChanged", config.store);
 
-      if (downloads.recentDownloadHistoryView) {
+      const recentDownloadHistoryPopupWebContents =
+        downloads.recentDownloadHistoryPopup.webContents;
+
+      if (recentDownloadHistoryPopupWebContents) {
         ipc.renderer.send(
-          downloads.recentDownloadHistoryView.webContents,
+          recentDownloadHistoryPopupWebContents,
           "config.configChanged",
           config.store,
         );
@@ -919,21 +922,21 @@ class Ipc {
         return;
       }
 
-      if (downloads.toggleRecentDownloadHistoryPopup(parentWindow)) {
+      if (downloads.recentDownloadHistoryPopup.toggle(parentWindow)) {
         downloads.checkDownloadHistoryItems(MAX_RECENT_DOWNLOAD_HISTORY_ITEMS);
       }
     });
 
     ipc.main.on("downloads.closeRecentDownloadHistoryPopup", () => {
-      downloads.closeRecentDownloadHistoryPopup();
+      downloads.recentDownloadHistoryPopup.close();
     });
 
     ipc.main.on("downloads.setDownloadHistoryPopupOnBlurEnabled", (_event, enabled) => {
-      downloads.downloadHistoryPopupOnBlurEnabled = enabled;
+      downloads.recentDownloadHistoryPopup.closeOnBlurEnabled = enabled;
     });
 
     ipc.main.on("downloads.openDownloadHistory", () => {
-      downloads.closeRecentDownloadHistoryPopup();
+      downloads.recentDownloadHistoryPopup.close();
 
       main.navigate("/download-history");
 

--- a/packages/app/lib/titlebar-popup.ts
+++ b/packages/app/lib/titlebar-popup.ts
@@ -1,0 +1,117 @@
+import { platform } from "@electron-toolkit/utils";
+import { APP_TITLEBAR_HEIGHT, BASE_SPACING } from "@meru/shared/constants";
+import type { BrowserWindow } from "electron";
+import { WebContentsView } from "electron";
+import { getPreloadPath, loadRenderer, type RendererPage } from "./window";
+
+/**
+ * A renderer page hung under the titlebar of the window it was opened from, as
+ * a child view rather than renderer-drawn markup: child views paint above the
+ * main window's HTML, so a dropdown would be covered wherever a workspace app
+ * view sits.
+ */
+export class TitlebarPopup {
+  private page: RendererPage;
+
+  private width: number;
+
+  private height: number;
+
+  private view: WebContentsView | null = null;
+
+  private parentWindow: BrowserWindow | null = null;
+
+  /**
+   * Held off while the pointer is over the button that toggles the popup, so
+   * that clicking the button closes it rather than the blur closing it and the
+   * click reopening it right away.
+   */
+  closeOnBlurEnabled = false;
+
+  constructor({ page, width, height }: { page: RendererPage; width: number; height: number }) {
+    this.page = page;
+    this.width = width;
+    this.height = height;
+  }
+
+  get webContents() {
+    return this.view?.webContents ?? null;
+  }
+
+  private setBounds = () => {
+    if (!this.view || !this.parentWindow) {
+      return;
+    }
+
+    const parentWindowBounds = platform.isWindows
+      ? this.parentWindow.getContentBounds()
+      : this.parentWindow.getBounds();
+
+    this.view.setBounds({
+      x: parentWindowBounds.width - this.width - BASE_SPACING,
+      y: APP_TITLEBAR_HEIGHT + BASE_SPACING,
+      width: this.width,
+      height: this.height,
+    });
+  };
+
+  close = () => {
+    if (!this.view || !this.parentWindow) {
+      return;
+    }
+
+    this.view.webContents.removeAllListeners();
+
+    this.view.webContents.close();
+
+    this.parentWindow.contentView.removeChildView(this.view);
+
+    this.parentWindow.removeListener("resize", this.setBounds);
+
+    this.view = null;
+    this.parentWindow = null;
+  };
+
+  /**
+   * Returns whether the popup ended up open, so callers can refresh what it is
+   * about to show. Toggling from the window it is already open in closes it;
+   * from another window it moves there.
+   */
+  toggle(parentWindow: BrowserWindow) {
+    if (this.view) {
+      const wasSameWindow = this.parentWindow === parentWindow;
+
+      this.close();
+
+      if (wasSameWindow) {
+        return false;
+      }
+    }
+
+    this.view = new WebContentsView({
+      webPreferences: {
+        preload: getPreloadPath("renderer"),
+      },
+    });
+
+    this.parentWindow = parentWindow;
+
+    loadRenderer(this.view, { page: this.page });
+
+    parentWindow.contentView.addChildView(this.view);
+
+    this.setBounds();
+
+    this.view.webContents.once("blur", () => {
+      if (this.closeOnBlurEnabled) {
+        this.close();
+      }
+    });
+
+    parentWindow.on("resize", this.setBounds);
+
+    this.view.setBorderRadius(BASE_SPACING * 2);
+
+    return true;
+  }
+}

--- a/packages/app/lib/window.ts
+++ b/packages/app/lib/window.ts
@@ -126,7 +126,7 @@ export function createBrowserWindow(options: BrowserWindowConstructorOptions) {
   return browserWindow;
 }
 
-type RendererPage = "main" | "workspace-app" | "desktop-sources" | "recent-download-history";
+export type RendererPage = "main" | "workspace-app" | "desktop-sources" | "recent-download-history";
 
 type LoadRendererOptions = {
   page: RendererPage;

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -362,7 +362,7 @@ export class AppMenu {
             label: "Downloads",
             accelerator: "CommandOrControl+Alt+L",
             click: () => {
-              downloads.closeRecentDownloadHistoryPopup();
+              downloads.recentDownloadHistoryPopup.close();
 
               main.navigate("/download-history");
 


### PR DESCRIPTION
The recent download history popup is about to stop being the only one: bookmarks are getting a popup of their own in the titlebar (noted in #739). Its machinery — a child `WebContentsView`, bounds under the titlebar, a resize listener, close-on-blur, border radius — is generic, and none of it is about downloads.

Pure refactor. No behaviour change.

## Changes

- New `TitlebarPopup` in `packages/app/lib/titlebar-popup.ts` holding the view, its parent window and the toggle/close/bounds logic, constructed with a page and a size. `RendererPage` is now exported from `lib/window.ts` so it can type that page.
- `Downloads` keeps a `recentDownloadHistoryPopup` instance instead of the four fields and three methods it had. Call sites read `downloads.recentDownloadHistoryPopup.{toggle,close,closeOnBlurEnabled,webContents}`.
- `toggle()` still returns whether the popup ended up open, which is what tells `downloads.toggleRecentDownloadHistoryPopup` to re-check the history items.
- `webContents` is a nullable getter, replacing the `recentDownloadHistoryView` field the config broadcast reached into.

## Risks and omissions

- The popup is still anchored to the parent window's top right rather than to the button that opens it — unchanged, and it is why a second popup can reuse the same bounds without looking out of place.
- `closeOnBlurEnabled` keeps the same default (`false`) and the same odd shape: it is flipped by the toggling button's hover handlers so that a click closes the popup instead of the blur closing it and the click reopening it. Documented on the field now, not changed.
- Not verified: the app was not run for this branch. Types, lint and format are green.

## Test plan

1. Click the downloads button in the main titlebar → the popup opens under it, top right, with rounded corners.
2. Click the downloads button again → it closes. Click it once more → it reopens.
3. With the popup open, click anywhere else in the window → it closes on blur.
4. With the popup open, resize the main window → it stays anchored to the top right.
5. Open the popup from a workspace app window, then click the downloads button in the main window → it moves to the main window rather than closing.
6. With the popup open, change a setting that writes to config (e.g. remove a download from the list inside the popup) → the list updates without reopening it.
7. With the popup open, use the app menu's `Downloads` entry → the popup closes and the full download history page opens.
8. Download a file with the popup open → it appears at the top of the list.
