### PR TITLE
list bookmarks in a titlebar popup

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -3,6 +3,7 @@ import { platform } from "@electron-toolkit/utils";
 import type { AccountConfig } from "@meru/shared/schemas";
 import { getVerticalTabsWidth, getVisibleVerticalTabs } from "@meru/shared/tabs";
 import { Account } from "./account";
+import { bookmarks } from "./bookmarks";
 import { config } from "./config";
 import { ipc } from "./ipc";
 import { licenseKey } from "./license-key";
@@ -229,6 +230,8 @@ class Accounts {
     this.updateAllViewBounds();
 
     this.refreshSelectedAccountView();
+
+    bookmarks.sendChangedToPopup();
   }
 
   selectPreviousAccount() {
@@ -421,6 +424,8 @@ class Accounts {
         tabs: account.instance.tabs.serialize(),
       })),
     );
+
+    bookmarks.sendChangedToPopup();
   }
 
   sendAccountsChangedToRenderer() {

--- a/packages/app/bookmarks.ts
+++ b/packages/app/bookmarks.ts
@@ -1,0 +1,42 @@
+import { BASE_SPACING } from "@meru/shared/constants";
+import { type BookmarkState, getBookmarkedTabs } from "@meru/shared/tabs";
+import { accounts } from "./accounts";
+import { ipc } from "./ipc";
+import { TitlebarPopup } from "./lib/titlebar-popup";
+
+/**
+ * Bookmarked entries render in the vertical tabs strip, which `New Windows`
+ * mode hides entirely — so the titlebar carries a popup of its own to keep them
+ * reachable, and it is the only surface that lists them when there is no strip.
+ */
+class Bookmarks {
+  popup = new TitlebarPopup({
+    page: "bookmarks",
+    width: BASE_SPACING * 40,
+    height: BASE_SPACING * 44,
+  });
+
+  serialize(): BookmarkState[] {
+    const selectedAccount = accounts.getSelectedAccount();
+
+    return getBookmarkedTabs(selectedAccount.instance.tabs.serialize()).map((tab) => ({
+      accountId: selectedAccount.config.id,
+      tabId: tab.id,
+      app: tab.app,
+      title: tab.title,
+      windowed: tab.windowed,
+    }));
+  }
+
+  sendChangedToPopup() {
+    const popupWebContents = this.popup.webContents;
+
+    if (!popupWebContents) {
+      return;
+    }
+
+    ipc.renderer.send(popupWebContents, "bookmarks.changed", this.serialize());
+  }
+}
+
+export const bookmarks = new Bookmarks();

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -24,6 +24,7 @@ import {
 } from "electron";
 import { machineId } from "node-machine-id";
 import { accounts } from "@/accounts";
+import { bookmarks } from "@/bookmarks";
 import { config } from "@/config";
 import { licenseKey } from "@/license-key";
 import { main } from "@/main";
@@ -913,6 +914,32 @@ class Ipc {
           "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAACXBIWXMAAAsTAAALEwEAmpwYAAABFklEQVR4nN3RzysEcRjH8afd1kE5ODg4ODgoBwcHRSFEfs0f4V9x9D+478HZqCmllB+llFLYqG1mWzTM0jhY6vtWa5GDnhnPiXe9Ls/38Dl8Rf5d3j3LXoPIa8CPEpyXcOElrOQemI+JFu4gs5jVXAOzt6CpNKGcwtzH7Ya1zAPTddA8vLqWjdQx075N1TOOTESgiV/cp/KjY7J9H69l+JOxKmium+6b9cS17qNVztWBkSvQ7KeO6PnLwZN7f7vEqQPDFbAQraEzsBCtwVOwEK2BE7AQrf5jsBCtviOwEK3eQ7AQrZ49sBCt7l2wEK2uHbAQrc5tsBCtUkDUEcBvlAJCdaDos1TwCQtbkItPWNxkUR34c70BSSmcO++HIKkAAAAASUVORK5CYII=",
         ),
       });
+    });
+
+    ipc.main.handle("bookmarks.getBookmarks", () => {
+      return bookmarks.serialize();
+    });
+
+    ipc.main.on("bookmarks.togglePopup", (event) => {
+      const parentWindow = BrowserWindow.fromWebContents(event.sender);
+
+      if (!parentWindow) {
+        return;
+      }
+
+      bookmarks.popup.toggle(parentWindow);
+    });
+
+    ipc.main.on("bookmarks.closePopup", () => {
+      bookmarks.popup.close();
+    });
+
+    ipc.main.on("bookmarks.setPopupCloseOnBlurEnabled", (_event, enabled) => {
+      bookmarks.popup.closeOnBlurEnabled = enabled;
+    });
+
+    ipc.main.on("bookmarks.removeBookmark", (_event, accountId, tabId) => {
+      accounts.getAccount(accountId).instance.tabs.setTabPersistence(tabId, null);
     });
 
     ipc.main.on("downloads.toggleRecentDownloadHistoryPopup", (event) => {

--- a/packages/app/lib/window.ts
+++ b/packages/app/lib/window.ts
@@ -126,7 +126,12 @@ export function createBrowserWindow(options: BrowserWindowConstructorOptions) {
   return browserWindow;
 }
 
-export type RendererPage = "main" | "workspace-app" | "desktop-sources" | "recent-download-history";
+export type RendererPage =
+  | "main"
+  | "workspace-app"
+  | "desktop-sources"
+  | "recent-download-history"
+  | "bookmarks";
 
 type LoadRendererOptions = {
   page: RendererPage;

--- a/packages/renderer/bookmarks.html
+++ b/packages/renderer/bookmarks.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="./globals.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./bookmarks.tsx"></script>
+  </body>
+</html>

--- a/packages/renderer/bookmarks.tsx
+++ b/packages/renderer/bookmarks.tsx
@@ -1,0 +1,117 @@
+import { ipc } from "@meru/shared/renderer/ipc";
+import type { BookmarkState } from "@meru/shared/tabs";
+import { Button } from "@meru/ui/components/button";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@meru/ui/components/empty";
+import { ScrollArea } from "@meru/ui/components/scroll-area";
+import { AppWindowIcon, BookmarkIcon, XIcon } from "lucide-react";
+import { PopupWindow } from "@/components/popup-window";
+import { TabIcon } from "@/components/tab-icon";
+import { renderApp } from "@/lib/react";
+import { useBookmarks } from "@/lib/react-query";
+
+function closePopup() {
+  ipc.main.send("bookmarks.closePopup");
+}
+
+function Bookmark({ accountId, tabId, app, title, windowed }: BookmarkState) {
+  return (
+    <div className="group relative">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="w-full justify-start group-hover:pr-7"
+        title={title}
+        onClick={() => {
+          ipc.main.send("tabs.selectTab", accountId, tabId);
+
+          closePopup();
+        }}
+      >
+        <TabIcon app={app} />
+        <span className="min-w-0 flex-1 overflow-hidden mask-r-from-[calc(100%-1.5rem)] text-left whitespace-nowrap">
+          {title}
+        </span>
+        {windowed && <AppWindowIcon className="size-3 shrink-0 text-muted-foreground" />}
+      </Button>
+      <Button
+        variant="secondary"
+        size="icon"
+        className="absolute top-1/2 right-1 size-5 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+        title="Remove Bookmark"
+        onClick={() => {
+          ipc.main.send("bookmarks.removeBookmark", accountId, tabId);
+        }}
+      >
+        <XIcon className="size-3" />
+      </Button>
+    </div>
+  );
+}
+
+function BookmarkList() {
+  const { bookmarks } = useBookmarks();
+
+  if (!bookmarks) {
+    return;
+  }
+
+  if (bookmarks.length === 0) {
+    return (
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <BookmarkIcon />
+          </EmptyMedia>
+          <EmptyTitle>No bookmarks yet</EmptyTitle>
+          <EmptyDescription>Bookmarked workspace apps appear here.</EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      {bookmarks.map((bookmark) => (
+        <Bookmark key={bookmark.tabId} {...bookmark} />
+      ))}
+    </div>
+  );
+}
+
+function Bookmarks() {
+  return (
+    <div className="flex h-screen flex-col rounded-2xl border">
+      <div className="p-4 font-semibold">Bookmarks</div>
+      <Button
+        size="icon"
+        variant="ghost"
+        className="absolute top-2 right-2 size-7"
+        onClick={closePopup}
+        title="Close"
+      >
+        <XIcon />
+      </Button>
+      <ScrollArea className="flex-1 overflow-hidden px-4 pb-4">
+        <div className="flex h-full flex-col">
+          <BookmarkList />
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}
+
+function BookmarksPopup() {
+  return (
+    <PopupWindow onClose={closePopup}>
+      <Bookmarks />
+    </PopupWindow>
+  );
+}
+
+renderApp(BookmarksPopup);

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -239,10 +239,13 @@ export function AppTitlebar() {
 
   const isWorkspaceAppTabActive = Boolean(activeTab?.app && activeTab.app !== "gmail");
 
-  // The strip is the only other place bookmarks are listed, and `New Windows`
-  // mode hides it — so the button is what keeps them reachable there. It stays
-  // out of the way until there is something to list.
-  const hasBookmarks = getBookmarkedTabs(allSelectedAccountTabs).length > 0;
+  // `New Windows` mode hides the strip, which is where bookmarks are otherwise
+  // listed — so the button exists to replace it, not to sit beside it. In
+  // `Tabs` mode the strip already has them. It also waits until there is
+  // something to list.
+  const shouldShowBookmarksButton =
+    config["workspaceApps.mode"] === "windows" &&
+    getBookmarkedTabs(allSelectedAccountTabs).length > 0;
 
   const shouldShowOutOfOfficeButton =
     accounts.length === 1 &&
@@ -423,7 +426,7 @@ export function AppTitlebar() {
                 ))}
               </TitlebarDropdownMenu>
             )}
-            {hasBookmarks && <BookmarksButton />}
+            {shouldShowBookmarksButton && <BookmarksButton />}
             <RecentDownloadHistoryButton />
             <DoNotDisturb />
           </div>

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -1,10 +1,12 @@
 import { accountColorsMap } from "@meru/shared/accounts";
 import { WEBSITE_URL } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
+import { getBookmarkedTabs } from "@meru/shared/tabs";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import { cn } from "@meru/ui/lib/utils";
 import {
+  BookmarkIcon,
   BriefcaseIcon,
   CircleAlertIcon,
   DownloadIcon,
@@ -33,7 +35,7 @@ import {
   WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME,
   WorkspaceAppsLauncher,
 } from "@/components/workspace-apps-launcher";
-import { useIsLicenseKeyValid, useVerticalTabs } from "@/lib/hooks";
+import { useIsLicenseKeyValid, useSelectedAccountTabs, useVerticalTabs } from "@/lib/hooks";
 import { useConfig } from "@/lib/react-query";
 import {
   useAccountsStore,
@@ -41,6 +43,25 @@ import {
   useFindInPageStore,
   useTrialStore,
 } from "../lib/stores";
+
+function BookmarksButton() {
+  return (
+    <TitlebarIconButton
+      onClick={() => {
+        ipc.main.send("bookmarks.togglePopup");
+      }}
+      onMouseEnter={() => {
+        ipc.main.send("bookmarks.setPopupCloseOnBlurEnabled", false);
+      }}
+      onMouseLeave={() => {
+        ipc.main.send("bookmarks.setPopupCloseOnBlurEnabled", true);
+      }}
+      title="Bookmarks"
+    >
+      <BookmarkIcon />
+    </TitlebarIconButton>
+  );
+}
 
 function RecentDownloadHistoryButton() {
   return (
@@ -169,6 +190,8 @@ export function AppTitlebar() {
 
   const { tabs: selectedAccountTabs, width: verticalTabsWidth } = useVerticalTabs();
 
+  const { tabs: allSelectedAccountTabs } = useSelectedAccountTabs();
+
   const activeTab = selectedAccountTabs.find((tab) => tab.active);
 
   const [location] = useLocation();
@@ -215,6 +238,11 @@ export function AppTitlebar() {
     config["gmail.savedSearches"].length > 0 && Boolean(config.licenseKey);
 
   const isWorkspaceAppTabActive = Boolean(activeTab?.app && activeTab.app !== "gmail");
+
+  // The strip is the only other place bookmarks are listed, and `New Windows`
+  // mode hides it — so the button is what keeps them reachable there. It stays
+  // out of the way until there is something to list.
+  const hasBookmarks = getBookmarkedTabs(allSelectedAccountTabs).length > 0;
 
   const shouldShowOutOfOfficeButton =
     accounts.length === 1 &&
@@ -395,6 +423,7 @@ export function AppTitlebar() {
                 ))}
               </TitlebarDropdownMenu>
             )}
+            {hasBookmarks && <BookmarksButton />}
             <RecentDownloadHistoryButton />
             <DoNotDisturb />
           </div>

--- a/packages/renderer/components/tab-icon.tsx
+++ b/packages/renderer/components/tab-icon.tsx
@@ -1,0 +1,11 @@
+import type { TabState } from "@meru/shared/tabs";
+import { GlobeIcon } from "lucide-react";
+import { WorkspaceAppIcon } from "@/components/workspace-app-icon";
+
+export function TabIcon({ app }: { app: TabState["app"] }) {
+  if (app && app !== "myaccount") {
+    return <WorkspaceAppIcon app={app} className="size-4" />;
+  }
+
+  return <GlobeIcon />;
+}

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -9,10 +9,10 @@ import { GMAIL_TAB_ID, getTabSection, type TabState } from "@meru/shared/tabs";
 import { workspaceApps } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import { cn } from "@meru/ui/lib/utils";
-import { AppWindowIcon, BookmarkIcon, CircleAlertIcon, GlobeIcon, XIcon } from "lucide-react";
+import { AppWindowIcon, BookmarkIcon, CircleAlertIcon, XIcon } from "lucide-react";
 import type { Ref } from "react";
+import { TabIcon } from "@/components/tab-icon";
 import { UnreadCountBadge } from "@/components/unread-count-badge";
-import { WorkspaceAppIcon } from "@/components/workspace-app-icon";
 import {
   VerticalTabsWorkspaceAppsLauncher,
   WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME,
@@ -55,14 +55,6 @@ function moveSectionTab(
   }
 
   ipc.main.send("tabs.moveTab", accountId, movedTabId, movedSectionTabIds.indexOf(movedTabId));
-}
-
-function TabIcon({ tab }: { tab: TabState }) {
-  if (tab.app && tab.app !== "myaccount") {
-    return <WorkspaceAppIcon app={tab.app} className="size-4" />;
-  }
-
-  return <GlobeIcon />;
 }
 
 function WindowedTabBadge({ className }: { className?: string }) {
@@ -160,7 +152,7 @@ function VerticalTab({
           ipc.main.send("tabs.showTabContextMenu", accountId, tab.id);
         }}
       >
-        <TabIcon tab={tab} />
+        <TabIcon app={tab.app} />
         {isWideRow && (
           <span className="min-w-0 flex-1 overflow-hidden mask-r-from-[calc(100%-1.5rem)] text-left whitespace-nowrap">
             {tab.title}

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -44,27 +44,37 @@ export function useCloseOnWindowBlur(isOpen: boolean, onClose: () => void) {
 }
 
 /**
+ * Every tab of the selected account, before the vertical tabs strip narrows
+ * them down — the titlebar surfaces entries the strip does not show.
+ */
+export function useSelectedAccountTabs() {
+  const accounts = useAccountsStore((state) => state.accounts);
+
+  const accountsTabs = useTabsStore((state) => state.accountsTabs);
+
+  const selectedAccount = accounts.find((account) => account.config.selected);
+
+  const tabs =
+    accountsTabs.find((accountTabs) => accountTabs.accountId === selectedAccount?.config.id)
+      ?.tabs ?? [];
+
+  return { selectedAccount, tabs };
+}
+
+/**
  * The tabs the vertical tabs strip renders and the width it takes up. The
  * titlebar reads it too, to know whether the strip is there to host the
  * Workspace Apps launcher.
  */
 export function useVerticalTabs() {
-  const accounts = useAccountsStore((state) => state.accounts);
-
-  const accountsTabs = useTabsStore((state) => state.accountsTabs);
+  const { selectedAccount, tabs: selectedAccountTabs } = useSelectedAccountTabs();
 
   const { config } = useConfig();
 
-  const selectedAccount = accounts.find((account) => account.config.selected);
-
-  const tabs = getVisibleVerticalTabs(
-    accountsTabs.find((accountTabs) => accountTabs.accountId === selectedAccount?.config.id)
-      ?.tabs ?? [],
-    {
-      workspaceAppsMode: config?.["workspaceApps.mode"] ?? "tabs",
-      showWindows: config?.["verticalTabs.showWindows"] ?? true,
-    },
-  );
+  const tabs = getVisibleVerticalTabs(selectedAccountTabs, {
+    workspaceAppsMode: config?.["workspaceApps.mode"] ?? "tabs",
+    showWindows: config?.["verticalTabs.showWindows"] ?? true,
+  });
 
   const width = getVerticalTabsWidth(tabs, config?.["verticalTabs.width"] ?? "auto");
 

--- a/packages/renderer/lib/react-query.ts
+++ b/packages/renderer/lib/react-query.ts
@@ -26,6 +26,27 @@ export function getConfig() {
   return queryClient.fetchQuery(configOptions);
 }
 
+ipc.renderer.on("bookmarks.changed", (_event, bookmarks) => {
+  queryClient.setQueryData(["bookmarks"], bookmarks);
+});
+
+/**
+ * Only the bookmarks popup runs this: it is a view of its own, so it fetches
+ * the list on mount and the main process pushes it again whenever tabs change
+ * underneath it.
+ */
+export function useBookmarks() {
+  const { data } = useQuery(
+    queryOptions({
+      queryKey: ["bookmarks"],
+      queryFn: () => ipc.main.invoke("bookmarks.getBookmarks"),
+      staleTime: Number.POSITIVE_INFINITY,
+    }),
+  );
+
+  return { bookmarks: data };
+}
+
 export function useConfigMutation({
   onSuccess,
 }: {

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -30,6 +30,26 @@ export type AccountTabsState = {
   tabs: TabState[];
 };
 
+/**
+ * A bookmarked entry as the titlebar's bookmarks popup lists it. Unlike the
+ * strip's `bookmarks` section, which only holds the dormant ones because an
+ * open bookmark moves into `normal`, this lists every bookmarked entry — the
+ * popup is a list of bookmarks, not of what is currently closed.
+ */
+export type BookmarkState = {
+  accountId: AccountConfig["id"];
+  tabId: string;
+  app: SupportedWorkspaceApp | undefined;
+  title: string;
+  windowed: boolean;
+};
+
+export function getBookmarkedTabs<BookmarkedTab extends Pick<TabState, "persistence">>(
+  tabs: BookmarkedTab[],
+) {
+  return tabs.filter((tab) => tab.persistence === "bookmarked");
+}
+
 export const tabSections = ["pinned", "normal", "bookmarks"] as const;
 
 export type TabSection = (typeof tabSections)[number];

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -9,7 +9,7 @@ import type {
   GmailLabelColors,
   GmailSavedSearches,
 } from "./schemas";
-import type { AccountTabsState, VerticalTabsWidth } from "./tabs";
+import type { AccountTabsState, BookmarkState, VerticalTabsWidth } from "./tabs";
 import type {
   LauncherWorkspaceApp,
   SupportedWorkspaceApp,
@@ -193,6 +193,10 @@ export type IpcMainEvents =
         app: SupportedWorkspaceApp,
         openBehavior?: WorkspaceAppOpenBehavior,
       ];
+      "bookmarks.togglePopup": [];
+      "bookmarks.closePopup": [];
+      "bookmarks.setPopupCloseOnBlurEnabled": [enabled: boolean];
+      "bookmarks.removeBookmark": [accountId: AccountConfig["id"], tabId: string];
       "doNotDisturb.toggle": [];
       "doNotDisturb.showOptions": [];
       "downloads.toggleRecentDownloadHistoryPopup": [];
@@ -220,6 +224,7 @@ export type IpcMainEvents =
       "about.getInfo": () => { version: string; os: string; deviceId: string };
       "about.exportLogs": () => { canceled: boolean };
       "workspaceApp.getLoadingState": (workspaceAppId?: string) => boolean;
+      "bookmarks.getBookmarks": () => BookmarkState[];
     };
 
 export type IpcRendererEvent = {
@@ -233,6 +238,7 @@ export type IpcRendererEvent = {
   "theme.darkModeChanged": [darkMode: boolean];
   "accounts.changed": [accounts: AccountInstances];
   "tabs.changed": [accountsTabs: AccountTabsState[]];
+  "bookmarks.changed": [bookmarks: BookmarkState[]];
   "accounts.openAddAccountDialog": [];
   "findInPage.activate": [];
   "findInPage.result": [result: { activeMatch: number; totalMatches: number }];


### PR DESCRIPTION
Bookmarked entries render only in the vertical tabs strip, and `New Windows` mode hides the strip — so in that mode they are unreachable, which #732 shipped as a known limitation and #739 recorded as needing a titlebar entry point. This is that entry point.

A dropdown would not do: child `WebContentsView`s paint above the main window's HTML, so anything the renderer draws is covered wherever a workspace app view sits. The bookmarks list is a view of its own, hung under the titlebar exactly like the recent download history, reusing the `TitlebarPopup` extracted in #746.

## Changes

- New `BookmarkIcon` button in the main titlebar, immediately left of the downloads button, opening a popup that lists the selected account's bookmarks as tab-style rows: app icon, title, and a window indicator for the ones that currently have a window.
- **The button only appears in `New Windows` mode**, and only once the account has a bookmark. It replaces the strip rather than sitting beside it: in `Tabs` mode the strip lists bookmarks already, and a second surface for the same entries would just be duplication.
- Clicking a bookmark goes through the existing `tabs.selectTab`, so the mode decides what happens: a window in `New Windows`, and a focus rather than a second copy if it is already open. The popup closes on the click.
- Each row has a hover `Remove Bookmark` action, worded as the tab context menu words it. It drops persistence rather than closing anything, so removing the bookmark of an app that is open leaves the app open.
- New `bookmarks` renderer page plus a `Bookmarks` class in the main process holding the popup and serialising the list.
- The popup fetches the list on mount (`bookmarks.getBookmarks`) and the main process pushes `bookmarks.changed` on every `sendTabsChangedToRenderer` and on `selectAccount`. It is a separate view, so it receives neither `tabs.changed` nor the accounts broadcast.
- `TabIcon` moved out of `vertical-tabs.tsx` into a component of its own, now that the popup draws the same rows.
- `useSelectedAccountTabs` split out of `useVerticalTabs`: the titlebar needs the account's tabs *before* the strip's mode and `Show Windows` filters narrow them, since the whole point is listing what the strip does not.

## What it lists

Every bookmarked entry, open or not — not the strip's `bookmarks` section, which only holds the dormant ones because an open bookmark moves into `normal`. The popup is a list of bookmarks; entries should not disappear from it because they happen to be open.

## Risks and omissions

- **This branch only makes bookmarks reachable, not creatable.** Bookmarking is still a tab context-menu action, so in `New Windows` mode there is no way to add one. #749 adds a bookmark toggle to the workspace app window titlebar; until it lands the gap is only half closed.
- **Gating on the mode leaves one hole open.** A `Tabs` mode strip can also collapse to nothing — turn `Show Windows` off with the only bookmark open in a window, and the strip disappears while the button stays hidden. Rarer than the `New Windows` case and not covered here.
- The popup is anchored to the window's top right rather than to the button, inherited from the downloads popup. With the button sitting one place to the left, the offset is visible.
- Bookmarks are per account and the popup shows the selected account's. Switching accounts while it is open re-pushes the list rather than closing it, but nothing in the popup says which account it belongs to.
- It lists the selected account only, so a second account's bookmarks stay out of reach until you switch to it. Same as the strip.
- Nothing is license-gated here, matching the strip — a lapsed license still lists and opens saved bookmarks.
- Not verified: the app was not run for this branch. Types, lint, format and `bun test` (120 pass) are green.

## Test plan

1. In `Tabs` mode with a bookmark saved → no bookmark button in the titlebar; the strip lists it as before.
2. Switch to `New Windows` mode → the strip disappears and the bookmark button appears left of the downloads button.
3. In `New Windows` mode with no bookmarks at all → no button.
4. Click the button → the popup opens under the titlebar, listing each bookmark with its icon and title.
5. Click a bookmark → it opens as a **window** and the popup closes.
6. Open the popup again → the same bookmark is listed with a window indicator, and clicking it focuses the open window rather than opening a second one.
7. Close that window, reopen the popup → the indicator is gone and clicking opens a window again.
8. Hover a row → the remove action appears. Click it on a bookmark whose app is open → the app stays open and the row disappears. Switch to `Tabs` mode → that entry has no bookmark icon in the strip.
9. Remove the last bookmark from the popup → the list shows the empty state, and the button is gone once the popup closes.
10. Open the popup, then click elsewhere in the window → it closes on blur. Click the bookmark button while the popup is open → it closes rather than reopening.
11. Press `Esc` with the popup open → it closes.
12. Resize the window with the popup open → it stays anchored top right.
13. Open the downloads popup, then click the bookmark button → downloads closes and bookmarks opens.
14. With two accounts, bookmark something in each → each account's titlebar lists only its own. Switch accounts with the popup open → the list follows the selected account.
15. Navigate a bookmarked app that is open in a window → the popup's title for it updates while open.
16. In `New Windows` mode, quit and relaunch → the bookmark is still listed and still opens as a window.
