### PR TITLE
bookmark workspace apps from their window titlebar

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -227,12 +227,23 @@ class Ipc {
       selectedAccount.instance.gmail.search(searchQuery);
     });
 
+    this.main.handle("workspaceApp.getBookmarkState", (_event, workspaceAppId) => {
+      return WorkspaceApp.fromId(workspaceAppId).bookmarkState;
+    });
+
+    ipc.main.on("workspaceApp.toggleBookmark", (_event, workspaceAppId) => {
+      const workspaceApp = WorkspaceApp.fromId(workspaceAppId);
+
+      workspaceApp.account.instance.tabs.setTabPersistence(
+        workspaceApp.id,
+        workspaceApp.persistence === "bookmarked" ? null : "bookmarked",
+      );
+    });
+
     ipc.main.on("workspaceApp.showMenu", (_event, workspaceAppId) => {
       const workspaceApp = WorkspaceApp.fromId(workspaceAppId);
 
       const isWindowsMode = config.get("workspaceApps.mode") === "windows";
-
-      const isSavableWorkspaceApp = !workspaceApp.isPopup && Boolean(workspaceApp.app);
 
       Menu.buildFromTemplate([
         ...(workspaceApp.isPopup || isWindowsMode
@@ -248,7 +259,7 @@ class Ipc {
                 type: "separator" as const,
               },
             ]),
-        ...(isSavableWorkspaceApp
+        ...(workspaceApp.isSavable
           ? [
               {
                 label: "Load on Launch",

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -466,6 +466,10 @@ export class Tabs {
       persistableTab.loadOnLaunch = false;
     }
 
+    if (persistableTab instanceof WorkspaceApp) {
+      persistableTab.broadcastBookmarkState();
+    }
+
     this.reorderTabs();
 
     this.broadcastTabsChanged();

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -5,6 +5,7 @@ import type { AccountConfig, TabPersistence } from "@meru/shared/schemas";
 import { clamp } from "@meru/shared/utils";
 import {
   type SupportedWorkspaceApp,
+  type WorkspaceAppBookmarkState,
   type WorkspaceAppOpenBehavior,
   workspaceApps,
 } from "@meru/shared/workspace-apps";
@@ -381,6 +382,17 @@ export class WorkspaceApp {
 
   get isPopup() {
     return !this.account.instance.tabs.getTab(this.id);
+  }
+
+  get isSavable() {
+    return !this.isPopup && Boolean(this.app);
+  }
+
+  get bookmarkState(): WorkspaceAppBookmarkState {
+    return {
+      savable: this.isSavable,
+      bookmarked: this.persistence === "bookmarked",
+    };
   }
 
   private get chromeWebContents() {
@@ -802,6 +814,22 @@ export class WorkspaceApp {
       this.chromeWebContents,
       "workspaceApp.loadingStateChanged",
       this.view.webContents.isLoading(),
+    );
+  };
+
+  /**
+   * Only a window has a bookmark button to keep in sync — an embedded tab shows
+   * its state in the strip, which redraws from the tabs broadcast.
+   */
+  broadcastBookmarkState = () => {
+    if (!this._window) {
+      return;
+    }
+
+    ipc.renderer.send(
+      this.chromeWebContents,
+      "workspaceApp.bookmarkStateChanged",
+      this.bookmarkState,
     );
   };
 

--- a/packages/renderer/workspace-app.tsx
+++ b/packages/renderer/workspace-app.tsx
@@ -1,6 +1,7 @@
 import { ipc } from "@meru/shared/renderer/ipc";
-import type { SupportedWorkspaceApp } from "@meru/shared/workspace-apps";
-import { DownloadIcon, EllipsisVerticalIcon } from "lucide-react";
+import type { SupportedWorkspaceApp, WorkspaceAppBookmarkState } from "@meru/shared/workspace-apps";
+import { cn } from "@meru/ui/lib/utils";
+import { BookmarkIcon, DownloadIcon, EllipsisVerticalIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { AccountBadge } from "@/components/account-badge";
 import { FindInPage } from "@/components/find-in-page";
@@ -32,6 +33,42 @@ function RecentDownloadHistoryButton() {
       title="Recent Download History"
     >
       <DownloadIcon />
+    </TitlebarIconButton>
+  );
+}
+
+/**
+ * Bookmarking is otherwise a tab context-menu action, which `New Windows` mode
+ * leaves no way to reach — this is the entry point that does not need a strip.
+ */
+function BookmarkButton({ workspaceAppId }: { workspaceAppId: string }) {
+  const [bookmarkState, setBookmarkState] = useState<WorkspaceAppBookmarkState>({
+    savable: false,
+    bookmarked: false,
+  });
+
+  useEffect(() => {
+    const unsubscribe = ipc.renderer.on("workspaceApp.bookmarkStateChanged", (_event, state) => {
+      setBookmarkState(state);
+    });
+
+    ipc.main.invoke("workspaceApp.getBookmarkState", workspaceAppId).then(setBookmarkState);
+
+    return unsubscribe;
+  }, [workspaceAppId]);
+
+  if (!bookmarkState.savable) {
+    return;
+  }
+
+  return (
+    <TitlebarIconButton
+      title={bookmarkState.bookmarked ? "Remove Bookmark" : "Bookmark"}
+      onClick={() => {
+        ipc.main.send("workspaceApp.toggleBookmark", workspaceAppId);
+      }}
+    >
+      <BookmarkIcon className={cn(bookmarkState.bookmarked && "fill-current")} />
     </TitlebarIconButton>
   );
 }
@@ -163,6 +200,7 @@ function WorkspaceApp() {
         <FindInPageControls />
         <TitlebarButtonGroup>
           <RecentDownloadHistoryButton />
+          <BookmarkButton workspaceAppId={workspaceAppId} />
           <TitlebarIconButton
             title="More Options"
             onClick={() => {

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -13,6 +13,7 @@ import type { AccountTabsState, BookmarkState, VerticalTabsWidth } from "./tabs"
 import type {
   LauncherWorkspaceApp,
   SupportedWorkspaceApp,
+  WorkspaceAppBookmarkState,
   WorkspaceAppOpenBehavior,
   WorkspaceAppsLauncherDisplay,
   WorkspaceAppsMode,
@@ -169,6 +170,7 @@ export type IpcMainEvents =
       "gmail.search": [searchQuery: string];
       "gmail.openUserStyles": [openIn: "editor" | "folder"];
       "workspaceApp.showMenu": [workspaceAppId: string];
+      "workspaceApp.toggleBookmark": [workspaceAppId: string];
       "workspaceApp.showNotification": [notification: WorkspaceAppNotification];
       "gmail.navigateTo": [hashLocation: GmailHashLocation];
       "gmail.closeComposeWindow": [];
@@ -224,6 +226,7 @@ export type IpcMainEvents =
       "about.getInfo": () => { version: string; os: string; deviceId: string };
       "about.exportLogs": () => { canceled: boolean };
       "workspaceApp.getLoadingState": (workspaceAppId?: string) => boolean;
+      "workspaceApp.getBookmarkState": (workspaceAppId: string) => WorkspaceAppBookmarkState;
       "bookmarks.getBookmarks": () => BookmarkState[];
     };
 
@@ -254,5 +257,6 @@ export type IpcRendererEvent = {
   "workspaceApp.navigationStateChanged": [state: { canGoBack: boolean; canGoForward: boolean }];
   "workspaceApp.pageTitleChanged": [title: string];
   "workspaceApp.loadingStateChanged": [loading: boolean];
+  "workspaceApp.bookmarkStateChanged": [bookmarkState: WorkspaceAppBookmarkState];
   "config.configChanged": [config: Config];
 };

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -82,3 +82,9 @@ export type WorkspaceAppsMode = keyof typeof workspaceAppsModes;
  * configured mode and the held modifier keys — never stored in the config.
  */
 export type WorkspaceAppOpenBehavior = "tab" | "backgroundTab" | "newWindow";
+
+export type WorkspaceAppBookmarkState = {
+  /** Popups such as the PDF viewer are never tabs, so they cannot be saved. */
+  savable: boolean;
+  bookmarked: boolean;
+};


### PR DESCRIPTION
Bookmarking is a tab context-menu action, so `New Windows` mode — which has no tab strip to right-click — offers no way to create a bookmark at all. #739 recorded this as the other half of the bookmarks gap: #747 made bookmarks reachable there, this makes them creatable, and together they close it.

Rebased onto `main` after #747 merged.

## Changes

- New bookmark icon button in the workspace app window titlebar, between the downloads button and `More Options`. It fills when the app is bookmarked, and its tooltip reads `Bookmark` / `Remove Bookmark` — the same wording the tab context menu uses.
- It follows the pattern already next to it: an invoke on mount (`workspaceApp.getBookmarkState`) plus a `workspaceApp.bookmarkStateChanged` broadcast, so the icon tracks persistence changed from anywhere else — the tab context menu, `Load on Launch`, or the window's own button.
- `WorkspaceApp.isSavable` replaces the local `isSavableWorkspaceApp` in the `workspaceApp.showMenu` handler, since the button needs the same answer. Popups such as the PDF viewer are never tabs, so the button does not render for them.
- `Tabs.setTabPersistence` broadcasts the new state when the tab is a windowed `WorkspaceApp`. Embedded tabs need nothing: the strip already redraws from the tabs broadcast.

## Risks and omissions

- **Bookmarking an app that is pinned unpins it**, and ticking `Load on Launch` on a bookmarked app turns the bookmark into a pin. Persistence holds one value, so pinned and bookmarked have always been mutually exclusive — the button now makes that visible instead of hiding it in a menu, but it does not warn.
- The button is only in workspace app windows. The main titlebar has no equivalent for the active tab; in `Tabs` mode the tab's context menu is still the way.
- Not verified: the app was not run for this branch. Types, lint, format and `bun test` (120 pass) are green.

## Test plan

1. Open a workspace app in a window (`Shift`+click a launcher app, or `Move to New Window` from a tab) → an outlined bookmark button sits between the downloads button and `More Options`.
2. Click it → the icon fills and the tooltip becomes `Remove Bookmark`.
3. Go back to the main window → in `Tabs` mode the strip shows the entry with a bookmark icon.
4. Click the button again → the icon empties, and the strip's bookmark icon is gone.
5. Same round trip in `New Windows` mode: bookmark from the window, then check the main titlebar → #747's bookmarks button has appeared, with the entry listed in its popup. Unbookmark from the window → the button goes away again.
6. With the window open and bookmarked, right-click the entry in the strip → `Remove Bookmark` → the window's button empties without touching the window.
7. Same in reverse: `Bookmark` from the strip → the window's button fills.
8. In the window's `More Options`, tick `Load on Launch` on a bookmarked app → the bookmark button empties, because the entry is now pinned.
9. Open a PDF from an app (the popup viewer) → no bookmark button in its titlebar, and `More Options` still has no `Load on Launch`.
10. In `New Windows` mode, open an app from the launcher, bookmark it, quit and relaunch → the entry is still saved and still listed in the bookmarks popup.
11. `Move to New Window` a bookmarked tab → the new window opens with the button already filled.
12. `Move to Tab` a bookmarked window, then detach it again → the button comes back filled.
