### PR TITLE
distinguish the bookmarks list button from the bookmark toggle

### DIFF
--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -6,12 +6,12 @@ import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import { cn } from "@meru/ui/lib/utils";
 import {
+  BookOpenIcon,
   BriefcaseIcon,
   CircleAlertIcon,
   DownloadIcon,
   EllipsisVerticalIcon,
   InboxIcon,
-  LibraryBigIcon,
   MailSearchIcon,
   MoonIcon,
   SparklesIcon,
@@ -58,7 +58,7 @@ function BookmarksButton() {
       }}
       title="Bookmarks"
     >
-      <LibraryBigIcon />
+      <BookOpenIcon />
     </TitlebarIconButton>
   );
 }

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -6,12 +6,12 @@ import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import { cn } from "@meru/ui/lib/utils";
 import {
-  BookmarkIcon,
   BriefcaseIcon,
   CircleAlertIcon,
   DownloadIcon,
   EllipsisVerticalIcon,
   InboxIcon,
+  LibraryBigIcon,
   MailSearchIcon,
   MoonIcon,
   SparklesIcon,
@@ -58,7 +58,7 @@ function BookmarksButton() {
       }}
       title="Bookmarks"
     >
-      <BookmarkIcon />
+      <LibraryBigIcon />
     </TitlebarIconButton>
   );
 }


### PR DESCRIPTION
## Problem

- The main window titlebar's bookmarks button opens a popup listing all bookmarks, but rendered lucide's `BookmarkIcon`.
- Workspace app windows' titlebars use that same `BookmarkIcon` for a different meaning: bookmark this page / this page is bookmarked.
- One icon, two meanings — a list affordance and a per-page toggle were visually indistinguishable.

## Changed

- `BookmarksButton` in `packages/renderer/components/app-titlebar.tsx` now renders `BookOpenIcon`, reserving `BookmarkIcon` for the per-page toggle.
- Follows Apple's convention: Safari's bookmarks sidebar button is SF Symbols' `book` (an open book with two facing pages), whose closest lucide match is `BookOpen`.

## Risks and omissions

- Purely visual; no behaviour, IPC, or visibility logic touched — `shouldShowBookmarksButton` is untouched, kept deliberately minimal since the bookmarks data model is being reworked in parallel.
- Only the list button is changed here. Completing the Safari convention means the per-page toggle in `packages/renderer/workspace-app.tsx` becomes a star (`StarIcon` / `StarOffIcon`) rather than today's `BookmarkIcon` — left for a follow-up.
- The branch name still says `library-icon`, from the bookshelf icon this branch originally shipped; not renamed to avoid churning the open PR.
- Not verified by running the app; `bun run types` passes.

## Test plan

1. Set Workspace Apps mode to `New Windows` and bookmark at least one workspace app — expect a bookmarks button to appear in the main window titlebar, showing an open-book icon rather than a bookmark ribbon or a bookshelf.
2. Click that button — expect the bookmarks popup to open and list the bookmarks exactly as before; click again to close.
3. Hover the button, then move the pointer over the open popup — expect the popup to stay open (close-on-blur suppression still works).
4. Open a workspace app window and check its titlebar — expect the bookmark ribbon icon there, unchanged, and visibly different from the main window's open-book list button.
5. Check the open-book icon at the titlebar's 16px render size — expect the spine and page outline to stay legible and not muddy, in both light and dark themes.
6. Switch Workspace Apps mode to `Tabs`, or remove all bookmarks — expect the main window titlebar button to disappear, as before.
