### PR TITLE
save bookmarks as URLs instead of flagged tabs

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { platform } from "@electron-toolkit/utils";
 import type { AccountConfig } from "@meru/shared/schemas";
-import { getVerticalTabsWidth, getVisibleVerticalTabs } from "@meru/shared/tabs";
+import {
+  getVerticalTabsWidth,
+  getVisibleBookmarks,
+  getVisibleVerticalTabs,
+} from "@meru/shared/tabs";
 import { Account } from "./account";
 import { bookmarks } from "./bookmarks";
 import { config } from "./config";
@@ -112,12 +116,22 @@ class Accounts {
   }
 
   getVerticalTabsWidth() {
+    const selectedAccount = this.getSelectedAccount();
+
+    const workspaceAppsMode = config.get("workspaceApps.mode");
+
     return getVerticalTabsWidth(
-      getVisibleVerticalTabs(this.getSelectedAccount().instance.tabs.serialize(), {
-        workspaceAppsMode: config.get("workspaceApps.mode"),
+      getVisibleVerticalTabs(selectedAccount.instance.tabs.serialize(), {
+        workspaceAppsMode,
         showWindows: config.get("verticalTabs.showWindows"),
       }),
-      config.get("verticalTabs.width"),
+      {
+        bookmarkCount: getVisibleBookmarks(
+          bookmarks.getAccountBookmarks(selectedAccount.config.id),
+          workspaceAppsMode,
+        ).length,
+        configuredWidth: config.get("verticalTabs.width"),
+      },
     );
   }
 
@@ -230,8 +244,6 @@ class Accounts {
     this.updateAllViewBounds();
 
     this.refreshSelectedAccountView();
-
-    bookmarks.sendChangedToPopup();
   }
 
   selectPreviousAccount() {
@@ -286,6 +298,7 @@ class Accounts {
       },
       workspaceApps: {
         savedTabs: [],
+        bookmarks: [],
       },
     };
 
@@ -404,6 +417,7 @@ class Accounts {
         return {
           ...accountConfig,
           workspaceApps: {
+            ...accountConfig.workspaceApps,
             savedTabs: instance.tabs.serializeSavedTabs(),
           },
         };
@@ -424,8 +438,6 @@ class Accounts {
         tabs: account.instance.tabs.serialize(),
       })),
     );
-
-    bookmarks.sendChangedToPopup();
   }
 
   sendAccountsChangedToRenderer() {

--- a/packages/app/bookmarks.ts
+++ b/packages/app/bookmarks.ts
@@ -1,13 +1,20 @@
+import { randomUUID } from "node:crypto";
 import { BASE_SPACING } from "@meru/shared/constants";
-import { type BookmarkState, getBookmarkedTabs } from "@meru/shared/tabs";
+import type { AccountConfig, Bookmark, BookmarkState } from "@meru/shared/schemas";
+import { clamp } from "@meru/shared/utils";
 import { accounts } from "./accounts";
+import { config } from "./config";
 import { ipc } from "./ipc";
 import { TitlebarPopup } from "./lib/titlebar-popup";
 
 /**
- * Bookmarked entries render in the vertical tabs strip, which `New Windows`
- * mode hides entirely — so the titlebar carries a popup of its own to keep them
- * reachable, and it is the only surface that lists them when there is no strip.
+ * The URLs an account has saved. A bookmark keeps the URL, title and app it was
+ * created from and never follows what the user browses to afterwards — opening
+ * one loads that URL again.
+ *
+ * Bookmarks render in the vertical tabs strip, which `New Windows` mode hides
+ * entirely — so the titlebar carries a popup of its own to keep them reachable,
+ * and it is the only surface that lists them when there is no strip.
  */
 class Bookmarks {
   popup = new TitlebarPopup({
@@ -16,15 +23,100 @@ class Bookmarks {
     height: BASE_SPACING * 44,
   });
 
+  getAccountBookmarks(accountId: AccountConfig["id"]): Bookmark[] {
+    const accountConfig = config.get("accounts").find((account) => account.id === accountId);
+
+    // Accounts written before bookmarks became a list of their own carry none
+    return accountConfig?.workspaceApps.bookmarks ?? [];
+  }
+
+  private setAccountBookmarks(accountId: AccountConfig["id"], updatedBookmarks: Bookmark[]) {
+    config.set(
+      "accounts",
+      config.get("accounts").map((accountConfig) =>
+        accountConfig.id === accountId
+          ? {
+              ...accountConfig,
+              workspaceApps: {
+                ...accountConfig.workspaceApps,
+                bookmarks: updatedBookmarks,
+              },
+            }
+          : accountConfig,
+      ),
+    );
+  }
+
+  isBookmarked(accountId: AccountConfig["id"], url: string) {
+    return this.getAccountBookmarks(accountId).some((bookmark) => bookmark.url === url);
+  }
+
+  /**
+   * Saves the given URL, or drops what is saved for it — the surfaces that
+   * offer bookmarking are toggles on the URL they are showing.
+   */
+  toggle(accountId: AccountConfig["id"], { app, url, title }: Omit<Bookmark, "id">) {
+    const accountBookmarks = this.getAccountBookmarks(accountId);
+
+    const remainingBookmarks = accountBookmarks.filter((bookmark) => bookmark.url !== url);
+
+    this.setAccountBookmarks(
+      accountId,
+      remainingBookmarks.length < accountBookmarks.length
+        ? remainingBookmarks
+        : [...accountBookmarks, { id: randomUUID(), app, url, title }],
+    );
+  }
+
+  remove(accountId: AccountConfig["id"], bookmarkId: Bookmark["id"]) {
+    this.setAccountBookmarks(
+      accountId,
+      this.getAccountBookmarks(accountId).filter((bookmark) => bookmark.id !== bookmarkId),
+    );
+  }
+
+  move(accountId: AccountConfig["id"], bookmarkId: Bookmark["id"], targetIndex: number) {
+    const accountBookmarks = this.getAccountBookmarks(accountId);
+
+    const movedBookmark = accountBookmarks.find((bookmark) => bookmark.id === bookmarkId);
+
+    if (!movedBookmark) {
+      return;
+    }
+
+    const remainingBookmarks = accountBookmarks.filter((bookmark) => bookmark.id !== bookmarkId);
+
+    remainingBookmarks.splice(clamp(targetIndex, 0, remainingBookmarks.length), 0, movedBookmark);
+
+    this.setAccountBookmarks(accountId, remainingBookmarks);
+  }
+
+  open(accountId: AccountConfig["id"], bookmarkId: Bookmark["id"]) {
+    const openedBookmark = this.getAccountBookmarks(accountId).find(
+      (bookmark) => bookmark.id === bookmarkId,
+    );
+
+    if (!openedBookmark) {
+      return;
+    }
+
+    const account = accounts.getAccount(accountId);
+
+    account.instance.tabs.openUrl(openedBookmark.url);
+
+    if (account.config.selected) {
+      accounts.refreshSelectedAccountView();
+    } else {
+      accounts.selectAccount(accountId);
+    }
+  }
+
   serialize(): BookmarkState[] {
     const selectedAccount = accounts.getSelectedAccount();
 
-    return getBookmarkedTabs(selectedAccount.instance.tabs.serialize()).map((tab) => ({
+    return this.getAccountBookmarks(selectedAccount.config.id).map((bookmark) => ({
+      ...bookmark,
       accountId: selectedAccount.config.id,
-      tabId: tab.id,
-      app: tab.app,
-      title: tab.title,
-      windowed: tab.windowed,
     }));
   }
 

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -1,8 +1,14 @@
 import { randomUUID } from "node:crypto";
 import { is, platform } from "@electron-toolkit/utils";
+import type { SavedTab } from "@meru/shared/schemas";
 import type { Config } from "@meru/shared/types";
 import { app } from "electron";
 import Store from "electron-store";
+
+/** A saved tab as it was written before bookmarks became a list of their own. */
+type LegacySavedTab = SavedTab & {
+  persistence?: "pinned" | "bookmarked";
+};
 
 export const DEFAULT_WINDOW_STATE_BOUNDS = {
   width: 1280,
@@ -29,6 +35,7 @@ export const config = new Store<Config>({
         },
         workspaceApps: {
           savedTabs: [],
+          bookmarks: [],
         },
       },
     ],
@@ -364,7 +371,7 @@ export const config = new Store<Config>({
       if (Array.isArray(accounts)) {
         for (const account of accounts) {
           if (typeof account.workspaceApps === "undefined") {
-            account.workspaceApps = { savedTabs: [] };
+            account.workspaceApps = { savedTabs: [], bookmarks: [] };
           }
         }
 
@@ -405,6 +412,39 @@ export const config = new Store<Config>({
 
       // @ts-expect-error
       store.delete("workspaceApps.openBehavior");
+
+      const accounts = store.get("accounts");
+
+      if (Array.isArray(accounts)) {
+        for (const account of accounts) {
+          const savedTabs = (account.workspaceApps?.savedTabs ?? []) as LegacySavedTab[];
+
+          // A bookmark used to be a saved tab flagged as bookmarked, which made
+          // it follow wherever that tab navigated. Bookmarks are a list of
+          // saved URLs of their own now, and every saved tab is a pinned one.
+          account.workspaceApps = {
+            savedTabs: savedTabs
+              .filter((savedTab) => savedTab.persistence !== "bookmarked")
+              .map((savedTab) => ({
+                app: savedTab.app,
+                url: savedTab.url,
+                title: savedTab.title,
+                loadOnLaunch: savedTab.loadOnLaunch,
+                windowed: savedTab.windowed,
+              })),
+            bookmarks: savedTabs
+              .filter((savedTab) => savedTab.persistence === "bookmarked")
+              .map((savedTab) => ({
+                id: randomUUID(),
+                app: savedTab.app,
+                url: savedTab.url,
+                title: savedTab.title,
+              })),
+          };
+        }
+
+        store.set("accounts", accounts);
+      }
     },
   },
 });

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -32,7 +32,6 @@ import { appMenu } from "@/menu";
 import { DormantTab } from "@/tabs";
 import {
   canOpenWorkspaceAppInApp,
-  getWorkspaceAppFromUrl,
   resolveWorkspaceAppOpenBehavior,
   WorkspaceApp,
 } from "@/workspace-app";
@@ -95,6 +94,16 @@ class Ipc {
 
     config.onDidChange("accounts", () => {
       accounts.sendAccountsChangedToRenderer();
+
+      // Bookmarks live in the account config, so every surface listing them
+      // redraws from here rather than from a change event of its own. The
+      // strip is one of them, and it can grow or vanish with them, so the
+      // views around it have to be laid out again.
+      accounts.updateAllViewBounds();
+
+      bookmarks.sendChangedToPopup();
+
+      WorkspaceApp.broadcastBookmarkStates();
     });
 
     this.main.on("accounts.selectAccount", (_event, selectedAccountId) => {
@@ -232,12 +241,7 @@ class Ipc {
     });
 
     ipc.main.on("workspaceApp.toggleBookmark", (_event, workspaceAppId) => {
-      const workspaceApp = WorkspaceApp.fromId(workspaceAppId);
-
-      workspaceApp.account.instance.tabs.setTabPersistence(
-        workspaceApp.id,
-        workspaceApp.persistence === "bookmarked" ? null : "bookmarked",
-      );
+      WorkspaceApp.fromId(workspaceAppId).toggleBookmark();
     });
 
     ipc.main.on("workspaceApp.showMenu", (_event, workspaceAppId) => {
@@ -264,7 +268,7 @@ class Ipc {
               {
                 label: "Load on Launch",
                 type: "checkbox" as const,
-                checked: workspaceApp.persistence === "pinned" && workspaceApp.loadOnLaunch,
+                checked: workspaceApp.pinned && workspaceApp.loadOnLaunch,
                 click: () => {
                   if (workspaceApp.loadOnLaunch) {
                     workspaceApp.loadOnLaunch = false;
@@ -276,7 +280,7 @@ class Ipc {
 
                   workspaceApp.loadOnLaunch = true;
 
-                  workspaceApp.account.instance.tabs.setTabPersistence(workspaceApp.id, "pinned");
+                  workspaceApp.account.instance.tabs.setTabPinned(workspaceApp.id, true);
                 },
               },
               {
@@ -348,7 +352,7 @@ class Ipc {
         (accountTab) =>
           accountTab.id !== tabId &&
           accountTab.id !== GMAIL_TAB_ID &&
-          accountTab.persistence !== "pinned" &&
+          !accountTab.pinned &&
           !accountTab.dormant,
       );
 
@@ -358,26 +362,12 @@ class Ipc {
 
       const hasClosableTabsBelow = account.instance.tabs.tabs
         .slice(contextTabIndex + 1)
-        .some((accountTab) => accountTab.persistence !== "pinned" && !accountTab.dormant);
+        .some((accountTab) => !accountTab.pinned && !accountTab.dormant);
 
       const isWindowsMode = config.get("workspaceApps.mode") === "windows";
 
       const openWorkspaceAppUrl = (url: string) => {
-        if (!canOpenWorkspaceAppInApp(getWorkspaceAppFromUrl(url))) {
-          openExternalUrl(url, { skipTrustedHostCheck: true });
-
-          return;
-        }
-
-        if (isWindowsMode) {
-          account.instance.tabs.openWindowedTab(url);
-
-          return;
-        }
-
-        const workspaceApp = account.instance.tabs.openTab(url);
-
-        account.instance.tabs.activateTab(workspaceApp.id);
+        account.instance.tabs.openUrl(url);
 
         if (account.config.selected) {
           accounts.refreshSelectedAccountView();
@@ -478,33 +468,23 @@ class Ipc {
               {
                 type: "separator" as const,
               },
-              tab.persistence === "pinned"
-                ? {
-                    label: "Unpin",
-                    click: () => {
-                      account.instance.tabs.setTabPersistence(tabId, null);
-                    },
-                  }
-                : {
-                    label: "Pin",
-                    click: () => {
-                      account.instance.tabs.setTabPersistence(tabId, "pinned");
-                    },
-                  },
-              tab.persistence === "bookmarked"
-                ? {
-                    label: "Remove Bookmark",
-                    click: () => {
-                      account.instance.tabs.setTabPersistence(tabId, null);
-                    },
-                  }
-                : {
-                    label: "Bookmark",
-                    click: () => {
-                      account.instance.tabs.setTabPersistence(tabId, "bookmarked");
-                    },
-                  },
-              ...(tab.persistence === "pinned"
+              {
+                label: tab.pinned ? "Unpin" : "Pin",
+                click: () => {
+                  account.instance.tabs.setTabPinned(tabId, !tab.pinned);
+                },
+              },
+              {
+                label: bookmarks.isBookmarked(accountId, tab.url) ? "Remove Bookmark" : "Bookmark",
+                click: () => {
+                  bookmarks.toggle(accountId, {
+                    app: tabApp,
+                    url: tab.url,
+                    title: tab.title,
+                  });
+                },
+              },
+              ...(tab.pinned
                 ? [
                     {
                       label: "Load on Launch",
@@ -949,8 +929,16 @@ class Ipc {
       bookmarks.popup.closeOnBlurEnabled = enabled;
     });
 
-    ipc.main.on("bookmarks.removeBookmark", (_event, accountId, tabId) => {
-      accounts.getAccount(accountId).instance.tabs.setTabPersistence(tabId, null);
+    ipc.main.on("bookmarks.openBookmark", (_event, accountId, bookmarkId) => {
+      bookmarks.open(accountId, bookmarkId);
+    });
+
+    ipc.main.on("bookmarks.removeBookmark", (_event, accountId, bookmarkId) => {
+      bookmarks.remove(accountId, bookmarkId);
+    });
+
+    ipc.main.on("bookmarks.moveBookmark", (_event, accountId, bookmarkId, targetIndex) => {
+      bookmarks.move(accountId, bookmarkId, targetIndex);
     });
 
     ipc.main.on("downloads.toggleRecentDownloadHistoryPopup", (event) => {

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { SavedTab, TabPersistence } from "@meru/shared/schemas";
+import type { SavedTab } from "@meru/shared/schemas";
 import { getTabSection, GMAIL_TAB_ID, type TabState, tabSections } from "@meru/shared/tabs";
 import type { SupportedWorkspaceApp } from "@meru/shared/workspace-apps";
 import type { WebContentsView } from "electron";
@@ -36,18 +36,18 @@ export function isWindowedTab(tab: Tab) {
 
 type SavedWorkspaceApp = WorkspaceApp & {
   app: SupportedWorkspaceApp;
-  persistence: TabPersistence;
+  pinned: true;
 };
 
 function isSavedWorkspaceApp(tab: Tab): tab is SavedWorkspaceApp {
-  return tab instanceof WorkspaceApp && tab.persistence !== null && tab.app !== undefined;
+  return tab instanceof WorkspaceApp && tab.pinned && tab.app !== undefined;
 }
 
 export type Tab = {
   id: string;
   app: SupportedWorkspaceApp | undefined;
   title: string;
-  persistence: TabPersistence | null;
+  pinned: boolean;
   dormant: boolean;
   loadOnLaunch?: boolean;
   isLoading: boolean;
@@ -56,6 +56,10 @@ export type Tab = {
   updateViewBounds?: () => void;
 };
 
+/**
+ * A saved tab that has not been opened yet. Only pinned tabs are saved, so a
+ * dormant tab is always a pinned one waiting to be materialized.
+ */
 export class DormantTab {
   id = randomUUID();
 
@@ -63,7 +67,7 @@ export class DormantTab {
 
   url: string;
 
-  persistence: TabPersistence;
+  pinned = true;
 
   dormant = true;
 
@@ -83,7 +87,6 @@ export class DormantTab {
     this.app = savedTab.app;
     this.url = savedTab.url;
     this.title = savedTab.title;
-    this.persistence = savedTab.persistence;
     this.loadOnLaunch = Boolean(savedTab.loadOnLaunch);
     this.windowed = Boolean(savedTab.windowed);
     this.zoomFactor = zoomFactor;
@@ -106,7 +109,7 @@ export class Tabs {
       {
         id: GMAIL_TAB_ID,
         app: gmail.app,
-        persistence: null,
+        pinned: false,
         dormant: false,
         get title() {
           return gmail.title;
@@ -205,7 +208,7 @@ export class Tabs {
 
     this.broadcastTabsChanged();
 
-    if (removedTab?.persistence) {
+    if (removedTab?.pinned) {
       accounts.saveTabs();
     }
   }
@@ -246,7 +249,7 @@ export class Tabs {
     const workspaceApp = new WorkspaceApp({
       accountId: this.accountId,
       url: dormantTab.url,
-      persistence: dormantTab.persistence,
+      pinned: dormantTab.pinned,
       loadOnLaunch: dormantTab.loadOnLaunch,
       asWindow: dormantTab.windowed || config.get("workspaceApps.mode") === "windows",
       savedAsWindow: dormantTab.windowed,
@@ -356,7 +359,6 @@ export class Tabs {
           app: savedWorkspaceApp.app,
           url: savedWorkspaceApp.url,
           title: savedWorkspaceApp.title,
-          persistence: savedWorkspaceApp.persistence,
           loadOnLaunch: savedWorkspaceApp.loadOnLaunch,
           windowed: savedWorkspaceApp.opensAsWindow,
         },
@@ -387,6 +389,29 @@ export class Tabs {
     }
   }
 
+  /**
+   * Opens a URL the way the configured mode dictates — in a window of its own,
+   * or in a tab that is activated right away. Apps that may not open inside
+   * Meru go to the default browser instead, leaving nothing to return.
+   */
+  openUrl(url: string) {
+    if (!canOpenWorkspaceAppInApp(getWorkspaceAppFromUrl(url))) {
+      openExternalUrl(url, { skipTrustedHostCheck: true });
+
+      return;
+    }
+
+    if (resolveWorkspaceAppOpenBehavior() === "newWindow") {
+      return this.openWindowedTab(url);
+    }
+
+    const workspaceApp = this.openTab(url);
+
+    this.activateTab(workspaceApp.id);
+
+    return workspaceApp;
+  }
+
   reopenClosedTab() {
     const reopenedTabUrl = this.recentlyClosedTabUrls.pop();
 
@@ -394,21 +419,7 @@ export class Tabs {
       return;
     }
 
-    if (!canOpenWorkspaceAppInApp(getWorkspaceAppFromUrl(reopenedTabUrl))) {
-      openExternalUrl(reopenedTabUrl, { skipTrustedHostCheck: true });
-
-      return;
-    }
-
-    if (resolveWorkspaceAppOpenBehavior() === "newWindow") {
-      return this.openWindowedTab(reopenedTabUrl);
-    }
-
-    const workspaceApp = this.openTab(reopenedTabUrl);
-
-    this.activateTab(workspaceApp.id);
-
-    return workspaceApp;
+    return this.openUrl(reopenedTabUrl);
   }
 
   get hasRecentlyClosedTabs() {
@@ -419,7 +430,7 @@ export class Tabs {
     const previousActiveTabId = this.activeTabId;
 
     for (const tab of this.tabs.slice()) {
-      if (tab.id !== keptTabId && tab.id !== GMAIL_TAB_ID && tab.persistence !== "pinned") {
+      if (tab.id !== keptTabId && tab.id !== GMAIL_TAB_ID && !tab.pinned) {
         this.closeTab(tab.id);
       }
     }
@@ -435,7 +446,7 @@ export class Tabs {
     const tabIndex = this.tabs.findIndex((tab) => tab.id === tabId);
 
     for (const tab of this.tabs.slice(tabIndex + 1)) {
-      if (tab.persistence !== "pinned") {
+      if (!tab.pinned) {
         this.closeTab(tab.id);
       }
     }
@@ -445,29 +456,24 @@ export class Tabs {
     }
   }
 
-  setTabPersistence(tabId: string, persistence: TabPersistence | null) {
-    const persistableTab = this.getTab(tabId);
+  setTabPinned(tabId: string, pinned: boolean) {
+    const pinnableTab = this.getTab(tabId);
 
-    if (persistableTab instanceof DormantTab) {
-      if (!persistence) {
-        this.removeTab(tabId);
+    // Unpinning a tab that was never opened leaves nothing behind to keep.
+    if (!pinned && pinnableTab instanceof DormantTab) {
+      this.removeTab(tabId);
 
-        return;
-      }
-
-      persistableTab.persistence = persistence;
-    } else if (persistableTab instanceof WorkspaceApp) {
-      persistableTab.persistence = persistence;
-    } else {
       return;
     }
 
-    if (persistence !== "pinned") {
-      persistableTab.loadOnLaunch = false;
+    if (!(pinnableTab instanceof WorkspaceApp)) {
+      return;
     }
 
-    if (persistableTab instanceof WorkspaceApp) {
-      persistableTab.broadcastBookmarkState();
+    pinnableTab.pinned = pinned;
+
+    if (!pinned) {
+      pinnableTab.loadOnLaunch = false;
     }
 
     this.reorderTabs();
@@ -515,7 +521,7 @@ export class Tabs {
 
     this.broadcastTabsChanged();
 
-    if (movedTab.persistence) {
+    if (movedTab.pinned) {
       accounts.saveTabs();
     }
   }
@@ -530,12 +536,11 @@ export class Tabs {
     const savedTabs: SavedTab[] = [];
 
     for (const tab of this.tabs) {
-      if (tab instanceof WorkspaceApp && tab.persistence && tab.app) {
+      if (tab instanceof WorkspaceApp && tab.pinned && tab.app) {
         savedTabs.push({
           app: tab.app,
           url: tab.url,
           title: tab.title,
-          persistence: tab.persistence,
           loadOnLaunch: tab.loadOnLaunch,
           windowed: tab.opensAsWindow,
         });
@@ -544,7 +549,6 @@ export class Tabs {
           app: tab.app,
           url: tab.url,
           title: tab.title,
-          persistence: tab.persistence,
           loadOnLaunch: tab.loadOnLaunch,
           windowed: tab.windowed,
         });
@@ -567,7 +571,7 @@ export class Tabs {
       id: tab.id,
       app: tab.app,
       title: tab.title,
-      persistence: tab.persistence,
+      pinned: tab.pinned,
       dormant: tab.dormant,
       windowed: isWindowedTab(tab),
       loadOnLaunch: Boolean(tab.loadOnLaunch),

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { APP_TITLEBAR_HEIGHT, GOOGLE_ACCOUNTS_URL } from "@meru/shared/constants";
 import { getWorkspaceAppUrl } from "@meru/shared/google";
-import type { AccountConfig, TabPersistence } from "@meru/shared/schemas";
+import type { AccountConfig } from "@meru/shared/schemas";
 import { clamp } from "@meru/shared/utils";
 import {
   type SupportedWorkspaceApp,
@@ -22,6 +22,7 @@ import {
   type WebContentsViewConstructorOptions,
 } from "electron";
 import { accounts } from "./accounts";
+import { bookmarks } from "./bookmarks";
 import { config } from "./config";
 import { ipc } from "./ipc";
 import { createChildWebContentsView, openViewDevToolsInDev } from "./lib/web-contents";
@@ -100,7 +101,7 @@ type WorkspaceAppOptions = {
   view?: WebContentsViewConstructorOptions;
   asWindow?: boolean;
   savedAsWindow?: boolean;
-  persistence?: TabPersistence | null;
+  pinned?: boolean;
   loadOnLaunch?: boolean;
   app?: SupportedWorkspaceApp;
   zoomFactor?: number;
@@ -138,6 +139,12 @@ export class WorkspaceApp {
   static applyPersistedZoomFactors() {
     for (const instance of WorkspaceApp.instances.values()) {
       instance.applyPersistedZoomFactor();
+    }
+  }
+
+  static broadcastBookmarkStates() {
+    for (const instance of WorkspaceApp.instances.values()) {
+      instance.broadcastBookmarkState();
     }
   }
 
@@ -388,11 +395,28 @@ export class WorkspaceApp {
     return !this.isPopup && Boolean(this.app);
   }
 
+  /**
+   * A bookmark saves the URL it was created from, so the button reflects the
+   * URL on display rather than anything about the app holding it — browsing on
+   * from a bookmarked page leaves the button empty again.
+   */
   get bookmarkState(): WorkspaceAppBookmarkState {
     return {
       savable: this.isSavable,
-      bookmarked: this.persistence === "bookmarked",
+      bookmarked: bookmarks.isBookmarked(this.accountId, this.url),
     };
+  }
+
+  toggleBookmark() {
+    if (!this.app) {
+      return;
+    }
+
+    bookmarks.toggle(this.accountId, {
+      app: this.app,
+      url: this.url,
+      title: this.title,
+    });
   }
 
   private get chromeWebContents() {
@@ -401,7 +425,7 @@ export class WorkspaceApp {
 
   view: WebContentsView;
 
-  persistence: TabPersistence | null;
+  pinned: boolean;
 
   dormant = false;
 
@@ -428,14 +452,14 @@ export class WorkspaceApp {
     view,
     asWindow,
     savedAsWindow,
-    persistence,
+    pinned,
     loadOnLaunch,
     app,
     zoomFactor,
   }: WorkspaceAppOptions) {
     this.accountId = accountId;
     this.app = app ?? getWorkspaceAppFromUrl(url);
-    this.persistence = persistence ?? null;
+    this.pinned = Boolean(pinned);
     this.loadOnLaunch = Boolean(loadOnLaunch);
     this.opensAsWindow =
       savedAsWindow ?? (Boolean(asWindow) && config.get("workspaceApps.mode") !== "windows");
@@ -637,18 +661,28 @@ export class WorkspaceApp {
   }
 
   private registerWindowedViewListeners() {
-    this.view.webContents.on("did-navigate", this.broadcastNavigationState);
-    this.view.webContents.on("did-navigate-in-page", this.broadcastNavigationState);
+    this.view.webContents.on("did-navigate", this.handleWindowedNavigation);
+    this.view.webContents.on("did-navigate-in-page", this.handleWindowedNavigation);
     this.view.webContents.on("did-start-loading", this.broadcastLoadingState);
     this.view.webContents.on("did-stop-loading", this.broadcastLoadingState);
   }
 
   private unregisterWindowedViewListeners() {
-    this.view.webContents.off("did-navigate", this.broadcastNavigationState);
-    this.view.webContents.off("did-navigate-in-page", this.broadcastNavigationState);
+    this.view.webContents.off("did-navigate", this.handleWindowedNavigation);
+    this.view.webContents.off("did-navigate-in-page", this.handleWindowedNavigation);
     this.view.webContents.off("did-start-loading", this.broadcastLoadingState);
     this.view.webContents.off("did-stop-loading", this.broadcastLoadingState);
   }
+
+  /**
+   * The bookmark button is keyed on the URL on display, so it has to be redrawn
+   * wherever the window navigates, alongside the back and forward controls.
+   */
+  private handleWindowedNavigation = () => {
+    this.broadcastNavigationState();
+
+    this.broadcastBookmarkState();
+  };
 
   private registerWindowListeners() {
     this.window.on("resize", this.updateViewBounds);
@@ -687,7 +721,7 @@ export class WorkspaceApp {
 
     this.account.instance.tabs.deactivateTab(this.id);
 
-    if (this.persistence) {
+    if (this.pinned) {
       accounts.saveTabs();
     }
   }
@@ -734,7 +768,7 @@ export class WorkspaceApp {
 
     this.updateViewBounds();
 
-    if (this.persistence) {
+    if (this.pinned) {
       accounts.saveTabs();
     }
   }
@@ -818,11 +852,11 @@ export class WorkspaceApp {
   };
 
   /**
-   * Only a window has a bookmark button to keep in sync — an embedded tab shows
-   * its state in the strip, which redraws from the tabs broadcast.
+   * Only a window has a bookmark button to keep in sync — an embedded tab is
+   * bookmarked from its context menu, which is built fresh on every open.
    */
   broadcastBookmarkState = () => {
-    if (!this._window) {
+    if (!this._window || this.viewDestroyed) {
       return;
     }
 

--- a/packages/renderer/bookmarks.tsx
+++ b/packages/renderer/bookmarks.tsx
@@ -1,5 +1,5 @@
 import { ipc } from "@meru/shared/renderer/ipc";
-import type { BookmarkState } from "@meru/shared/tabs";
+import type { BookmarkState } from "@meru/shared/schemas";
 import { Button } from "@meru/ui/components/button";
 import {
   Empty,
@@ -9,7 +9,7 @@ import {
   EmptyTitle,
 } from "@meru/ui/components/empty";
 import { ScrollArea } from "@meru/ui/components/scroll-area";
-import { AppWindowIcon, BookmarkIcon, XIcon } from "lucide-react";
+import { BookmarkIcon, XIcon } from "lucide-react";
 import { PopupWindow } from "@/components/popup-window";
 import { TabIcon } from "@/components/tab-icon";
 import { renderApp } from "@/lib/react";
@@ -19,7 +19,7 @@ function closePopup() {
   ipc.main.send("bookmarks.closePopup");
 }
 
-function Bookmark({ accountId, tabId, app, title, windowed }: BookmarkState) {
+function Bookmark({ accountId, id, app, title }: BookmarkState) {
   return (
     <div className="group relative">
       <Button
@@ -28,7 +28,7 @@ function Bookmark({ accountId, tabId, app, title, windowed }: BookmarkState) {
         className="w-full justify-start group-hover:pr-7"
         title={title}
         onClick={() => {
-          ipc.main.send("tabs.selectTab", accountId, tabId);
+          ipc.main.send("bookmarks.openBookmark", accountId, id);
 
           closePopup();
         }}
@@ -37,7 +37,6 @@ function Bookmark({ accountId, tabId, app, title, windowed }: BookmarkState) {
         <span className="min-w-0 flex-1 overflow-hidden mask-r-from-[calc(100%-1.5rem)] text-left whitespace-nowrap">
           {title}
         </span>
-        {windowed && <AppWindowIcon className="size-3 shrink-0 text-muted-foreground" />}
       </Button>
       <Button
         variant="secondary"
@@ -45,7 +44,7 @@ function Bookmark({ accountId, tabId, app, title, windowed }: BookmarkState) {
         className="absolute top-1/2 right-1 size-5 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
         title="Remove Bookmark"
         onClick={() => {
-          ipc.main.send("bookmarks.removeBookmark", accountId, tabId);
+          ipc.main.send("bookmarks.removeBookmark", accountId, id);
         }}
       >
         <XIcon className="size-3" />
@@ -69,7 +68,7 @@ function BookmarkList() {
             <BookmarkIcon />
           </EmptyMedia>
           <EmptyTitle>No bookmarks yet</EmptyTitle>
-          <EmptyDescription>Bookmarked workspace apps appear here.</EmptyDescription>
+          <EmptyDescription>Bookmarked pages appear here.</EmptyDescription>
         </EmptyHeader>
       </Empty>
     );
@@ -78,7 +77,7 @@ function BookmarkList() {
   return (
     <div className="flex flex-col gap-1">
       {bookmarks.map((bookmark) => (
-        <Bookmark key={bookmark.tabId} {...bookmark} />
+        <Bookmark key={bookmark.id} {...bookmark} />
       ))}
     </div>
   );

--- a/packages/renderer/bookmarks.tsx
+++ b/packages/renderer/bookmarks.tsx
@@ -9,7 +9,7 @@ import {
   EmptyTitle,
 } from "@meru/ui/components/empty";
 import { ScrollArea } from "@meru/ui/components/scroll-area";
-import { BookmarkIcon, XIcon } from "lucide-react";
+import { BookOpenIcon, XIcon } from "lucide-react";
 import { PopupWindow } from "@/components/popup-window";
 import { TabIcon } from "@/components/tab-icon";
 import { renderApp } from "@/lib/react";
@@ -65,7 +65,7 @@ function BookmarkList() {
       <Empty>
         <EmptyHeader>
           <EmptyMedia variant="icon">
-            <BookmarkIcon />
+            <BookOpenIcon />
           </EmptyMedia>
           <EmptyTitle>No bookmarks yet</EmptyTitle>
           <EmptyDescription>Bookmarked pages appear here.</EmptyDescription>

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -1,7 +1,6 @@
 import { accountColorsMap } from "@meru/shared/accounts";
 import { WEBSITE_URL } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
-import { getBookmarkedTabs } from "@meru/shared/tabs";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import { cn } from "@meru/ui/lib/utils";
@@ -35,7 +34,7 @@ import {
   WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME,
   WorkspaceAppsLauncher,
 } from "@/components/workspace-apps-launcher";
-import { useIsLicenseKeyValid, useSelectedAccountTabs, useVerticalTabs } from "@/lib/hooks";
+import { useIsLicenseKeyValid, useSelectedAccountBookmarks, useVerticalTabs } from "@/lib/hooks";
 import { useConfig } from "@/lib/react-query";
 import {
   useAccountsStore,
@@ -190,7 +189,7 @@ export function AppTitlebar() {
 
   const { tabs: selectedAccountTabs, width: verticalTabsWidth } = useVerticalTabs();
 
-  const { tabs: allSelectedAccountTabs } = useSelectedAccountTabs();
+  const selectedAccountBookmarks = useSelectedAccountBookmarks();
 
   const activeTab = selectedAccountTabs.find((tab) => tab.active);
 
@@ -244,8 +243,7 @@ export function AppTitlebar() {
   // `Tabs` mode the strip already has them. It also waits until there is
   // something to list.
   const shouldShowBookmarksButton =
-    config["workspaceApps.mode"] === "windows" &&
-    getBookmarkedTabs(allSelectedAccountTabs).length > 0;
+    config["workspaceApps.mode"] === "windows" && selectedAccountBookmarks.length > 0;
 
   const shouldShowOutOfOfficeButton =
     accounts.length === 1 &&

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -4,12 +4,12 @@ import { type DragEndEvent, DragDropProvider, PointerSensor } from "@dnd-kit/rea
 import { useSortable } from "@dnd-kit/react/sortable";
 import { VERTICAL_TABS_WIDE_WIDTH } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
-import type { AccountConfig } from "@meru/shared/schemas";
+import type { AccountConfig, Bookmark } from "@meru/shared/schemas";
 import { GMAIL_TAB_ID, getTabSection, type TabState } from "@meru/shared/tabs";
 import { workspaceApps } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import { cn } from "@meru/ui/lib/utils";
-import { AppWindowIcon, BookmarkIcon, CircleAlertIcon, XIcon } from "lucide-react";
+import { AppWindowIcon, CircleAlertIcon, XIcon } from "lucide-react";
 import type { Ref } from "react";
 import { TabIcon } from "@/components/tab-icon";
 import { UnreadCountBadge } from "@/components/unread-count-badge";
@@ -55,6 +55,33 @@ function moveSectionTab(
   }
 
   ipc.main.send("tabs.moveTab", accountId, movedTabId, movedSectionTabIds.indexOf(movedTabId));
+}
+
+function moveBookmark(accountId: AccountConfig["id"], bookmarks: Bookmark[], event: DragEndEvent) {
+  if (event.canceled) {
+    return;
+  }
+
+  const bookmarkIds = bookmarks.map((bookmark) => bookmark.id);
+
+  const movedBookmarkIds = move(bookmarkIds, event);
+
+  if (movedBookmarkIds === bookmarkIds) {
+    return;
+  }
+
+  const movedBookmarkId = event.operation.source?.id;
+
+  if (typeof movedBookmarkId !== "string") {
+    return;
+  }
+
+  ipc.main.send(
+    "bookmarks.moveBookmark",
+    accountId,
+    movedBookmarkId,
+    movedBookmarkIds.indexOf(movedBookmarkId),
+  );
 }
 
 function WindowedTabBadge({ className }: { className?: string }) {
@@ -161,9 +188,6 @@ function VerticalTab({
         {isWideRow && tab.windowed && (
           <AppWindowIcon className="size-3 shrink-0 text-muted-foreground" />
         )}
-        {isWideRow && tab.persistence === "bookmarked" && (
-          <BookmarkIcon className="size-3 shrink-0 text-muted-foreground" />
-        )}
       </Button>
       {!isWideRow && tab.windowed && <WindowedTabBadge className="-right-1 -bottom-1" />}
       {gmailStatus && <GmailTabStatusBadge {...gmailStatus} />}
@@ -223,6 +247,89 @@ function SortableVerticalTab({
   );
 }
 
+/**
+ * A saved URL rather than an open tab: there is nothing to close, and opening
+ * it loads the URL it was bookmarked at.
+ */
+function VerticalTabsBookmark({
+  ref,
+  bookmark,
+  accountId,
+  isWide,
+  className,
+}: {
+  ref?: Ref<HTMLDivElement>;
+  bookmark: Bookmark;
+  accountId: AccountConfig["id"];
+  isWide: boolean;
+  className?: string;
+}) {
+  return (
+    <div ref={ref} className={cn("group relative", className)}>
+      <Button
+        variant="ghost"
+        size={isWide ? "sm" : "icon"}
+        className={cn(isWide && "w-full justify-start group-hover:pr-7")}
+        title={bookmark.title}
+        onClick={() => {
+          ipc.main.send("bookmarks.openBookmark", accountId, bookmark.id);
+        }}
+      >
+        <TabIcon app={bookmark.app} />
+        {isWide && (
+          <span className="min-w-0 flex-1 overflow-hidden mask-r-from-[calc(100%-1.5rem)] text-left whitespace-nowrap">
+            {bookmark.title}
+          </span>
+        )}
+      </Button>
+      <Button
+        variant="secondary"
+        size="icon"
+        data-tab-close
+        className={cn(
+          "absolute opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
+          isWide
+            ? "top-1/2 right-1 size-5 -translate-y-1/2"
+            : "-top-1 -right-1 size-4 rounded-full",
+        )}
+        title="Remove Bookmark"
+        onClick={() => {
+          ipc.main.send("bookmarks.removeBookmark", accountId, bookmark.id);
+        }}
+      >
+        <XIcon className="size-3" />
+      </Button>
+    </div>
+  );
+}
+
+function SortableVerticalTabsBookmark({
+  bookmark,
+  accountId,
+  isWide,
+  sectionIndex,
+}: {
+  bookmark: Bookmark;
+  accountId: AccountConfig["id"];
+  isWide: boolean;
+  sectionIndex: number;
+}) {
+  const { ref, isDragging } = useSortable({
+    id: bookmark.id,
+    index: sectionIndex,
+  });
+
+  return (
+    <VerticalTabsBookmark
+      ref={ref}
+      bookmark={bookmark}
+      accountId={accountId}
+      isWide={isWide}
+      className={cn("touch-none", isDragging && "opacity-50")}
+    />
+  );
+}
+
 export function VerticalTabs() {
   const { config } = useConfig();
 
@@ -231,6 +338,7 @@ export function VerticalTabs() {
   const {
     selectedAccount,
     tabs: selectedAccountTabs,
+    bookmarks: selectedAccountBookmarks,
     width: verticalTabsWidth,
   } = useVerticalTabs();
 
@@ -243,8 +351,6 @@ export function VerticalTabs() {
   const pinnedSectionTabs = selectedAccountTabs.filter((tab) => getTabSection(tab) === "pinned");
 
   const normalTabs = selectedAccountTabs.filter((tab) => getTabSection(tab) === "normal");
-
-  const bookmarkedTabs = selectedAccountTabs.filter((tab) => getTabSection(tab) === "bookmarks");
 
   const launcherApps = config?.["workspaceApps.launcherApps"] ?? [];
 
@@ -326,16 +432,16 @@ export function VerticalTabs() {
         plugins={verticalTabsPlugins}
         sensors={verticalTabsSensors}
         onDragEnd={(event) => {
-          moveSectionTab(selectedAccount.config.id, bookmarkedTabs, event);
+          moveBookmark(selectedAccount.config.id, selectedAccountBookmarks, event);
         }}
       >
-        {bookmarkedTabs.map((tab, bookmarkedTabIndex) => (
-          <SortableVerticalTab
-            key={tab.id}
-            tab={tab}
+        {selectedAccountBookmarks.map((bookmark, bookmarkIndex) => (
+          <SortableVerticalTabsBookmark
+            key={bookmark.id}
+            bookmark={bookmark}
             accountId={selectedAccount.config.id}
-            presentation={isWide ? "wideRow" : "narrowIcon"}
-            sectionIndex={bookmarkedTabIndex}
+            isWide={isWide}
+            sectionIndex={bookmarkIndex}
           />
         ))}
       </DragDropProvider>

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -2,7 +2,11 @@ import type { GmailInboxMessage } from "@meru/shared/gmail";
 import { ms } from "@meru/shared/ms";
 import { ipc } from "@meru/shared/renderer/ipc";
 import type { AccountConfig } from "@meru/shared/schemas";
-import { getVerticalTabsWidth, getVisibleVerticalTabs } from "@meru/shared/tabs";
+import {
+  getVerticalTabsWidth,
+  getVisibleBookmarks,
+  getVisibleVerticalTabs,
+} from "@meru/shared/tabs";
 import { useEffect, useRef, useState } from "react";
 import { useConfig } from "./react-query";
 import { useAccountsStore, useTabsStore, useTrialStore } from "./stores";
@@ -45,7 +49,7 @@ export function useCloseOnWindowBlur(isOpen: boolean, onClose: () => void) {
 
 /**
  * Every tab of the selected account, before the vertical tabs strip narrows
- * them down — the titlebar surfaces entries the strip does not show.
+ * them down to the ones it shows.
  */
 export function useSelectedAccountTabs() {
   const accounts = useAccountsStore((state) => state.accounts);
@@ -62,23 +66,43 @@ export function useSelectedAccountTabs() {
 }
 
 /**
- * The tabs the vertical tabs strip renders and the width it takes up. The
- * titlebar reads it too, to know whether the strip is there to host the
- * Workspace Apps launcher.
+ * The bookmarks of the selected account. They are saved in its config, so the
+ * accounts broadcast carries them to every surface that lists them.
+ */
+export function useSelectedAccountBookmarks() {
+  const accounts = useAccountsStore((state) => state.accounts);
+
+  // Accounts written before bookmarks became a list of their own carry none
+  return accounts.find((account) => account.config.selected)?.config.workspaceApps.bookmarks ?? [];
+}
+
+/**
+ * What the vertical tabs strip renders and the width it takes up. The titlebar
+ * reads it too, to know whether the strip is there to host the Workspace Apps
+ * launcher.
  */
 export function useVerticalTabs() {
   const { selectedAccount, tabs: selectedAccountTabs } = useSelectedAccountTabs();
 
+  const selectedAccountBookmarks = useSelectedAccountBookmarks();
+
   const { config } = useConfig();
 
+  const workspaceAppsMode = config?.["workspaceApps.mode"] ?? "tabs";
+
   const tabs = getVisibleVerticalTabs(selectedAccountTabs, {
-    workspaceAppsMode: config?.["workspaceApps.mode"] ?? "tabs",
+    workspaceAppsMode,
     showWindows: config?.["verticalTabs.showWindows"] ?? true,
   });
 
-  const width = getVerticalTabsWidth(tabs, config?.["verticalTabs.width"] ?? "auto");
+  const bookmarks = getVisibleBookmarks(selectedAccountBookmarks, workspaceAppsMode);
 
-  return { selectedAccount, tabs, width };
+  const width = getVerticalTabsWidth(tabs, {
+    bookmarkCount: bookmarks.length,
+    configuredWidth: config?.["verticalTabs.width"] ?? "auto",
+  });
+
+  return { selectedAccount, tabs, bookmarks, width };
 }
 
 export function useIsLicenseKeyValid() {

--- a/packages/renderer/lib/react-query.ts
+++ b/packages/renderer/lib/react-query.ts
@@ -32,8 +32,8 @@ ipc.renderer.on("bookmarks.changed", (_event, bookmarks) => {
 
 /**
  * Only the bookmarks popup runs this: it is a view of its own, so it fetches
- * the list on mount and the main process pushes it again whenever tabs change
- * underneath it.
+ * the list on mount and the main process pushes it again whenever the saved
+ * bookmarks change underneath it.
  */
 export function useBookmarks() {
   const { data } = useQuery(

--- a/packages/renderer/workspace-app.tsx
+++ b/packages/renderer/workspace-app.tsx
@@ -38,8 +38,10 @@ function RecentDownloadHistoryButton() {
 }
 
 /**
- * Bookmarking is otherwise a tab context-menu action, which `New Windows` mode
- * leaves no way to reach — this is the entry point that does not need a strip.
+ * Saves the URL on display, or drops the bookmark holding it — filled while the
+ * window sits on a bookmarked URL, empty as soon as it browses on. Bookmarking
+ * is otherwise a tab context-menu action, which `New Windows` mode leaves no
+ * way to reach.
  */
 function BookmarkButton({ workspaceAppId }: { workspaceAppId: string }) {
   const [bookmarkState, setBookmarkState] = useState<WorkspaceAppBookmarkState>({

--- a/packages/renderer/workspace-app.tsx
+++ b/packages/renderer/workspace-app.tsx
@@ -1,7 +1,7 @@
 import { ipc } from "@meru/shared/renderer/ipc";
 import type { SupportedWorkspaceApp, WorkspaceAppBookmarkState } from "@meru/shared/workspace-apps";
 import { cn } from "@meru/ui/lib/utils";
-import { BookmarkIcon, DownloadIcon, EllipsisVerticalIcon } from "lucide-react";
+import { DownloadIcon, EllipsisVerticalIcon, StarIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { AccountBadge } from "@/components/account-badge";
 import { FindInPage } from "@/components/find-in-page";
@@ -70,7 +70,7 @@ function BookmarkButton({ workspaceAppId }: { workspaceAppId: string }) {
         ipc.main.send("workspaceApp.toggleBookmark", workspaceAppId);
       }}
     >
-      <BookmarkIcon className={cn(bookmarkState.bookmarked && "fill-current")} />
+      <StarIcon className={cn(bookmarkState.bookmarked && "fill-current")} />
     </TitlebarIconButton>
   );
 }

--- a/packages/shared/schemas.ts
+++ b/packages/shared/schemas.ts
@@ -21,22 +21,37 @@ export const accountColors = [
   "pink",
 ] as const;
 
-export const tabPersistenceSchema = z.enum(["pinned", "bookmarked"]);
+const workspaceAppSchema = z.custom<SupportedWorkspaceApp>(
+  (value) => typeof value === "string" && value in workspaceApps,
+);
 
-export type TabPersistence = z.infer<typeof tabPersistenceSchema>;
-
+/**
+ * A pinned tab as it is restored on the next launch. It keeps following the app
+ * it holds, so its `url` and `title` are rewritten as the user browses.
+ */
 export const savedTabSchema = z.object({
-  app: z.custom<SupportedWorkspaceApp>(
-    (value) => typeof value === "string" && value in workspaceApps,
-  ),
+  app: workspaceAppSchema,
   url: z.string(),
   title: z.string(),
-  persistence: tabPersistenceSchema,
   loadOnLaunch: z.boolean(),
   windowed: z.boolean(),
 });
 
 export type SavedTab = z.infer<typeof savedTabSchema>;
+
+/**
+ * A saved URL, captured when the bookmark was created. Unlike a saved tab, a
+ * bookmark never follows what the user browses to afterwards — opening one
+ * loads the URL it was created from.
+ */
+export const bookmarkSchema = z.object({
+  id: z.string(),
+  app: workspaceAppSchema,
+  url: z.string(),
+  title: z.string(),
+});
+
+export type Bookmark = z.infer<typeof bookmarkSchema>;
 
 export const accountConfigSchema = z.object({
   id: z.string(),
@@ -51,12 +66,21 @@ export const accountConfigSchema = z.object({
   }),
   workspaceApps: z.object({
     savedTabs: z.array(savedTabSchema),
+    bookmarks: z.array(bookmarkSchema),
   }),
 });
 
 export type AccountConfig = z.infer<typeof accountConfigSchema>;
 
 export type AccountConfigs = AccountConfig[];
+
+/**
+ * A bookmark as the surfaces listing it receive it, tagged with the account it
+ * belongs to so that opening or removing it targets the right one.
+ */
+export type BookmarkState = Bookmark & {
+  accountId: AccountConfig["id"];
+};
 
 export const accountConfigInputSchema = accountConfigSchema
   .pick({

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -1,5 +1,5 @@
 import { VERTICAL_TABS_NARROW_WIDTH, VERTICAL_TABS_WIDE_WIDTH } from "./constants";
-import type { AccountConfig, TabPersistence } from "./schemas";
+import type { AccountConfig } from "./schemas";
 import type { SupportedWorkspaceApp, WorkspaceAppsMode } from "./workspace-apps";
 
 export const GMAIL_TAB_ID = "gmail";
@@ -16,7 +16,7 @@ export type TabState = {
   id: string;
   app: SupportedWorkspaceApp | undefined;
   title: string;
-  persistence: TabPersistence | null;
+  pinned: boolean;
   dormant: boolean;
   windowed: boolean;
   loadOnLaunch: boolean;
@@ -30,37 +30,13 @@ export type AccountTabsState = {
   tabs: TabState[];
 };
 
-/**
- * A bookmarked entry as the titlebar's bookmarks popup lists it. Unlike the
- * strip's `bookmarks` section, which only holds the dormant ones because an
- * open bookmark moves into `normal`, this lists every bookmarked entry — the
- * popup is a list of bookmarks, not of what is currently closed.
- */
-export type BookmarkState = {
-  accountId: AccountConfig["id"];
-  tabId: string;
-  app: SupportedWorkspaceApp | undefined;
-  title: string;
-  windowed: boolean;
-};
-
-export function getBookmarkedTabs<BookmarkedTab extends Pick<TabState, "persistence">>(
-  tabs: BookmarkedTab[],
-) {
-  return tabs.filter((tab) => tab.persistence === "bookmarked");
-}
-
-export const tabSections = ["pinned", "normal", "bookmarks"] as const;
+export const tabSections = ["pinned", "normal"] as const;
 
 export type TabSection = (typeof tabSections)[number];
 
-export function getTabSection(tab: Pick<TabState, "id" | "persistence" | "dormant">): TabSection {
-  if (tab.id === GMAIL_TAB_ID || tab.persistence === "pinned") {
+export function getTabSection(tab: Pick<TabState, "id" | "pinned">): TabSection {
+  if (tab.id === GMAIL_TAB_ID || tab.pinned) {
     return "pinned";
-  }
-
-  if (tab.persistence === "bookmarked" && tab.dormant) {
-    return "bookmarks";
   }
 
   return "normal";
@@ -86,30 +62,43 @@ export function getVisibleVerticalTabs<VerticalTab extends Pick<TabState, "dorma
   return showWindows ? tabs : tabs.filter((tab) => !tab.windowed);
 }
 
-export function getVerticalTabsWidth(
-  tabs: Pick<TabState, "app" | "persistence">[],
-  configuredVerticalTabsWidth: VerticalTabsWidth,
+/**
+ * The strip is the home of the bookmarks section, and `windows` mode hides the
+ * strip — there the titlebar popup lists them instead.
+ */
+export function getVisibleBookmarks<VisibleBookmark>(
+  bookmarks: VisibleBookmark[],
+  workspaceAppsMode: WorkspaceAppsMode,
 ) {
-  if (tabs.length <= 1) {
+  return workspaceAppsMode === "windows" ? [] : bookmarks;
+}
+
+export function getVerticalTabsWidth(
+  tabs: Pick<TabState, "app" | "pinned">[],
+  { bookmarkCount, configuredWidth }: { bookmarkCount: number; configuredWidth: VerticalTabsWidth },
+) {
+  if (tabs.length <= 1 && bookmarkCount === 0) {
     return 0;
   }
 
-  if (configuredVerticalTabsWidth === "narrow") {
+  if (configuredWidth === "narrow") {
     return VERTICAL_TABS_NARROW_WIDTH;
   }
 
-  if (configuredVerticalTabsWidth === "wide") {
+  if (configuredWidth === "wide") {
     return VERTICAL_TABS_WIDE_WIDTH;
   }
 
-  if (tabs.some((tab) => tab.persistence === "bookmarked")) {
+  // Bookmarks are told apart by their title rather than by their app icon,
+  // which several of them can share.
+  if (bookmarkCount > 0) {
     return VERTICAL_TABS_WIDE_WIDTH;
   }
 
   const workspaceAppTabCounts = new Map<SupportedWorkspaceApp, number>();
 
   for (const tab of tabs) {
-    if (tab.app && tab.persistence !== "pinned") {
+    if (tab.app && !tab.pinned) {
       workspaceAppTabCounts.set(tab.app, (workspaceAppTabCounts.get(tab.app) ?? 0) + 1);
     }
   }

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -6,10 +6,12 @@ import type {
   AccountConfigInput,
   AccountConfigs,
   AccountInstances,
+  Bookmark,
+  BookmarkState,
   GmailLabelColors,
   GmailSavedSearches,
 } from "./schemas";
-import type { AccountTabsState, BookmarkState, VerticalTabsWidth } from "./tabs";
+import type { AccountTabsState, VerticalTabsWidth } from "./tabs";
 import type {
   LauncherWorkspaceApp,
   SupportedWorkspaceApp,
@@ -198,7 +200,13 @@ export type IpcMainEvents =
       "bookmarks.togglePopup": [];
       "bookmarks.closePopup": [];
       "bookmarks.setPopupCloseOnBlurEnabled": [enabled: boolean];
-      "bookmarks.removeBookmark": [accountId: AccountConfig["id"], tabId: string];
+      "bookmarks.openBookmark": [accountId: AccountConfig["id"], bookmarkId: Bookmark["id"]];
+      "bookmarks.removeBookmark": [accountId: AccountConfig["id"], bookmarkId: Bookmark["id"]];
+      "bookmarks.moveBookmark": [
+        accountId: AccountConfig["id"],
+        bookmarkId: Bookmark["id"],
+        targetIndex: number,
+      ];
       "doNotDisturb.toggle": [];
       "doNotDisturb.showOptions": [];
       "downloads.toggleRecentDownloadHistoryPopup": [];

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -84,7 +84,8 @@ export type WorkspaceAppsMode = keyof typeof workspaceAppsModes;
 export type WorkspaceAppOpenBehavior = "tab" | "backgroundTab" | "newWindow";
 
 export type WorkspaceAppBookmarkState = {
-  /** Popups such as the PDF viewer are never tabs, so they cannot be saved. */
+  /** Popups such as the PDF viewer are never tabs, so they offer no bookmarking. */
   savable: boolean;
+  /** Whether the URL on display is among the account's bookmarks. */
   bookmarked: boolean;
 };


### PR DESCRIPTION
## Problem

- A bookmark was a flag on a live tab (`savedTab.persistence === "bookmarked"`), and a saved tab's `url`/`title` are rewritten on every navigation — so browsing inside a bookmark silently rewrote it.
- Reopening a bookmark landed wherever the user last left it, not where it was saved.

## What changed

- Bookmarks are their own per-account list: `accounts[].workspaceApps.bookmarks` (`bookmarkSchema` = `id`, `app`, `url`, `title`), captured when the bookmark is created and never touched by navigation.
- `packages/app/bookmarks.ts` becomes the store (add/toggle/remove/move/open/serialize) on top of the config; the titlebar popup keeps rendering from it.
- Saved tabs are therefore always pinned, so `persistence: "pinned" | "bookmarked" | null` collapses to a `pinned` boolean across `SavedTab`, `TabState`, `Tab`, `DormantTab`, `WorkspaceApp`; `setTabPersistence` → `setTabPinned`; the strip's `tabSections` drops its `bookmarks` section of dormant tabs.
- The workspace app window's bookmark button reflects the URL on display: `WorkspaceApp.bookmarkState` asks the store whether that URL is saved, and the windowed `did-navigate`/`did-navigate-in-page` handler redraws it as the user browses.
- The strip keeps a Bookmarks section, now listing saved bookmarks (click opens the saved URL, hover-X removes, drag reorders) instead of dormant bookmarked tabs. Bookmarks now also keep the strip open and force its wide layout when they are the only thing in it.
- Every bookmark surface redraws from the single `config.onDidChange("accounts")` listener (popup list, window buttons, view bounds).
- `Tabs.openUrl` extracted from `reopenClosedTab` and reused by bookmark opening and the tab context menu's duplicate/new-tab actions.
- Tab context menu: Pin/Unpin unchanged in behaviour; Bookmark/Remove Bookmark now toggles the tab's current URL in the bookmark list.
- Bookmark glyphs follow Apple's/Safari's convention instead of lucide's ribbon: a **star** is one bookmark, a **book** is the collection.
  - Workspace app window titlebar toggle: `StarIcon`, `fill-current` while the displayed URL is bookmarked, outline otherwise.
  - Bookmarks popup empty state: `BookOpenIcon` (Safari's sidebar uses SF Symbols' `book`, which renders open).
  - Wording is untouched — the button still reads `Bookmark`/`Remove Bookmark`.

## Risks

- **Data migration** (`">3.58.0"` in `packages/app/config.ts`): every account's `savedTabs` is rewritten — entries with `persistence: "bookmarked"` become bookmarks, the rest stay as saved tabs with `persistence` stripped. A user upgrading with bookmarks has them converted exactly once; a failure here loses bookmarks and pinned tabs. It is folded into the existing `">3.58.0"` bucket, which is unreleased, so no released config has run it yet. Untested against a real pre-upgrade config file — only reasoned through.
- Bookmarks are matched by exact URL string. Toggling off works from the page it was saved on; a URL that differs by a query param or fragment reads as unbookmarked and bookmarking it again adds a second entry.
- `accounts.updateAllViewBounds()` now runs on every `accounts` config change (tab saves, account selection included), not just on bookmark changes. It is idempotent, but it is more work per write than before.
- Reads defend with `?? []` where an account may predate the key, but `accountConfigSchema` is not enforced against the store, so a config that skips the migration would carry `bookmarks: undefined` into the renderer stores.

## Omissions

- Bookmarking still requires a recognised Workspace app (the bookmark stores `app` for its icon), so a non-Google page in a tab has no Bookmark action — unchanged from before.
- Popup windows (PDF viewer, My Account) still show no bookmark button; `savable` was left as-is rather than widened.
- The main window titlebar's Bookmarks button (`packages/renderer/components/app-titlebar.tsx`) still uses the ribbon `BookmarkIcon`; that surface is owned by a separate branch, so it is deliberately untouched here and the two icon sets will only agree once both land.
- Nothing was run or screenshotted here; only type check, lint, format and the JS build were verified.

## Test plan

1. Bookmark a Doc from its tab context menu, then navigate inside that tab to another document. Expected: the strip's bookmark entry keeps the original title, and reopening it loads the original document, not the one navigated to.
2. Open a workspace app in its own window (`New Windows` mode or Move to New Window), click the star button in its titlebar. Expected: the star fills, entry appears in the titlebar bookmarks popup.
3. In that same window, navigate to a different page. Expected: the star empties back to an outline without the bookmark changing; navigating back to the bookmarked URL fills it again.
4. Click the filled star. Expected: it empties and the entry disappears from the popup and the strip.
5. Open a bookmark from the strip in `Tabs` mode and from the titlebar popup in `New Windows` mode. Expected: a tab, respectively a window, at the saved URL; popup closes on click.
6. Remove a bookmark with the hover-X in the strip and with the X in the popup. Expected: it disappears from both surfaces at once.
7. Drag bookmarks within the strip's bookmarks section. Expected: order sticks after restarting the app.
8. Pin a tab, close it, restart. Expected: it comes back as a dormant pinned tab in the pinned section; Load on Launch still restores it eagerly.
9. Upgrade path: with a config from `main` holding both bookmarked and pinned saved tabs, launch this branch. Expected: the bookmarked ones are listed under Bookmarks (no dormant tab left behind), the pinned ones are unchanged, and `config.json` shows `workspaceApps.bookmarks` populated with `savedTabs` holding only the pinned entries and no `persistence` key.
10. With only Gmail open and at least one bookmark, in `Tabs` mode. Expected: the strip stays open and wide so the bookmarks are reachable; switching to `New Windows` mode hides the strip and shows the titlebar Bookmarks button instead.
11. Multiple accounts: bookmark in account A, switch to account B. Expected: B's strip and popup list only B's bookmarks.
12. Remove every bookmark, then open the titlebar bookmarks popup. Expected: the empty state shows an open-book icon above "No bookmarks yet".
