### PR TITLE
always show the bookmarks button, with an empty state in the popup

### DIFF
--- a/packages/app/bookmarks.ts
+++ b/packages/app/bookmarks.ts
@@ -12,9 +12,11 @@ import { TitlebarPopup } from "./lib/titlebar-popup";
  * created from and never follows what the user browses to afterwards — opening
  * one loads that URL again.
  *
- * Bookmarks render in the vertical tabs strip, which `New Windows` mode hides
- * entirely — so the titlebar carries a popup of its own to keep them reachable,
- * and it is the only surface that lists them when there is no strip.
+ * Bookmarks render in the vertical tabs strip, but the titlebar's popup lists
+ * them unconditionally — the strip is gone in `New Windows` mode and absent in
+ * `Tabs` mode until a second tab opens, so the popup is the one surface that is
+ * always there. It stays reachable while empty, where it explains how to add
+ * one.
  */
 class Bookmarks {
   popup = new TitlebarPopup({

--- a/packages/renderer/bookmarks.tsx
+++ b/packages/renderer/bookmarks.tsx
@@ -69,6 +69,9 @@ function BookmarkList() {
           </EmptyMedia>
           <EmptyTitle>No bookmarks yet</EmptyTitle>
           <EmptyDescription>Bookmarked pages appear here.</EmptyDescription>
+          <EmptyDescription>
+            Bookmark a page with the star in its window titlebar, or from a tab's context menu.
+          </EmptyDescription>
         </EmptyHeader>
       </Empty>
     );

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -34,7 +34,7 @@ import {
   WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME,
   WorkspaceAppsLauncher,
 } from "@/components/workspace-apps-launcher";
-import { useIsLicenseKeyValid, useSelectedAccountBookmarks, useVerticalTabs } from "@/lib/hooks";
+import { useIsLicenseKeyValid, useVerticalTabs } from "@/lib/hooks";
 import { useConfig } from "@/lib/react-query";
 import {
   useAccountsStore,
@@ -189,8 +189,6 @@ export function AppTitlebar() {
 
   const { tabs: selectedAccountTabs, width: verticalTabsWidth } = useVerticalTabs();
 
-  const selectedAccountBookmarks = useSelectedAccountBookmarks();
-
   const activeTab = selectedAccountTabs.find((tab) => tab.active);
 
   const [location] = useLocation();
@@ -237,13 +235,6 @@ export function AppTitlebar() {
     config["gmail.savedSearches"].length > 0 && Boolean(config.licenseKey);
 
   const isWorkspaceAppTabActive = Boolean(activeTab?.app && activeTab.app !== "gmail");
-
-  // `New Windows` mode hides the strip, which is where bookmarks are otherwise
-  // listed — so the button exists to replace it, not to sit beside it. In
-  // `Tabs` mode the strip already has them. It also waits until there is
-  // something to list.
-  const shouldShowBookmarksButton =
-    config["workspaceApps.mode"] === "windows" && selectedAccountBookmarks.length > 0;
 
   const shouldShowOutOfOfficeButton =
     accounts.length === 1 &&
@@ -424,7 +415,7 @@ export function AppTitlebar() {
                 ))}
               </TitlebarDropdownMenu>
             )}
-            {shouldShowBookmarksButton && <BookmarksButton />}
+            <BookmarksButton />
             <RecentDownloadHistoryButton />
             <DoNotDisturb />
           </div>


### PR DESCRIPTION
## Problem

The main window's bookmarks button was gated on `workspaceApps.mode === "windows" && bookmarks.length > 0`, which caused two things:

- The button appeared and disappeared as the bookmark list filled and emptied, shoving the icons left of it sideways.
- The popup's empty state could never be seen. The button was hidden in exactly the case the empty state exists for.

It also left a reachability gap: in `Tabs` mode bookmarks live in the vertical tabs strip, but the strip is not rendered until a second tab opens, so a user with one tab had no way to reach their bookmarks at all.

## What changed

- The bookmarks button is now always in the titlebar, matching the download history button beside it.
- `shouldShowBookmarksButton` and the `useSelectedAccountBookmarks` call it needed are gone from `app-titlebar.tsx`; the hook is still used by `useVerticalTabs`.
- The popup's empty state gains a second line naming the two ways to bookmark a page, since it is now the first thing a user with no bookmarks sees. The existing `Empty` markup already matched the download history one, so only the copy changed.
- Updated the `Bookmarks` doc comment in `packages/app/bookmarks.ts`, which justified the popup by `New Windows` mode hiding the strip. That is no longer the whole reason it exists.

## Decisions worth challenging

- **I dropped the mode check as well as the count check.** "Always show" plus the comparison to recent download history — which has no mode gating — read as unconditional. The consequence is that in `Tabs` mode with the strip visible, bookmarks are reachable from both the strip and the titlebar. That is the arrangement browsers use (bookmarks bar plus bookmarks menu) and it closes the one-tab gap above, but it is duplication and easy to reverse: restore `config["workspaceApps.mode"] === "windows" &&` if you would rather the button stay out of `Tabs` mode.
- **The empty-state copy names a star and a context menu.** If the wording should match whatever the menus actually say verbatim, tell me and I will align it.

## Risks and omissions

- The button now occupies titlebar width permanently, in every mode and on every account. On a narrow window that is one more icon competing with the account buttons and launcher.
- Not run in a real app — no visual confirmation of the empty state's layout with two description lines, or of the titlebar at narrow widths.

## Test plan

1. Start with an account that has no bookmarks, in `Tabs` mode. **Expected:** the open-book bookmarks button is present in the titlebar.
2. Click it. **Expected:** the popup opens showing "No bookmarks yet", the open-book icon, and two lines of description, the second naming the star in a window titlebar and a tab's context menu.
3. With only one tab open (so the vertical tabs strip is not rendered), click the button again. **Expected:** bookmarks are still reachable — this was previously impossible.
4. Bookmark a page, then reopen the popup. **Expected:** the empty state is replaced by the bookmark; the titlebar button does not move or change.
5. Remove the last bookmark with the popup open. **Expected:** the empty state returns and the titlebar button stays exactly where it is — nothing in the titlebar shifts.
6. Switch to `New Windows` mode. **Expected:** the button is still present and behaves identically.
7. Narrow the window as far as it goes with several accounts configured. **Expected:** the titlebar stays legible and the bookmarks button is not clipped or overlapping.
8. Check the popup's empty state in both light and dark themes. **Expected:** both description lines are readable and the block stays vertically centred.
