### PR TITLE
Open DevTools in dev only behind a --devtools flag

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -30,7 +30,7 @@ import { accounts } from "@/accounts";
 import { config } from "@/config";
 import { ipc } from "@/ipc";
 import { log } from "@/lib/log";
-import { createChildWebContentsView, openViewDevToolsInDev } from "@/lib/web-contents";
+import { createChildWebContentsView, openViewDevToolsOnLaunch } from "@/lib/web-contents";
 import { getPreloadPath } from "@/lib/window";
 import { xmlParser } from "@/lib/xml";
 import { licenseKey } from "@/license-key";
@@ -421,7 +421,7 @@ export class Gmail {
 
     registerTabBroadcasts(this.view);
 
-    openViewDevToolsInDev(this.view);
+    openViewDevToolsOnLaunch(this.view);
 
     return this.view.webContents.loadURL(this.url);
   }

--- a/packages/app/lib/dev-tools.ts
+++ b/packages/app/lib/dev-tools.ts
@@ -1,0 +1,4 @@
+import { is } from "@electron-toolkit/utils";
+import { app } from "electron";
+
+export const shouldOpenDevToolsOnLaunch = is.dev && app.commandLine.hasSwitch("devtools");

--- a/packages/app/lib/web-contents.ts
+++ b/packages/app/lib/web-contents.ts
@@ -1,4 +1,3 @@
-import { is } from "@electron-toolkit/utils";
 import {
   type Session,
   type WebContents,
@@ -7,6 +6,7 @@ import {
 } from "electron";
 import { setupWindowContextMenu } from "@/context-menu";
 import { ipc } from "@/ipc";
+import { shouldOpenDevToolsOnLaunch } from "./dev-tools";
 
 export function applyViewZoomLimits(view: WebContentsView) {
   view.webContents.on("dom-ready", () => {
@@ -14,8 +14,8 @@ export function applyViewZoomLimits(view: WebContentsView) {
   });
 }
 
-export function openViewDevToolsInDev(view: WebContentsView) {
-  if (is.dev) {
+export function openViewDevToolsOnLaunch(view: WebContentsView) {
+  if (shouldOpenDevToolsOnLaunch) {
     view.webContents.openDevTools({ mode: "bottom" });
   }
 }

--- a/packages/app/lib/window.ts
+++ b/packages/app/lib/window.ts
@@ -9,6 +9,7 @@ import {
   screen,
   WebContentsView,
 } from "electron";
+import { shouldOpenDevToolsOnLaunch } from "./dev-tools";
 import { isLinuxWindowControlsEnabled } from "./linux";
 
 const CASCADE_OFFSET = 30;
@@ -151,7 +152,9 @@ export function loadRenderer(
   if (is.dev) {
     window.webContents.loadURL(`http://localhost:3000/${pageFileName}?${searchParams.toString()}`);
 
-    window.webContents.openDevTools({ mode: "detach" });
+    if (shouldOpenDevToolsOnLaunch) {
+      window.webContents.openDevTools({ mode: "detach" });
+    }
   } else {
     window.webContents.loadFile(path.join("build-js", "renderer", pageFileName), {
       search: searchParams.toString(),

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -25,7 +25,7 @@ import { accounts } from "./accounts";
 import { bookmarks } from "./bookmarks";
 import { config } from "./config";
 import { ipc } from "./ipc";
-import { createChildWebContentsView, openViewDevToolsInDev } from "./lib/web-contents";
+import { createChildWebContentsView, openViewDevToolsOnLaunch } from "./lib/web-contents";
 import {
   createBrowserWindow,
   getCascadedWindowBounds,
@@ -558,7 +558,7 @@ export class WorkspaceApp {
 
     view.webContents.loadURL(url);
 
-    openViewDevToolsInDev(view);
+    openViewDevToolsOnLaunch(view);
 
     return view;
   }

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -15,6 +15,10 @@ const args = parseArgs({
     dev: {
       type: "boolean",
     },
+    devtools: {
+      type: "boolean",
+      short: "d",
+    },
   },
   strict: true,
   allowPositionals: true,
@@ -148,7 +152,7 @@ if (args.values.dev) {
   let isRestartingElectron = false;
 
   const startElectron = () => {
-    electron = spawn(["electron", "."], {
+    electron = spawn(["electron", ".", ...(args.values.devtools ? ["--devtools"] : [])], {
       onExit: async () => {
         if (isRestartingElectron) {
           isRestartingElectron = false;


### PR DESCRIPTION
## Problem

- `bun dev` opened DevTools automatically for every renderer window and every Gmail/workspace-app view, which is noise most of the time.

## Changes

- `scripts/build.ts` takes `-d` / `--devtools` and forwards a `--devtools` switch to the spawned Electron process.
- New `packages/app/lib/dev-tools.ts` exports `shouldOpenDevToolsOnLaunch` (`is.dev` **and** the switch), used by both auto-open sites: `loadRenderer` in `lib/window.ts` and `openViewDevToolsInDev` in `lib/web-contents.ts` (renamed to `openViewDevToolsOnLaunch`, since it is no longer dev-only in effect).
- Without the flag, `bun dev` still loads renderers from the Vite dev server — only the automatic DevTools opening is gone. The View menu's DevTools items are untouched.

## Risks / omissions

- The Electron side reads the flag via `app.commandLine.hasSwitch("devtools")`, matching the existing `launch-minimized` switch, but **I could not run Electron in this environment** (missing system libs), so the switch pickup is unverified end to end. Arg forwarding through `bun run dev -d` / `--devtools` was verified with a standalone parseArgs harness.
- Types, lint and format checks pass.

## Test plan

1. `bun dev` — app starts, no DevTools open in the main window, the Gmail view, or workspace app views/windows.
2. `bun dev -d` — DevTools open detached for the main window and at the bottom for the Gmail view; opening a workspace app opens its DevTools too.
3. `bun dev --devtools` — same as step 2.
4. With `bun dev` running (no flag), edit a file under `packages/app/` to trigger the Electron restart — DevTools stay closed after the restart; repeat with `-d` and they reopen.
5. `bun dev` (no flag), then View → Toggle Developer Tools — DevTools still open manually.
6. `bun run build:linux` (or your platform) and launch the packaged app — no DevTools, unchanged behavior.