### PR TITLE
Tell the docs.google.com apps apart by their path

### DIFF
--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { getWorkspaceAppFromUrl } from "@meru/shared/google";
 import type { SavedTab } from "@meru/shared/schemas";
 import { getTabSection, GMAIL_TAB_ID, type TabState, tabSections } from "@meru/shared/tabs";
 import type { SupportedWorkspaceApp } from "@meru/shared/workspace-apps";
@@ -11,7 +12,6 @@ import { appMenu } from "./menu";
 import { openExternalUrl } from "./url";
 import {
   canOpenWorkspaceAppInApp,
-  getWorkspaceAppFromUrl,
   resolveWorkspaceAppOpenBehavior,
   WorkspaceApp,
 } from "./workspace-app";

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { APP_TITLEBAR_HEIGHT, GOOGLE_ACCOUNTS_URL } from "@meru/shared/constants";
-import { getWorkspaceAppUrl } from "@meru/shared/google";
+import { getWorkspaceAppFromUrl, getWorkspaceAppUrl } from "@meru/shared/google";
 import type { AccountConfig } from "@meru/shared/schemas";
 import { clamp } from "@meru/shared/utils";
 import {
@@ -48,27 +48,6 @@ const GOOGLE_MEET_TOGGLE_CAMERA_ACCELERATOR = "CommandOrControl+Shift+2";
 const GOOGLE_CHAT_ATTACHMENT_URL_REGEXP = /chat\.google\.com\/u\/\d\/api\/get_attachment_url/;
 
 const GOOGLE_PDF_VIEWER_URL_REGEXP = /googleusercontent\.com\/viewer\/secure\/pdf/;
-
-const workspaceAppsBySubdomain = new Map<string, SupportedWorkspaceApp>(
-  (Object.keys(workspaceApps) as SupportedWorkspaceApp[]).map((workspaceApp) => [
-    new URL(getWorkspaceAppUrl(workspaceApp)).hostname.replace(".google.com", ""),
-    workspaceApp,
-  ]),
-);
-
-const SUPPORTED_WORKSPACE_APPS_URL_REGEXP = new RegExp(
-  `(${Array.from(workspaceAppsBySubdomain.keys()).join("|")})(?:\\.usercontent)?\\.google\\.com`,
-);
-
-export function getWorkspaceAppFromUrl(url: string) {
-  const workspaceAppSubdomain = url.match(SUPPORTED_WORKSPACE_APPS_URL_REGEXP)?.[1];
-
-  if (!workspaceAppSubdomain) {
-    return undefined;
-  }
-
-  return workspaceAppsBySubdomain.get(workspaceAppSubdomain);
-}
 
 /**
  * Whether an app may open inside Meru at all. `Open in App` and its exclusions

--- a/packages/shared/google.test.ts
+++ b/packages/shared/google.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { getWorkspaceAppFromUrl } from "./google";
+
+describe("getWorkspaceAppFromUrl", () => {
+  test("resolves an app from its own subdomain", () => {
+    expect(getWorkspaceAppFromUrl("https://calendar.google.com/calendar/u/0/r")).toBe("calendar");
+    expect(getWorkspaceAppFromUrl("https://drive.google.com/drive/u/0/my-drive")).toBe("drive");
+    expect(getWorkspaceAppFromUrl("https://keep.google.com/u/0/")).toBe("keep");
+  });
+
+  test("resolves the docs.google.com apps from their path", () => {
+    expect(getWorkspaceAppFromUrl("https://docs.google.com/document/d/abc123/edit")).toBe("docs");
+    expect(getWorkspaceAppFromUrl("https://docs.google.com/spreadsheets/d/abc123/edit")).toBe(
+      "sheets",
+    );
+    expect(getWorkspaceAppFromUrl("https://docs.google.com/presentation/d/abc123/edit")).toBe(
+      "slides",
+    );
+    expect(getWorkspaceAppFromUrl("https://docs.google.com/forms/d/abc123/edit")).toBe("forms");
+  });
+
+  test("resolves the docs.google.com apps behind an account or domain prefix", () => {
+    expect(getWorkspaceAppFromUrl("https://docs.google.com/spreadsheets/u/1/d/abc123/edit")).toBe(
+      "sheets",
+    );
+    expect(getWorkspaceAppFromUrl("https://docs.google.com/u/1/spreadsheets/d/abc123/edit")).toBe(
+      "sheets",
+    );
+    expect(
+      getWorkspaceAppFromUrl("https://docs.google.com/a/example.com/presentation/d/abc123/edit"),
+    ).toBe("slides");
+  });
+
+  test("resolves the docs.google.com app home pages", () => {
+    expect(getWorkspaceAppFromUrl("https://docs.google.com/spreadsheets/u/0/")).toBe("sheets");
+    expect(getWorkspaceAppFromUrl("https://docs.google.com/spreadsheets")).toBe("sheets");
+    expect(getWorkspaceAppFromUrl("https://docs.google.com/spreadsheets?usp=sheets_home")).toBe(
+      "sheets",
+    );
+  });
+
+  test("falls back to Docs for the rest of docs.google.com", () => {
+    expect(getWorkspaceAppFromUrl("https://docs.google.com/")).toBe("docs");
+    expect(getWorkspaceAppFromUrl("https://docs.google.com/drawings/d/abc123/edit")).toBe("docs");
+  });
+
+  test("resolves an app from its usercontent subdomain", () => {
+    expect(getWorkspaceAppFromUrl("https://drive.usercontent.google.com/download?id=abc123")).toBe(
+      "drive",
+    );
+  });
+
+  test("returns undefined for unsupported urls", () => {
+    expect(getWorkspaceAppFromUrl("https://example.com/spreadsheets/d/abc123")).toBeUndefined();
+    expect(getWorkspaceAppFromUrl("https://myaccount.google.com/")).toBe("myaccount");
+    expect(getWorkspaceAppFromUrl("https://photos.google.com/")).toBeUndefined();
+  });
+});

--- a/packages/shared/google.ts
+++ b/packages/shared/google.ts
@@ -7,3 +7,46 @@ export function getWorkspaceAppUrl(app: SupportedWorkspaceApp) {
 export function getGoogleDomainFaviconUrl(domain: string, size: number) {
   return `https://www.google.com/s2/favicons?domain=${domain}&sz=${size}`;
 }
+
+const workspaceAppsBySubdomain = new Map<string, SupportedWorkspaceApp>(
+  (Object.keys(workspaceApps) as SupportedWorkspaceApp[]).map((workspaceApp) => [
+    new URL(getWorkspaceAppUrl(workspaceApp)).hostname.replace(".google.com", ""),
+    workspaceApp,
+  ]),
+);
+
+const WORKSPACE_APPS_SUBDOMAIN_REGEXP = new RegExp(
+  `(${Array.from(workspaceAppsBySubdomain.keys()).join("|")})(?:\\.usercontent)?\\.google\\.com`,
+);
+
+/**
+ * Docs, Sheets, Slides and Forms all share the `docs.google.com` host — their
+ * own subdomains only redirect there — so the leading path segment is the only
+ * thing telling them apart. Anything else on that host stays Docs.
+ */
+const workspaceAppsByDocsPathSegment: Record<string, SupportedWorkspaceApp> = {
+  document: "docs",
+  spreadsheets: "sheets",
+  presentation: "slides",
+  forms: "forms",
+};
+
+const WORKSPACE_APPS_DOCS_PATH_REGEXP = new RegExp(
+  `docs\\.google\\.com/(?:(?:u/\\d+|a/[^/]+)/)?(${Object.keys(workspaceAppsByDocsPathSegment).join("|")})(?:[/?#]|$)`,
+);
+
+export function getWorkspaceAppFromUrl(url: string) {
+  const docsPathSegment = url.match(WORKSPACE_APPS_DOCS_PATH_REGEXP)?.[1];
+
+  if (docsPathSegment) {
+    return workspaceAppsByDocsPathSegment[docsPathSegment];
+  }
+
+  const workspaceAppSubdomain = url.match(WORKSPACE_APPS_SUBDOMAIN_REGEXP)?.[1];
+
+  if (!workspaceAppSubdomain) {
+    return undefined;
+  }
+
+  return workspaceAppsBySubdomain.get(workspaceAppSubdomain);
+}


### PR DESCRIPTION
## Problem

- Opening a sheet (from Drive, a link, or the launcher) showed the **Docs** icon in the window titlebar.
- `getWorkspaceAppFromUrl` matched on subdomain only, and Sheets, Slides and Forms all live on `docs.google.com` — `sheets.google.com` and friends just redirect there — so every one of them resolved to `docs`.
- The resolved app drives more than the icon: the titlebar/tab icon, the `Google <App>` title cleanup, the `app` stored on a bookmark, the per-app zoom factor, and the `Open in App` exclusion check. All of them were wrong for Sheets/Slides/Forms.

## Changes

- Moved `getWorkspaceAppFromUrl` out of `packages/app/workspace-app.ts` into `packages/shared/google.ts`, next to `getWorkspaceAppUrl` — it is pure URL logic, and the move makes it unit-testable (`packages/app/workspace-app.ts` pulls in Electron).
- It now checks the `docs.google.com` path first: `document` → Docs, `spreadsheets` → Sheets, `presentation` → Slides, `forms` → Forms, tolerating a `u/<n>/` or `a/<domain>/` prefix in either position. Everything else on that host still falls back to Docs (e.g. Drawings, which is not a supported app), and non-`docs.google.com` URLs keep the existing subdomain matching.
- Added `packages/shared/google.test.ts` covering subdomain resolution, the four docs-host apps, account/domain-prefixed and home-page URLs, the Docs fallback, `usercontent` hosts, and unsupported URLs.

## Risks / omissions

- Bookmarks saved before this change keep the `app: "docs"` they were stored with, so their icon in the bookmarks list stays Docs until re-saved. No migration included.
- Per-app zoom factors are keyed by app, so a Sheets tab no longer inherits the zoom saved under Docs — it starts from the Sheets entry (unset, so default) the first time.
- `workspaceApps.openInAppExcludedApps` now applies correctly per app: someone who excluded Docs to keep sheets opening externally will find Sheets opening in Meru again, which is the intended behavior but a visible change.
- Types, lint, format and `bun test` (127 tests) pass. **Not verified in the running app** — I cannot launch Electron in this environment.

## Test plan

1. Open a spreadsheet from Drive — the titlebar shows the **Sheets** icon, not Docs.
2. Open a doc, a presentation and a form the same way — Docs, Slides and Forms icons respectively.
3. Open Sheets from the apps launcher (it redirects `sheets.google.com` → `docs.google.com/spreadsheets`) — the icon stays Sheets across the redirect, and the title reads `… - Sheets`.
4. In tabs mode, do the same and check the tab icon in the vertical tabs strip.
5. Bookmark an open sheet, then open the bookmarks popup — the entry carries the Sheets icon.
6. With a second account, open a sheet under `/u/1/` — still Sheets.
7. Settings → Workspace Apps → exclude **Docs** from `Open in App`, then open a doc (opens externally) and a sheet (still opens in Meru).
8. Open a Drawing (`docs.google.com/drawings/…`) — falls back to the Docs icon, unchanged.