### PR TITLE
bookmark a tab from its row

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -95,11 +95,14 @@ class Ipc {
     config.onDidChange("accounts", () => {
       accounts.sendAccountsChangedToRenderer();
 
-      // Bookmarks live in the account config, so every surface listing them
-      // redraws from here rather than from a change event of its own. The
-      // strip is one of them, and it can grow or vanish with them, so the
-      // views around it have to be laid out again.
+      // Bookmarks live in the account config, so every surface reflecting them
+      // redraws from here rather than from a change event of its own. The strip
+      // is one of them, and it can grow or vanish with them, so the views around
+      // it have to be laid out again. Its tab rows star the URL they sit on, so
+      // they are sent again too.
       accounts.updateAllViewBounds();
+
+      accounts.sendTabsChangedToRenderer();
 
       bookmarks.sendChangedToPopup();
 

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -5,6 +5,7 @@ import { getTabSection, GMAIL_TAB_ID, type TabState, tabSections } from "@meru/s
 import type { SupportedWorkspaceApp } from "@meru/shared/workspace-apps";
 import type { WebContentsView } from "electron";
 import { accounts } from "./accounts";
+import { bookmarks } from "./bookmarks";
 import { config } from "./config";
 import type { Gmail } from "./gmail";
 import { main } from "./main";
@@ -32,6 +33,14 @@ export function registerTabBroadcasts(view: WebContentsView) {
 
 export function isWindowedTab(tab: Tab) {
   return tab instanceof WorkspaceApp && tab.isWindowed;
+}
+
+/**
+ * The Gmail tab stands for the account's inbox rather than a URL, so it is the
+ * one tab with nothing to save.
+ */
+function isBookmarkableTab(tab: Tab): tab is WorkspaceApp | DormantTab {
+  return tab instanceof WorkspaceApp || tab instanceof DormantTab;
 }
 
 type SavedWorkspaceApp = WorkspaceApp & {
@@ -574,6 +583,7 @@ export class Tabs {
       pinned: tab.pinned,
       dormant: tab.dormant,
       windowed: isWindowedTab(tab),
+      bookmarked: isBookmarkableTab(tab) && bookmarks.isBookmarked(this.accountId, tab.url),
       loadOnLaunch: Boolean(tab.loadOnLaunch),
       loading: tab.isLoading,
       navigationHistory: tab.navigationHistory,

--- a/packages/renderer/bookmarks.tsx
+++ b/packages/renderer/bookmarks.tsx
@@ -70,7 +70,8 @@ function BookmarkList() {
           <EmptyTitle>No bookmarks yet</EmptyTitle>
           <EmptyDescription>Bookmarked pages appear here.</EmptyDescription>
           <EmptyDescription>
-            Bookmark a page with the star in its window titlebar, or from a tab's context menu.
+            Bookmark a page with the star on its tab or window titlebar, or from a tab's context
+            menu.
           </EmptyDescription>
         </EmptyHeader>
       </Empty>

--- a/packages/renderer/bookmarks.tsx
+++ b/packages/renderer/bookmarks.tsx
@@ -41,7 +41,7 @@ function Bookmark({ accountId, id, app, title }: BookmarkState) {
       <Button
         variant="secondary"
         size="icon"
-        className="absolute top-1/2 right-1 size-5 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+        className="absolute inset-y-0 right-1 my-auto size-5 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
         title="Remove Bookmark"
         onClick={() => {
           ipc.main.send("bookmarks.removeBookmark", accountId, id);

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -149,12 +149,10 @@ function VerticalTab({
    */
   const isBookmarkable = isWideRow && !tab.dormant && Boolean(tab.app);
 
-  const wideRowActionCount = (isBookmarkable ? 1 : 0) + (isCloseable ? 1 : 0);
-
   /**
-   * A bookmarked row shows its star whether pointed at or not, so the room for
-   * the controls is there from the start rather than made on hover — a title
-   * growing back under a star that stays put reads as the star sliding away.
+   * A bookmarked row shows its star at rest, on the row's edge, and hands that
+   * spot over when pointed at: the star steps left, the close button takes the
+   * edge. The room for one control is therefore held from the start.
    */
   const showsRestingStar = isBookmarkable && tab.bookmarked;
 
@@ -169,10 +167,13 @@ function VerticalTab({
         className={cn(
           tab.dormant && "opacity-50",
           isWideRow && "w-full justify-start",
-          isWideRow && wideRowActionCount === 1 && (showsRestingStar ? "pr-7" : "group-hover:pr-7"),
-          isWideRow &&
-            wideRowActionCount === 2 &&
-            (showsRestingStar ? "pr-13" : "group-hover:pr-13"),
+          // The hover controls take their room instantly rather than over a
+          // transition, which would slide the resting star out from under the
+          // one that replaces it
+          isWideRow && "transition-colors",
+          isWideRow && isBookmarkable && "group-hover:pr-13",
+          isWideRow && !isBookmarkable && isCloseable && "group-hover:pr-7",
+          showsRestingStar && "pr-7",
           presentation === "gridIcon" && "w-full",
         )}
         title={tab.title}
@@ -211,10 +212,10 @@ function VerticalTab({
       {!isWideRow && tab.windowed && <WindowedTabBadge className="-right-1 -bottom-1" />}
       {gmailStatus && <GmailTabStatusBadge {...gmailStatus} />}
       {/*
-       * A bookmarked row keeps its star on show and drops the button around it,
-       * so the mark at rest and the toggle on hover are one element that never
-       * moves. The close button, which only ever shows on hover, keeps the
-       * row's right edge.
+       * A bookmarked row keeps this button on show at rest, on the edge and
+       * stripped back to its star, so the mark and the control it stands for
+       * are one thing. Pointing at the row gives it back its button and moves
+       * it left, clearing the edge for the close button.
        */}
       {isBookmarkable && (
         <Button
@@ -222,11 +223,10 @@ function VerticalTab({
           size="icon"
           data-tab-action
           className={cn(
-            "absolute top-1/2 size-5 -translate-y-1/2",
-            isCloseable ? "right-7" : "right-1",
+            "absolute top-1/2 size-5 -translate-y-1/2 transition-colors",
             tab.bookmarked
-              ? "bg-transparent text-muted-foreground group-hover:bg-secondary group-hover:text-secondary-foreground"
-              : "opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
+              ? "right-1 bg-transparent text-muted-foreground group-hover:right-7 group-hover:bg-secondary group-hover:text-secondary-foreground"
+              : "right-7 opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
           )}
           title={tab.bookmarked ? "Remove Bookmark" : "Bookmark"}
           onClick={() => {
@@ -244,7 +244,7 @@ function VerticalTab({
           className={cn(
             "absolute opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
             isWideRow
-              ? "top-1/2 right-1 size-5 -translate-y-1/2"
+              ? "top-1/2 right-1 size-5 -translate-y-1/2 transition-colors"
               : "-top-1 -right-1 size-4 rounded-full",
           )}
           title="Close"

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -198,6 +198,14 @@ function VerticalTab({
         {isWideRow && tab.windowed && (
           <AppWindowIcon className="size-3 shrink-0 text-muted-foreground" />
         )}
+        {/*
+         * A bookmarked row says so at rest, alongside the windowed marker. It
+         * steps aside on hover, where the toggle below takes over showing the
+         * same star.
+         */}
+        {isBookmarkable && tab.bookmarked && (
+          <StarIcon className="size-3 shrink-0 fill-current text-muted-foreground group-hover:hidden" />
+        )}
       </Button>
       {!isWideRow && tab.windowed && <WindowedTabBadge className="-right-1 -bottom-1" />}
       {gmailStatus && <GmailTabStatusBadge {...gmailStatus} />}

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -151,6 +151,13 @@ function VerticalTab({
 
   const wideRowActionCount = (isBookmarkable ? 1 : 0) + (isCloseable ? 1 : 0);
 
+  /**
+   * A bookmarked row shows its star whether pointed at or not, so the room for
+   * the controls is there from the start rather than made on hover — a title
+   * growing back under a star that stays put reads as the star sliding away.
+   */
+  const showsRestingStar = isBookmarkable && tab.bookmarked;
+
   const canOpenSecondInstance =
     tab.app && !workspaceApps[tab.app].singleInstance && !workspaceApps[tab.app].popupOnly;
 
@@ -162,12 +169,10 @@ function VerticalTab({
         className={cn(
           tab.dormant && "opacity-50",
           isWideRow && "w-full justify-start",
-          // The padding that clears room for the hover controls snaps rather
-          // than animates: growing it over time drags the markers at the end of
-          // the row along with it
-          isWideRow && "transition-colors",
-          isWideRow && wideRowActionCount === 1 && "group-hover:pr-7",
-          isWideRow && wideRowActionCount === 2 && "group-hover:pr-13",
+          isWideRow && wideRowActionCount === 1 && (showsRestingStar ? "pr-7" : "group-hover:pr-7"),
+          isWideRow &&
+            wideRowActionCount === 2 &&
+            (showsRestingStar ? "pr-13" : "group-hover:pr-13"),
           presentation === "gridIcon" && "w-full",
         )}
         title={tab.title}
@@ -202,29 +207,27 @@ function VerticalTab({
         {isWideRow && tab.windowed && (
           <AppWindowIcon className="size-3 shrink-0 text-muted-foreground" />
         )}
-        {/*
-         * A bookmarked row says so at rest, after the windowed marker and over
-         * the toggle's own spot, so hovering swaps the two where they stand.
-         */}
-        {isBookmarkable && tab.bookmarked && (
-          <StarIcon className="size-3 shrink-0 fill-current text-muted-foreground group-hover:hidden" />
-        )}
       </Button>
       {!isWideRow && tab.windowed && <WindowedTabBadge className="-right-1 -bottom-1" />}
       {gmailStatus && <GmailTabStatusBadge {...gmailStatus} />}
       {/*
-       * The toggle owns the row's right edge, landing on the marker above
-       * rather than beside it: hovering a bookmarked row wraps the star it
-       * already shows in a button instead of moving it. The close button only
-       * ever shows on hover, so it takes the room to the left, where its coming
-       * and going shifts nothing.
+       * A bookmarked row keeps its star on show and drops the button around it,
+       * so the mark at rest and the toggle on hover are one element that never
+       * moves. The close button, which only ever shows on hover, keeps the
+       * row's right edge.
        */}
       {isBookmarkable && (
         <Button
           variant="secondary"
           size="icon"
           data-tab-action
-          className="absolute top-1/2 right-1 size-5 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+          className={cn(
+            "absolute top-1/2 size-5 -translate-y-1/2",
+            isCloseable ? "right-7" : "right-1",
+            tab.bookmarked
+              ? "bg-transparent text-muted-foreground group-hover:bg-secondary group-hover:text-secondary-foreground"
+              : "opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
+          )}
           title={tab.bookmarked ? "Remove Bookmark" : "Bookmark"}
           onClick={() => {
             ipc.main.send("workspaceApp.toggleBookmark", tab.id);
@@ -241,7 +244,7 @@ function VerticalTab({
           className={cn(
             "absolute opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
             isWideRow
-              ? cn("top-1/2 size-5 -translate-y-1/2", isBookmarkable ? "right-7" : "right-1")
+              ? "top-1/2 right-1 size-5 -translate-y-1/2"
               : "-top-1 -right-1 size-4 rounded-full",
           )}
           title="Close"

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -162,6 +162,10 @@ function VerticalTab({
         className={cn(
           tab.dormant && "opacity-50",
           isWideRow && "w-full justify-start",
+          // The padding that clears room for the hover controls snaps rather
+          // than animates: growing it over time drags the markers at the end of
+          // the row along with it
+          isWideRow && "transition-colors",
           isWideRow && wideRowActionCount === 1 && "group-hover:pr-7",
           isWideRow && wideRowActionCount === 2 && "group-hover:pr-13",
           presentation === "gridIcon" && "w-full",
@@ -199,9 +203,8 @@ function VerticalTab({
           <AppWindowIcon className="size-3 shrink-0 text-muted-foreground" />
         )}
         {/*
-         * A bookmarked row says so at rest, alongside the windowed marker. It
-         * steps aside on hover, where the toggle below takes over showing the
-         * same star.
+         * A bookmarked row says so at rest, after the windowed marker and over
+         * the toggle's own spot, so hovering swaps the two where they stand.
          */}
         {isBookmarkable && tab.bookmarked && (
           <StarIcon className="size-3 shrink-0 fill-current text-muted-foreground group-hover:hidden" />
@@ -209,15 +212,19 @@ function VerticalTab({
       </Button>
       {!isWideRow && tab.windowed && <WindowedTabBadge className="-right-1 -bottom-1" />}
       {gmailStatus && <GmailTabStatusBadge {...gmailStatus} />}
+      {/*
+       * The toggle owns the row's right edge, landing on the marker above
+       * rather than beside it: hovering a bookmarked row wraps the star it
+       * already shows in a button instead of moving it. The close button only
+       * ever shows on hover, so it takes the room to the left, where its coming
+       * and going shifts nothing.
+       */}
       {isBookmarkable && (
         <Button
           variant="secondary"
           size="icon"
           data-tab-action
-          className={cn(
-            "absolute top-1/2 size-5 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
-            isCloseable ? "right-7" : "right-1",
-          )}
+          className="absolute top-1/2 right-1 size-5 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
           title={tab.bookmarked ? "Remove Bookmark" : "Bookmark"}
           onClick={() => {
             ipc.main.send("workspaceApp.toggleBookmark", tab.id);
@@ -234,7 +241,7 @@ function VerticalTab({
           className={cn(
             "absolute opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
             isWideRow
-              ? "top-1/2 right-1 size-5 -translate-y-1/2"
+              ? cn("top-1/2 size-5 -translate-y-1/2", isBookmarkable ? "right-7" : "right-1")
               : "-top-1 -right-1 size-4 rounded-full",
           )}
           title="Close"

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -223,7 +223,9 @@ function VerticalTab({
           size="icon"
           data-tab-action
           className={cn(
-            "absolute top-1/2 size-5 -translate-y-1/2 transition-colors",
+            // Centred with margins rather than a transform, which the button's
+            // own press nudge would overwrite
+            "absolute inset-y-0 my-auto size-5 transition-colors",
             tab.bookmarked
               ? "right-1 bg-transparent text-muted-foreground group-hover:right-7 group-hover:bg-secondary group-hover:text-secondary-foreground"
               : "right-7 opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
@@ -244,7 +246,7 @@ function VerticalTab({
           className={cn(
             "absolute opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
             isWideRow
-              ? "top-1/2 right-1 size-5 -translate-y-1/2 transition-colors"
+              ? "inset-y-0 right-1 my-auto size-5 transition-colors"
               : "-top-1 -right-1 size-4 rounded-full",
           )}
           title="Close"
@@ -333,9 +335,7 @@ function VerticalTabsBookmark({
         data-tab-action
         className={cn(
           "absolute opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
-          isWide
-            ? "top-1/2 right-1 size-5 -translate-y-1/2"
-            : "-top-1 -right-1 size-4 rounded-full",
+          isWide ? "inset-y-0 right-1 my-auto size-5" : "-top-1 -right-1 size-4 rounded-full",
         )}
         title="Remove Bookmark"
         onClick={() => {

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -9,7 +9,7 @@ import { GMAIL_TAB_ID, getTabSection, type TabState } from "@meru/shared/tabs";
 import { workspaceApps } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import { cn } from "@meru/ui/lib/utils";
-import { AppWindowIcon, CircleAlertIcon, XIcon } from "lucide-react";
+import { AppWindowIcon, CircleAlertIcon, StarIcon, XIcon } from "lucide-react";
 import type { Ref } from "react";
 import { TabIcon } from "@/components/tab-icon";
 import { UnreadCountBadge } from "@/components/unread-count-badge";
@@ -27,7 +27,7 @@ const verticalTabsSensors = [
   PointerSensor.configure({
     activationConstraints: [new PointerActivationConstraints.Distance({ value: 5 })],
     preventActivation: (event) =>
-      event.target instanceof Element && event.target.closest("[data-tab-close]") !== null,
+      event.target instanceof Element && event.target.closest("[data-tab-action]") !== null,
   }),
 ];
 
@@ -142,6 +142,15 @@ function VerticalTab({
 
   const isWideRow = presentation === "wideRow";
 
+  /**
+   * The same toggle a workspace app window carries in its titlebar: it saves the
+   * URL the tab is on and empties again as the tab browses on. Only the wide row
+   * has the space for it — the other presentations keep the context menu.
+   */
+  const isBookmarkable = isWideRow && !tab.dormant && Boolean(tab.app);
+
+  const wideRowActionCount = (isBookmarkable ? 1 : 0) + (isCloseable ? 1 : 0);
+
   const canOpenSecondInstance =
     tab.app && !workspaceApps[tab.app].singleInstance && !workspaceApps[tab.app].popupOnly;
 
@@ -153,7 +162,8 @@ function VerticalTab({
         className={cn(
           tab.dormant && "opacity-50",
           isWideRow && "w-full justify-start",
-          isWideRow && isCloseable && "group-hover:pr-7",
+          isWideRow && wideRowActionCount === 1 && "group-hover:pr-7",
+          isWideRow && wideRowActionCount === 2 && "group-hover:pr-13",
           presentation === "gridIcon" && "w-full",
         )}
         title={tab.title}
@@ -191,11 +201,28 @@ function VerticalTab({
       </Button>
       {!isWideRow && tab.windowed && <WindowedTabBadge className="-right-1 -bottom-1" />}
       {gmailStatus && <GmailTabStatusBadge {...gmailStatus} />}
+      {isBookmarkable && (
+        <Button
+          variant="secondary"
+          size="icon"
+          data-tab-action
+          className={cn(
+            "absolute top-1/2 size-5 -translate-y-1/2 opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
+            isCloseable ? "right-7" : "right-1",
+          )}
+          title={tab.bookmarked ? "Remove Bookmark" : "Bookmark"}
+          onClick={() => {
+            ipc.main.send("workspaceApp.toggleBookmark", tab.id);
+          }}
+        >
+          <StarIcon className={cn("size-3", tab.bookmarked && "fill-current")} />
+        </Button>
+      )}
       {isCloseable && (
         <Button
           variant="secondary"
           size="icon"
-          data-tab-close
+          data-tab-action
           className={cn(
             "absolute opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
             isWideRow
@@ -285,7 +312,7 @@ function VerticalTabsBookmark({
       <Button
         variant="secondary"
         size="icon"
-        data-tab-close
+        data-tab-action
         className={cn(
           "absolute opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
           isWide

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -19,6 +19,8 @@ export type TabState = {
   pinned: boolean;
   dormant: boolean;
   windowed: boolean;
+  /** Whether the URL the tab is on is among the account's bookmarks. */
+  bookmarked: boolean;
   loadOnLaunch: boolean;
   loading: boolean;
   navigationHistory: { canGoBack: boolean; canGoForward: boolean };


### PR DESCRIPTION
- Bookmarking a tab was only reachable from its context menu; a workspace app window has had a star in its titlebar since #749.
- The wide tab row now carries that same star, toggling through the same `workspaceApp.toggleBookmark` handler the window's star uses: filled while the tab sits on a bookmarked URL, empty as soon as it browses on.
- A bookmarked row keeps that star on show at rest, on the row's right edge and stripped back to the bare icon, so the mark and the control it stands for are one element. Pointing at the row gives it back its button and steps it left, handing the edge to the close button.
- Room for one control is held from the start on a bookmarked row; the second is made on hover, as on `main`. The wide row's controls take that room instantly rather than over a transition, which would slide the resting star out from under the one replacing it.
- The star is shown only for tabs holding a Workspace App, mirroring the window's `savable` rule.
- `TabState` gains `bookmarked`, computed in `Tabs.serialize` from the account's bookmarks, so the star follows navigation through the existing tabs broadcast. Tabs are broadcast again on an accounts config change, so a toggle from any surface (tab, window titlebar, context menu, bookmark row) redraws it.
- The drag sensor's `data-tab-close` opt-out is renamed `data-tab-action` now that it guards more than closing.
- The bookmarks popup empty state mentions the tab star.
- Fixes a pre-existing glitch the new button shared: the strip's overlay buttons centred themselves with a transform, which a press overwrites with the button's own `active:translate-y-px`, dropping them half their height for as long as the click is held. They centre with auto margins now. This also covers a bookmark row's remove button and the bookmarks popup's, which are not otherwise touched here.

Risks and omissions:

- Narrow and grid presentations are unchanged — no room for a second overlay button, so they keep the context menu and show no bookmarked marker.
- A bookmarked row's title is shortened by the room held for its star, and shortens further on hover as it has since the close button existed.
- The wide row's title, star and close button now snap between their resting and hovered positions; narrow tabs and bookmark rows keep their fade.
- Every `Tabs.serialize` now does a bookmark lookup per tab. Serialization already runs on navigation, title and loading events; the lookup is a scan of the account's bookmarks in the in-memory config.
- Not verified in a running app — no screenshots, no manual pass. Type check, lint, format and `build:js` pass, and the new Tailwind utilities were confirmed in the built CSS.

Test plan:

1. With `Vertical Tabs Width` at `Wide` (or auto-wide), open a Workspace App tab and hover its row → an empty star appears left of the close button, both fully visible, title truncating before them.
2. Click the star → a bookmark row for that URL appears below the tabs. Move the pointer off the row → the filled star stays, moving to the row's right edge, in line with the close buttons of the rows around it and without a button background.
3. Hover and unhover the bookmarked row repeatedly → the star steps left and back cleanly, with no intermediate frame where it and the close button overlap.
4. Click the star on a bookmarked row → both the fill and the bookmark row go, and the row is bare at rest again.
5. Bookmark the tab, then navigate inside it to another page → the star empties and stops showing at rest; navigate back to the bookmarked URL → it returns.
6. Bookmark a tab that is also windowed → the windowed marker sits at the end of the title, the star to its right, no overlap.
7. Open the same app in its own window (`Move to New Window`), toggle the star in the window titlebar → the strip's row for that tab updates in step, and vice versa.
8. Toggle `Bookmark` from the tab's context menu → the row's star matches.
9. Hover the Gmail tab and pinned tabs (grid, wide mode) → no star, unchanged behaviour.
10. A tab on a non-Workspace-App page (e.g. an external site opened in-app) → no star at rest or on hover, close button at the right edge as on `main`.
11. Press and hold the star, the close button, a bookmark row's remove button and the same button in the bookmarks popup → each nudges down a pixel and stays centred, rather than dropping to the row's lower edge for the duration of the press.
12. Drag a tab row by its star and by its close button → neither starts a drag; dragging the row itself still reorders.
13. Switch the strip to `Narrow` → tabs show only the close badge, no star.
14. With no bookmarks saved, open the bookmarks popup → the empty state reads "…with the star on its tab or window titlebar, or from a tab's context menu."
