### PR TITLE
remove the bookmarks section from the tab strip

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -1,13 +1,8 @@
 import { randomUUID } from "node:crypto";
 import { platform } from "@electron-toolkit/utils";
 import type { AccountConfig } from "@meru/shared/schemas";
-import {
-  getVerticalTabsWidth,
-  getVisibleBookmarks,
-  getVisibleVerticalTabs,
-} from "@meru/shared/tabs";
+import { getVerticalTabsWidth, getVisibleVerticalTabs } from "@meru/shared/tabs";
 import { Account } from "./account";
-import { bookmarks } from "./bookmarks";
 import { config } from "./config";
 import { ipc } from "./ipc";
 import { licenseKey } from "./license-key";
@@ -118,20 +113,12 @@ class Accounts {
   getVerticalTabsWidth() {
     const selectedAccount = this.getSelectedAccount();
 
-    const workspaceAppsMode = config.get("workspaceApps.mode");
-
     return getVerticalTabsWidth(
       getVisibleVerticalTabs(selectedAccount.instance.tabs.serialize(), {
-        workspaceAppsMode,
+        workspaceAppsMode: config.get("workspaceApps.mode"),
         showWindows: config.get("verticalTabs.showWindows"),
       }),
-      {
-        bookmarkCount: getVisibleBookmarks(
-          bookmarks.getAccountBookmarks(selectedAccount.config.id),
-          workspaceAppsMode,
-        ).length,
-        configuredWidth: config.get("verticalTabs.width"),
-      },
+      { configuredWidth: config.get("verticalTabs.width") },
     );
   }
 

--- a/packages/app/bookmarks.ts
+++ b/packages/app/bookmarks.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { BASE_SPACING } from "@meru/shared/constants";
 import type { AccountConfig, Bookmark, BookmarkState } from "@meru/shared/schemas";
-import { clamp } from "@meru/shared/utils";
 import { accounts } from "./accounts";
 import { config } from "./config";
 import { ipc } from "./ipc";
@@ -12,11 +11,10 @@ import { TitlebarPopup } from "./lib/titlebar-popup";
  * created from and never follows what the user browses to afterwards — opening
  * one loads that URL again.
  *
- * Bookmarks render in the vertical tabs strip, but the titlebar's popup lists
- * them unconditionally — the strip is gone in `New Windows` mode and absent in
- * `Tabs` mode until a second tab opens, so the popup is the one surface that is
- * always there. It stays reachable while empty, where it explains how to add
- * one.
+ * The titlebar's popup is the one surface that lists them, and it is always
+ * there — unlike the vertical tabs strip, which is gone in `New Windows` mode
+ * and absent in `Tabs` mode until a second tab opens. The popup stays reachable
+ * while empty, where it explains how to add a bookmark.
  */
 class Bookmarks {
   popup = new TitlebarPopup({
@@ -75,22 +73,6 @@ class Bookmarks {
       accountId,
       this.getAccountBookmarks(accountId).filter((bookmark) => bookmark.id !== bookmarkId),
     );
-  }
-
-  move(accountId: AccountConfig["id"], bookmarkId: Bookmark["id"], targetIndex: number) {
-    const accountBookmarks = this.getAccountBookmarks(accountId);
-
-    const movedBookmark = accountBookmarks.find((bookmark) => bookmark.id === bookmarkId);
-
-    if (!movedBookmark) {
-      return;
-    }
-
-    const remainingBookmarks = accountBookmarks.filter((bookmark) => bookmark.id !== bookmarkId);
-
-    remainingBookmarks.splice(clamp(targetIndex, 0, remainingBookmarks.length), 0, movedBookmark);
-
-    this.setAccountBookmarks(accountId, remainingBookmarks);
   }
 
   open(accountId: AccountConfig["id"], bookmarkId: Bookmark["id"]) {

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -96,12 +96,8 @@ class Ipc {
       accounts.sendAccountsChangedToRenderer();
 
       // Bookmarks live in the account config, so every surface reflecting them
-      // redraws from here rather than from a change event of its own. The strip
-      // is one of them, and it can grow or vanish with them, so the views around
-      // it have to be laid out again. Its tab rows star the URL they sit on, so
-      // they are sent again too.
-      accounts.updateAllViewBounds();
-
+      // redraws from here rather than from a change event of its own. The strip's
+      // tab rows star the URL they sit on, so they are sent again too.
       accounts.sendTabsChangedToRenderer();
 
       bookmarks.sendChangedToPopup();
@@ -938,10 +934,6 @@ class Ipc {
 
     ipc.main.on("bookmarks.removeBookmark", (_event, accountId, bookmarkId) => {
       bookmarks.remove(accountId, bookmarkId);
-    });
-
-    ipc.main.on("bookmarks.moveBookmark", (_event, accountId, bookmarkId, targetIndex) => {
-      bookmarks.move(accountId, bookmarkId, targetIndex);
     });
 
     ipc.main.on("downloads.toggleRecentDownloadHistoryPopup", (event) => {

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -4,7 +4,7 @@ import { type DragEndEvent, DragDropProvider, PointerSensor } from "@dnd-kit/rea
 import { useSortable } from "@dnd-kit/react/sortable";
 import { VERTICAL_TABS_WIDE_WIDTH } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
-import type { AccountConfig, Bookmark } from "@meru/shared/schemas";
+import type { AccountConfig } from "@meru/shared/schemas";
 import { GMAIL_TAB_ID, getTabSection, type TabState } from "@meru/shared/tabs";
 import { workspaceApps } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
@@ -55,33 +55,6 @@ function moveSectionTab(
   }
 
   ipc.main.send("tabs.moveTab", accountId, movedTabId, movedSectionTabIds.indexOf(movedTabId));
-}
-
-function moveBookmark(accountId: AccountConfig["id"], bookmarks: Bookmark[], event: DragEndEvent) {
-  if (event.canceled) {
-    return;
-  }
-
-  const bookmarkIds = bookmarks.map((bookmark) => bookmark.id);
-
-  const movedBookmarkIds = move(bookmarkIds, event);
-
-  if (movedBookmarkIds === bookmarkIds) {
-    return;
-  }
-
-  const movedBookmarkId = event.operation.source?.id;
-
-  if (typeof movedBookmarkId !== "string") {
-    return;
-  }
-
-  ipc.main.send(
-    "bookmarks.moveBookmark",
-    accountId,
-    movedBookmarkId,
-    movedBookmarkIds.indexOf(movedBookmarkId),
-  );
 }
 
 function WindowedTabBadge({ className }: { className?: string }) {
@@ -294,87 +267,6 @@ function SortableVerticalTab({
   );
 }
 
-/**
- * A saved URL rather than an open tab: there is nothing to close, and opening
- * it loads the URL it was bookmarked at.
- */
-function VerticalTabsBookmark({
-  ref,
-  bookmark,
-  accountId,
-  isWide,
-  className,
-}: {
-  ref?: Ref<HTMLDivElement>;
-  bookmark: Bookmark;
-  accountId: AccountConfig["id"];
-  isWide: boolean;
-  className?: string;
-}) {
-  return (
-    <div ref={ref} className={cn("group relative", className)}>
-      <Button
-        variant="ghost"
-        size={isWide ? "sm" : "icon"}
-        className={cn(isWide && "w-full justify-start group-hover:pr-7")}
-        title={bookmark.title}
-        onClick={() => {
-          ipc.main.send("bookmarks.openBookmark", accountId, bookmark.id);
-        }}
-      >
-        <TabIcon app={bookmark.app} />
-        {isWide && (
-          <span className="min-w-0 flex-1 overflow-hidden mask-r-from-[calc(100%-1.5rem)] text-left whitespace-nowrap">
-            {bookmark.title}
-          </span>
-        )}
-      </Button>
-      <Button
-        variant="secondary"
-        size="icon"
-        data-tab-action
-        className={cn(
-          "absolute opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
-          isWide ? "inset-y-0 right-1 my-auto size-5" : "-top-1 -right-1 size-4 rounded-full",
-        )}
-        title="Remove Bookmark"
-        onClick={() => {
-          ipc.main.send("bookmarks.removeBookmark", accountId, bookmark.id);
-        }}
-      >
-        <XIcon className="size-3" />
-      </Button>
-    </div>
-  );
-}
-
-function SortableVerticalTabsBookmark({
-  bookmark,
-  accountId,
-  isWide,
-  sectionIndex,
-}: {
-  bookmark: Bookmark;
-  accountId: AccountConfig["id"];
-  isWide: boolean;
-  sectionIndex: number;
-}) {
-  const { ref, isDragging } = useSortable({
-    id: bookmark.id,
-    index: sectionIndex,
-  });
-
-  return (
-    <VerticalTabsBookmark
-      ref={ref}
-      bookmark={bookmark}
-      accountId={accountId}
-      isWide={isWide}
-      className={cn("touch-none", isDragging && "opacity-50")}
-    />
-  );
-}
-
 export function VerticalTabs() {
   const { config } = useConfig();
 
@@ -383,7 +275,6 @@ export function VerticalTabs() {
   const {
     selectedAccount,
     tabs: selectedAccountTabs,
-    bookmarks: selectedAccountBookmarks,
     width: verticalTabsWidth,
   } = useVerticalTabs();
 
@@ -470,23 +361,6 @@ export function VerticalTabs() {
             accountId={selectedAccount.config.id}
             presentation={isWide ? "wideRow" : "narrowIcon"}
             sectionIndex={normalTabIndex}
-          />
-        ))}
-      </DragDropProvider>
-      <DragDropProvider
-        plugins={verticalTabsPlugins}
-        sensors={verticalTabsSensors}
-        onDragEnd={(event) => {
-          moveBookmark(selectedAccount.config.id, selectedAccountBookmarks, event);
-        }}
-      >
-        {selectedAccountBookmarks.map((bookmark, bookmarkIndex) => (
-          <SortableVerticalTabsBookmark
-            key={bookmark.id}
-            bookmark={bookmark}
-            accountId={selectedAccount.config.id}
-            isWide={isWide}
-            sectionIndex={bookmarkIndex}
           />
         ))}
       </DragDropProvider>

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -2,11 +2,7 @@ import type { GmailInboxMessage } from "@meru/shared/gmail";
 import { ms } from "@meru/shared/ms";
 import { ipc } from "@meru/shared/renderer/ipc";
 import type { AccountConfig } from "@meru/shared/schemas";
-import {
-  getVerticalTabsWidth,
-  getVisibleBookmarks,
-  getVisibleVerticalTabs,
-} from "@meru/shared/tabs";
+import { getVerticalTabsWidth, getVisibleVerticalTabs } from "@meru/shared/tabs";
 import { useEffect, useRef, useState } from "react";
 import { useConfig } from "./react-query";
 import { useAccountsStore, useTabsStore, useTrialStore } from "./stores";
@@ -66,17 +62,6 @@ export function useSelectedAccountTabs() {
 }
 
 /**
- * The bookmarks of the selected account. They are saved in its config, so the
- * accounts broadcast carries them to every surface that lists them.
- */
-export function useSelectedAccountBookmarks() {
-  const accounts = useAccountsStore((state) => state.accounts);
-
-  // Accounts written before bookmarks became a list of their own carry none
-  return accounts.find((account) => account.config.selected)?.config.workspaceApps.bookmarks ?? [];
-}
-
-/**
  * What the vertical tabs strip renders and the width it takes up. The titlebar
  * reads it too, to know whether the strip is there to host the Workspace Apps
  * launcher.
@@ -84,25 +69,18 @@ export function useSelectedAccountBookmarks() {
 export function useVerticalTabs() {
   const { selectedAccount, tabs: selectedAccountTabs } = useSelectedAccountTabs();
 
-  const selectedAccountBookmarks = useSelectedAccountBookmarks();
-
   const { config } = useConfig();
 
-  const workspaceAppsMode = config?.["workspaceApps.mode"] ?? "tabs";
-
   const tabs = getVisibleVerticalTabs(selectedAccountTabs, {
-    workspaceAppsMode,
+    workspaceAppsMode: config?.["workspaceApps.mode"] ?? "tabs",
     showWindows: config?.["verticalTabs.showWindows"] ?? true,
   });
 
-  const bookmarks = getVisibleBookmarks(selectedAccountBookmarks, workspaceAppsMode);
-
   const width = getVerticalTabsWidth(tabs, {
-    bookmarkCount: bookmarks.length,
     configuredWidth: config?.["verticalTabs.width"] ?? "auto",
   });
 
-  return { selectedAccount, tabs, bookmarks, width };
+  return { selectedAccount, tabs, width };
 }
 
 export function useIsLicenseKeyValid() {

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -64,22 +64,11 @@ export function getVisibleVerticalTabs<VerticalTab extends Pick<TabState, "dorma
   return showWindows ? tabs : tabs.filter((tab) => !tab.windowed);
 }
 
-/**
- * The strip is the home of the bookmarks section, and `windows` mode hides the
- * strip — there the titlebar popup lists them instead.
- */
-export function getVisibleBookmarks<VisibleBookmark>(
-  bookmarks: VisibleBookmark[],
-  workspaceAppsMode: WorkspaceAppsMode,
-) {
-  return workspaceAppsMode === "windows" ? [] : bookmarks;
-}
-
 export function getVerticalTabsWidth(
   tabs: Pick<TabState, "app" | "pinned">[],
-  { bookmarkCount, configuredWidth }: { bookmarkCount: number; configuredWidth: VerticalTabsWidth },
+  { configuredWidth }: { configuredWidth: VerticalTabsWidth },
 ) {
-  if (tabs.length <= 1 && bookmarkCount === 0) {
+  if (tabs.length <= 1) {
     return 0;
   }
 
@@ -88,12 +77,6 @@ export function getVerticalTabsWidth(
   }
 
   if (configuredWidth === "wide") {
-    return VERTICAL_TABS_WIDE_WIDTH;
-  }
-
-  // Bookmarks are told apart by their title rather than by their app icon,
-  // which several of them can share.
-  if (bookmarkCount > 0) {
     return VERTICAL_TABS_WIDE_WIDTH;
   }
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -202,11 +202,6 @@ export type IpcMainEvents =
       "bookmarks.setPopupCloseOnBlurEnabled": [enabled: boolean];
       "bookmarks.openBookmark": [accountId: AccountConfig["id"], bookmarkId: Bookmark["id"]];
       "bookmarks.removeBookmark": [accountId: AccountConfig["id"], bookmarkId: Bookmark["id"]];
-      "bookmarks.moveBookmark": [
-        accountId: AccountConfig["id"],
-        bookmarkId: Bookmark["id"],
-        targetIndex: number,
-      ];
       "doNotDisturb.toggle": [];
       "doNotDisturb.showOptions": [];
       "downloads.toggleRecentDownloadHistoryPopup": [];


### PR DESCRIPTION
## Problem

- The tab strip listed the account's bookmarks below its tabs, duplicating the list the titlebar's bookmarks button already shows in a popup.
- The popup is the more complete surface: it is there in `New Windows` mode and while the strip is hidden, and it explains itself while empty.

## Changes

- Drop the bookmarks section (and its drag-and-drop reordering) from the tab strip; tab rows keep their star, which is still how a bookmark is added.
- The strip's width no longer accounts for bookmarks: it hides again at a single tab, and `Auto` picks narrow/wide from tabs alone.
- Drop the code that only served the section: `getVisibleBookmarks`, `useSelectedAccountBookmarks`, `Bookmarks.move` and the `bookmarks.moveBookmark` IPC event.
- The account-config listener no longer re-lays out views on a bookmark change (nothing resizes with them); it still re-sends tabs so rows restar.

## Risks / omissions

- Bookmarks can no longer be reordered anywhere — the strip's drag-and-drop was the only place offering it. The popup lists them in creation order.
- Not verified in the running app; types, lint and format checks pass.

## Test plan

1. With bookmarks saved and two or more tabs open, open the main window → the strip lists only tabs; no bookmark rows below them.
2. Click the titlebar's bookmarks button → the popup lists every bookmark; clicking one opens it, the ✕ removes it.
3. With bookmarks saved but only Gmail open (no second tab) → the strip stays hidden, and the Gmail view fills the window with no gap where the strip was.
4. Set Appearance → tab strip width to `Auto`, open two tabs of the same app → the strip goes wide; open two tabs of different apps → it stays narrow, regardless of how many bookmarks exist.
5. Hover a tab row of a workspace app → the star appears; click it → the row's star fills, and the popup gains that bookmark. Click again → it empties and the popup loses it.
6. Switch Workspace Apps mode to `New Windows` → the strip is gone; the titlebar bookmarks button still lists and opens bookmarks.
7. Remove the last bookmark from the popup while it is open → the popup falls back to its empty state without closing.
