### PR TITLE
reorder bookmarks in the titlebar popup

### DIFF
--- a/packages/app/bookmarks.ts
+++ b/packages/app/bookmarks.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { BASE_SPACING } from "@meru/shared/constants";
 import type { AccountConfig, Bookmark, BookmarkState } from "@meru/shared/schemas";
+import { clamp } from "@meru/shared/utils";
 import { accounts } from "./accounts";
 import { config } from "./config";
 import { ipc } from "./ipc";
@@ -73,6 +74,22 @@ class Bookmarks {
       accountId,
       this.getAccountBookmarks(accountId).filter((bookmark) => bookmark.id !== bookmarkId),
     );
+  }
+
+  move(accountId: AccountConfig["id"], bookmarkId: Bookmark["id"], targetIndex: number) {
+    const accountBookmarks = this.getAccountBookmarks(accountId);
+
+    const movedBookmark = accountBookmarks.find((bookmark) => bookmark.id === bookmarkId);
+
+    if (!movedBookmark) {
+      return;
+    }
+
+    const remainingBookmarks = accountBookmarks.filter((bookmark) => bookmark.id !== bookmarkId);
+
+    remainingBookmarks.splice(clamp(targetIndex, 0, remainingBookmarks.length), 0, movedBookmark);
+
+    this.setAccountBookmarks(accountId, remainingBookmarks);
   }
 
   open(accountId: AccountConfig["id"], bookmarkId: Bookmark["id"]) {

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -936,6 +936,10 @@ class Ipc {
       bookmarks.remove(accountId, bookmarkId);
     });
 
+    ipc.main.on("bookmarks.moveBookmark", (_event, accountId, bookmarkId, targetIndex) => {
+      bookmarks.move(accountId, bookmarkId, targetIndex);
+    });
+
     ipc.main.on("downloads.toggleRecentDownloadHistoryPopup", (event) => {
       const parentWindow = BrowserWindow.fromWebContents(event.sender);
 

--- a/packages/renderer/bookmarks.tsx
+++ b/packages/renderer/bookmarks.tsx
@@ -1,3 +1,6 @@
+import { move } from "@dnd-kit/helpers";
+import { type DragEndEvent, DragDropProvider } from "@dnd-kit/react";
+import { useSortable } from "@dnd-kit/react/sortable";
 import { ipc } from "@meru/shared/renderer/ipc";
 import type { BookmarkState } from "@meru/shared/schemas";
 import { Button } from "@meru/ui/components/button";
@@ -9,9 +12,12 @@ import {
   EmptyTitle,
 } from "@meru/ui/components/empty";
 import { ScrollArea } from "@meru/ui/components/scroll-area";
+import { cn } from "@meru/ui/lib/utils";
 import { BookOpenIcon, XIcon } from "lucide-react";
+import type { Ref } from "react";
 import { PopupWindow } from "@/components/popup-window";
 import { TabIcon } from "@/components/tab-icon";
+import { sortablePlugins, sortableSensors } from "@/lib/dnd";
 import { renderApp } from "@/lib/react";
 import { useBookmarks } from "@/lib/react-query";
 
@@ -19,9 +25,17 @@ function closePopup() {
   ipc.main.send("bookmarks.closePopup");
 }
 
-function Bookmark({ accountId, id, app, title }: BookmarkState) {
+function Bookmark({
+  ref,
+  bookmark: { accountId, id, app, title },
+  className,
+}: {
+  ref?: Ref<HTMLDivElement>;
+  bookmark: BookmarkState;
+  className?: string;
+}) {
   return (
-    <div className="group relative">
+    <div ref={ref} className={cn("group relative", className)}>
       <Button
         variant="ghost"
         size="sm"
@@ -41,6 +55,7 @@ function Bookmark({ accountId, id, app, title }: BookmarkState) {
       <Button
         variant="secondary"
         size="icon"
+        data-sortable-action
         className="absolute inset-y-0 right-1 my-auto size-5 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
         title="Remove Bookmark"
         onClick={() => {
@@ -50,6 +65,55 @@ function Bookmark({ accountId, id, app, title }: BookmarkState) {
         <XIcon className="size-3" />
       </Button>
     </div>
+  );
+}
+
+function SortableBookmark({ bookmark, index }: { bookmark: BookmarkState; index: number }) {
+  const { ref, isDragging } = useSortable({ id: bookmark.id, index });
+
+  return (
+    <Bookmark
+      ref={ref}
+      bookmark={bookmark}
+      className={cn("touch-none", isDragging && "opacity-50")}
+    />
+  );
+}
+
+/**
+ * The list is the order bookmarks are saved in, so dragging one writes that
+ * order back to the account it belongs to.
+ */
+function moveBookmark(bookmarks: BookmarkState[], event: DragEndEvent) {
+  if (event.canceled) {
+    return;
+  }
+
+  const bookmarkIds = bookmarks.map((bookmark) => bookmark.id);
+
+  const movedBookmarkIds = move(bookmarkIds, event);
+
+  if (movedBookmarkIds === bookmarkIds) {
+    return;
+  }
+
+  const movedBookmarkId = event.operation.source?.id;
+
+  if (typeof movedBookmarkId !== "string") {
+    return;
+  }
+
+  const movedBookmark = bookmarks.find((bookmark) => bookmark.id === movedBookmarkId);
+
+  if (!movedBookmark) {
+    return;
+  }
+
+  ipc.main.send(
+    "bookmarks.moveBookmark",
+    movedBookmark.accountId,
+    movedBookmarkId,
+    movedBookmarkIds.indexOf(movedBookmarkId),
   );
 }
 
@@ -79,11 +143,19 @@ function BookmarkList() {
   }
 
   return (
-    <div className="flex flex-col gap-1">
-      {bookmarks.map((bookmark) => (
-        <Bookmark key={bookmark.id} {...bookmark} />
-      ))}
-    </div>
+    <DragDropProvider
+      plugins={sortablePlugins}
+      sensors={sortableSensors}
+      onDragEnd={(event) => {
+        moveBookmark(bookmarks, event);
+      }}
+    >
+      <div className="flex flex-col gap-1">
+        {bookmarks.map((bookmark, bookmarkIndex) => (
+          <SortableBookmark key={bookmark.id} bookmark={bookmark} index={bookmarkIndex} />
+        ))}
+      </div>
+    </DragDropProvider>
   );
 }
 

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -1,6 +1,5 @@
-import { Accessibility, defaultPreset, PointerActivationConstraints } from "@dnd-kit/dom";
 import { move } from "@dnd-kit/helpers";
-import { type DragEndEvent, DragDropProvider, PointerSensor } from "@dnd-kit/react";
+import { type DragEndEvent, DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { VERTICAL_TABS_WIDE_WIDTH } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
@@ -17,19 +16,10 @@ import {
   VerticalTabsWorkspaceAppsLauncher,
   WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME,
 } from "@/components/workspace-apps-launcher";
+import { sortablePlugins, sortableSensors } from "@/lib/dnd";
 import { useIsLicenseKeyValid, useVerticalTabs } from "@/lib/hooks";
 import { useConfig } from "@/lib/react-query";
 import { getModifierOpenBehavior } from "@/lib/workspace-apps";
-
-const verticalTabsPlugins = defaultPreset.plugins.filter((plugin) => plugin !== Accessibility);
-
-const verticalTabsSensors = [
-  PointerSensor.configure({
-    activationConstraints: [new PointerActivationConstraints.Distance({ value: 5 })],
-    preventActivation: (event) =>
-      event.target instanceof Element && event.target.closest("[data-tab-action]") !== null,
-  }),
-];
 
 function moveSectionTab(
   accountId: AccountConfig["id"],
@@ -194,7 +184,7 @@ function VerticalTab({
         <Button
           variant="secondary"
           size="icon"
-          data-tab-action
+          data-sortable-action
           className={cn(
             // Centred with margins rather than a transform, which the button's
             // own press nudge would overwrite
@@ -215,7 +205,7 @@ function VerticalTab({
         <Button
           variant="secondary"
           size="icon"
-          data-tab-action
+          data-sortable-action
           className={cn(
             "absolute opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
             isWideRow
@@ -312,8 +302,8 @@ export function VerticalTabs() {
       }}
     >
       <DragDropProvider
-        plugins={verticalTabsPlugins}
-        sensors={verticalTabsSensors}
+        plugins={sortablePlugins}
+        sensors={sortableSensors}
         onDragEnd={(event) => {
           moveSectionTab(selectedAccount.config.id, pinnedSectionTabs, event);
         }}
@@ -348,8 +338,8 @@ export function VerticalTabs() {
         )}
       </DragDropProvider>
       <DragDropProvider
-        plugins={verticalTabsPlugins}
-        sensors={verticalTabsSensors}
+        plugins={sortablePlugins}
+        sensors={sortableSensors}
         onDragEnd={(event) => {
           moveSectionTab(selectedAccount.config.id, normalTabs, event);
         }}

--- a/packages/renderer/lib/dnd.ts
+++ b/packages/renderer/lib/dnd.ts
@@ -1,0 +1,17 @@
+import { Accessibility, defaultPreset, PointerActivationConstraints } from "@dnd-kit/dom";
+import { PointerSensor } from "@dnd-kit/react";
+
+export const sortablePlugins = defaultPreset.plugins.filter((plugin) => plugin !== Accessibility);
+
+/**
+ * A row is dragged by its whole surface, so the buttons sitting on it — closing
+ * a tab, removing a bookmark — mark themselves `data-sortable-action` to be
+ * clicked rather than dragged from.
+ */
+export const sortableSensors = [
+  PointerSensor.configure({
+    activationConstraints: [new PointerActivationConstraints.Distance({ value: 5 })],
+    preventActivation: (event) =>
+      event.target instanceof Element && event.target.closest("[data-sortable-action]") !== null,
+  }),
+];

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -202,6 +202,11 @@ export type IpcMainEvents =
       "bookmarks.setPopupCloseOnBlurEnabled": [enabled: boolean];
       "bookmarks.openBookmark": [accountId: AccountConfig["id"], bookmarkId: Bookmark["id"]];
       "bookmarks.removeBookmark": [accountId: AccountConfig["id"], bookmarkId: Bookmark["id"]];
+      "bookmarks.moveBookmark": [
+        accountId: AccountConfig["id"],
+        bookmarkId: Bookmark["id"],
+        targetIndex: number,
+      ];
       "doNotDisturb.toggle": [];
       "doNotDisturb.showOptions": [];
       "downloads.toggleRecentDownloadHistoryPopup": [];


### PR DESCRIPTION
Reordering went with the tab strip's bookmarks section (#757); this brings it back on the popup that replaced it.

- Popup rows are now sortable: dragging one writes the account's bookmark order back via the restored `Bookmarks.move` + `bookmarks.moveBookmark` IPC.
- The strip's dnd setup moved to `packages/renderer/lib/dnd.ts` (`sortablePlugins`, `sortableSensors`) so both lists share it; buttons that must be clicked rather than dragged from are now `data-sortable-action` (was `data-tab-action`), which also covers the popup's remove ✕.
- The move sends the dragged row's own `accountId` rather than assuming a single account, though the popup only ever lists the selected one.

No keyboard reordering — the shared sensors are pointer-only, as the strip's already were. Not run in the app; types, lint and format pass.

## Test plan

1. Drag the last of three bookmarks to the top of the popup → it lands there, and the order survives closing the popup and restarting the app.
2. Click a row without dragging → the bookmark opens and the popup closes; hover a row and click its ✕ → it's removed and no drag starts from that click.
3. Reorder tabs in the strip → still works, i.e. the shared dnd module didn't change it.
