### PR TITLE
hide the titlebar bookmarks button when the tab strip has one

### DIFF
--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -224,9 +224,10 @@ export function AppTitlebar() {
   const shouldShowWorkspaceAppsLauncher =
     isLicenseKeyValid && config["workspaceApps.launcherApps"].length > 0;
 
-  // The vertical tabs strip hosts the launcher whenever it is there, so that
-  // opening another app stays in the same place as switching between them.
-  const isWorkspaceAppsLauncherHostedByVerticalTabs = verticalTabsWidth > 0;
+  // The vertical tabs strip hosts the launcher and the bookmarks button
+  // whenever it is there, so that opening another app or a bookmarked page
+  // stays in the same place as switching between tabs.
+  const areLauncherAndBookmarksHostedByVerticalTabs = verticalTabsWidth > 0;
 
   const shouldShowUnifiedInboxButton =
     isLicenseKeyValid && config["unifiedInbox.enabled"] && accounts.length > 1;
@@ -384,7 +385,7 @@ export function AppTitlebar() {
               <TitlebarButtonGroup
                 className={cn(
                   WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME,
-                  isWorkspaceAppsLauncherHostedByVerticalTabs && "hidden opacity-0",
+                  areLauncherAndBookmarksHostedByVerticalTabs && "hidden opacity-0",
                 )}
               >
                 <WorkspaceAppsLauncher
@@ -415,7 +416,7 @@ export function AppTitlebar() {
                 ))}
               </TitlebarDropdownMenu>
             )}
-            <BookmarksButton />
+            {!areLauncherAndBookmarksHostedByVerticalTabs && <BookmarksButton />}
             <RecentDownloadHistoryButton />
             <DoNotDisturb />
           </div>


### PR DESCRIPTION
- The titlebar bookmarks button no longer renders while the vertical tabs strip is visible — the strip already carries its own, opening the same popup beside it.
- Reuses the width check the launcher already handles this way, renamed to cover both.

Unlike the launcher, which stays mounted and fades out, this one is dropped outright — there is no cross-fade between the two placements.

Test plan
1. With more than one tab open, the strip shows: the titlebar has no bookmarks button and the strip's one at the bottom opens the popup.
2. Close down to a single tab so the strip goes away — the bookmarks button is back in the titlebar.