### PR TITLE
switch the tab strip between narrow and wide from a button

### DIFF
--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -338,6 +338,10 @@ function VerticalTabsBookmarks({ isWide }: { isWide: boolean }) {
  * it can be widened or narrowed where it stands rather than through settings.
  * That leaves `auto` behind for good: a width picked by hand stays picked, the
  * same as choosing one in settings.
+ *
+ * The only control in the strip that keeps its icon shape in both widths, where
+ * the others grow a label: it is the one that resizes what it sits in, so it
+ * stays the same button under the pointer and only turns its arrow around.
  */
 function VerticalTabsWidthToggle({ isWide }: { isWide: boolean }) {
   const configMutation = useConfigMutation();
@@ -345,15 +349,14 @@ function VerticalTabsWidthToggle({ isWide }: { isWide: boolean }) {
   return (
     <Button
       variant="ghost"
-      size={isWide ? "sm" : "icon"}
-      className={cn("mt-auto text-muted-foreground", isWide && "w-full justify-start")}
+      size="icon"
+      className="mt-auto text-muted-foreground"
       title={isWide ? "Narrow Tabs" : "Wide Tabs"}
       onClick={() => {
         configMutation.mutate({ "verticalTabs.width": isWide ? "narrow" : "wide" });
       }}
     >
       {isWide ? <ChevronsLeftIcon /> : <ChevronsRightIcon />}
-      {isWide && "Narrow Tabs"}
     </Button>
   );
 }

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -11,6 +11,8 @@ import { cn } from "@meru/ui/lib/utils";
 import {
   AppWindowIcon,
   BookOpenIcon,
+  ChevronsLeftIcon,
+  ChevronsRightIcon,
   CircleAlertIcon,
   MergeIcon,
   StarIcon,
@@ -22,7 +24,7 @@ import { UnreadCountBadge } from "@/components/unread-count-badge";
 import { VerticalTabsWorkspaceAppsLauncher } from "@/components/workspace-apps-launcher";
 import { sortablePlugins, sortableSensors } from "@/lib/dnd";
 import { useIsLicenseKeyValid, useVerticalTabs } from "@/lib/hooks";
-import { useConfig } from "@/lib/react-query";
+import { useConfig, useConfigMutation } from "@/lib/react-query";
 import { HOST_HANDOVER_FADE_CLASS_NAME } from "@/lib/utils";
 import { getModifierOpenBehavior } from "@/lib/workspace-apps";
 
@@ -331,6 +333,31 @@ function VerticalTabsBookmarks({ isWide }: { isWide: boolean }) {
   );
 }
 
+/**
+ * Sets the width setting to whichever of the two widths the strip is not on, so
+ * it can be widened or narrowed where it stands rather than through settings.
+ * That leaves `auto` behind for good: a width picked by hand stays picked, the
+ * same as choosing one in settings.
+ */
+function VerticalTabsWidthToggle({ isWide }: { isWide: boolean }) {
+  const configMutation = useConfigMutation();
+
+  return (
+    <Button
+      variant="ghost"
+      size={isWide ? "sm" : "icon"}
+      className={cn("mt-auto text-muted-foreground", isWide && "w-full justify-start")}
+      title={isWide ? "Narrow Tabs" : "Wide Tabs"}
+      onClick={() => {
+        configMutation.mutate({ "verticalTabs.width": isWide ? "narrow" : "wide" });
+      }}
+    >
+      {isWide ? <ChevronsLeftIcon /> : <ChevronsRightIcon />}
+      {isWide && "Narrow Tabs"}
+    </Button>
+  );
+}
+
 export function VerticalTabs() {
   const { config } = useConfig();
 
@@ -446,6 +473,7 @@ export function VerticalTabs() {
         </div>
       )}
       <VerticalTabsBookmarks isWide={isWide} />
+      <VerticalTabsWidthToggle isWide={isWide} />
     </div>
   );
 }

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -236,7 +236,7 @@ export function WorkspaceAppsSettings() {
                 />
                 <ConfigSelectField
                   label="Width"
-                  description="How wide the vertical tabs sidebar is. Auto switches between narrow and wide automatically based on the open tabs."
+                  description="How wide the vertical tabs sidebar is. Auto switches between narrow and wide automatically based on the open tabs. The button at the bottom of the sidebar switches between narrow and wide as well."
                   configKey="verticalTabs.width"
                   placeholder="Select width"
                   licenseKeyRequired


### PR DESCRIPTION
- Adds a width toggle pinned to the bottom of the vertical tabs strip: a chevron pointing right to widen, left to narrow.
- Icon-only in both widths, unlike the other buttons in the strip, which grow a label when wide — it resizes what it sits in, so it stays the same button in the same place under the pointer and only turns its arrow around.
- Clicking writes `verticalTabs.width` as `narrow`/`wide`, so it also leaves `auto` behind for good — same as picking a width in settings.
- Mentions the button in the Width setting's description.

Note: the strip still has no scroll handling, so with enough tabs to overflow the button is pushed out of view along with everything else below them. Not verified in the running app.

Test plan:
1. Open two or more tabs so the strip appears; the button sits at the bottom edge, below Bookmarks.
2. Click it — the strip swaps width and the workspace app view resizes with it; the button keeps its size and position, with only the chevron flipping direction.
3. Open Settings › Workspace Apps › Vertical Tabs — Width now reads Narrow or Wide (never Auto) after a click.