### PR TITLE
hide and show the tab strip from the titlebar

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -52,6 +52,10 @@ class Accounts {
       accounts.updateAllViewBounds();
     });
 
+    config.onDidChange("verticalTabs.visible", () => {
+      accounts.updateAllViewBounds();
+    });
+
     config.onDidChange("workspaceApps.mode", () => {
       accounts.updateAllViewBounds();
     });
@@ -111,6 +115,10 @@ class Accounts {
   }
 
   getVerticalTabsWidth() {
+    if (!config.get("verticalTabs.visible")) {
+      return 0;
+    }
+
     const selectedAccount = this.getSelectedAccount();
 
     return getVerticalTabsWidth(

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -119,6 +119,7 @@ export const config = new Store<Config>({
     "unifiedInbox.rowsPerPage": 10,
     "spellchecker.languages": [],
     "verticalTabs.showWindows": true,
+    "verticalTabs.visible": true,
     "verticalTabs.width": "auto",
   },
   migrations: {

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -13,6 +13,8 @@ import {
   InboxIcon,
   MailSearchIcon,
   MoonIcon,
+  PanelLeftCloseIcon,
+  PanelLeftOpenIcon,
   SparklesIcon,
 } from "lucide-react";
 import { useState } from "react";
@@ -35,13 +37,33 @@ import {
   WorkspaceAppsLauncher,
 } from "@/components/workspace-apps-launcher";
 import { useIsLicenseKeyValid, useVerticalTabs } from "@/lib/hooks";
-import { useConfig } from "@/lib/react-query";
+import { useConfig, useConfigMutation } from "@/lib/react-query";
 import {
   useAccountsStore,
   useAppUpdaterStore,
   useFindInPageStore,
   useTrialStore,
 } from "../lib/stores";
+
+/**
+ * Puts the vertical tabs strip away and brings it back. It sits next to the
+ * navigation controls, where the strip it collapses starts, and is only offered
+ * while the strip has tabs to show — hiding an empty strip would do nothing.
+ */
+function VerticalTabsToggleButton({ isVisible }: { isVisible: boolean }) {
+  const configMutation = useConfigMutation();
+
+  return (
+    <TitlebarIconButton
+      title={isVisible ? "Hide Vertical Tabs" : "Show Vertical Tabs"}
+      onClick={() => {
+        configMutation.mutate({ "verticalTabs.visible": !isVisible });
+      }}
+    >
+      {isVisible ? <PanelLeftCloseIcon /> : <PanelLeftOpenIcon />}
+    </TitlebarIconButton>
+  );
+}
 
 function BookmarksButton() {
   return (
@@ -187,7 +209,11 @@ function DoNotDisturb() {
 export function AppTitlebar() {
   const accounts = useAccountsStore((state) => state.accounts);
 
-  const { tabs: selectedAccountTabs, width: verticalTabsWidth } = useVerticalTabs();
+  const {
+    tabs: selectedAccountTabs,
+    canShow: canShowVerticalTabs,
+    width: verticalTabsWidth,
+  } = useVerticalTabs();
 
   const activeTab = selectedAccountTabs.find((tab) => tab.active);
 
@@ -322,6 +348,11 @@ export function AppTitlebar() {
     return (
       <>
         <TitlebarLeft>
+          {canShowVerticalTabs && (
+            <TitlebarButtonGroup>
+              <VerticalTabsToggleButton isVisible={config["verticalTabs.visible"]} />
+            </TitlebarButtonGroup>
+          )}
           <TitlebarButtonGroup>
             <TitlebarNavigationControls
               canGoBack={Boolean(activeTab?.navigationHistory.canGoBack)}

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -64,7 +64,7 @@ export function useSelectedAccountTabs() {
 /**
  * What the vertical tabs strip renders and the width it takes up. The titlebar
  * reads it too, to know whether the strip is there to host the Workspace Apps
- * launcher.
+ * launcher and whether to offer the toggle that hides it.
  */
 export function useVerticalTabs() {
   const { selectedAccount, tabs: selectedAccountTabs } = useSelectedAccountTabs();
@@ -76,11 +76,14 @@ export function useVerticalTabs() {
     showWindows: config?.["verticalTabs.showWindows"] ?? true,
   });
 
-  const width = getVerticalTabsWidth(tabs, {
+  /** The width the strip takes when shown, and 0 when it has nothing to show. */
+  const shownWidth = getVerticalTabsWidth(tabs, {
     configuredWidth: config?.["verticalTabs.width"] ?? "auto",
   });
 
-  return { selectedAccount, tabs, width };
+  const isVisible = config?.["verticalTabs.visible"] ?? true;
+
+  return { selectedAccount, tabs, canShow: shownWidth > 0, width: isVisible ? shownWidth : 0 };
 }
 
 export function useIsLicenseKeyValid() {

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -158,6 +158,7 @@ export type Config = {
   "unifiedInbox.rowsPerPage": number;
   "spellchecker.languages": string[];
   "verticalTabs.showWindows": boolean;
+  "verticalTabs.visible": boolean;
   "verticalTabs.width": VerticalTabsWidth;
 };
 


### PR DESCRIPTION
- Adds a toggle next to the navigation controls that puts the tab strip away and brings it back, saved as `verticalTabs.visible` so it holds across restarts.
- The main process lays the workspace app views out next to the strip, so it is told as the setting flips.
- The button is only there while the strip has tabs to show — the strip is absent until a second tab opens, and hiding nothing would do nothing.
- With the strip away the Workspace Apps launcher falls back to the titlebar, as it does whenever the strip is not there. `Ctrl+Tab` still switches tabs.

Not verified in the running app — this environment has no display. There is no settings field for it; the button is the only control, and the strip's own context menu was left alone.

Test plan:
1. Open a second tab and click the panel button left of Back — the strip collapses, the Gmail/app view widens to the window edge and the launcher reappears in the titlebar.
2. Click it again — the strip comes back at the width the setting resolves to, and the launcher returns to it.
3. Hide the strip, restart the app — it stays hidden.
4. Close every tab but Gmail — the button goes away with the strip.