### PR TITLE
fix freeze on quit while a titlebar popup is open

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -522,7 +522,14 @@ export class Gmail {
   }
 
   destroy() {
-    this.view.webContents.removeAllListeners();
+    // Electron registers listeners of its own on every webContents, and taking
+    // those down along with ours leaves it unable to tear itself down — see the
+    // same carve-out in `WorkspaceApp.teardown`
+    for (const registeredEvent of this.view.webContents.eventNames()) {
+      if (registeredEvent !== "destroyed") {
+        this.view.webContents.removeAllListeners(registeredEvent);
+      }
+    }
 
     this.view.webContents.close();
 

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -3,6 +3,7 @@ import { APP_ID } from "@meru/shared/constants";
 import { app, session } from "electron";
 import { accounts } from "@/accounts";
 import { blocker } from "@/blocker";
+import { bookmarks } from "@/bookmarks";
 import { config } from "@/config";
 import { downloads } from "@/downloads";
 import { ipc } from "@/ipc";
@@ -188,6 +189,12 @@ async function init() {
 
       main.isQuittingApp = true;
     }
+
+    // Taken down before the windows they hang on, so quitting never reaches
+    // into a view the window destroyed underneath it
+    bookmarks.popup.close();
+
+    downloads.recentDownloadHistoryPopup.close();
   });
 }
 

--- a/packages/app/lib/titlebar-popup.ts
+++ b/packages/app/lib/titlebar-popup.ts
@@ -55,7 +55,7 @@ export class TitlebarPopup {
   }
 
   private setBounds = () => {
-    if (!this.view || !this.parentWindow) {
+    if (!this.view || !this.parentWindow || this.parentWindow.isDestroyed()) {
       return;
     }
 
@@ -73,21 +73,45 @@ export class TitlebarPopup {
     });
   };
 
-  close = () => {
-    if (!this.view || !this.parentWindow) {
-      return;
+  private handleBlur = () => {
+    if (this.closeOnBlurEnabled) {
+      this.close();
     }
+  };
 
-    this.view.webContents.removeAllListeners();
-
-    this.view.webContents.close();
-
-    this.parentWindow.contentView.removeChildView(this.view);
-
-    this.parentWindow.removeListener("resize", this.setBounds);
+  /**
+   * Quitting tears the window down underneath an open popup, and the blur that
+   * comes with it lands here while the window and the view are already going
+   * away — so the state is dropped up front and every native object is checked
+   * before it is touched, leaving nothing half torn down to hang the quit on.
+   */
+  close = () => {
+    const { view, parentWindow } = this;
 
     this.view = null;
     this.parentWindow = null;
+    this.anchorX = null;
+    this.closeOnBlurEnabled = false;
+
+    if (!view || !parentWindow) {
+      return;
+    }
+
+    if (!parentWindow.isDestroyed()) {
+      parentWindow.removeListener("resize", this.setBounds);
+
+      parentWindow.removeListener("closed", this.close);
+
+      parentWindow.contentView.removeChildView(view);
+    }
+
+    if (!view.webContents.isDestroyed()) {
+      // Only the listener this class added comes off: removing them all takes
+      // Electron's own with it and leaves the webContents unable to tear down.
+      view.webContents.off("blur", this.handleBlur);
+
+      view.webContents.close();
+    }
   };
 
   /**
@@ -124,13 +148,13 @@ export class TitlebarPopup {
 
     this.setBounds();
 
-    this.view.webContents.once("blur", () => {
-      if (this.closeOnBlurEnabled) {
-        this.close();
-      }
-    });
+    this.view.webContents.once("blur", this.handleBlur);
 
     parentWindow.on("resize", this.setBounds);
+
+    // A window closing out from under the popup — a workspace app window it was
+    // hung on, or the main window on quit — leaves the view attached to it
+    parentWindow.once("closed", this.close);
 
     this.view.setBorderRadius(BASE_SPACING * 2);
 


### PR DESCRIPTION
- Close the bookmarks and recent downloads popups in `before-quit`, ahead of the windows they hang on — quitting with one open left its view attached to the window being destroyed, and the blur that came with the teardown ran `close` into the destroyed window and view, throwing part-way through and stranding the quit.
- `TitlebarPopup.close` drops its state up front and checks `isDestroyed()` on the window and the webContents before touching either, so a late blur or a window that went first is a no-op instead of a half-finished teardown.
- A window closing under an open popup now closes it, which also stops the `resize` listener leaking onto a destroyed window.
- `close` removes only its own `blur` listener rather than calling `removeAllListeners()` — the same carve-out `WorkspaceApp.teardown` needed in #692. The Gmail view teardown had the same blanket call and gets the carve-out too.

I could not reproduce or verify this at runtime, so the diagnosis is from reading the teardown paths against Electron's view ownership. The Gmail change rides along because it is the same unsafe call, not because it was seen to misbehave.

## Test plan

1. Open the bookmarks popup from the titlebar, quit the app — it exits cleanly, and relaunching starts fresh.
2. Same with the recent downloads popup, and with the bookmarks popup opened from the vertical tabs strip.
3. Open the bookmarks popup from a detached workspace app window, close that window with the popup still up, then quit — no leftover window and no stall.
4. Open a popup, click into the Gmail view — it still closes on blur; clicking the button again still toggles it.