### PR TITLE
move the titlebar bookmarks button next to the workspace apps launcher

### DIFF
--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -395,6 +395,7 @@ export function AppTitlebar() {
                 />
               </TitlebarButtonGroup>
             )}
+            {!areLauncherAndBookmarksHostedByVerticalTabs && <BookmarksButton />}
             {shouldShowSavedSearchesButton && (
               <TitlebarDropdownMenu
                 title="Saved Searches"
@@ -416,7 +417,6 @@ export function AppTitlebar() {
                 ))}
               </TitlebarDropdownMenu>
             )}
-            {!areLauncherAndBookmarksHostedByVerticalTabs && <BookmarksButton />}
             <RecentDownloadHistoryButton />
             <DoNotDisturb />
           </div>

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -30,12 +30,10 @@ import {
   TitlebarTitle,
 } from "@/components/titlebar";
 import { UnreadCountBadge } from "@/components/unread-count-badge";
-import {
-  WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME,
-  WorkspaceAppsLauncher,
-} from "@/components/workspace-apps-launcher";
+import { WorkspaceAppsLauncher } from "@/components/workspace-apps-launcher";
 import { useIsLicenseKeyValid, useVerticalTabs } from "@/lib/hooks";
 import { useConfig } from "@/lib/react-query";
+import { HOST_HANDOVER_FADE_CLASS_NAME } from "@/lib/utils";
 import {
   useAccountsStore,
   useAppUpdaterStore,
@@ -43,9 +41,10 @@ import {
   useTrialStore,
 } from "../lib/stores";
 
-function BookmarksButton() {
+function BookmarksButton({ className }: { className?: string }) {
   return (
     <TitlebarIconButton
+      className={className}
       onClick={() => {
         ipc.main.send("bookmarks.togglePopup", "titlebar");
       }}
@@ -384,7 +383,7 @@ export function AppTitlebar() {
             {shouldShowWorkspaceAppsLauncher && (
               <TitlebarButtonGroup
                 className={cn(
-                  WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME,
+                  HOST_HANDOVER_FADE_CLASS_NAME,
                   areLauncherAndBookmarksHostedByVerticalTabs && "hidden opacity-0",
                 )}
               >
@@ -395,7 +394,12 @@ export function AppTitlebar() {
                 />
               </TitlebarButtonGroup>
             )}
-            {!areLauncherAndBookmarksHostedByVerticalTabs && <BookmarksButton />}
+            <BookmarksButton
+              className={cn(
+                HOST_HANDOVER_FADE_CLASS_NAME,
+                areLauncherAndBookmarksHostedByVerticalTabs && "hidden opacity-0",
+              )}
+            />
             {shouldShowSavedSearchesButton && (
               <TitlebarDropdownMenu
                 title="Saved Searches"

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -12,13 +12,11 @@ import { AppWindowIcon, BookOpenIcon, CircleAlertIcon, StarIcon, XIcon } from "l
 import type { Ref } from "react";
 import { TabIcon } from "@/components/tab-icon";
 import { UnreadCountBadge } from "@/components/unread-count-badge";
-import {
-  VerticalTabsWorkspaceAppsLauncher,
-  WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME,
-} from "@/components/workspace-apps-launcher";
+import { VerticalTabsWorkspaceAppsLauncher } from "@/components/workspace-apps-launcher";
 import { sortablePlugins, sortableSensors } from "@/lib/dnd";
 import { useIsLicenseKeyValid, useVerticalTabs } from "@/lib/hooks";
 import { useConfig } from "@/lib/react-query";
+import { HOST_HANDOVER_FADE_CLASS_NAME } from "@/lib/utils";
 import { getModifierOpenBehavior } from "@/lib/workspace-apps";
 
 function moveSectionTab(
@@ -384,7 +382,7 @@ export function VerticalTabs() {
         ))}
       </DragDropProvider>
       {shouldShowWorkspaceAppsLauncher && (
-        <div className={cn(WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME, isWide && "w-full")}>
+        <div className={cn(HOST_HANDOVER_FADE_CLASS_NAME, isWide && "w-full")}>
           <VerticalTabsWorkspaceAppsLauncher launcherApps={launcherApps} isWide={isWide} />
         </div>
       )}

--- a/packages/renderer/components/workspace-apps-launcher.tsx
+++ b/packages/renderer/components/workspace-apps-launcher.tsx
@@ -25,15 +25,6 @@ import { WorkspaceAppIcon } from "@/components/workspace-app-icon";
 import { useCloseOnWindowBlur } from "@/lib/hooks";
 import { getModifierOpenBehavior } from "@/lib/workspace-apps";
 
-/**
- * Fades the launcher in when it takes over a host and out when it hands over,
- * without either host having to keep it mounted: `transition-discrete` holds
- * the `display` flip until the fade has played, and `starting:` supplies the
- * transparent state it fades in from.
- */
-export const WORKSPACE_APPS_LAUNCHER_FADE_CLASS_NAME =
-  "transition-[opacity,display] transition-discrete duration-150 starting:opacity-0";
-
 function useLauncherApps() {
   const [isOpen, setIsOpen] = useState(false);
 

--- a/packages/renderer/lib/utils.ts
+++ b/packages/renderer/lib/utils.ts
@@ -1,3 +1,12 @@
+/**
+ * Fades a control in when it takes over a host and out when it hands over,
+ * without either host having to keep it mounted: `transition-discrete` holds
+ * the `display` flip until the fade has played, and `starting:` supplies the
+ * transparent state it fades in from.
+ */
+export const HOST_HANDOVER_FADE_CLASS_NAME =
+  "transition-[opacity,display] transition-discrete duration-150 starting:opacity-0";
+
 export const platform = {
   isMacOS: window.electron.process.platform === "darwin",
   isWindows: window.electron.process.platform === "win32",


### PR DESCRIPTION
- The bookmarks button now sits directly after the workspace apps launcher in the titlebar, matching the launcher-then-bookmarks order the vertical tabs strip already uses.
- It also fades on host handover like the launcher does, instead of popping in and out: it stays mounted and gets `hidden opacity-0` when the tab strip hosts it.
- The fade class moved out of `workspace-apps-launcher.tsx` into `lib/utils.ts` as `HOST_HANDOVER_FADE_CLASS_NAME`, since it is no longer launcher-specific.

The fade relies on `transition-discrete` + `starting:`, so it only plays in browsers/Electron versions that support discrete transitions — unchanged from how the launcher already behaved.

Test plan:
1. With at least one launcher app configured and the tab strip hidden, toggle the strip on and off — the titlebar launcher and bookmarks button fade out and back in together, at the same rate.
2. With no launcher apps configured, toggle the strip — the bookmarks button alone still fades rather than popping.