### PR TITLE
use the workspace apps launcher icon for the tab strip launcher button

### DIFF
--- a/packages/renderer/components/workspace-apps-launcher.tsx
+++ b/packages/renderer/components/workspace-apps-launcher.tsx
@@ -14,7 +14,7 @@ import {
   DropdownMenuTrigger,
 } from "@meru/ui/components/dropdown-menu";
 import { cn } from "@meru/ui/lib/utils";
-import { LayoutGridIcon, PlusIcon } from "lucide-react";
+import { LayoutGridIcon } from "lucide-react";
 import { type MouseEvent, useState } from "react";
 import {
   TitlebarDropdownMenu,
@@ -110,10 +110,10 @@ export function VerticalTabsWorkspaceAppsLauncher({
             variant="ghost"
             size={isWide ? "sm" : "icon"}
             className={cn("text-muted-foreground", isWide && "w-full justify-start")}
-            title="New Tab"
+            title="Open App"
           >
-            <PlusIcon />
-            {isWide && "New Tab"}
+            <LayoutGridIcon />
+            {isWide && "Open App"}
           </Button>
         }
       />


### PR DESCRIPTION
- The vertical tab strip's launcher button now uses `LayoutGridIcon` — the same icon as the titlebar workspace apps launcher — instead of `PlusIcon`.
- Relabelled from "New Tab" to "Open App" (tooltip in the narrow strip, inline label in the wide one), since the dropdown opens a workspace app rather than a blank tab.

Naming: "Open App" over "Open Workspace App" / "Launch Workspace App" — it sits next to the one-word "Bookmarks" button, and the dropdown already names each workspace app.

Test plan
1. With vertical tabs narrow, hover the launcher button below the tabs — grid icon, tooltip reads "Open App".
2. Switch the strip to wide — the row reads "Open App" with the grid icon, matching the "Bookmarks" row below it.