### PR TITLE
hide the gmail unread badge in the tab strip while gmail is active, behind a setting

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -120,6 +120,7 @@ export const config = new Store<Config>({
     "spellchecker.languages": [],
     "verticalTabs.showWindows": true,
     "verticalTabs.width": "auto",
+    "verticalTabs.hideUnreadBadgeWhenActive": false,
   },
   migrations: {
     ">=3.4.0": (store) => {

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -309,14 +309,16 @@ export function VerticalTabs() {
 
   const shouldShowWorkspaceAppsLauncher = isLicenseKeyValid && launcherApps.length > 0;
 
-  // Gmail is already in front while its tab is active, so its unread count is
-  // only in the way there. Attention still has to be flagged either way.
-  const isGmailTabActive = selectedAccountTabs.some((tab) => tab.id === GMAIL_TAB_ID && tab.active);
+  // Gmail is already in front while its tab is active, so the count can be
+  // taken as read there. Attention is still flagged either way.
+  const hidesUnreadCount =
+    config?.["verticalTabs.hideUnreadBadgeWhenActive"] &&
+    selectedAccountTabs.some((tab) => tab.id === GMAIL_TAB_ID && tab.active);
 
   const gmailTabStatus = {
     attentionRequired: selectedAccount.gmail.attentionRequired,
     unreadCount:
-      config?.["accounts.unreadBadge"] && !isGmailTabActive
+      config?.["accounts.unreadBadge"] && !hidesUnreadCount
         ? selectedAccount.gmail.unreadCount
         : null,
   };

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -309,9 +309,16 @@ export function VerticalTabs() {
 
   const shouldShowWorkspaceAppsLauncher = isLicenseKeyValid && launcherApps.length > 0;
 
+  // Gmail is already in front while its tab is active, so its unread count is
+  // only in the way there. Attention still has to be flagged either way.
+  const isGmailTabActive = selectedAccountTabs.some((tab) => tab.id === GMAIL_TAB_ID && tab.active);
+
   const gmailTabStatus = {
     attentionRequired: selectedAccount.gmail.attentionRequired,
-    unreadCount: config?.["accounts.unreadBadge"] ? selectedAccount.gmail.unreadCount : null,
+    unreadCount:
+      config?.["accounts.unreadBadge"] && !isGmailTabActive
+        ? selectedAccount.gmail.unreadCount
+        : null,
   };
 
   return (

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -246,7 +246,7 @@ export function WorkspaceAppsSettings() {
                   }))}
                 />
                 <ConfigSwitchField
-                  label="Hide Unread Badge When Active"
+                  label="Hide Gmail Unread Badge When Active"
                   description="Hide the unread badge on the Gmail tab while it is the active tab, since the inbox is already in front. Accounts that need attention are still flagged."
                   configKey="verticalTabs.hideUnreadBadgeWhenActive"
                   licenseKeyRequired

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -245,6 +245,12 @@ export function WorkspaceAppsSettings() {
                     label,
                   }))}
                 />
+                <ConfigSwitchField
+                  label="Hide Unread Badge When Active"
+                  description="Hide the unread badge on the Gmail tab while it is the active tab, since the inbox is already in front. Accounts that need attention are still flagged."
+                  configKey="verticalTabs.hideUnreadBadgeWhenActive"
+                  licenseKeyRequired
+                />
               </FieldSet>
             </>
           )}

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -159,6 +159,7 @@ export type Config = {
   "spellchecker.languages": string[];
   "verticalTabs.showWindows": boolean;
   "verticalTabs.width": VerticalTabsWidth;
+  "verticalTabs.hideUnreadBadgeWhenActive": boolean;
 };
 
 export type IpcMainEvents =


### PR DESCRIPTION
- Adds `verticalTabs.hideUnreadBadgeWhenActive`, off by default, under Settings → Workspace Apps → Vertical Tabs (license-gated like its siblings).
- With it on, the Gmail tab in the tab strip drops its unread badge while that tab is active — Gmail is already in front, so the count can be taken as read there. The badge returns as soon as another tab takes over.
- The attention-required icon is unaffected and still shows regardless of which tab is active.

Only the tab strip is touched; the multi-account buttons in the titlebar keep their unread badges. Not verified in a running app.

Test plan:
1. With unread mail and the setting off, select the Gmail tab — the badge stays, as before.
2. Turn the setting on and select the Gmail tab — the badge disappears; switch to another tab and it comes back with the current count.
3. Trigger an account that needs attention (e.g. signed out) with the setting on and the Gmail tab active — the yellow alert icon still shows.