### PR TITLE
open the tab strip launcher menu below its button

### DIFF
--- a/packages/renderer/components/workspace-apps-launcher.tsx
+++ b/packages/renderer/components/workspace-apps-launcher.tsx
@@ -118,13 +118,16 @@ export function VerticalTabsWorkspaceAppsLauncher({
         }
       />
       <DropdownMenuBackdrop />
-      {/* Opens upward at trigger width so it stays inside the strip — anything
-          wider would be painted over by the workspace app view next to it.
-          That leaves room for app names only in the wide strip. */}
+      {/* Always opens downward — the button sits below the tabs, so flipping
+          upward once enough tabs stack above it would make the menu jump around.
+          Trigger width keeps it inside the strip: anything wider would be
+          painted over by the workspace app view next to it, which leaves room
+          for app names only in the wide strip. */}
       <DropdownMenuContent
-        side="top"
+        side="bottom"
         align="center"
         collisionPadding={0}
+        collisionAvoidance={{ side: "none", fallbackAxisSide: "none" }}
         className={cn("flex flex-col gap-1 p-0.5", !isWide && "w-auto min-w-0")}
       >
         {launcherApps.map((app) => (

--- a/packages/renderer/components/workspace-apps-launcher.tsx
+++ b/packages/renderer/components/workspace-apps-launcher.tsx
@@ -118,16 +118,12 @@ export function VerticalTabsWorkspaceAppsLauncher({
         }
       />
       <DropdownMenuBackdrop />
-      {/* Always opens downward — the button sits below the tabs, so flipping
-          upward once enough tabs stack above it would make the menu jump around.
-          Trigger width keeps it inside the strip: anything wider would be
-          painted over by the workspace app view next to it, which leaves room
-          for app names only in the wide strip. */}
+      {/* Opens at trigger width so it stays inside the strip — anything wider
+          would be painted over by the workspace app view next to it. That
+          leaves room for app names only in the wide strip. */}
       <DropdownMenuContent
-        side="bottom"
         align="center"
         collisionPadding={0}
-        collisionAvoidance={{ side: "none", fallbackAxisSide: "none" }}
         className={cn("flex flex-col gap-1 p-0.5", !isWide && "w-auto min-w-0")}
       >
         {launcherApps.map((app) => (

--- a/packages/ui/components/dropdown-menu.tsx
+++ b/packages/ui/components/dropdown-menu.tsx
@@ -35,13 +35,12 @@ function DropdownMenuContent({
   side = "bottom",
   sideOffset = 4,
   collisionPadding,
-  collisionAvoidance,
   className,
   ...props
 }: MenuPrimitive.Popup.Props &
   Pick<
     MenuPrimitive.Positioner.Props,
-    "align" | "alignOffset" | "side" | "sideOffset" | "collisionPadding" | "collisionAvoidance"
+    "align" | "alignOffset" | "side" | "sideOffset" | "collisionPadding"
   >) {
   return (
     <MenuPrimitive.Portal>
@@ -52,7 +51,6 @@ function DropdownMenuContent({
         side={side}
         sideOffset={sideOffset}
         collisionPadding={collisionPadding}
-        collisionAvoidance={collisionAvoidance}
       >
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"

--- a/packages/ui/components/dropdown-menu.tsx
+++ b/packages/ui/components/dropdown-menu.tsx
@@ -35,12 +35,13 @@ function DropdownMenuContent({
   side = "bottom",
   sideOffset = 4,
   collisionPadding,
+  collisionAvoidance,
   className,
   ...props
 }: MenuPrimitive.Popup.Props &
   Pick<
     MenuPrimitive.Positioner.Props,
-    "align" | "alignOffset" | "side" | "sideOffset" | "collisionPadding"
+    "align" | "alignOffset" | "side" | "sideOffset" | "collisionPadding" | "collisionAvoidance"
   >) {
   return (
     <MenuPrimitive.Portal>
@@ -51,6 +52,7 @@ function DropdownMenuContent({
         side={side}
         sideOffset={sideOffset}
         collisionPadding={collisionPadding}
+        collisionAvoidance={collisionAvoidance}
       >
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"


### PR DESCRIPTION
- The tab strip's workspace apps launcher menu was pinned to `side="top"`, so it opened upward whenever tabs stacked above the button and only fell back to downward when there was no room — the side flipped with tab count.
- Dropping `side="top"` leaves the `DropdownMenuContent` default: it opens below the button, and flips above only when it genuinely does not fit below.

Test plan
1. Open several tabs so the launcher button sits well below the top of the tab strip, then click it — the menu opens below the button, not above.
2. Shrink the window so there is little room under the button — the menu flips above instead of being cut off.