### PR TITLE
group the workspace apps window settings into their own section

### DIFF
--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -255,22 +255,26 @@ export function WorkspaceAppsSettings() {
             </>
           )}
           <FieldSeparator />
+          <FieldSet>
+            <FieldLegend>Windows</FieldLegend>
+            <ConfigSwitchField
+              label="Show Account Label"
+              description="Show the account label in the titlebar of Workspace Apps windows if using more than one account."
+              configKey="workspaceApps.showAccountLabel"
+              licenseKeyRequired
+            />
+            <ConfigSwitchField
+              label="Show Account Color"
+              description="Show a colored indicator on top of Workspace Apps windows to indicate which account is being used when an account has a color configured."
+              configKey="workspaceApps.showAccountColor"
+              licenseKeyRequired
+            />
+          </FieldSet>
+          <FieldSeparator />
           <ConfigSwitchField
             label="Persist Zoom"
             description="Remember the zoom level of Workspace Apps across restarts. Each app keeps its own zoom level, shared by all its tabs and windows."
             configKey="workspaceApps.persistZoom"
-            licenseKeyRequired
-          />
-          <ConfigSwitchField
-            label="Show Account Label"
-            description="Show the account label in the titlebar of Workspace Apps windows if using more than one account."
-            configKey="workspaceApps.showAccountLabel"
-            licenseKeyRequired
-          />
-          <ConfigSwitchField
-            label="Show Account Color"
-            description="Show a colored indicator on top of Workspace Apps windows to indicate which account is being used when an account has a color configured."
-            configKey="workspaceApps.showAccountColor"
             licenseKeyRequired
           />
           <FieldSeparator />


### PR DESCRIPTION
- Move Show Account Label and Show Account Color into a Windows section in Workspace Apps settings, next to the existing Vertical Tabs section.
- Persist Zoom stays a general field since it applies to both tabs and windows.

The Windows section always shows, including in Tabs mode — apps can still be opened in their own window with Shift, so the settings stay reachable there.

Test plan:
1. Settings → Workspace Apps: the two account label/color switches sit under a Windows heading, below Vertical Tabs.
2. Switch Mode to New Windows: the Vertical Tabs section disappears, Windows stays.