### PR TITLE
open an app's links in a tab designated for it

### DIFF
--- a/packages/app/bookmarks.ts
+++ b/packages/app/bookmarks.ts
@@ -119,7 +119,9 @@ class Bookmarks {
 
     const account = accounts.getAccount(accountId);
 
-    account.instance.tabs.openUrl(openedBookmark.url);
+    if (!account.instance.tabs.openInAppLinksTab(openedBookmark.url)) {
+      account.instance.tabs.openUrl(openedBookmark.url);
+    }
 
     if (account.config.selected) {
       accounts.refreshSelectedAccountView();

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -432,6 +432,7 @@ export const config = new Store<Config>({
                 title: savedTab.title,
                 loadOnLaunch: savedTab.loadOnLaunch,
                 windowed: savedTab.windowed,
+                opensAppLinks: false,
               })),
             bookmarks: savedTabs
               .filter((savedTab) => savedTab.persistence === "bookmarked")

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -432,7 +432,7 @@ export const config = new Store<Config>({
                 title: savedTab.title,
                 loadOnLaunch: savedTab.loadOnLaunch,
                 windowed: savedTab.windowed,
-                opensAppLinks: false,
+                opensLinksForApp: null,
               })),
             bookmarks: savedTabs
               .filter((savedTab) => savedTab.persistence === "bookmarked")

--- a/packages/app/dialogs.ts
+++ b/packages/app/dialogs.ts
@@ -1,4 +1,6 @@
+import { type SupportedWorkspaceApp, workspaceApps } from "@meru/shared/workspace-apps";
 import { app, dialog } from "electron";
+import { main } from "./main";
 
 export async function showRestartDialog() {
   const { response } = await dialog.showMessageBox({
@@ -14,4 +16,26 @@ export async function showRestartDialog() {
     app.relaunch();
     app.quit();
   }
+}
+
+/**
+ * Only one tab per app can take that app's links, so designating a new one
+ * takes it away from the tab holding it. Asks before doing so.
+ */
+export async function confirmAppLinksTabHandover(
+  workspaceApp: SupportedWorkspaceApp,
+  appLinksTabTitle: string,
+) {
+  const appLabel = workspaceApps[workspaceApp].label;
+
+  const { response } = await dialog.showMessageBox(main.window, {
+    type: "info",
+    buttons: ["Open Links Here", "Cancel"],
+    message: `Open ${appLabel} links in this tab?`,
+    detail: `“${appLinksTabTitle}” opens all ${appLabel} links right now. It will stop doing so.`,
+    defaultId: 0,
+    cancelId: 1,
+  });
+
+  return response === 0;
 }

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -498,11 +498,13 @@ class Ipc {
                     },
                   ]
                 : []),
-              ...(workspaceApps[tabApp].singleInstance
+              ...(workspaceApps[tabApp].singleInstance || workspaceApps[tabApp].popupOnly
                 ? []
                 : [
                     {
-                      label: `Open ${workspaceApps[tabApp].label} Links in This Tab`,
+                      label: `Open ${workspaceApps[tabApp].label} Links in This ${
+                        tab instanceof WorkspaceApp && tab.isWindowed ? "Window" : "Tab"
+                      }`,
                       type: "checkbox" as const,
                       checked: Boolean(tab.opensAppLinks),
                       click: async () => {
@@ -519,6 +521,12 @@ class Ipc {
                           appLinksTab.id !== tabId &&
                           !(await confirmAppLinksTabHandover(tabApp, appLinksTab.title))
                         ) {
+                          return;
+                        }
+
+                        // The tab keeps browsing while the dialog is up, and it
+                        // is a different app's tab once it navigates away.
+                        if (account.instance.tabs.getTab(tabId)?.app !== tabApp) {
                           return;
                         }
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -35,6 +35,7 @@ import {
   resolveWorkspaceAppOpenBehavior,
   WorkspaceApp,
 } from "@/workspace-app";
+import { confirmAppLinksTabHandover } from "./dialogs";
 import { DoNotDisturb, doNotDisturb } from "./do-not-disturb";
 import { downloads } from "./downloads";
 import { GMAIL_USER_STYLES_PATH } from "./gmail";
@@ -497,6 +498,34 @@ class Ipc {
                     },
                   ]
                 : []),
+              ...(workspaceApps[tabApp].singleInstance
+                ? []
+                : [
+                    {
+                      label: `Open ${workspaceApps[tabApp].label} Links in This Tab`,
+                      type: "checkbox" as const,
+                      checked: Boolean(tab.opensAppLinks),
+                      click: async () => {
+                        if (tab.opensAppLinks) {
+                          account.instance.tabs.setTabOpensAppLinks(tabId, false);
+
+                          return;
+                        }
+
+                        const appLinksTab = account.instance.tabs.getAppLinksTab(tabApp);
+
+                        if (
+                          appLinksTab &&
+                          appLinksTab.id !== tabId &&
+                          !(await confirmAppLinksTabHandover(tabApp, appLinksTab.title))
+                        ) {
+                          return;
+                        }
+
+                        account.instance.tabs.setTabOpensAppLinks(tabId, true);
+                      },
+                    },
+                  ]),
             ]
           : []),
         {

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -348,6 +348,11 @@ class Ipc {
 
       const tabApp = tab.app;
 
+      // A designated tab keeps offering the app it was designated for even
+      // after browsing on, so that the designation stays visible and removable
+      // from the tab holding it.
+      const appLinksApp = tab.opensLinksForApp ?? tabApp;
+
       const hasOtherClosableTabs = account.instance.tabs.tabs.some(
         (accountTab) =>
           accountTab.id !== tabId &&
@@ -498,39 +503,34 @@ class Ipc {
                     },
                   ]
                 : []),
-              ...(workspaceApps[tabApp].singleInstance || workspaceApps[tabApp].popupOnly
+              ...(!appLinksApp ||
+              workspaceApps[appLinksApp].singleInstance ||
+              workspaceApps[appLinksApp].popupOnly
                 ? []
                 : [
                     {
-                      label: `Open ${workspaceApps[tabApp].label} Links in This ${
+                      label: `Open ${workspaceApps[appLinksApp].label} Links in This ${
                         tab instanceof WorkspaceApp && tab.isWindowed ? "Window" : "Tab"
                       }`,
                       type: "checkbox" as const,
-                      checked: Boolean(tab.opensAppLinks),
+                      checked: Boolean(tab.opensLinksForApp),
                       click: async () => {
-                        if (tab.opensAppLinks) {
-                          account.instance.tabs.setTabOpensAppLinks(tabId, false);
+                        if (tab.opensLinksForApp) {
+                          account.instance.tabs.setTabOpensLinksForApp(tabId, null);
 
                           return;
                         }
 
-                        const appLinksTab = account.instance.tabs.getAppLinksTab(tabApp);
+                        const appLinksTab = account.instance.tabs.getAppLinksTab(appLinksApp);
 
                         if (
                           appLinksTab &&
-                          appLinksTab.id !== tabId &&
-                          !(await confirmAppLinksTabHandover(tabApp, appLinksTab.title))
+                          !(await confirmAppLinksTabHandover(appLinksApp, appLinksTab.title))
                         ) {
                           return;
                         }
 
-                        // The tab keeps browsing while the dialog is up, and it
-                        // is a different app's tab once it navigates away.
-                        if (account.instance.tabs.getTab(tabId)?.app !== tabApp) {
-                          return;
-                        }
-
-                        account.instance.tabs.setTabOpensAppLinks(tabId, true);
+                        account.instance.tabs.setTabOpensLinksForApp(tabId, appLinksApp);
                       },
                     },
                   ]),

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -503,37 +503,41 @@ class Ipc {
                     },
                   ]
                 : []),
-              ...(!appLinksApp ||
-              workspaceApps[appLinksApp].singleInstance ||
-              workspaceApps[appLinksApp].popupOnly
-                ? []
-                : [
-                    {
-                      label: `Open ${workspaceApps[appLinksApp].label} Links in This ${
-                        tab instanceof WorkspaceApp && tab.isWindowed ? "Window" : "Tab"
-                      }`,
-                      type: "checkbox" as const,
-                      checked: Boolean(tab.opensLinksForApp),
-                      click: async () => {
-                        if (tab.opensLinksForApp) {
-                          account.instance.tabs.setTabOpensLinksForApp(tabId, null);
+            ]
+          : []),
+        ...(appLinksApp &&
+        !workspaceApps[appLinksApp].singleInstance &&
+        !workspaceApps[appLinksApp].popupOnly
+          ? [
+              // A tab that browsed off Google has no app and so no menu group of
+              // its own, but it can still be holding a designation from before —
+              // which then needs a separator to sit under.
+              ...(tabApp ? [] : [{ type: "separator" as const }]),
+              {
+                label: `Open ${workspaceApps[appLinksApp].label} Links in This ${
+                  tab instanceof WorkspaceApp && tab.isWindowed ? "Window" : "Tab"
+                }`,
+                type: "checkbox" as const,
+                checked: Boolean(tab.opensLinksForApp),
+                click: async () => {
+                  if (tab.opensLinksForApp) {
+                    account.instance.tabs.setTabOpensLinksForApp(tabId, null);
 
-                          return;
-                        }
+                    return;
+                  }
 
-                        const appLinksTab = account.instance.tabs.getAppLinksTab(appLinksApp);
+                  const appLinksTab = account.instance.tabs.getAppLinksTab(appLinksApp);
 
-                        if (
-                          appLinksTab &&
-                          !(await confirmAppLinksTabHandover(appLinksApp, appLinksTab.title))
-                        ) {
-                          return;
-                        }
+                  if (
+                    appLinksTab &&
+                    !(await confirmAppLinksTabHandover(appLinksApp, appLinksTab.title))
+                  ) {
+                    return;
+                  }
 
-                        account.instance.tabs.setTabOpensLinksForApp(tabId, appLinksApp);
-                      },
-                    },
-                  ]),
+                  account.instance.tabs.setTabOpensLinksForApp(tabId, appLinksApp);
+                },
+              },
             ]
           : []),
         {

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -59,7 +59,7 @@ export type Tab = {
   pinned: boolean;
   dormant: boolean;
   loadOnLaunch?: boolean;
-  opensAppLinks?: boolean;
+  opensLinksForApp?: SupportedWorkspaceApp | null;
   isLoading: boolean;
   navigationHistory: { canGoBack: boolean; canGoForward: boolean };
   view?: WebContentsView;
@@ -87,7 +87,7 @@ export class DormantTab {
 
   loadOnLaunch: boolean;
 
-  opensAppLinks: boolean;
+  opensLinksForApp: SupportedWorkspaceApp | null;
 
   windowed: boolean;
 
@@ -100,7 +100,7 @@ export class DormantTab {
     this.url = savedTab.url;
     this.title = savedTab.title;
     this.loadOnLaunch = Boolean(savedTab.loadOnLaunch);
-    this.opensAppLinks = Boolean(savedTab.opensAppLinks);
+    this.opensLinksForApp = savedTab.opensLinksForApp ?? null;
     this.windowed = Boolean(savedTab.windowed);
     this.zoomFactor = zoomFactor;
   }
@@ -252,7 +252,9 @@ export class Tabs {
    * has not been opened yet.
    */
   private openDormantTab(dormantTab: DormantTab, url?: string) {
-    if (!canOpenWorkspaceAppInApp(dormantTab.app)) {
+    // A designated tab is woken on the link's app, which is not necessarily the
+    // one it was saved on.
+    if (!canOpenWorkspaceAppInApp(url ? getWorkspaceAppFromUrl(url) : dormantTab.app)) {
       openExternalUrl(url ?? dormantTab.url, { skipTrustedHostCheck: true });
 
       return;
@@ -275,7 +277,7 @@ export class Tabs {
       url: url ?? dormantTab.url,
       pinned: dormantTab.pinned,
       loadOnLaunch: dormantTab.loadOnLaunch,
-      opensAppLinks: dormantTab.opensAppLinks,
+      opensLinksForApp: dormantTab.opensLinksForApp,
       asWindow: dormantTab.windowed || config.get("workspaceApps.mode") === "windows",
       savedAsWindow: dormantTab.windowed,
       app: dormantTab.app,
@@ -385,7 +387,7 @@ export class Tabs {
           url: savedWorkspaceApp.url,
           title: savedWorkspaceApp.title,
           loadOnLaunch: savedWorkspaceApp.loadOnLaunch,
-          opensAppLinks: savedWorkspaceApp.opensAppLinks,
+          opensLinksForApp: savedWorkspaceApp.opensLinksForApp,
           windowed: savedWorkspaceApp.opensAsWindow,
         },
         savedWorkspaceApp.zoomFactor,
@@ -510,30 +512,30 @@ export class Tabs {
   }
 
   /**
-   * The tab every link to `app` opens in, if the user designated one. Only one
-   * tab per app can hold it, but a tab that browsed onto another app carries the
-   * designation with it, so the first match wins.
+   * The tab every link to `app` opens in, if the user designated one. The tab
+   * holds the app it was designated for rather than the one it happens to be
+   * showing, so browsing on never hands the designation to another app.
    */
   getAppLinksTab(app: SupportedWorkspaceApp) {
-    return this.tabs.find((tab) => tab.opensAppLinks && tab.app === app);
+    return this.tabs.find((tab) => tab.opensLinksForApp === app);
   }
 
-  setTabOpensAppLinks(tabId: string, opensAppLinks: boolean) {
+  setTabOpensLinksForApp(tabId: string, app: SupportedWorkspaceApp | null) {
     const designatedTab = this.getTab(tabId);
 
-    if (!designatedTab?.app) {
+    if (!(designatedTab instanceof WorkspaceApp) && !(designatedTab instanceof DormantTab)) {
       return;
     }
 
-    if (opensAppLinks) {
-      for (const tab of this.tabs) {
-        if (tab.opensAppLinks && tab.app === designatedTab.app) {
-          tab.opensAppLinks = false;
-        }
+    if (app) {
+      const previousAppLinksTab = this.getAppLinksTab(app);
+
+      if (previousAppLinksTab) {
+        previousAppLinksTab.opensLinksForApp = null;
       }
     }
 
-    designatedTab.opensAppLinks = opensAppLinks;
+    designatedTab.opensLinksForApp = app;
 
     accounts.saveTabs();
   }
@@ -630,7 +632,7 @@ export class Tabs {
           url: tab.url,
           title: tab.title,
           loadOnLaunch: tab.loadOnLaunch,
-          opensAppLinks: tab.opensAppLinks,
+          opensLinksForApp: tab.opensLinksForApp,
           windowed: tab.opensAsWindow,
         });
       } else if (tab instanceof DormantTab) {
@@ -639,7 +641,7 @@ export class Tabs {
           url: tab.url,
           title: tab.title,
           loadOnLaunch: tab.loadOnLaunch,
-          opensAppLinks: tab.opensAppLinks,
+          opensLinksForApp: tab.opensLinksForApp,
           windowed: tab.windowed,
         });
       }

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -59,6 +59,7 @@ export type Tab = {
   pinned: boolean;
   dormant: boolean;
   loadOnLaunch?: boolean;
+  opensAppLinks?: boolean;
   isLoading: boolean;
   navigationHistory: { canGoBack: boolean; canGoForward: boolean };
   view?: WebContentsView;
@@ -86,6 +87,8 @@ export class DormantTab {
 
   loadOnLaunch: boolean;
 
+  opensAppLinks: boolean;
+
   windowed: boolean;
 
   title: string;
@@ -97,6 +100,7 @@ export class DormantTab {
     this.url = savedTab.url;
     this.title = savedTab.title;
     this.loadOnLaunch = Boolean(savedTab.loadOnLaunch);
+    this.opensAppLinks = Boolean(savedTab.opensAppLinks);
     this.windowed = Boolean(savedTab.windowed);
     this.zoomFactor = zoomFactor;
   }
@@ -232,19 +236,7 @@ export class Tabs {
     }
 
     if (activatedTab instanceof DormantTab) {
-      if (!canOpenWorkspaceAppInApp(activatedTab.app)) {
-        openExternalUrl(activatedTab.url, { skipTrustedHostCheck: true });
-
-        return;
-      }
-
-      const materializedTab = this.materializeDormantTab(activatedTab);
-
-      if (!materializedTab.isWindowed) {
-        this.activeTabId = materializedTab.id;
-      }
-
-      this.broadcastTabsChanged();
+      this.openDormantTab(activatedTab);
 
       return;
     }
@@ -254,12 +246,36 @@ export class Tabs {
     this.broadcastTabsChanged();
   }
 
-  private materializeDormantTab(dormantTab: DormantTab) {
+  /**
+   * Wakes a saved tab up and brings it forward, optionally on a URL other than
+   * the one it was saved on — that is how a link lands in a designated tab that
+   * has not been opened yet.
+   */
+  private openDormantTab(dormantTab: DormantTab, url?: string) {
+    if (!canOpenWorkspaceAppInApp(dormantTab.app)) {
+      openExternalUrl(url ?? dormantTab.url, { skipTrustedHostCheck: true });
+
+      return;
+    }
+
+    const materializedTab = this.materializeDormantTab(dormantTab, url);
+
+    if (!materializedTab.isWindowed) {
+      this.activeTabId = materializedTab.id;
+    }
+
+    this.broadcastTabsChanged();
+
+    return materializedTab;
+  }
+
+  private materializeDormantTab(dormantTab: DormantTab, url?: string) {
     const workspaceApp = new WorkspaceApp({
       accountId: this.accountId,
-      url: dormantTab.url,
+      url: url ?? dormantTab.url,
       pinned: dormantTab.pinned,
       loadOnLaunch: dormantTab.loadOnLaunch,
+      opensAppLinks: dormantTab.opensAppLinks,
       asWindow: dormantTab.windowed || config.get("workspaceApps.mode") === "windows",
       savedAsWindow: dormantTab.windowed,
       app: dormantTab.app,
@@ -369,6 +385,7 @@ export class Tabs {
           url: savedWorkspaceApp.url,
           title: savedWorkspaceApp.title,
           loadOnLaunch: savedWorkspaceApp.loadOnLaunch,
+          opensAppLinks: savedWorkspaceApp.opensAppLinks,
           windowed: savedWorkspaceApp.opensAsWindow,
         },
         savedWorkspaceApp.zoomFactor,
@@ -492,6 +509,68 @@ export class Tabs {
     accounts.saveTabs();
   }
 
+  /**
+   * The tab every link to `app` opens in, if the user designated one. Only one
+   * tab per app can hold it, but a tab that browsed onto another app carries the
+   * designation with it, so the first match wins.
+   */
+  getAppLinksTab(app: SupportedWorkspaceApp) {
+    return this.tabs.find((tab) => tab.opensAppLinks && tab.app === app);
+  }
+
+  setTabOpensAppLinks(tabId: string, opensAppLinks: boolean) {
+    const designatedTab = this.getTab(tabId);
+
+    if (!designatedTab?.app) {
+      return;
+    }
+
+    if (opensAppLinks) {
+      for (const tab of this.tabs) {
+        if (tab.opensAppLinks && tab.app === designatedTab.app) {
+          tab.opensAppLinks = false;
+        }
+      }
+    }
+
+    designatedTab.opensAppLinks = opensAppLinks;
+
+    accounts.saveTabs();
+  }
+
+  /**
+   * Opens a URL in the tab designated for its app, and returns that tab so the
+   * caller knows the URL was taken. Apps that may not open inside Meru are left
+   * to the caller, which falls back to the default browser.
+   */
+  openInAppLinksTab(url: string) {
+    const app = getWorkspaceAppFromUrl(url);
+
+    if (!app || !canOpenWorkspaceAppInApp(app)) {
+      return;
+    }
+
+    const appLinksTab = this.getAppLinksTab(app);
+
+    if (!appLinksTab) {
+      return;
+    }
+
+    if (appLinksTab instanceof DormantTab) {
+      return this.openDormantTab(appLinksTab, url);
+    }
+
+    if (!(appLinksTab instanceof WorkspaceApp)) {
+      return;
+    }
+
+    appLinksTab.navigate(url);
+
+    this.activateTab(appLinksTab.id);
+
+    return appLinksTab;
+  }
+
   moveTab(tabId: string, targetSectionIndex: number) {
     if (tabId === GMAIL_TAB_ID) {
       return;
@@ -551,6 +630,7 @@ export class Tabs {
           url: tab.url,
           title: tab.title,
           loadOnLaunch: tab.loadOnLaunch,
+          opensAppLinks: tab.opensAppLinks,
           windowed: tab.opensAsWindow,
         });
       } else if (tab instanceof DormantTab) {
@@ -559,6 +639,7 @@ export class Tabs {
           url: tab.url,
           title: tab.title,
           loadOnLaunch: tab.loadOnLaunch,
+          opensAppLinks: tab.opensAppLinks,
           windowed: tab.windowed,
         });
       }

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -82,7 +82,7 @@ type WorkspaceAppOptions = {
   savedAsWindow?: boolean;
   pinned?: boolean;
   loadOnLaunch?: boolean;
-  opensAppLinks?: boolean;
+  opensLinksForApp?: SupportedWorkspaceApp | null;
   app?: SupportedWorkspaceApp;
   zoomFactor?: number;
 };
@@ -435,7 +435,7 @@ export class WorkspaceApp {
    * Whether every link to this tab's app opens here instead of in a new tab.
    * Only one tab per app can hold it.
    */
-  opensAppLinks = false;
+  opensLinksForApp: SupportedWorkspaceApp | null = null;
 
   /**
    * Whether this app should be restored in its own window, as opposed to
@@ -460,7 +460,7 @@ export class WorkspaceApp {
     savedAsWindow,
     pinned,
     loadOnLaunch,
-    opensAppLinks,
+    opensLinksForApp,
     app,
     zoomFactor,
   }: WorkspaceAppOptions) {
@@ -468,7 +468,7 @@ export class WorkspaceApp {
     this.app = app ?? getWorkspaceAppFromUrl(url);
     this.pinned = Boolean(pinned);
     this.loadOnLaunch = Boolean(loadOnLaunch);
-    this.opensAppLinks = Boolean(opensAppLinks);
+    this.opensLinksForApp = opensLinksForApp ?? null;
     this.opensAsWindow =
       savedAsWindow ?? (Boolean(asWindow) && config.get("workspaceApps.mode") !== "windows");
 

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -266,8 +266,10 @@ export class WorkspaceApp {
       const account = accounts.getAccount(accountId);
 
       // A tab designated for this app takes the link, unless the modifier keys
-      // asked for a window or a background tab of its own.
-      if (!requestedOpenBehavior) {
+      // asked for a window or a background tab of its own. A Chat attachment is
+      // a download dressed as a Chat URL, so it must never land in the tab the
+      // user is chatting in.
+      if (!requestedOpenBehavior && !GOOGLE_CHAT_ATTACHMENT_URL_REGEXP.test(url)) {
         const appLinksTab = account.instance.tabs.openInAppLinksTab(url);
 
         if (appLinksTab) {

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -35,7 +35,7 @@ import {
 } from "./lib/window";
 import { licenseKey } from "./license-key";
 import { main } from "./main";
-import { registerTabBroadcasts } from "./tabs";
+import { isWindowedTab, registerTabBroadcasts } from "./tabs";
 import { openExternalUrl } from "./url";
 
 export const MIN_ZOOM_FACTOR = 0.1;
@@ -82,6 +82,7 @@ type WorkspaceAppOptions = {
   savedAsWindow?: boolean;
   pinned?: boolean;
   loadOnLaunch?: boolean;
+  opensAppLinks?: boolean;
   app?: SupportedWorkspaceApp;
   zoomFactor?: number;
 };
@@ -262,9 +263,27 @@ export class WorkspaceApp {
             ? "backgroundTab"
             : undefined;
 
-      const openBehavior = resolveWorkspaceAppOpenBehavior(requestedOpenBehavior);
-
       const account = accounts.getAccount(accountId);
+
+      // A tab designated for this app takes the link, unless the modifier keys
+      // asked for a window or a background tab of its own.
+      if (!requestedOpenBehavior) {
+        const appLinksTab = account.instance.tabs.openInAppLinksTab(url);
+
+        if (appLinksTab) {
+          // A designated tab living in its own window has already been focused,
+          // and raising the main window over it would undo that.
+          if (!isWindowedTab(appLinksTab)) {
+            accounts.selectAccount(accountId);
+
+            main.show();
+          }
+
+          return { action: "deny" };
+        }
+      }
+
+      const openBehavior = resolveWorkspaceAppOpenBehavior(requestedOpenBehavior);
 
       if (openBehavior === "newWindow") {
         account.instance.tabs.openWindowedTab(url);
@@ -411,6 +430,12 @@ export class WorkspaceApp {
   loadOnLaunch = false;
 
   /**
+   * Whether every link to this tab's app opens here instead of in a new tab.
+   * Only one tab per app can hold it.
+   */
+  opensAppLinks = false;
+
+  /**
    * Whether this app should be restored in its own window, as opposed to
    * whether it currently has one. The two only differ in `windows` mode, where
    * every app is windowed because the mode says so rather than because the user
@@ -433,6 +458,7 @@ export class WorkspaceApp {
     savedAsWindow,
     pinned,
     loadOnLaunch,
+    opensAppLinks,
     app,
     zoomFactor,
   }: WorkspaceAppOptions) {
@@ -440,6 +466,7 @@ export class WorkspaceApp {
     this.app = app ?? getWorkspaceAppFromUrl(url);
     this.pinned = Boolean(pinned);
     this.loadOnLaunch = Boolean(loadOnLaunch);
+    this.opensAppLinks = Boolean(opensAppLinks);
     this.opensAsWindow =
       savedAsWindow ?? (Boolean(asWindow) && config.get("workspaceApps.mode") !== "windows");
 
@@ -878,6 +905,10 @@ export class WorkspaceApp {
 
   goForward() {
     this.view.webContents.navigationHistory.goForward();
+  }
+
+  navigate(url: string) {
+    this.view.webContents.loadURL(url);
   }
 
   reload() {

--- a/packages/shared/schemas.ts
+++ b/packages/shared/schemas.ts
@@ -28,8 +28,8 @@ const workspaceAppSchema = z.custom<SupportedWorkspaceApp>(
 /**
  * A pinned tab as it is restored on the next launch. It keeps following the app
  * it holds, so its `url` and `title` are rewritten as the user browses.
- * `opensAppLinks` marks the one tab of its app that every link to that app
- * opens in.
+ * `opensLinksForApp` names the app whose links all open in this tab, which the
+ * tab keeps holding even after browsing on to another app.
  */
 export const savedTabSchema = z.object({
   app: workspaceAppSchema,
@@ -37,7 +37,7 @@ export const savedTabSchema = z.object({
   title: z.string(),
   loadOnLaunch: z.boolean(),
   windowed: z.boolean(),
-  opensAppLinks: z.boolean(),
+  opensLinksForApp: workspaceAppSchema.nullable(),
 });
 
 export type SavedTab = z.infer<typeof savedTabSchema>;

--- a/packages/shared/schemas.ts
+++ b/packages/shared/schemas.ts
@@ -28,6 +28,8 @@ const workspaceAppSchema = z.custom<SupportedWorkspaceApp>(
 /**
  * A pinned tab as it is restored on the next launch. It keeps following the app
  * it holds, so its `url` and `title` are rewritten as the user browses.
+ * `opensAppLinks` marks the one tab of its app that every link to that app
+ * opens in.
  */
 export const savedTabSchema = z.object({
   app: workspaceAppSchema,
@@ -35,6 +37,7 @@ export const savedTabSchema = z.object({
   title: z.string(),
   loadOnLaunch: z.boolean(),
   windowed: z.boolean(),
+  opensAppLinks: z.boolean(),
 });
 
 export type SavedTab = z.infer<typeof savedTabSchema>;


### PR DESCRIPTION
- Adds `Open <App> Links in This Tab` to the tab context menu, on any tab with a known app. While it is on, links to that app navigate that tab and bring it forward instead of opening a new one — the same reuse Gmail already gets for free from `singleInstance`.
- Only one tab per app can hold it. Turning it on while another tab of the app holds it asks first, naming the tab that will lose it.
- The designation names the app explicitly (`opensLinksForApp: SupportedWorkspaceApp | null` on `SavedTab`) rather than deriving it from what the tab currently shows, which drifts on every navigation. A tab designated for Calendar that browses on to Drive still takes Calendar links — and a Calendar link navigates it back to Calendar — so two tabs can never end up claiming one app. Its menu item keeps reading `Open Calendar Links…` wherever it browsed, including off Google entirely, which is how you turn it back off.
- Persisted on pinned tabs, so it survives a restart. On an unpinned tab it lasts for the session and goes away with the tab, silently — only pinned tabs are saved.
- A designated tab that has been closed (dormant) materializes on the link's URL rather than on the app's home URL.
- Consumers are in-app links (`WorkspaceApp.handleWindowOpen`) and bookmarks. Cmd/Shift-click still open a background tab or a new window, and `New <App> Tab`, `Duplicate` and `Reopen Closed Tab` still always open a new tab.

Not covered, deliberately: the workspace apps launcher still opens a fresh tab per click, the windowed-app titlebar menu doesn't offer the item, and nothing in the tab strip marks which tab is designated — the context menu is the only place it shows. The reuse hook explicitly skips Google Chat attachment URLs, which match as `chat` but are really downloads; the pre-existing branch that downloads them still sits below the open-in-app block and stays unreachable for licensed users, which this PR does not change. Two known edges: a config carrying two saved tabs designated for one app (only reachable by hand-editing) is restored verbatim and won't self-heal, and closing a pinned windowed designated tab while its context menu is open re-creates it under a new id, so a subsequent uncheck no-ops. Verified by type/lint/format checks and a build — not exercised in a running app against a live Google account.

## Test plan

1. Right-click a Calendar tab → check `Open Calendar Links in This Tab`, then click an event link in Gmail. That tab navigates to the event and becomes active; no new tab appears.
2. Turn it on for a second Calendar tab. A dialog names the first tab — cancelling leaves the first designated, confirming moves it.
3. Browse the designated tab to Drive, then click a Calendar link in Gmail. It goes back to that tab, on Calendar. Its context menu still reads `Open Calendar Links in This Tab`, checked — as it does after browsing the tab to a non-Google page, where it is the only item in its group.
4. Pin the designated tab, close it so it goes dormant, then click an event link in Gmail. The tab wakes up on that event's URL, not on the Calendar home page.
5. Quit and relaunch. A pinned designated tab is still designated; an unpinned one is not.