### PR TITLE
disable text selection in the tab strip

### DIFF
--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -325,7 +325,10 @@ export function VerticalTabs() {
 
   return (
     <div
-      className={cn("flex flex-col border-r", isWide ? "gap-1 p-2" : "items-center gap-2 py-2")}
+      className={cn(
+        "flex flex-col border-r select-none",
+        isWide ? "gap-1 p-2" : "items-center gap-2 py-2",
+      )}
       style={{ width: verticalTabsWidth, minWidth: verticalTabsWidth }}
       onContextMenu={(event) => {
         if (event.defaultPrevented) {


### PR DESCRIPTION
- The tab strip's unread count badge sits outside the tab button, so its text could be selected by dragging across it. The strip's root now carries `select-none`.

The main and workspace titlebars already inherit `select-none` from the shared `Titlebar` component, so no change was needed there.

Test plan:
1. Enable the tab strip and an account with unread mail, then drag across the unread count badge on the Gmail tab — nothing highlights.
2. Drag across a wide-row tab title and the Bookmarks label — nothing highlights.