### PR TITLE
mark the designated tab in the tab strip

### DIFF
--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -667,6 +667,7 @@ export class Tabs {
       dormant: tab.dormant,
       windowed: isWindowedTab(tab),
       bookmarked: isBookmarkableTab(tab) && bookmarks.isBookmarked(this.accountId, tab.url),
+      opensLinksForApp: tab.opensLinksForApp ?? null,
       loadOnLaunch: Boolean(tab.loadOnLaunch),
       loading: tab.isLoading,
       navigationHistory: tab.navigationHistory,

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -8,8 +8,15 @@ import { GMAIL_TAB_ID, getTabSection, type TabState } from "@meru/shared/tabs";
 import { workspaceApps } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import { cn } from "@meru/ui/lib/utils";
-import { AppWindowIcon, BookOpenIcon, CircleAlertIcon, StarIcon, XIcon } from "lucide-react";
-import type { Ref } from "react";
+import {
+  AppWindowIcon,
+  BookOpenIcon,
+  CircleAlertIcon,
+  MergeIcon,
+  StarIcon,
+  XIcon,
+} from "lucide-react";
+import type { ReactNode, Ref } from "react";
 import { TabIcon } from "@/components/tab-icon";
 import { UnreadCountBadge } from "@/components/unread-count-badge";
 import { VerticalTabsWorkspaceAppsLauncher } from "@/components/workspace-apps-launcher";
@@ -45,16 +52,38 @@ function moveSectionTab(
   ipc.main.send("tabs.moveTab", accountId, movedTabId, movedSectionTabIds.indexOf(movedTabId));
 }
 
-function WindowedTabBadge({ className }: { className?: string }) {
+function TabBadge({ className, children }: { className?: string; children: ReactNode }) {
   return (
     <div
       className={cn(
-        "absolute flex size-4 items-center justify-center rounded-full bg-secondary text-secondary-foreground",
+        "pointer-events-none absolute flex size-4 items-center justify-center rounded-full bg-secondary text-secondary-foreground",
         className,
       )}
     >
-      <AppWindowIcon className="size-2.5" />
+      {children}
     </div>
+  );
+}
+
+function WindowedTabBadge({ className }: { className?: string }) {
+  return (
+    <TabBadge className={className}>
+      <AppWindowIcon className="size-2.5" />
+    </TabBadge>
+  );
+}
+
+/**
+ * Two lanes becoming one: every link to the app opens in this tab. It takes the
+ * corner opposite the windowed badge, so a tab that is both keeps each mark to
+ * itself. Which app it stands for is left to the tab's tooltip — the tab keeps
+ * the designation after browsing elsewhere, so the mark alone cannot say.
+ */
+function AppLinksTabBadge({ className }: { className?: string }) {
+  return (
+    <TabBadge className={className}>
+      <MergeIcon className="size-2.5" />
+    </TabBadge>
   );
 }
 
@@ -120,6 +149,14 @@ function VerticalTab({
   const canOpenSecondInstance =
     tab.app && !workspaceApps[tab.app].singleInstance && !workspaceApps[tab.app].popupOnly;
 
+  /**
+   * The mark on a designated tab cannot name the app it stands for, so the tab's
+   * own tooltip does.
+   */
+  const tooltip = tab.opensLinksForApp
+    ? `${tab.title} — Opens ${workspaceApps[tab.opensLinksForApp].label} Links`
+    : tab.title;
+
   return (
     <div ref={ref} className={cn("group relative", className)}>
       <Button
@@ -137,7 +174,7 @@ function VerticalTab({
           showsRestingStar && "pr-7",
           presentation === "gridIcon" && "w-full",
         )}
-        title={tab.title}
+        title={tooltip}
         onClick={(event) => {
           const modifierOpenBehavior = getModifierOpenBehavior(event);
 
@@ -166,11 +203,15 @@ function VerticalTab({
             {tab.title}
           </span>
         )}
+        {isWideRow && tab.opensLinksForApp && (
+          <MergeIcon className="size-3 shrink-0 text-muted-foreground" />
+        )}
         {isWideRow && tab.windowed && (
           <AppWindowIcon className="size-3 shrink-0 text-muted-foreground" />
         )}
       </Button>
       {!isWideRow && tab.windowed && <WindowedTabBadge className="-right-1 -bottom-1" />}
+      {!isWideRow && tab.opensLinksForApp && <AppLinksTabBadge className="-bottom-1 -left-1" />}
       {gmailStatus && <GmailTabStatusBadge {...gmailStatus} />}
       {/*
        * A bookmarked row keeps this button on show at rest, on the edge and

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -21,6 +21,11 @@ export type TabState = {
   windowed: boolean;
   /** Whether the URL the tab is on is among the account's bookmarks. */
   bookmarked: boolean;
+  /**
+   * The app whose links all open in this tab, which the tab keeps holding even
+   * after browsing on to another app — so it is not always `app`.
+   */
+  opensLinksForApp: SupportedWorkspaceApp | null;
   loadOnLaunch: boolean;
   loading: boolean;
   navigationHistory: { canGoBack: boolean; canGoForward: boolean };


### PR DESCRIPTION
Stacked on #770, which added the designation but left it invisible in the strip.

- `TabState` carries `opensLinksForApp`, so the renderer knows which tab holds a designation and for which app.
- Icon tabs get a `Merge` badge in the bottom-left corner — the corner opposite the windowed badge, so a tab that is both keeps each mark to itself.
- Wide rows get the same glyph inline after the title, next to the window icon. Without it an unpinned designated tab would have no mark at all, since a 16px corner badge doesn't fit a 28px row.
- The badge can't name the app it stands for — a designated tab keeps its designation after browsing elsewhere — so the tab's tooltip does: `Calendar — August — Opens Calendar Links`.
- `WindowedTabBadge` now shares a `TabBadge` base, which also makes it `pointer-events-none`. That corner previously swallowed clicks meant for the tab.

Only checked in the vertical tab strip; the windowed-app titlebar shows no mark. Not verified against a real designated tab in `bun dev` — the visual work was done against pixel replicas of the strip, not the running app.

## Test plan

1. Designate a pinned tab (right-click → `Open Calendar Links in This Tab`). Expect a merge glyph in its bottom-left corner in both narrow and wide strip modes, and the tooltip to end in `— Opens Calendar Links`.
2. Do the same on a windowed pinned tab. Expect two badges, one per bottom corner, neither clipping the other.
3. Designate an *unpinned* tab in wide mode. Expect the glyph inline after the title, left of the window icon, with the title truncating to make room.
4. Click the bottom-left corner of a windowed tab. Expect the tab to activate rather than the click being swallowed.
