### PR TITLE
let the app links badge be turned off

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -121,6 +121,7 @@ export const config = new Store<Config>({
     "verticalTabs.showWindows": true,
     "verticalTabs.width": "auto",
     "verticalTabs.hideUnreadBadgeWhenActive": false,
+    "verticalTabs.showAppLinksBadge": true,
   },
   migrations: {
     ">=3.4.0": (store) => {

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -126,6 +126,8 @@ function VerticalTab({
   gmailStatus?: GmailTabStatus;
   className?: string;
 }) {
+  const { config } = useConfig();
+
   const isPinnedSectionTab = getTabSection(tab) === "pinned";
 
   const isCloseable = !isPinnedSectionTab && !tab.dormant;
@@ -149,9 +151,13 @@ function VerticalTab({
   const canOpenSecondInstance =
     tab.app && !workspaceApps[tab.app].singleInstance && !workspaceApps[tab.app].popupOnly;
 
+  const showsAppLinksBadge = Boolean(
+    config?.["verticalTabs.showAppLinksBadge"] && tab.opensLinksForApp,
+  );
+
   /**
    * The mark on a designated tab cannot name the app it stands for, so the tab's
-   * own tooltip does.
+   * own tooltip does — and it keeps saying so once the badge is turned off.
    */
   const tooltip = tab.opensLinksForApp
     ? `${tab.title} — Opens ${workspaceApps[tab.opensLinksForApp].label} Links`
@@ -203,7 +209,7 @@ function VerticalTab({
             {tab.title}
           </span>
         )}
-        {isWideRow && tab.opensLinksForApp && (
+        {isWideRow && showsAppLinksBadge && (
           <MergeIcon className="size-3 shrink-0 text-muted-foreground" />
         )}
         {isWideRow && tab.windowed && (
@@ -211,7 +217,7 @@ function VerticalTab({
         )}
       </Button>
       {!isWideRow && tab.windowed && <WindowedTabBadge className="-right-1 -bottom-1" />}
-      {!isWideRow && tab.opensLinksForApp && <AppLinksTabBadge className="-bottom-1 -left-1" />}
+      {!isWideRow && showsAppLinksBadge && <AppLinksTabBadge className="-bottom-1 -left-1" />}
       {gmailStatus && <GmailTabStatusBadge {...gmailStatus} />}
       {/*
        * A bookmarked row keeps this button on show at rest, on the edge and

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -251,6 +251,12 @@ export function WorkspaceAppsSettings() {
                   configKey="verticalTabs.hideUnreadBadgeWhenActive"
                   licenseKeyRequired
                 />
+                <ConfigSwitchField
+                  label="Show App Links Badge"
+                  description="Mark the tab that opens all of an app's links, set from the tab's context menu. With this off the tab still takes the links, and its tooltip still says so."
+                  configKey="verticalTabs.showAppLinksBadge"
+                  licenseKeyRequired
+                />
               </FieldSet>
             </>
           )}

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -160,6 +160,7 @@ export type Config = {
   "verticalTabs.showWindows": boolean;
   "verticalTabs.width": VerticalTabsWidth;
   "verticalTabs.hideUnreadBadgeWhenActive": boolean;
+  "verticalTabs.showAppLinksBadge": boolean;
 };
 
 export type IpcMainEvents =


### PR DESCRIPTION
Follows #772, which added the badge with no way to turn it off.

- New `verticalTabs.showAppLinksBadge`, on by default, under Settings → Workspace Apps → Vertical Tabs.
- Hides both the corner badge on icon tabs and the inline glyph on wide rows.
- Only the mark goes. The tab still takes the app's links, and its tooltip still says which app — so the setting is about strip noise, not about the behaviour.
- No migration: a new key with a default is filled in by electron-store for existing configs.

Sits in the Vertical Tabs fieldset, which only renders in `tabs` mode — consistent with the badge itself, which only exists in the strip. Not verified in `bun dev`.

## Test plan

1. Designate a tab, then turn off Settings → Workspace Apps → Vertical Tabs → Show App Links Badge. Expect the merge glyph to disappear from the strip immediately, in both narrow and wide modes.
2. With it off, click a Calendar link in Gmail. Expect it to still open in the designated tab, and that tab's tooltip to still end in `— Opens Calendar Links`.
