### PR TITLE
broadcast the app links designation so the tab badge appears at once

### DIFF
--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -537,6 +537,8 @@ export class Tabs {
 
     designatedTab.opensLinksForApp = app;
 
+    this.broadcastTabsChanged();
+
     accounts.saveTabs();
   }
 


### PR DESCRIPTION
- `Tabs.setTabOpensLinksForApp` saved the designation but never broadcast the tab state, so the renderer kept the stale tabs until some other event (activating a tab, a navigation, a title change) pushed a fresh list — the badge only showed up after switching tabs.
- Broadcast before saving, matching `setTabPinned` and the other mutators.

One broadcast also clears the badge on the tab that lost the designation in a handover, since the whole tab list is re-sent.

Test plan:
1. Right-click a tab and check "Open <App> Links in This Tab" — the merge badge appears on that tab immediately, with no tab switch.
2. Designate a second tab for the same app and confirm the handover — the first tab's badge clears at once.
3. Uncheck the item on the designated tab — the badge disappears immediately.