### PR TITLE
hold the tab strip's controls in place across both widths

### DIFF
--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -403,14 +403,15 @@ export function VerticalTabs() {
   return (
     <div
       className={cn(
-        "flex flex-col border-r select-none",
-        // The wide gutter is the narrow strip's, not a gutter of its own: a
-        // centred icon button in the narrow strip stands 16px off the edge, so
-        // the wide strip insets its rows by the same. The column then hinges on
-        // its left edge as the strip resizes, and the controls at the foot —
-        // the width toggle above all, which does the resizing — stay put rather
-        // than stepping sideways under the pointer.
-        isWide ? "gap-1 px-4 py-2" : "items-center gap-2 py-2",
+        // The one gutter on every edge of both widths is the narrow strip's own
+        // measure: it leaves exactly an icon button's width between its sides,
+        // which is what a 32px button centred in a 64px strip already sat on.
+        // The column therefore hinges on its left edge as the strip resizes,
+        // and the controls at the foot — the width toggle above all, which does
+        // the resizing — stay put rather than stepping out from under the
+        // pointer.
+        "flex flex-col border-r p-4 select-none",
+        isWide ? "gap-1" : "items-center gap-2",
       )}
       style={{ width: verticalTabsWidth, minWidth: verticalTabsWidth }}
       onContextMenu={(event) => {

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -403,15 +403,14 @@ export function VerticalTabs() {
   return (
     <div
       className={cn(
-        // The one gutter on every edge of both widths is the narrow strip's own
-        // measure: it leaves exactly an icon button's width between its sides,
-        // which is what a 32px button centred in a 64px strip already sat on.
-        // The column therefore hinges on its left edge as the strip resizes,
-        // and the controls at the foot — the width toggle above all, which does
-        // the resizing — stay put rather than stepping out from under the
-        // pointer.
-        "flex flex-col border-r p-4 select-none",
-        isWide ? "gap-1" : "items-center gap-2",
+        "flex flex-col border-r select-none",
+        // The wide gutter is the narrow strip's, not a gutter of its own: a
+        // centred icon button in the narrow strip stands 16px off the edge, so
+        // the wide strip insets its rows by the same. The column then hinges on
+        // its left edge as the strip resizes, and the controls at the foot —
+        // the width toggle above all, which does the resizing — stay put rather
+        // than stepping sideways under the pointer.
+        isWide ? "gap-1 px-4 py-2" : "items-center gap-2 py-2",
       )}
       style={{ width: verticalTabsWidth, minWidth: verticalTabsWidth }}
       onContextMenu={(event) => {

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -404,7 +404,13 @@ export function VerticalTabs() {
     <div
       className={cn(
         "flex flex-col border-r select-none",
-        isWide ? "gap-1 p-2" : "items-center gap-2 py-2",
+        // The wide gutter is the narrow strip's, not a gutter of its own: a
+        // centred icon button in the narrow strip stands 16px off the edge, so
+        // the wide strip insets its rows by the same. The column then hinges on
+        // its left edge as the strip resizes, and the controls at the foot —
+        // the width toggle above all, which does the resizing — stay put rather
+        // than stepping sideways under the pointer.
+        isWide ? "gap-1 px-4 py-2" : "items-center gap-2 py-2",
       )}
       style={{ width: verticalTabsWidth, minWidth: verticalTabsWidth }}
       onContextMenu={(event) => {


### PR DESCRIPTION
The width toggle stepped 8px sideways when it resized the strip: the narrow strip centres a 32px icon button in 64px, leaving a 16px gutter, while the wide strip's `p-2` inset everything by 8px.

- The strip is now padded 16px on every edge in both widths (`p-4`), the narrow strip's own measure — its sides already sat an icon button's width apart, and its top and bottom now match.
- The width toggle, bookmarks and launcher buttons keep their position across the switch, so the toggle stays under the pointer — what its one-button-in-both-widths design was after.
- The padding is identical in both branches now, so it hoists out of the conditional `className`.

Wide rows lose 16px of width (208 → 192), so tab titles truncate a little earlier, and the first tab in both widths sits 8px further down. The gaps still differ (`gap-1` wide, `gap-2` narrow), so tabs themselves still shift vertically on toggle — unifying those is a separate call. Not verified in the running app; the geometry is from the classes alone.

## Test plan

1. With the strip wide, click the toggle at the foot and click it again without moving the pointer — it should narrow, then widen back, with the button staying under the cursor both times.
2. Open the launcher dropdown in the wide strip — it sizes to the trigger, so it should still sit inside the strip and not be painted over by the app view.
3. Give a tab a long title in the wide strip — it should truncate/fade rather than overflow the narrower row.
