### PR TITLE
let the width toggle take the full row in the wide tab strip

### DIFF
--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -342,8 +342,10 @@ function VerticalTabsBookmarks({ isWide }: { isWide: boolean }) {
  *
  * The only control in the strip that goes without a label in either width: the
  * arrow it turns around already says which way the strip is about to go. In the
- * wide strip it still takes the full row the controls above it take, so its icon
- * sits in the same column as theirs rather than alone in the corner.
+ * wide strip it takes the full row the controls above it take, but keeps that
+ * arrow centred rather than dropping it into their icon column: with nothing to
+ * the right of it, an icon column of one would only read as a label gone
+ * missing, and centred it stays where the narrow strip has it.
  *
  * `default` rather than the `sm` its neighbours widen into, because that is the
  * one size that matches `icon`'s height and glyph: only the button's width may
@@ -363,10 +365,7 @@ function VerticalTabsWidthToggle({
     <Button
       variant="ghost"
       size={isWide ? "default" : "icon"}
-      className={cn(
-        "mt-auto text-muted-foreground transition-colors",
-        isWide && "w-full justify-start",
-      )}
+      className={cn("mt-auto text-muted-foreground transition-colors", isWide && "w-full")}
       title={isWide ? "Narrow Tabs" : "Wide Tabs"}
       onClick={() => {
         ipc.main.send("tabs.setVerticalTabsWidth", accountId, isWide ? "narrow" : "wide");

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -347,7 +347,10 @@ function VerticalTabsBookmarks({ isWide }: { isWide: boolean }) {
  *
  * `default` rather than the `sm` its neighbours widen into, because that is the
  * one size that matches `icon`'s height and glyph: only the button's width may
- * change under the pointer that just resized the strip.
+ * change under the pointer that just resized the strip. That width lands at
+ * once too — `transition-colors` in place of the button's default
+ * `transition-all`, which would animate the box and its padding out of step
+ * with the strip the click has already resized, dragging the arrow along.
  */
 function VerticalTabsWidthToggle({
   accountId,
@@ -360,7 +363,10 @@ function VerticalTabsWidthToggle({
     <Button
       variant="ghost"
       size={isWide ? "default" : "icon"}
-      className={cn("mt-auto text-muted-foreground", isWide && "w-full justify-start")}
+      className={cn(
+        "mt-auto text-muted-foreground transition-colors",
+        isWide && "w-full justify-start",
+      )}
       title={isWide ? "Narrow Tabs" : "Wide Tabs"}
       onClick={() => {
         ipc.main.send("tabs.setVerticalTabsWidth", accountId, isWide ? "narrow" : "wide");

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -344,6 +344,10 @@ function VerticalTabsBookmarks({ isWide }: { isWide: boolean }) {
  * arrow it turns around already says which way the strip is about to go. In the
  * wide strip it still takes the full row the controls above it take, so its icon
  * sits in the same column as theirs rather than alone in the corner.
+ *
+ * `default` rather than the `sm` its neighbours widen into, because that is the
+ * one size that matches `icon`'s height and glyph: only the button's width may
+ * change under the pointer that just resized the strip.
  */
 function VerticalTabsWidthToggle({
   accountId,
@@ -355,7 +359,7 @@ function VerticalTabsWidthToggle({
   return (
     <Button
       variant="ghost"
-      size={isWide ? "sm" : "icon"}
+      size={isWide ? "default" : "icon"}
       className={cn("mt-auto text-muted-foreground", isWide && "w-full justify-start")}
       title={isWide ? "Narrow Tabs" : "Wide Tabs"}
       onClick={() => {

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -340,9 +340,10 @@ function VerticalTabsBookmarks({ isWide }: { isWide: boolean }) {
  * the setting — `auto` included — has the strip back on the next one, or as
  * soon as it is set again or the strip's context menu resets the width.
  *
- * The only control in the strip that keeps its icon shape in both widths, where
- * the others grow a label: it is the one that resizes what it sits in, so it
- * stays the same button under the pointer and only turns its arrow around.
+ * The only control in the strip that goes without a label in either width: the
+ * arrow it turns around already says which way the strip is about to go. In the
+ * wide strip it still takes the full row the controls above it take, so its icon
+ * sits in the same column as theirs rather than alone in the corner.
  */
 function VerticalTabsWidthToggle({
   accountId,
@@ -354,8 +355,8 @@ function VerticalTabsWidthToggle({
   return (
     <Button
       variant="ghost"
-      size="icon"
-      className="mt-auto text-muted-foreground"
+      size={isWide ? "sm" : "icon"}
+      className={cn("mt-auto text-muted-foreground", isWide && "w-full justify-start")}
       title={isWide ? "Narrow Tabs" : "Wide Tabs"}
       onClick={() => {
         ipc.main.send("tabs.setVerticalTabsWidth", accountId, isWide ? "narrow" : "wide");


### PR DESCRIPTION
- The tab strip's width toggle now spans the full row in the wide strip (`w-full`) instead of staying a lone icon button in the corner, with its arrow centred rather than dropped into the launcher and bookmarks icon column — there is no label to its right, so centred is where the narrow strip already has it.
- Only its width changes: it uses the `default` size in the wide strip rather than the `sm` its neighbours widen into, since `default` is the one size matching `icon`'s height and glyph. The button under the pointer that just resized the strip keeps its height and arrow.
- That width lands at once — `transition-colors` in place of the button's default `transition-all`, which animated the box and its padding out of step with the strip the click had already resized and dragged the arrow along with it. Same override the wide tab rows already use.
- Unchanged in the narrow strip: still the centred icon button.

Two things left alone: in the wide strip the toggle is a row taller than the `sm` bookmarks button above it, and the bookmarks and launcher buttons still animate their own width on `transition-all` when the strip resizes — that is #779's job. Not visually verified; I didn't run the app.

## Test plan

1. Set the tab strip to wide — the toggle at the foot fills the strip's width with its arrow centred, at the same height and glyph size it had when narrow.
2. Click it without moving the pointer — the button snaps to its new width with the strip, no sliding arrow, and only turns the arrow around.
