### PR TITLE
set the tab strip's width from the button for this run only

### DIFF
--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -1,6 +1,7 @@
 import { platform } from "@electron-toolkit/utils";
 import { GOOGLE_MEET_URL } from "@meru/shared/constants";
 import type { AccountConfig } from "@meru/shared/schemas";
+import type { VerticalTabsSessionWidth } from "@meru/shared/tabs";
 import type { SelectedDesktopSource } from "@meru/shared/types";
 import { app, type IpcMainEvent, ipcMain, type Session, session } from "electron";
 import { blocker } from "./blocker";
@@ -20,6 +21,13 @@ export class Account {
   gmail: Gmail;
 
   tabs: Tabs;
+
+  /**
+   * The width the strip was last given by hand, kept here rather than in the
+   * config so it belongs to this account for this run of the app and is gone by
+   * the next one. `null` leaves the width to the setting.
+   */
+  verticalTabsWidth: VerticalTabsSessionWidth | null = null;
 
   constructor(accountConfig: AccountConfig) {
     this.accountId = accountConfig.id;

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { platform } from "@electron-toolkit/utils";
 import type { AccountConfig } from "@meru/shared/schemas";
-import { getVerticalTabsWidth, getVisibleVerticalTabs } from "@meru/shared/tabs";
+import {
+  getVerticalTabsWidth,
+  getVisibleVerticalTabs,
+  type VerticalTabsSessionWidth,
+} from "@meru/shared/tabs";
 import { Account } from "./account";
 import { config } from "./config";
 import { ipc } from "./ipc";
@@ -44,8 +48,17 @@ class Accounts {
       }
     });
 
+    // A width chosen in settings speaks for every account, so it takes back the
+    // strips a button press had set aside for this run — otherwise picking a
+    // width there would leave them where they stand and read as broken.
     config.onDidChange("verticalTabs.width", () => {
+      for (const account of accounts.instances.values()) {
+        account.verticalTabsWidth = null;
+      }
+
       accounts.updateAllViewBounds();
+
+      accounts.sendAccountsChangedToRenderer();
     });
 
     config.onDidChange("verticalTabs.showWindows", () => {
@@ -118,8 +131,19 @@ class Accounts {
         workspaceAppsMode: config.get("workspaceApps.mode"),
         showWindows: config.get("verticalTabs.showWindows"),
       }),
-      { configuredWidth: config.get("verticalTabs.width") },
+      {
+        configuredWidth: config.get("verticalTabs.width"),
+        sessionWidth: selectedAccount.instance.verticalTabsWidth,
+      },
     );
+  }
+
+  setVerticalTabsWidth(accountId: AccountConfig["id"], width: VerticalTabsSessionWidth) {
+    this.getAccount(accountId).instance.verticalTabsWidth = width;
+
+    this.updateAllViewBounds();
+
+    this.sendAccountsChangedToRenderer();
   }
 
   updateAllViewBounds() {
@@ -438,6 +462,7 @@ class Accounts {
       this.getAccounts().map((account) => ({
         config: account.config,
         gmail: account.instance.gmail.store.getState(),
+        verticalTabsWidth: account.instance.verticalTabsWidth,
       })),
     );
   }

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -138,7 +138,8 @@ class Accounts {
     );
   }
 
-  setVerticalTabsWidth(accountId: AccountConfig["id"], width: VerticalTabsSessionWidth) {
+  /** `null` hands the width back to the setting, `auto` included. */
+  setVerticalTabsWidth(accountId: AccountConfig["id"], width: VerticalTabsSessionWidth | null) {
     this.getAccount(accountId).instance.verticalTabsWidth = width;
 
     this.updateAllViewBounds();

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -605,6 +605,10 @@ class Ipc {
       ]).popup();
     });
 
+    ipc.main.on("tabs.setVerticalTabsWidth", (_event, accountId, width) => {
+      accounts.setVerticalTabsWidth(accountId, width);
+    });
+
     ipc.main.handle("config.getConfig", () => config.store);
 
     ipc.main.handle(

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -602,6 +602,19 @@ class Ipc {
             }
           },
         },
+        {
+          type: "separator",
+        },
+        // The way back from a width set by the button, which is otherwise the
+        // Width setting's to give — and there is nothing to reset to on `auto`,
+        // where picking it again in settings changes nothing.
+        {
+          label: "Reset Width",
+          enabled: Boolean(account.instance.verticalTabsWidth),
+          click: () => {
+            accounts.setVerticalTabsWidth(accountId, null);
+          },
+        },
       ]).popup();
     });
 

--- a/packages/app/main.ts
+++ b/packages/app/main.ts
@@ -65,6 +65,7 @@ class Main {
         accounts.getAccounts().map((account) => ({
           config: account.config,
           gmail: account.instance.gmail.store.getState(),
+          verticalTabsWidth: account.instance.verticalTabsWidth,
         })),
       ),
     );

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -24,7 +24,7 @@ import { UnreadCountBadge } from "@/components/unread-count-badge";
 import { VerticalTabsWorkspaceAppsLauncher } from "@/components/workspace-apps-launcher";
 import { sortablePlugins, sortableSensors } from "@/lib/dnd";
 import { useIsLicenseKeyValid, useVerticalTabs } from "@/lib/hooks";
-import { useConfig, useConfigMutation } from "@/lib/react-query";
+import { useConfig } from "@/lib/react-query";
 import { HOST_HANDOVER_FADE_CLASS_NAME } from "@/lib/utils";
 import { getModifierOpenBehavior } from "@/lib/workspace-apps";
 
@@ -334,18 +334,23 @@ function VerticalTabsBookmarks({ isWide }: { isWide: boolean }) {
 }
 
 /**
- * Sets the width setting to whichever of the two widths the strip is not on, so
- * it can be widened or narrowed where it stands rather than through settings.
- * That leaves `auto` behind for good: a width picked by hand stays picked, the
- * same as choosing one in settings.
+ * Puts the strip on whichever of the two widths it is not on, so it can be
+ * widened or narrowed where it stands rather than through settings. It leaves
+ * the setting alone: the width is this account's for this run of the app, and
+ * the setting — `auto` included — has the strip back on the next one, or as
+ * soon as it is set again.
  *
  * The only control in the strip that keeps its icon shape in both widths, where
  * the others grow a label: it is the one that resizes what it sits in, so it
  * stays the same button under the pointer and only turns its arrow around.
  */
-function VerticalTabsWidthToggle({ isWide }: { isWide: boolean }) {
-  const configMutation = useConfigMutation();
-
+function VerticalTabsWidthToggle({
+  accountId,
+  isWide,
+}: {
+  accountId: AccountConfig["id"];
+  isWide: boolean;
+}) {
   return (
     <Button
       variant="ghost"
@@ -353,7 +358,7 @@ function VerticalTabsWidthToggle({ isWide }: { isWide: boolean }) {
       className="mt-auto text-muted-foreground"
       title={isWide ? "Narrow Tabs" : "Wide Tabs"}
       onClick={() => {
-        configMutation.mutate({ "verticalTabs.width": isWide ? "narrow" : "wide" });
+        ipc.main.send("tabs.setVerticalTabsWidth", accountId, isWide ? "narrow" : "wide");
       }}
     >
       {isWide ? <ChevronsLeftIcon /> : <ChevronsRightIcon />}
@@ -483,7 +488,7 @@ export function VerticalTabs() {
         </div>
       )}
       <VerticalTabsBookmarks isWide={isWide} />
-      <VerticalTabsWidthToggle isWide={isWide} />
+      <VerticalTabsWidthToggle accountId={selectedAccount.config.id} isWide={isWide} />
     </div>
   );
 }

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -338,7 +338,7 @@ function VerticalTabsBookmarks({ isWide }: { isWide: boolean }) {
  * widened or narrowed where it stands rather than through settings. It leaves
  * the setting alone: the width is this account's for this run of the app, and
  * the setting — `auto` included — has the strip back on the next one, or as
- * soon as it is set again.
+ * soon as it is set again or the strip's context menu resets the width.
  *
  * The only control in the strip that keeps its icon shape in both widths, where
  * the others grow a label: it is the one that resizes what it sits in, so it

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -78,6 +78,7 @@ export function useVerticalTabs() {
 
   const width = getVerticalTabsWidth(tabs, {
     configuredWidth: config?.["verticalTabs.width"] ?? "auto",
+    sessionWidth: selectedAccount?.verticalTabsWidth ?? null,
   });
 
   return { selectedAccount, tabs, width };

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -236,7 +236,7 @@ export function WorkspaceAppsSettings() {
                 />
                 <ConfigSelectField
                   label="Width"
-                  description="How wide the vertical tabs sidebar is. Auto switches between narrow and wide automatically based on the open tabs. The button at the bottom of the sidebar switches between narrow and wide for that account until Meru quits, leaving this setting as it is."
+                  description="How wide the vertical tabs sidebar is. Auto switches between narrow and wide automatically based on the open tabs. The button at the bottom of the sidebar switches between narrow and wide for that account until Meru quits, leaving this setting as it is. Right-click the sidebar and choose Reset Width to hand it back."
                   configKey="verticalTabs.width"
                   placeholder="Select width"
                   licenseKeyRequired

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -236,7 +236,7 @@ export function WorkspaceAppsSettings() {
                 />
                 <ConfigSelectField
                   label="Width"
-                  description="How wide the vertical tabs sidebar is. Auto switches between narrow and wide automatically based on the open tabs. The button at the bottom of the sidebar switches between narrow and wide as well."
+                  description="How wide the vertical tabs sidebar is. Auto switches between narrow and wide automatically based on the open tabs. The button at the bottom of the sidebar switches between narrow and wide for that account until Meru quits, leaving this setting as it is."
                   configKey="verticalTabs.width"
                   placeholder="Select width"
                   licenseKeyRequired

--- a/packages/shared/schemas.ts
+++ b/packages/shared/schemas.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { isValidCssColorInput } from "./color";
 import type { GmailState } from "./gmail";
+import type { VerticalTabsSessionWidth } from "./tabs";
 import { type SupportedWorkspaceApp, workspaceApps } from "./workspace-apps";
 
 export const accountColors = [
@@ -100,6 +101,8 @@ export type AccountConfigInput = z.infer<typeof accountConfigInputSchema>;
 export type AccountInstance = {
   config: AccountConfig;
   gmail: GmailState;
+  /** The width the account's tab strip was last given by hand, for this run. */
+  verticalTabsWidth: VerticalTabsSessionWidth | null;
 };
 
 export type AccountInstances = AccountInstance[];

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -12,6 +12,13 @@ export const verticalTabsWidths = {
 
 export type VerticalTabsWidth = keyof typeof verticalTabsWidths;
 
+/**
+ * A width picked by hand in the strip, for one account until the app quits. It
+ * is one of the two real widths: `auto` is a rule for choosing between them,
+ * which is what picking by hand steps over.
+ */
+export type VerticalTabsSessionWidth = Exclude<VerticalTabsWidth, "auto">;
+
 export type TabState = {
   id: string;
   app: SupportedWorkspaceApp | undefined;
@@ -71,10 +78,20 @@ export function getVisibleVerticalTabs<VerticalTab extends Pick<TabState, "dorma
 
 export function getVerticalTabsWidth(
   tabs: Pick<TabState, "app" | "pinned">[],
-  { configuredWidth }: { configuredWidth: VerticalTabsWidth },
+  {
+    configuredWidth,
+    sessionWidth,
+  }: { configuredWidth: VerticalTabsWidth; sessionWidth: VerticalTabsSessionWidth | null },
 ) {
   if (tabs.length <= 1) {
     return 0;
+  }
+
+  // A width picked in the strip stands in front of the setting, but only for as
+  // long as there is a strip to pick it in: it cannot bring back one the tab
+  // count has taken away.
+  if (sessionWidth) {
+    return sessionWidth === "narrow" ? VERTICAL_TABS_NARROW_WIDTH : VERTICAL_TABS_WIDE_WIDTH;
   }
 
   if (configuredWidth === "narrow") {

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -11,7 +11,7 @@ import type {
   GmailLabelColors,
   GmailSavedSearches,
 } from "./schemas";
-import type { AccountTabsState, VerticalTabsWidth } from "./tabs";
+import type { AccountTabsState, VerticalTabsSessionWidth, VerticalTabsWidth } from "./tabs";
 import type {
   LauncherWorkspaceApp,
   SupportedWorkspaceApp,
@@ -201,6 +201,10 @@ export type IpcMainEvents =
       "tabs.moveTab": [accountId: AccountConfig["id"], tabId: string, targetSectionIndex: number];
       "tabs.showTabContextMenu": [accountId: AccountConfig["id"], tabId: string];
       "tabs.showVerticalTabsContextMenu": [accountId: AccountConfig["id"]];
+      "tabs.setVerticalTabsWidth": [
+        accountId: AccountConfig["id"],
+        width: VerticalTabsSessionWidth,
+      ];
       "workspaceApps.openApp": [
         app: SupportedWorkspaceApp,
         openBehavior?: WorkspaceAppOpenBehavior,


### PR DESCRIPTION
- The strip's width button no longer writes `verticalTabs.width`. It sets the width on the account in the main process, in memory, so it lasts for this run of the app and belongs to that account alone.
- `getVerticalTabsWidth` takes a `sessionWidth` that stands in front of the setting, checked after the "one tab, no strip" guard so a held width can't resurrect a hidden strip.
- Main is the source of truth because it works out the `WebContentsView` bounds from the same width; the value rides along on the `AccountInstance` payload, so the renderer stays in step and a reload picks it back up from the URL params.
- Reset Width in the strip's context menu hands the width back to the setting, greyed out until there is one to give back — the only way back on `auto`, where re-picking the setting is a no-op.
- Choosing a width in settings also clears every account's held width, otherwise the setting would look broken while a stale one sat on top.

Not run in the app: types, lint, format and a production build pass, but I haven't driven the UI.

Test plan
1. With two or more tabs open, press the width button — the strip resizes and the Gmail/app view beside it moves with it, with no gap or overlap at the seam.
2. Open Settings → Workspace Apps → Vertical Tabs: Width is still whatever it was before the press (`Auto` by default).
3. Switch accounts — the other account's strip is on its own width, not the one just set.
4. Right-click the strip → Reset Width: it goes back to what the setting says, and the item greys out again.
5. Set Width in settings while a strip is held on the other width — that strip snaps to the setting straight away.