### PR TITLE
stop the tab strip's buttons animating into their new width

### DIFF
--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -171,12 +171,15 @@ function VerticalTab({
         variant={tab.active ? "secondary" : !isWideRow && isPinnedSectionTab ? "outline" : "ghost"}
         size={isWideRow ? "sm" : "icon"}
         className={cn(
+          // Colours transition, the box never does. The hover controls take
+          // their room instantly rather than over a transition, which would
+          // slide the resting star out from under the one that replaces it;
+          // and the tab takes the shape its new presentation gives it in the
+          // same step the strip changes width, rather than animating into it
+          // once the strip has already arrived.
+          "transition-colors",
           tab.dormant && "opacity-50",
           isWideRow && "w-full justify-start",
-          // The hover controls take their room instantly rather than over a
-          // transition, which would slide the resting star out from under the
-          // one that replaces it
-          isWideRow && "transition-colors",
           isWideRow && isBookmarkable && "group-hover:pr-13",
           isWideRow && !isBookmarkable && isCloseable && "group-hover:pr-7",
           showsRestingStar && "pr-7",
@@ -254,10 +257,8 @@ function VerticalTab({
           size="icon"
           data-sortable-action
           className={cn(
-            "absolute opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
-            isWideRow
-              ? "inset-y-0 right-1 my-auto size-5 transition-colors"
-              : "-top-1 -right-1 size-4 rounded-full",
+            "absolute opacity-0 transition-colors group-hover:opacity-100 focus-visible:opacity-100",
+            isWideRow ? "inset-y-0 right-1 my-auto size-5" : "-top-1 -right-1 size-4 rounded-full",
           )}
           title="Close"
           onClick={() => {
@@ -315,7 +316,10 @@ function VerticalTabsBookmarks({ isWide }: { isWide: boolean }) {
     <Button
       variant="ghost"
       size={isWide ? "sm" : "icon"}
-      className={cn("text-muted-foreground", isWide && "w-full justify-start")}
+      // Colours transition, the box never does: the button takes its new width
+      // in the same step the strip does rather than animating into it once the
+      // strip has already arrived
+      className={cn("text-muted-foreground transition-colors", isWide && "w-full justify-start")}
       title="Bookmarks"
       onClick={() => {
         ipc.main.send("bookmarks.togglePopup", "verticalTabs");

--- a/packages/renderer/components/workspace-apps-launcher.tsx
+++ b/packages/renderer/components/workspace-apps-launcher.tsx
@@ -109,7 +109,13 @@ export function VerticalTabsWorkspaceAppsLauncher({
           <Button
             variant="ghost"
             size={isWide ? "sm" : "icon"}
-            className={cn("text-muted-foreground", isWide && "w-full justify-start")}
+            // Colours transition, the box never does: the button takes its new
+            // width in the same step the strip does rather than animating into
+            // it once the strip has already arrived
+            className={cn(
+              "text-muted-foreground transition-colors",
+              isWide && "w-full justify-start",
+            )}
             title="Open App"
           >
             <LayoutGridIcon />


### PR DESCRIPTION
- No control in the tab strip animates its box any more — `transition-colors` in place of the `Button`'s default `transition-all` on the tab rows, the bookmarks button and the launcher button. They were animating into their new shape *after* the strip had already snapped to its new width, so they slid around under the pointer that had just resized them.
- The tab rows had that override already, but only in the wide row: a narrow icon still animated down from row width, and a pinned grid tile from its grid cell.
- The close button's `transition-colors` moves out of the wide-row branch of its `className` and up into the shared part, so the narrow one stops animating its position, size and radius across the change too.
- One behaviour change falls out of that: the narrow close button now pops in on hover instead of fading. That matches the wide row and the resting star, which already popped.

The width toggle isn't touched here — it got the same override in #777, which this is otherwise independent of. Not visually verified; I didn't run the app.

## Test plan

1. With the strip narrow, click the width toggle at the foot — the tab rows, pinned tiles and the bookmarks and launcher buttons all land at their wide shape in the same step the strip does, none of them widening after it has arrived. Then click it again for the reverse.
2. Hover a tab row in the narrow strip — the close button appears at once in the corner rather than fading in.
