### PR TITLE
close a tab and jump to a pinned tab from the keyboard

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -1,6 +1,6 @@
 import { is, platform } from "@electron-toolkit/utils";
 import { GITHUB_REPO_URL, WEBSITE_URL } from "@meru/shared/constants";
-import { getTabSection, GMAIL_TAB_ID } from "@meru/shared/tabs";
+import { getTabSection, getVisibleVerticalTabs, GMAIL_TAB_ID } from "@meru/shared/tabs";
 import {
   app,
   BrowserWindow,
@@ -161,6 +161,54 @@ export class AppMenu {
 
       accounts.refreshSelectedAccountView();
     };
+
+    /**
+     * The nth entry of the pinned section as the strip shows it, Gmail counting
+     * as the first: the numbers stand for what is on screen, so the filters the
+     * strip renders through decide what they land on.
+     */
+    const selectPinnedTab = (pinnedTabIndex: number) => {
+      const selectedAccountTabs = accounts.getSelectedAccount().instance.tabs;
+
+      const pinnedTabs = getVisibleVerticalTabs(selectedAccountTabs.serialize(), {
+        workspaceAppsMode: config.get("workspaceApps.mode"),
+        showWindows: config.get("verticalTabs.showWindows"),
+      }).filter((tab) => getTabSection(tab) === "pinned");
+
+      const pinnedTab = pinnedTabs[pinnedTabIndex];
+
+      if (!pinnedTab) {
+        return;
+      }
+
+      selectedAccountTabs.activateTab(pinnedTab.id);
+
+      // A windowed entry is brought forward in its own window, which leaves the
+      // main window showing whatever it already was.
+      if (pinnedTab.windowed) {
+        return;
+      }
+
+      main.navigate("/");
+
+      accounts.refreshSelectedAccountView();
+    };
+
+    const selectPinnedTabItems: MenuItemConstructorOptions[] = Array.from(
+      { length: 9 },
+      (_pinnedTabEntry, pinnedTabIndex) => ({
+        label: `Select Pinned Tab ${pinnedTabIndex + 1} (hidden shortcut)`,
+        // Literal Ctrl on every platform, like the Ctrl+Tab pair above:
+        // Command+Shift+3..6 are macOS screenshot shortcuts that never reach the
+        // app, and Command/Ctrl+1..9 already select accounts.
+        accelerator: `Ctrl+Shift+${pinnedTabIndex + 1}`,
+        visible: is.dev,
+        acceleratorWorksWhenHidden: true,
+        click: () => {
+          selectPinnedTab(pinnedTabIndex);
+        },
+      }),
+    );
 
     const selectedAccountActiveTab = selectedAccount.instance.tabs.activeTab;
 
@@ -499,6 +547,7 @@ export class AppMenu {
             acceleratorWorksWhenHidden: true,
             click: selectPreviousTab,
           },
+          ...selectPinnedTabItems,
           {
             type: "separator",
           },

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -1,6 +1,6 @@
 import { is, platform } from "@electron-toolkit/utils";
 import { GITHUB_REPO_URL, WEBSITE_URL } from "@meru/shared/constants";
-import { GMAIL_TAB_ID } from "@meru/shared/tabs";
+import { getTabSection, GMAIL_TAB_ID } from "@meru/shared/tabs";
 import {
   app,
   BrowserWindow,
@@ -161,6 +161,14 @@ export class AppMenu {
 
       accounts.refreshSelectedAccountView();
     };
+
+    const selectedAccountActiveTab = selectedAccount.instance.tabs.activeTab;
+
+    // Exactly what the strip's close button offers: the pinned section — Gmail
+    // included — and dormant entries carry no close button, so the shortcut has
+    // nothing to close there either.
+    const isActiveTabCloseable =
+      getTabSection(selectedAccountActiveTab) !== "pinned" && !selectedAccountActiveTab.dormant;
 
     const isGmailVisible =
       focusedWindow === main.window &&
@@ -493,6 +501,18 @@ export class AppMenu {
           },
           {
             type: "separator",
+          },
+          {
+            label: "Close Tab",
+            accelerator: "CommandOrControl+Shift+W",
+            enabled: isActiveTabCloseable,
+            click: () => {
+              const selectedAccountTabs = accounts.getSelectedAccount().instance.tabs;
+
+              selectedAccountTabs.closeTab(selectedAccountTabs.activeTabId);
+
+              accounts.refreshSelectedAccountView();
+            },
           },
           {
             label: "Reopen Closed Tab",

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -508,6 +508,11 @@ export class Tabs {
 
     this.broadcastTabsChanged();
 
+    // Pinning carries a tab in and out of the section that cannot be closed
+    // without changing which tab is active, so nothing else would rebuild the
+    // menu on the Close Tab entry's behalf.
+    appMenu.refresh();
+
     accounts.saveTabs();
   }
 


### PR DESCRIPTION
The Tabs menu had no way to close a tab and no way to reach a specific one.

- **Close Tab** on `Cmd/Ctrl+Shift+W`, greyed out on the Gmail tab, pinned tabs and dormant entries — the same rule the strip uses to decide whether a row gets a close button, so the keyboard closes exactly what the mouse can.
- **`Cmd/Ctrl+W` still closes the main window**, deliberately unlike a browser: keeping Gmail and the workspace apps open is the point of the app, closing the window is cheap and reversible, and closing a tab is the destructive act — so the reflex key stays on the safe one.
- **`Ctrl+Shift+1..9`** select the nth entry of the pinned section as the strip shows it, Gmail counting as 1. Literal `Ctrl` on every platform, matching the `Ctrl+Tab` pair already there: `Cmd+Shift+3..6` are macOS screenshot shortcuts the app never receives, and `Cmd/Ctrl+1..9` already switch accounts. Hidden entries, so they do not appear in the menu.
- `appMenu.refresh()` added to `Tabs.setTabPinned`. The menu already rebuilds when the active tab changes, but pinning the active tab does not change which tab is active, so Close Tab would have kept a stale enabled state.

Not run — types, lint and format only, on a headless box. Whether Close Tab greys and ungreys correctly is the part worth exercising by hand. Two knock-ons worth knowing: dev builds now show nine extra rows in the Tabs menu, following the `visible: is.dev` pattern the file already uses for hidden shortcuts, and the nine accelerators are undiscoverable in production until a shortcuts settings page exists — recorded in `TODO.md` in the companion PR.

## Test plan

1. Open a few workspace app tabs. With an unpinned one active, `Cmd/Ctrl+Shift+W` closes it. With the Gmail tab active, the Tabs menu shows Close Tab greyed and the key does nothing.
2. Pin the active tab from its context menu, then open the Tabs menu without switching tabs — Close Tab is greyed already.
3. `Ctrl+Shift+1` selects Gmail, `Ctrl+Shift+2` and `3` the next pinned entries in the order the strip shows them. With fewer than nine pinned entries, `Ctrl+Shift+9` does nothing.
4. `Cmd/Ctrl+W` still closes the main window.