### PR TITLE
scroll the tab strip's sections so its foot is never clipped

### DIFF
--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -7,6 +7,7 @@ import type { AccountConfig } from "@meru/shared/schemas";
 import { GMAIL_TAB_ID, getTabSection, type TabState } from "@meru/shared/tabs";
 import { workspaceApps } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
+import { ScrollArea } from "@meru/ui/components/scroll-area";
 import { cn } from "@meru/ui/lib/utils";
 import {
   AppWindowIcon,
@@ -378,7 +379,7 @@ function VerticalTabsWidthToggle({
       variant="ghost"
       size={isWide ? "default" : "icon"}
       className={cn(
-        "mt-auto text-muted-foreground opacity-0 transition-[color,background-color,opacity] group-hover/vertical-tabs:opacity-100 focus-visible:opacity-100",
+        "text-muted-foreground opacity-0 transition-[color,background-color,opacity] group-hover/vertical-tabs:opacity-100 focus-visible:opacity-100",
         isWide && "w-full",
       )}
       title={isWide ? "Narrow Tabs" : "Wide Tabs"}
@@ -445,9 +446,10 @@ export function VerticalTabs() {
         // The column therefore hinges on its left edge as the strip resizes,
         // and the controls at the foot — the width toggle above all, which does
         // the resizing — stay put rather than stepping out from under the
-        // pointer.
+        // pointer. The scrolling sections reach past that gutter and lay it out
+        // again themselves, so a scrollbar can never take it from the column.
         "group/vertical-tabs flex flex-col border-r p-4 select-none",
-        isWide ? "gap-1" : "items-center gap-2",
+        isWide ? "gap-1" : "gap-2",
       )}
       style={{ width: verticalTabsWidth, minWidth: verticalTabsWidth }}
       onContextMenu={(event) => {
@@ -460,66 +462,100 @@ export function VerticalTabs() {
         ipc.main.send("tabs.showVerticalTabsContextMenu", selectedAccount.config.id);
       }}
     >
-      <DragDropProvider
-        plugins={sortablePlugins}
-        sensors={sortableSensors}
-        onDragEnd={(event) => {
-          moveSectionTab(selectedAccount.config.id, pinnedSectionTabs, event);
-        }}
-      >
-        {isWide ? (
-          <div className="mb-1 grid w-full grid-cols-2 gap-2">
-            {pinnedSectionTabs.map((tab, pinnedSectionTabIndex) => (
-              <SortableVerticalTab
-                key={tab.id}
-                tab={tab}
-                accountId={selectedAccount.config.id}
-                presentation="gridIcon"
-                sectionIndex={pinnedSectionTabIndex}
-                gmailStatus={tab.id === GMAIL_TAB_ID ? gmailTabStatus : undefined}
-                className={cn(
-                  pinnedSectionTabs.length % 2 === 1 && pinnedSectionTabIndex === 0 && "col-span-2",
-                )}
-              />
-            ))}
+      {/*
+       * Everything between the head of the strip and its foot, split in the
+       * pinned section's favour: the pinned tabs are laid out at whatever
+       * height they come to, under no ceiling and no share of the strip they
+       * may not pass, and the normal tabs — measured from nothing upwards — are
+       * left with what remains. Pinning heavily is therefore meant to squeeze
+       * the normal tabs into a thin scrolling column rather than to cost the
+       * pinned ones a row.
+       */}
+      <div className="flex min-h-0 flex-1 flex-col gap-2">
+        <DragDropProvider
+          plugins={sortablePlugins}
+          sensors={sortableSensors}
+          onDragEnd={(event) => {
+            moveSectionTab(selectedAccount.config.id, pinnedSectionTabs, event);
+          }}
+        >
+          {/*
+           * Scrolls only where there is genuinely nowhere left to put the
+           * pinned tabs — the normal tabs having already given up everything
+           * they had — so that heavy pinning can never push the section's own
+           * rows out of the strip the way it used to.
+           *
+           * Both sections reach out to the strip's sides and set the gutter out
+           * again inside themselves, so the scrollbar rides in the gutter
+           * rather than over the tabs, and the column stands in the same place
+           * whether there is one or not. The four pixels top and bottom are for
+           * the badges the icons hang over their corners, which the edge a
+           * scroll container clips at would otherwise shave off.
+           */}
+          <ScrollArea className="-mx-4 -my-1 min-h-0">
+            <div
+              className={cn(
+                "px-4 py-1",
+                isWide ? "grid grid-cols-2 gap-2" : "flex flex-col items-center gap-2",
+              )}
+            >
+              {pinnedSectionTabs.map((tab, pinnedSectionTabIndex) => (
+                <SortableVerticalTab
+                  key={tab.id}
+                  tab={tab}
+                  accountId={selectedAccount.config.id}
+                  presentation={isWide ? "gridIcon" : "narrowIcon"}
+                  sectionIndex={pinnedSectionTabIndex}
+                  gmailStatus={tab.id === GMAIL_TAB_ID ? gmailTabStatus : undefined}
+                  className={cn(
+                    isWide &&
+                      pinnedSectionTabs.length % 2 === 1 &&
+                      pinnedSectionTabIndex === 0 &&
+                      "col-span-2",
+                  )}
+                />
+              ))}
+            </div>
+          </ScrollArea>
+        </DragDropProvider>
+        <DragDropProvider
+          plugins={sortablePlugins}
+          sensors={sortableSensors}
+          onDragEnd={(event) => {
+            moveSectionTab(selectedAccount.config.id, normalTabs, event);
+          }}
+        >
+          <ScrollArea className="-mx-4 -my-1 min-h-0 flex-1">
+            <div className={cn("flex flex-col px-4 py-1", isWide ? "gap-1" : "items-center gap-2")}>
+              {normalTabs.map((tab, normalTabIndex) => (
+                <SortableVerticalTab
+                  key={tab.id}
+                  tab={tab}
+                  accountId={selectedAccount.config.id}
+                  presentation={isWide ? "wideRow" : "narrowIcon"}
+                  sectionIndex={normalTabIndex}
+                />
+              ))}
+            </div>
+          </ScrollArea>
+        </DragDropProvider>
+      </div>
+      {/*
+       * The foot of the strip stands outside the scrolling: these are the
+       * controls that have to be there however many tabs are open, the width
+       * toggle most of all, which has to be where the pointer that just clicked
+       * it left it. The sections above take all the room going, so the foot
+       * needs no pushing down of its own.
+       */}
+      <div className={cn("flex flex-col", isWide ? "gap-1" : "items-center gap-2")}>
+        {shouldShowWorkspaceAppsLauncher && (
+          <div className={cn(HOST_HANDOVER_FADE_CLASS_NAME, isWide && "w-full")}>
+            <VerticalTabsWorkspaceAppsLauncher launcherApps={launcherApps} isWide={isWide} />
           </div>
-        ) : (
-          pinnedSectionTabs.map((tab, pinnedSectionTabIndex) => (
-            <SortableVerticalTab
-              key={tab.id}
-              tab={tab}
-              accountId={selectedAccount.config.id}
-              presentation="narrowIcon"
-              sectionIndex={pinnedSectionTabIndex}
-              gmailStatus={tab.id === GMAIL_TAB_ID ? gmailTabStatus : undefined}
-            />
-          ))
         )}
-      </DragDropProvider>
-      <DragDropProvider
-        plugins={sortablePlugins}
-        sensors={sortableSensors}
-        onDragEnd={(event) => {
-          moveSectionTab(selectedAccount.config.id, normalTabs, event);
-        }}
-      >
-        {normalTabs.map((tab, normalTabIndex) => (
-          <SortableVerticalTab
-            key={tab.id}
-            tab={tab}
-            accountId={selectedAccount.config.id}
-            presentation={isWide ? "wideRow" : "narrowIcon"}
-            sectionIndex={normalTabIndex}
-          />
-        ))}
-      </DragDropProvider>
-      {shouldShowWorkspaceAppsLauncher && (
-        <div className={cn(HOST_HANDOVER_FADE_CLASS_NAME, isWide && "w-full")}>
-          <VerticalTabsWorkspaceAppsLauncher launcherApps={launcherApps} isWide={isWide} />
-        </div>
-      )}
-      <VerticalTabsBookmarks isWide={isWide} />
-      <VerticalTabsWidthToggle accountId={selectedAccount.config.id} isWide={isWide} />
+        <VerticalTabsBookmarks isWide={isWide} />
+        <VerticalTabsWidthToggle accountId={selectedAccount.config.id} isWide={isWide} />
+      </div>
     </div>
   );
 }

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -396,6 +396,36 @@ function VerticalTabsWidthToggle({
   );
 }
 
+/**
+ * What the pinned tabs have to leave the normal ones as the strip fills: the
+ * rows the list has, up to three of them and the eight pixels of a fourth that
+ * say it carries on past the three. A shorter list is left whole — the room
+ * held for it is the room it fills, so none of it can stand empty between the
+ * last tab and the launcher.
+ *
+ * The rows are measured here rather than left to the layout because the room is
+ * held open from above, as a ceiling on the pinned tabs: see the section for
+ * why it cannot be a floor under these ones.
+ */
+function getNormalSectionReservedHeight(normalTabCount: number, isWide: boolean) {
+  if (normalTabCount === 0) {
+    return 0;
+  }
+
+  // A row as each width lays it out: the narrow strip's 32px icon button or the
+  // wide strip's 28px row, each in a tab box standing four pixels taller than
+  // the button it holds, and under it the gap the section sets between rows.
+  const rowHeight = isWide ? 34 : 36;
+
+  const rowGap = isWide ? 4 : 8;
+
+  const listHeight = normalTabCount * rowHeight + (normalTabCount - 1) * rowGap;
+
+  const threeRowsAndASliver = rowHeight * 3 + rowGap * 2 + 8;
+
+  return Math.min(listHeight, threeRowsAndASliver);
+}
+
 export function VerticalTabs() {
   const { config } = useConfig();
 
@@ -417,14 +447,7 @@ export function VerticalTabs() {
 
   const normalTabs = selectedAccountTabs.filter((tab) => getTabSection(tab) === "normal");
 
-  /**
-   * The room the pinned tabs leave the normal ones is three rows and the sliver
-   * of a fourth that says the list goes on, and it is only worth holding open
-   * for a list with three rows to put in it: any shorter and it would stand
-   * part empty under the last tab, which is the one thing the strip's controls
-   * may not have above them.
-   */
-  const holdsNormalSectionFloor = normalTabs.length >= 3;
+  const normalSectionReservedHeight = getNormalSectionReservedHeight(normalTabs.length, isWide);
 
   const launcherApps = config?.["workspaceApps.launcherApps"] ?? [];
 
@@ -485,8 +508,9 @@ export function VerticalTabs() {
        *
        * They then divide what is left between them in the pinned section's
        * favour. The pinned tabs take the height they come to and hold it while
-       * the normal tabs give ground, down to the last three rows they are left
-       * with; only past that do the pinned tabs give any. Pinning heavily
+       * the normal tabs give ground, down to the three rows and the sliver of a
+       * fourth held for them — or to the whole of a list too short to fill even
+       * that; only past there do the pinned tabs give any. Pinning heavily
        * therefore squeezes the normal tabs into a thin scrolling column rather
        * than costing the pinned ones a row, but it can no longer squeeze them
        * out of sight.
@@ -500,20 +524,20 @@ export function VerticalTabs() {
           }}
         >
           {/*
-           * Yields to nothing until the normal tabs are down to their floor,
-           * and reaching that is the one case where this section scrolls rather
-           * than takes the room it wants.
+           * Yields to nothing until the normal tabs are down to the room held
+           * for them, and reaching that is the one case where this section
+           * scrolls rather than takes the height it wants.
            *
-           * The floor is held open from up here, as a ceiling on this section
+           * That room is held open from up here, as a ceiling on this section
            * rather than a floor under that one. A floor would hold its room
            * open at rest as well, standing between the last tab and the
            * launcher, and being a minimum it could not give way on a window too
            * short to honour it — it would run the two sections over the very
            * controls this is all in aid of. A ceiling only ever takes room
-           * away, so it can push nothing out of the strip; where the room for a
-           * floor isn't there at all, it stands aside and the two sections
-           * halve what there is between them. Its measure is the floor plus the
-           * gap over it, less the bleed below, which is the floor exactly.
+           * away, so it can push nothing out of the strip; where the room held
+           * isn't there to hold, it stands aside and the two sections halve
+           * what there is between them. Its measure is the room plus the gap
+           * over it, less the bleed below, and the two cancel.
            *
            * Both sections reach out to the strip's sides and set the gutter out
            * again inside themselves, so the scrollbar rides in the gutter
@@ -523,12 +547,12 @@ export function VerticalTabs() {
            * scroll container clips at would otherwise shave off.
            */}
           <ScrollArea
-            className={cn(
-              "-mx-4 -my-1 shrink-0",
-              holdsNormalSectionFloor
-                ? "max-h-[max(50%,calc(100%-7rem))]"
-                : "max-h-[calc(100%+0.5rem)]",
-            )}
+            className="-mx-4 -my-1 shrink-0"
+            style={{
+              maxHeight: normalSectionReservedHeight
+                ? `max(50%, calc(100% - ${normalSectionReservedHeight}px))`
+                : "calc(100% + 0.5rem)",
+            }}
           >
             <div
               className={cn(
@@ -570,8 +594,8 @@ export function VerticalTabs() {
           >
             {/*
              * The section that gives ground: it scrolls from the first row it
-             * cannot show, and gives no further than the three rows the ceiling
-             * above holds open for it.
+             * cannot show, and gives no further than the room the ceiling above
+             * holds open for it.
              */}
             <ScrollArea className="-mx-4 -my-1 min-h-0">
               <div

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -417,6 +417,15 @@ export function VerticalTabs() {
 
   const normalTabs = selectedAccountTabs.filter((tab) => getTabSection(tab) === "normal");
 
+  /**
+   * The room the pinned tabs leave the normal ones is three rows and the sliver
+   * of a fourth that says the list goes on, and it is only worth holding open
+   * for a list with three rows to put in it: any shorter and it would stand
+   * part empty under the last tab, which is the one thing the strip's controls
+   * may not have above them.
+   */
+  const holdsNormalSectionFloor = normalTabs.length >= 3;
+
   const launcherApps = config?.["workspaceApps.launcherApps"] ?? [];
 
   const shouldShowWorkspaceAppsLauncher = isLicenseKeyValid && launcherApps.length > 0;
@@ -475,10 +484,12 @@ export function VerticalTabs() {
        * many are open.
        *
        * They then divide what is left between them in the pinned section's
-       * favour. The pinned tabs never yield — no ceiling, no share of the strip
-       * they may not pass — and the normal tabs give up everything they have
-       * first, so pinning heavily squeezes the normal tabs into a thin
-       * scrolling column rather than costing the pinned ones a row.
+       * favour. The pinned tabs take the height they come to and hold it while
+       * the normal tabs give ground, down to the last three rows they are left
+       * with; only past that do the pinned tabs give any. Pinning heavily
+       * therefore squeezes the normal tabs into a thin scrolling column rather
+       * than costing the pinned ones a row, but it can no longer squeeze them
+       * out of sight.
        */}
       <div className="flex min-h-0 w-full flex-col gap-2">
         <DragDropProvider
@@ -489,14 +500,20 @@ export function VerticalTabs() {
           }}
         >
           {/*
-           * Yields to nothing: the normal tabs give up everything they have
-           * before a pinned row gives up a pixel. The one bound on it is the
-           * height the two sections have between them, which it can only reach
-           * once the normal tabs are down to nothing, and reaching it is the
-           * single case where this section scrolls — so the pinned tabs can
-           * never be what pushes the strip's controls out. That bound carries
-           * the section's own bleed with it, the height it is measured against
-           * being the one the bleed has already taken back.
+           * Yields to nothing until the normal tabs are down to their floor,
+           * and reaching that is the one case where this section scrolls rather
+           * than takes the room it wants.
+           *
+           * The floor is held open from up here, as a ceiling on this section
+           * rather than a floor under that one. A floor would hold its room
+           * open at rest as well, standing between the last tab and the
+           * launcher, and being a minimum it could not give way on a window too
+           * short to honour it — it would run the two sections over the very
+           * controls this is all in aid of. A ceiling only ever takes room
+           * away, so it can push nothing out of the strip; where the room for a
+           * floor isn't there at all, it stands aside and the two sections
+           * halve what there is between them. Its measure is the floor plus the
+           * gap over it, less the bleed below, which is the floor exactly.
            *
            * Both sections reach out to the strip's sides and set the gutter out
            * again inside themselves, so the scrollbar rides in the gutter
@@ -505,7 +522,14 @@ export function VerticalTabs() {
            * the badges the icons hang over their corners, which the edge a
            * scroll container clips at would otherwise shave off.
            */}
-          <ScrollArea className="-mx-4 -my-1 max-h-[calc(100%+0.5rem)] shrink-0">
+          <ScrollArea
+            className={cn(
+              "-mx-4 -my-1 shrink-0",
+              holdsNormalSectionFloor
+                ? "max-h-[max(50%,calc(100%-7rem))]"
+                : "max-h-[calc(100%+0.5rem)]",
+            )}
+          >
             <div
               className={cn(
                 "px-4 py-1",
@@ -544,7 +568,11 @@ export function VerticalTabs() {
               moveSectionTab(selectedAccount.config.id, normalTabs, event);
             }}
           >
-            {/* The section that gives ground: it scrolls from the first row it cannot show */}
+            {/*
+             * The section that gives ground: it scrolls from the first row it
+             * cannot show, and gives no further than the three rows the ceiling
+             * above holds open for it.
+             */}
             <ScrollArea className="-mx-4 -my-1 min-h-0">
               <div
                 className={cn("flex flex-col px-4 py-1", isWide ? "gap-1" : "items-center gap-2")}

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -366,6 +366,10 @@ function VerticalTabsBookmarks({ isWide }: { isWide: boolean }) {
  * that crossing the strip on the way somewhere else doesn't read as a flicker.
  * It holds its room in the column throughout, so the controls above it stay
  * where they are, and focus brings it back for the keyboard.
+ *
+ * An auto margin is what puts it at the foot: the tabs and the controls under
+ * them take only the height they need, so this is the one thing in the strip
+ * that has to be sent down to reach it.
  */
 function VerticalTabsWidthToggle({
   accountId,
@@ -379,7 +383,7 @@ function VerticalTabsWidthToggle({
       variant="ghost"
       size={isWide ? "default" : "icon"}
       className={cn(
-        "text-muted-foreground opacity-0 transition-[color,background-color,opacity] group-hover/vertical-tabs:opacity-100 focus-visible:opacity-100",
+        "mt-auto text-muted-foreground opacity-0 transition-[color,background-color,opacity] group-hover/vertical-tabs:opacity-100 focus-visible:opacity-100",
         isWide && "w-full",
       )}
       title={isWide ? "Narrow Tabs" : "Wide Tabs"}
@@ -449,7 +453,7 @@ export function VerticalTabs() {
         // pointer. The scrolling sections reach past that gutter and lay it out
         // again themselves, so a scrollbar can never take it from the column.
         "group/vertical-tabs flex flex-col border-r p-4 select-none",
-        isWide ? "gap-1" : "gap-2",
+        isWide ? "gap-1" : "items-center gap-2",
       )}
       style={{ width: verticalTabsWidth, minWidth: verticalTabsWidth }}
       onContextMenu={(event) => {
@@ -463,15 +467,20 @@ export function VerticalTabs() {
       }}
     >
       {/*
-       * Everything between the head of the strip and its foot, split in the
-       * pinned section's favour: the pinned tabs are laid out at whatever
-       * height they come to, under no ceiling and no share of the strip they
-       * may not pass, and the normal tabs — measured from nothing upwards — are
-       * left with what remains. Pinning heavily is therefore meant to squeeze
-       * the normal tabs into a thin scrolling column rather than to cost the
-       * pinned ones a row.
+       * The tabs take the height they come to and no more, so the launcher and
+       * the bookmarks button carry on straight under the last of them rather
+       * than being sent to the foot. What they give up, they give up to the
+       * strip's own controls: those hold their height, and the tabs are the one
+       * thing here that yields, which is what keeps them in the strip however
+       * many are open.
+       *
+       * They then divide what is left between them in the pinned section's
+       * favour. The pinned tabs never yield — no ceiling, no share of the strip
+       * they may not pass — and the normal tabs give up everything they have
+       * first, so pinning heavily squeezes the normal tabs into a thin
+       * scrolling column rather than costing the pinned ones a row.
        */}
-      <div className="flex min-h-0 flex-1 flex-col gap-2">
+      <div className="flex min-h-0 w-full flex-col gap-2">
         <DragDropProvider
           plugins={sortablePlugins}
           sensors={sortableSensors}
@@ -480,10 +489,14 @@ export function VerticalTabs() {
           }}
         >
           {/*
-           * Scrolls only where there is genuinely nowhere left to put the
-           * pinned tabs — the normal tabs having already given up everything
-           * they had — so that heavy pinning can never push the section's own
-           * rows out of the strip the way it used to.
+           * Yields to nothing: the normal tabs give up everything they have
+           * before a pinned row gives up a pixel. The one bound on it is the
+           * height the two sections have between them, which it can only reach
+           * once the normal tabs are down to nothing, and reaching it is the
+           * single case where this section scrolls — so the pinned tabs can
+           * never be what pushes the strip's controls out. That bound carries
+           * the section's own bleed with it, the height it is measured against
+           * being the one the bleed has already taken back.
            *
            * Both sections reach out to the strip's sides and set the gutter out
            * again inside themselves, so the scrollbar rides in the gutter
@@ -492,7 +505,7 @@ export function VerticalTabs() {
            * the badges the icons hang over their corners, which the edge a
            * scroll container clips at would otherwise shave off.
            */}
-          <ScrollArea className="-mx-4 -my-1 min-h-0">
+          <ScrollArea className="-mx-4 -my-1 max-h-[calc(100%+0.5rem)] shrink-0">
             <div
               className={cn(
                 "px-4 py-1",
@@ -518,44 +531,45 @@ export function VerticalTabs() {
             </div>
           </ScrollArea>
         </DragDropProvider>
-        <DragDropProvider
-          plugins={sortablePlugins}
-          sensors={sortableSensors}
-          onDragEnd={(event) => {
-            moveSectionTab(selectedAccount.config.id, normalTabs, event);
-          }}
-        >
-          <ScrollArea className="-mx-4 -my-1 min-h-0 flex-1">
-            <div className={cn("flex flex-col px-4 py-1", isWide ? "gap-1" : "items-center gap-2")}>
-              {normalTabs.map((tab, normalTabIndex) => (
-                <SortableVerticalTab
-                  key={tab.id}
-                  tab={tab}
-                  accountId={selectedAccount.config.id}
-                  presentation={isWide ? "wideRow" : "narrowIcon"}
-                  sectionIndex={normalTabIndex}
-                />
-              ))}
-            </div>
-          </ScrollArea>
-        </DragDropProvider>
-      </div>
-      {/*
-       * The foot of the strip stands outside the scrolling: these are the
-       * controls that have to be there however many tabs are open, the width
-       * toggle most of all, which has to be where the pointer that just clicked
-       * it left it. The sections above take all the room going, so the foot
-       * needs no pushing down of its own.
-       */}
-      <div className={cn("flex flex-col", isWide ? "gap-1" : "items-center gap-2")}>
-        {shouldShowWorkspaceAppsLauncher && (
-          <div className={cn(HOST_HANDOVER_FADE_CLASS_NAME, isWide && "w-full")}>
-            <VerticalTabsWorkspaceAppsLauncher launcherApps={launcherApps} isWide={isWide} />
-          </div>
+        {/*
+         * Left out entirely while there is nothing to put in it, rather than
+         * standing as an empty row's worth of space between the pinned tabs and
+         * the launcher.
+         */}
+        {normalTabs.length > 0 && (
+          <DragDropProvider
+            plugins={sortablePlugins}
+            sensors={sortableSensors}
+            onDragEnd={(event) => {
+              moveSectionTab(selectedAccount.config.id, normalTabs, event);
+            }}
+          >
+            {/* The section that gives ground: it scrolls from the first row it cannot show */}
+            <ScrollArea className="-mx-4 -my-1 min-h-0">
+              <div
+                className={cn("flex flex-col px-4 py-1", isWide ? "gap-1" : "items-center gap-2")}
+              >
+                {normalTabs.map((tab, normalTabIndex) => (
+                  <SortableVerticalTab
+                    key={tab.id}
+                    tab={tab}
+                    accountId={selectedAccount.config.id}
+                    presentation={isWide ? "wideRow" : "narrowIcon"}
+                    sectionIndex={normalTabIndex}
+                  />
+                ))}
+              </div>
+            </ScrollArea>
+          </DragDropProvider>
         )}
-        <VerticalTabsBookmarks isWide={isWide} />
-        <VerticalTabsWidthToggle accountId={selectedAccount.config.id} isWide={isWide} />
       </div>
+      {shouldShowWorkspaceAppsLauncher && (
+        <div className={cn(HOST_HANDOVER_FADE_CLASS_NAME, isWide && "w-full")}>
+          <VerticalTabsWorkspaceAppsLauncher launcherApps={launcherApps} isWide={isWide} />
+        </div>
+      )}
+      <VerticalTabsBookmarks isWide={isWide} />
+      <VerticalTabsWidthToggle accountId={selectedAccount.config.id} isWide={isWide} />
     </div>
   );
 }

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -412,11 +412,19 @@ function getNormalSectionReservedHeight(normalTabCount: number, isWide: boolean)
     return 0;
   }
 
-  // A row as each width lays it out: the narrow strip's 32px icon button or the
-  // wide strip's 28px row, each in a tab box standing four pixels taller than
-  // the button it holds, and under it the gap the section sets between rows.
-  const rowHeight = isWide ? 34 : 36;
+  // A row is the button and nothing besides: the narrow strip's `icon` at 32px,
+  // the wide strip's `sm` at 28px. The tab's own box is a block around an
+  // inline-flex button and so lays it on a line, but at the 16px over 24px the
+  // strip inherits, that line's strut sits inside the button's own descent and
+  // adds nothing to it. The room it has to do that in is four pixels in the
+  // wide row and six in the narrow, measured against Inter: a face that hangs
+  // further below its baseline, or a taller inherited line-height, would start
+  // adding a pixel or two to a row here without anything failing to say so.
+  // Nothing breaks when it does — the ceiling would hold a shade under three
+  // rows open, and show a shade less of the fourth.
+  const rowHeight = isWide ? 28 : 32;
 
+  // As the section sets it between its rows
   const rowGap = isWide ? 4 : 8;
 
   const listHeight = normalTabCount * rowHeight + (normalTabCount - 1) * rowGap;


### PR DESCRIPTION
The strip never scrolled. Past roughly 17 narrow tabs the column overflowed the window and was silently clipped, taking the Workspace Apps launcher, the Bookmarks button and the width toggle with it — the three controls recent work put there.

- Pinned and normal tabs each scroll in their own region.
- **The pinned section takes what it needs and holds it**, while the normal tabs give ground — but no further than three rows and the sliver of a fourth that says the list carries on (120px narrow, 100px wide). A list too short to fill even that is left whole, so one or two open tabs stay visible however much is pinned. Past that point the pinned section scrolls instead.
- The room is held open as a **ceiling on the pinned section, not a floor under the normal one**. A floor would hold its room open at rest too, opening a hole between the last tab and the launcher, and being a minimum it could not give way on a short window — it would run the sections over the very controls this PR exists to keep visible. A ceiling can only take room away, so overflow is impossible by construction rather than by testing. On windows too short to honour it, it stands aside and the two sections halve what there is.
- The resting strip is unchanged: the launcher and Bookmarks still flow directly under the last tab, the width toggle still sits at the foot on its auto margin.
- Each section bleeds out of the strip's padding and lays the gutter back inside itself, so the scrollbar rides in the gutter instead of over the tab column and the column does not shift when one appears. The 4px vertical bleed keeps the corner badges — unread count, windowed, app links — off the clip edge.
- The normal section is not rendered when there are no normal tabs, so no dead space opens above the launcher.

Not run in the real app: every agent that worked on this was on a headless box. What backs it is geometric — a static replica of the DOM with the compiled CSS and the app's own bundled Inter, measured in headless Electron across 26 configurations (both widths × few tabs, many tabs, 40 pinned, no normal tabs, one, two and three tab lists, and 300px and 200px windows), checking scroll thresholds, the gap above the launcher, the width toggle's position, badge clipping, overlap of the footer controls and horizontal overflow. dnd auto-scroll is verified by reading `@dnd-kit` source — `AutoScroller` survives `sortablePlugins` and Base UI's viewport is `overflow: scroll`, so the container is found with no configuration — but nothing was dragged.

What bites: the reserved height is computed in JS from **hard-coded row heights**, 32px narrow and 28px wide. CSS cannot express "at most this, but never more than the content wants" — `min-height` stretches the section at rest, `fit-content` is not allowed inside `min()`, and the ceiling has no access to its sibling's natural height. Those are the button heights: the tab's block wrapper does lay the inline-flex button on a line, but at the strip's inherited 16px/24px that line's strut fits inside the button's own descent with four pixels to spare in the wide row and six in the narrow. A typeface hanging further below its baseline, or a taller inherited line-height, would add a pixel or two silently. Nothing breaks when it does — being a ceiling, it would simply hold slightly under three rows open.

## Test plan

1. Open ~25 tabs in the narrow strip. The normal tabs scroll; launcher, Bookmarks and the width toggle stay visible and unclipped. Switch to wide — same, and the toggle does not move under the pointer.
2. With two or three tabs open, the launcher sits directly under the last tab with no gap above it, and the width toggle is at the foot — identical to before this change.
3. Pin around twenty apps with a few tabs open. The pinned section scrolls within itself; three tab rows and a sliver of the fourth stay visible rather than the tabs disappearing.
4. Drag a tab to the top or bottom edge of the scrolling normal section — the list should scroll under the drag.