### PR TITLE
open my account in a tab

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -380,7 +380,7 @@ class Ipc {
       };
 
       Menu.buildFromTemplate([
-        ...(tabApp && !workspaceApps[tabApp].singleInstance && !workspaceApps[tabApp].popupOnly
+        ...(tabApp && !workspaceApps[tabApp].singleInstance
           ? [
               {
                 label: `New ${workspaceApps[tabApp].label} ${isWindowsMode ? "Window" : "Tab"}`,
@@ -505,9 +505,7 @@ class Ipc {
                 : []),
             ]
           : []),
-        ...(appLinksApp &&
-        !workspaceApps[appLinksApp].singleInstance &&
-        !workspaceApps[appLinksApp].popupOnly
+        ...(appLinksApp && !workspaceApps[appLinksApp].singleInstance
           ? [
               // A tab that browsed off Google has no app and so no menu group of
               // its own, but it can still be holding a designation from before —

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -250,12 +250,6 @@ export class WorkspaceApp {
       canOpenWorkspaceAppInApp(matchedSupportedWorkspaceApp);
 
     if (isWorkspaceAppEnabledToOpenInApp) {
-      if (workspaceApps[matchedSupportedWorkspaceApp].popupOnly) {
-        new WorkspaceApp({ accountId, url, asWindow: true });
-
-        return { action: "deny" };
-      }
-
       const requestedOpenBehavior =
         disposition === "new-window"
           ? "newWindow"

--- a/packages/renderer/components/tab-icon.tsx
+++ b/packages/renderer/components/tab-icon.tsx
@@ -3,7 +3,7 @@ import { GlobeIcon } from "lucide-react";
 import { WorkspaceAppIcon } from "@/components/workspace-app-icon";
 
 export function TabIcon({ app }: { app: TabState["app"] }) {
-  if (app && app !== "myaccount") {
+  if (app) {
     return <WorkspaceAppIcon app={app} className="size-4" />;
   }
 

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -151,8 +151,7 @@ function VerticalTab({
    */
   const showsRestingStar = isBookmarkable && tab.bookmarked;
 
-  const canOpenSecondInstance =
-    tab.app && !workspaceApps[tab.app].singleInstance && !workspaceApps[tab.app].popupOnly;
+  const canOpenSecondInstance = tab.app && !workspaceApps[tab.app].singleInstance;
 
   const showsAppLinksBadge = Boolean(
     config?.["verticalTabs.showAppLinksBadge"] && tab.opensLinksForApp,

--- a/packages/renderer/components/workspace-app-icon.tsx
+++ b/packages/renderer/components/workspace-app-icon.tsx
@@ -1083,6 +1083,46 @@ export function WorkspaceAppIcon({
         </svg>
       );
     }
+    // Drawn by hand in the style of the icons around it — the account avatar as
+    // Meru renders it, not Google's own artwork.
+    case "myaccount": {
+      return (
+        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+          <mask
+            id={`mask0_myaccount-${instanceId}`}
+            style={{
+              maskType: "alpha",
+            }}
+            maskUnits="userSpaceOnUse"
+            x={1}
+            y={1}
+            width={22}
+            height={22}
+          >
+            <circle cx={12} cy={12} r={11} fill="white" />
+          </mask>
+          <circle cx={12} cy={12} r={11} fill={`url(#paint0_linear_myaccount-${instanceId})`} />
+          <g mask={`url(#mask0_myaccount-${instanceId})`}>
+            <circle cx={12} cy={9.6} r={3.7} fill="white" />
+            <ellipse cx={12} cy={22.2} rx={8} ry={6.2} fill="white" />
+          </g>
+          <defs>
+            <linearGradient
+              id={`paint0_linear_myaccount-${instanceId}`}
+              x1={12}
+              y1={1}
+              x2={12}
+              y2={23}
+              gradientUnits="userSpaceOnUse"
+            >
+              <stop stopColor="#78C9FF" />
+              <stop offset={0.55} stopColor="#3186FF" />
+              <stop offset={1} stopColor="#0057CC" />
+            </linearGradient>
+          </defs>
+        </svg>
+      );
+    }
     case "notebooklm": {
       return (
         <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -4,7 +4,6 @@ type WorkspaceAppDefinition = {
   label: string;
   url?: string;
   availableInLauncher?: boolean;
-  popupOnly?: boolean;
   singleInstance?: boolean;
 };
 
@@ -21,7 +20,7 @@ const workspaceAppDefinitions = {
   groups: { label: "Groups" },
   keep: { label: "Keep" },
   meet: { label: "Meet" },
-  myaccount: { label: "My Account", availableInLauncher: false, popupOnly: true },
+  myaccount: { label: "My Account", availableInLauncher: false },
   notebooklm: { label: "NotebookLM" },
   sheets: { label: "Sheets" },
   sites: { label: "Sites" },


### PR DESCRIPTION
My Account could only ever be a window: it carried `popupOnly: true`, which routed it to a forced-window branch before the ordinary tab resolution ran.

- Drops the flag, so My Account opens as a tab like any other app. It stays out of the launcher — it is reached from Gmail's avatar menu.
- `popupOnly` was orphaned by that and is gone entirely: the type, the forced-window branch, two context-menu conditions in `ipc.ts`, and the `canOpenSecondInstance` check in the strip. `myaccount` was its only definition; the PDF viewer takes the separate URL-regex route and never used it, so PDFs are unaffected and stay windows the strip has no record of.
- Gives it an icon, and deletes the `app !== "myaccount"` carve-out in `tab-icon.tsx` that existed only because the icon was missing. The globe means "a page we do not recognise" again.

**The icon is drawn by hand, not Google's artwork**, and wants a human eye before this merges — no brand asset was fetched or traced. It is a gradient disc in the blues Contacts and Drive already use, with a white avatar silhouette, and it carries a code comment saying as much. The thing to check is whether it is distinguishable from Contacts at 16px in the strip, since that is also a blue person glyph. Preview at several sizes, on both themes and beside its neighbours: https://claude.ai/code/artifact/ef8c25e7-cf47-4c48-b255-82d20730b76a

One behaviour nuance worth knowing: My Account already appears in Settings → the open-in-app exclusion list today, so that list is unchanged. What changes is what excluding it does — previously it skipped the forced-window branch and went to the external browser, now it sends an otherwise-ordinary tab there.

Not run in the app: the agent's box was headless and reaching My Account needs a signed-in Google account. Types, lint, format and the 127 existing tests pass, including the one asserting `myaccount.google.com` maps to this app.

## Test plan

1. In Gmail, open the avatar menu → Manage your Google Account. It opens as a tab in the strip rather than a separate window.
2. The tab carries the account icon, not a globe. At narrow width, check it reads as distinct from the Contacts tab beside it.
3. Right-click the My Account tab — "New My Account Tab" and "Open My Account Links in This Tab" now appear, both previously suppressed.
4. Add My Account to Settings → Workspace Apps → the open-in-app exclusions, then open it from the avatar menu: it goes to the external browser.