### PR TITLE
extract webcontents listener teardown into a helper

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -30,7 +30,11 @@ import { accounts } from "@/accounts";
 import { config } from "@/config";
 import { ipc } from "@/ipc";
 import { log } from "@/lib/log";
-import { createChildWebContentsView, openViewDevToolsOnLaunch } from "@/lib/web-contents";
+import {
+  createChildWebContentsView,
+  openViewDevToolsOnLaunch,
+  removeWebContentsListeners,
+} from "@/lib/web-contents";
 import { getPreloadPath } from "@/lib/window";
 import { xmlParser } from "@/lib/xml";
 import { licenseKey } from "@/license-key";
@@ -522,14 +526,7 @@ export class Gmail {
   }
 
   destroy() {
-    // Electron registers listeners of its own on every webContents, and taking
-    // those down along with ours leaves it unable to tear itself down — see the
-    // same carve-out in `WorkspaceApp.teardown`
-    for (const registeredEvent of this.view.webContents.eventNames()) {
-      if (registeredEvent !== "destroyed") {
-        this.view.webContents.removeAllListeners(registeredEvent);
-      }
-    }
+    removeWebContentsListeners(this.view.webContents);
 
     this.view.webContents.close();
 

--- a/packages/app/lib/web-contents.ts
+++ b/packages/app/lib/web-contents.ts
@@ -32,6 +32,22 @@ export function broadcastFoundInPageResults(
   });
 }
 
+/**
+ * Takes down every listener on a webContents except `"destroyed"`: Electron
+ * pairs a "destroyed" listener on a webContents with a
+ * "current-render-view-deleted" listener on its opener when the view was
+ * created via a window open handler. Removing the "destroyed" listener leaves
+ * the opener-side listener dangling, which then crashes the app by calling into
+ * this destroyed webContents (e.g. on quit).
+ */
+export function removeWebContentsListeners(webContents: WebContents) {
+  for (const registeredEvent of webContents.eventNames()) {
+    if (registeredEvent !== "destroyed") {
+      webContents.removeAllListeners(registeredEvent);
+    }
+  }
+}
+
 export function createChildWebContentsView({
   session,
   preload,

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -25,7 +25,11 @@ import { accounts } from "./accounts";
 import { bookmarks } from "./bookmarks";
 import { config } from "./config";
 import { ipc } from "./ipc";
-import { createChildWebContentsView, openViewDevToolsOnLaunch } from "./lib/web-contents";
+import {
+  createChildWebContentsView,
+  openViewDevToolsOnLaunch,
+  removeWebContentsListeners,
+} from "./lib/web-contents";
 import {
   createBrowserWindow,
   getCascadedWindowBounds,
@@ -593,16 +597,7 @@ export class WorkspaceApp {
 
   private teardown() {
     if (!this.viewDestroyed) {
-      // Electron pairs a "destroyed" listener on this webContents with a
-      // "current-render-view-deleted" listener on its opener when the view was
-      // created via a window open handler. Removing the "destroyed" listener
-      // leaves the opener-side listener dangling, which then crashes the app by
-      // calling into this destroyed webContents (e.g. on quit).
-      for (const registeredEvent of this.view.webContents.eventNames()) {
-        if (registeredEvent !== "destroyed") {
-          this.view.webContents.removeAllListeners(registeredEvent);
-        }
-      }
+      removeWebContentsListeners(this.view.webContents);
 
       this.view.webContents.close();
     }


### PR DESCRIPTION
- Adds `removeWebContentsListeners(webContents)` to `packages/app/lib/web-contents.ts`, taking down every listener except `"destroyed"`.
- The explanation of the `"destroyed"` carve-out (Electron's opener-side `current-render-view-deleted` pairing) now lives once, on the helper.
- Replaces the two byte-identical loops in `WorkspaceApp.teardown` and `Gmail.destroy`, dropping the per-site paragraphs and the cross-reference from gmail to workspace-app.
- `TitlebarPopup.close` was left alone: it removes one known listener (`off("blur", …)`) rather than looping over `eventNames()`, so the helper would change its behaviour.

Quit-time teardown behaviour was not exercised at runtime — only typechecked, linted and format-checked.

Test plan
1. Open a Gmail window-opened workspace app tab (e.g. a Google Docs link from a mail), close it, then quit the app — no crash from the opener-side listener.
2. Remove an account so `Gmail.destroy` runs, then quit — no crash, and the view is gone from the window.
3. Open a titlebar popup (bookmarks or downloads), leave it open and quit — unchanged from before, since that path was not touched.