### PR TITLE
dedupe comments in shared and renderer

### DIFF
--- a/packages/renderer/bookmarks.tsx
+++ b/packages/renderer/bookmarks.tsx
@@ -80,10 +80,7 @@ function SortableBookmark({ bookmark, index }: { bookmark: BookmarkState; index:
   );
 }
 
-/**
- * The list is the order bookmarks are saved in, so dragging one writes that
- * order back to the account it belongs to.
- */
+/** The list is the order bookmarks are saved in. */
 function moveBookmark(bookmarks: BookmarkState[], event: DragEndEvent) {
   if (event.canceled) {
     return;

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -43,10 +43,7 @@ export function useCloseOnWindowBlur(isOpen: boolean, onClose: () => void) {
   }, [isOpen, onClose]);
 }
 
-/**
- * Every tab of the selected account, before the vertical tabs strip narrows
- * them down to the ones it shows.
- */
+/** Every tab of the selected account, before the vertical tabs strip narrows them down. */
 export function useSelectedAccountTabs() {
   const accounts = useAccountsStore((state) => state.accounts);
 

--- a/packages/renderer/lib/react-query.ts
+++ b/packages/renderer/lib/react-query.ts
@@ -31,9 +31,9 @@ ipc.renderer.on("bookmarks.changed", (_event, bookmarks) => {
 });
 
 /**
- * Only the bookmarks popup runs this: it is a view of its own, so it fetches
- * the list on mount and the main process pushes it again whenever the saved
- * bookmarks change underneath it.
+ * The bookmarks popup is a view of its own, so it fetches the list on mount and
+ * the main process pushes it again whenever the saved bookmarks change
+ * underneath it.
  */
 export function useBookmarks() {
   const { data } = useQuery(

--- a/packages/shared/schemas.ts
+++ b/packages/shared/schemas.ts
@@ -29,8 +29,6 @@ const workspaceAppSchema = z.custom<SupportedWorkspaceApp>(
 /**
  * A pinned tab as it is restored on the next launch. It keeps following the app
  * it holds, so its `url` and `title` are rewritten as the user browses.
- * `opensLinksForApp` names the app whose links all open in this tab, which the
- * tab keeps holding even after browsing on to another app.
  */
 export const savedTabSchema = z.object({
   app: workspaceAppSchema,
@@ -78,10 +76,7 @@ export type AccountConfig = z.infer<typeof accountConfigSchema>;
 
 export type AccountConfigs = AccountConfig[];
 
-/**
- * A bookmark as the surfaces listing it receive it, tagged with the account it
- * belongs to so that opening or removing it targets the right one.
- */
+/** Tagged with the account it belongs to so that opening or removing it targets the right one. */
 export type BookmarkState = Bookmark & {
   accountId: AccountConfig["id"];
 };

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -87,9 +87,6 @@ export function getVerticalTabsWidth(
     return 0;
   }
 
-  // A width picked in the strip stands in front of the setting, but only for as
-  // long as there is a strip to pick it in: it cannot bring back one the tab
-  // count has taken away.
   if (sessionWidth) {
     return sessionWidth === "narrow" ? VERTICAL_TABS_NARROW_WIDTH : VERTICAL_TABS_WIDE_WIDTH;
   }

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -44,10 +44,7 @@ export type NotificationTime = {
   days?: number[]; // 0=Sun,1=Mon,...,6=Sat; undefined/empty = all days
 };
 
-/**
- * Which button asked for the bookmarks popup, and so where it hangs: at the end
- * of the titlebar, or beside the vertical tabs strip.
- */
+/** Which button asked for the bookmarks popup, and so where it hangs. */
 export type BookmarksPopupPlacement = "titlebar" | "verticalTabs";
 
 export type WorkspaceAppNotification = {


### PR DESCRIPTION
Comment-only pass over `packages/shared` and `packages/renderer` — no executable code changed.

- `getVerticalTabsWidth` loses its session-width note; the `VerticalTabsSessionWidth` type doc is the canonical home and the `tabs.length <= 1` early return above already says a session width cannot bring a strip back.
- `savedTabSchema` drops the `opensLinksForApp` sentence that was word-for-word the field doc on `TabState.opensLinksForApp`.
- `BookmarkState`, `BookmarksPopupPlacement`, `useSelectedAccountTabs` and `moveBookmark` docs shrink to the part the type or body does not already say.
- `useBookmarks` keeps the push-invalidation half but drops "only the bookmarks popup runs this" — a caller census that rots.

Two flagged blocks were left alone on purpose: the `verticalTabsWidth` one-liner on `AccountInstance` (the field name drops "Session", so the pointer still earns its place) and the two `bookmarked` field docs, which read as duplicates but say different things — "the URL the tab is on" vs "the URL on display".

Test plan

1. `bun run types && bun run lint && bun run fmt:check` — all pass.
2. `git diff origin/main -- . ':!*.md'` — every hunk is inside a comment; no statement, type member or signature changes.
