### PR TITLE
dedupe and trim dark-theme comments

### DIFF
--- a/packages/dark-theme/background-image.ts
+++ b/packages/dark-theme/background-image.ts
@@ -81,8 +81,7 @@ function isGradientLayer(layer: string): boolean {
   return false;
 }
 
-// The url a `url(...)` layer points at, with matching outer quotes stripped, or
-// null when the layer isn't a url function at all.
+// The url a `url(...)` layer points at, with matching outer quotes stripped.
 function readUrlLayerTarget(layer: string): string | null {
   if (layer.length < 5 || !layer.endsWith(")") || layer.slice(0, 4).toLowerCase() !== "url(") {
     return null;

--- a/packages/dark-theme/css-value.ts
+++ b/packages/dark-theme/css-value.ts
@@ -32,8 +32,8 @@ function isHexDigitCharCode(charCode: number): boolean {
   );
 }
 
-// The length of a case-insensitive `rgb(`/`rgba(`/`hsl(`/`hsla(` opener at the
-// given position, or 0 when the position doesn't start one.
+// The length of a case-insensitive color-function opener at the given position,
+// or 0 when the position doesn't start one.
 function colorFunctionStartLengthAt(value: string, index: number): number {
   const firstLetter = value.charCodeAt(index) | LOWERCASE_BIT;
   let cursor: number;
@@ -177,8 +177,8 @@ function isCustomPropertyNameCharCode(charCode: number): boolean {
   );
 }
 
-// The position right after `var(` + whitespace + `--name` + whitespace, or -1
-// when the position doesn't start a var() reference with a custom property name.
+// The position right after `var(` + `--name`, or -1 when the position doesn't
+// start a var() reference with a custom property name.
 function varReferenceBodyStart(value: string, varStart: number): number {
   let cursor = varStart + 4;
 

--- a/packages/dark-theme/ignore.ts
+++ b/packages/dark-theme/ignore.ts
@@ -6,7 +6,6 @@ export type IgnorePropertyRule = {
 };
 
 // Whether an ignore rule's property list covers a property the engine is about to set.
-// "border-color" is a shorthand for the four per-side colors the engine writes.
 export function coversProperty(properties: string[], property: string) {
   if (properties.includes(property)) {
     return true;

--- a/packages/dark-theme/image.ts
+++ b/packages/dark-theme/image.ts
@@ -347,8 +347,8 @@ function rememberImageDetails(url: string, details: ImageDetails | null) {
 }
 
 // The same url often appears many times in one batch (a logo repeated through a
-// message, a sprite shared by many elements); deduping in-flight analyses keeps
-// that from spawning parallel fetches and full decodes of the same image.
+// message, a sprite shared by many elements), which would otherwise spawn
+// parallel fetches and full decodes of the same image.
 const pendingImageDetailsByUrl = new Map<string, Promise<ImageDetails | null>>();
 
 async function loadAndAnalyzeImage(url: string): Promise<ImageDetails | null> {

--- a/packages/dark-theme/index.ts
+++ b/packages/dark-theme/index.ts
@@ -76,8 +76,8 @@ export type DarkThemeOptions = Partial<Theme> & {
 };
 
 export type DarkThemeController = {
-  // Undo theming on a still-live subtree: disconnect the observer, restore every
-  // element's original inline styles, and release references.
+  // Undo theming on a still-live subtree: restore every element's original inline
+  // styles.
   revert: () => void;
   // Tear down without restoring styles: disconnect the observer and release
   // references. Use when the themed subtree is being discarded (e.g. removed from
@@ -454,8 +454,7 @@ export function applyDarkTheme(root: HTMLElement, options?: DarkThemeOptions): D
     let id = pseudoIds.get(element);
 
     if (id === undefined) {
-      // Nothing to do for an element that has never had, and still has no, pseudo
-      // rules — avoids stamping ids and rebuilding the sheet for the common case.
+      // Avoids stamping ids and rebuilding the sheet for the common case.
       if (pseudos.length === 0) {
         return;
       }
@@ -620,11 +619,10 @@ export function applyDarkTheme(root: HTMLElement, options?: DarkThemeOptions): D
       }
 
       // All additions and refreshes across the mutation list are collected first
-      // and processed as two batches — handling each node separately would
-      // interleave getComputedStyle reads with inline-style writes and force a
-      // synchronous style recalc per node during bursty re-renders. Sets dedupe
-      // an element reported through several mutation records (added directly and
-      // inside an added ancestor), which would otherwise be snapshotted twice.
+      // and processed as two batches, for the same read-then-write reason as
+      // processBatch. Sets dedupe an element reported through several mutation
+      // records (added directly and inside an added ancestor), which would
+      // otherwise be snapshotted twice.
       const addedElements = new Set<HTMLElement>();
       const refreshTargets = new Set<HTMLElement>();
       const removedElements = new Set<HTMLElement>();
@@ -679,8 +677,6 @@ export function applyDarkTheme(root: HTMLElement, options?: DarkThemeOptions): D
       childList: true,
       subtree: true,
       attributes: true,
-      // class plus aria-checked, the attributes that drive a state style swap (a
-      // scroll shadow, a star icon that changes on toggle) so re-theming catches it.
       attributeFilter: ["class", "aria-checked"],
     });
   }

--- a/packages/dark-theme/modify-colors.ts
+++ b/packages/dark-theme/modify-colors.ts
@@ -203,8 +203,7 @@ function isPackableChannel(channelValue: number): boolean {
   return Number.isInteger(channelValue) && channelValue >= 0 && channelValue <= 255;
 }
 
-// Bounded like the parse cache: arbitrary email HTML feeds an open-ended stream
-// of distinct colors, and dropping entries only costs recomputation.
+// Bounded like the parse cache.
 const COLOR_CACHE_MAX_ENTRIES = 4096;
 
 function remapThroughCache(

--- a/packages/dark-theme/state-rules.ts
+++ b/packages/dark-theme/state-rules.ts
@@ -68,13 +68,11 @@ function darkenCandidateDeclarations(candidate: StateRuleCandidate, theme: Theme
   const darkenedDeclarations: DarkenedStateRule["declarations"] = [];
 
   for (const { property, value } of candidate.declarations) {
-    // The variable's runtime value is out of reach — the page may define it
-    // via inline styles or constructed stylesheets no stylesheet walk can
-    // see — so `var(--x, fallback)` is pinned to its darkened fallback
-    // instead of trusting the var to resolve dark. Pinning also applies when
-    // the fallback needs no darkening (a light live value would still leak),
-    // but not when the flattened value carries no visible color (keeps a bare
-    // `var(--x, transparent)` from emitting a useless override).
+    // Pinning `var(--x, fallback)` to its darkened fallback (see
+    // substituteVarFallbacks) also applies when the fallback needs no darkening
+    // (a light live value would still leak), but not when the flattened value
+    // carries no visible color (keeps a bare `var(--x, transparent)` from
+    // emitting a useless override).
     const flattenedValue = substituteVarFallbacks(value);
     const darkenedValue = darkenDeclaration(property, flattenedValue, theme);
 
@@ -140,8 +138,7 @@ function getDarkenedStateRules(collection: StylesheetCollection, theme: Theme) {
 // verbatim and wrapping the whole set in `@scope (scopeSelector)` so they apply
 // only inside the themed subtree, never the natively-dark Gmail shell around it.
 //
-// Only same-origin stylesheets can be read (cross-origin sheets throw on
-// cssRules, the same CORS wall image analysis hits).
+// Only same-origin stylesheets can be read (see stylesheets.ts).
 export function buildDarkStateOverrides(
   root: HTMLElement,
   theme: Theme,
@@ -192,9 +189,9 @@ export function buildDarkStateOverrides(
   const collection = getStylesheetCollection(root.ownerDocument);
 
   for (const darkenedRule of getDarkenedStateRules(collection, theme)) {
-    // The live selector matching behind applicableIgnoreRules only runs when an
-    // ignore rule actually covers one of the darkened properties — for the vast
-    // majority of state rules none does, and the query can be skipped outright.
+    // For the vast majority of state rules no ignore rule covers a darkened
+    // property, and the live selector matching behind applicableIgnoreRules can
+    // be skipped outright.
     const isCoveredByIgnoreRules = ignorePropertyRules.some((ignoreRule) =>
       darkenedRule.declarations.some(({ property }) =>
         coversProperty(ignoreRule.properties, property),

--- a/packages/dark-theme/stylesheets.ts
+++ b/packages/dark-theme/stylesheets.ts
@@ -113,9 +113,8 @@ function isInjectedStyleSheet(sheet: CSSStyleSheet) {
   );
 }
 
-// Walks every style rule in the document, descending into grouping rules (media,
-// supports, scope). Cross-origin stylesheets throw on cssRules — the same CORS
-// wall image analysis hits — so their rules are skipped.
+// Cross-origin stylesheets throw on cssRules — the same CORS wall image analysis
+// hits — so their rules are skipped.
 function forEachStyleRule(ownerDocument: Document, visit: (rule: CSSStyleRule) => void) {
   for (const sheet of ownerDocument.styleSheets) {
     if (isInjectedStyleSheet(sheet)) {

--- a/packages/dark-theme/variables.ts
+++ b/packages/dark-theme/variables.ts
@@ -29,7 +29,7 @@ const hasLightColorToken = (value: string) => {
 // the same strings on every message open), so the light-token check and
 // darkening memoize per value string. Keyed by value rather than property name
 // because a property can resolve differently per themed root. Bounded like the
-// parse caches — dropping entries only costs recomputation.
+// parse caches.
 const DARKENED_VALUE_CACHE_MAX_ENTRIES = 4096;
 const darkenedValuesByThemeKey = new Map<string, Map<string, string | null>>();
 
@@ -75,9 +75,8 @@ function darkenLightValue(value: string, theme: Theme) {
 // whole subtree and stops at its boundary, without touching the natively-dark
 // Gmail shell around it.
 //
-// Only same-origin stylesheets can be read (cross-origin sheets throw on
-// cssRules, the same CORS wall image analysis hits), so properties declared only
-// in cross-origin sheets are missed.
+// Only same-origin stylesheets can be read (see stylesheets.ts), so properties
+// declared only in cross-origin sheets are missed.
 export function buildDarkVariableOverrides(
   root: HTMLElement,
   theme: Theme,


### PR DESCRIPTION
Comment-only cleanup of `packages/dark-theme` — no executable code changed.

- The CORS-wall constraint is now stated once, in `stylesheets.ts` (`forEachStyleRule`); `state-rules.ts` and `variables.ts` point there, keeping only what's local to them (variables still notes that cross-origin-only properties are missed).
- The read-all-colors-before-writing rationale stays in full at `processBatch`; the observer block now points at it and keeps only the new fact (the Sets dedupe an element reported through several mutation records).
- The bounded-cache rationale stays in `color.ts` next to the parse cache; `modify-colors.ts` and `variables.ts` shorten to "bounded like the parse cache".
- The `var()`-fallback-pinning explanation stays in `css-value.ts` (`substituteVarFallbacks`); `state-rules.ts` keeps only the two `continue` conditions that are new there.
- `ignore.ts` states the `border-color` shorthand once, on the type; `index.ts` drops the comment that restated the `attributeFilter` array below it.
- Thin summaries trimmed to their non-obvious part: `revert()` doc, the pseudo-id early return, the in-flight image dedupe map, the ignore-rule fast path, the two `css-value.ts` scanner helpers (sentinel return values kept), `readUrlLayerTarget`.

The cross-origin image workaround comments were left intact.

Test plan:
1. `bun run types && bun run lint && bun run fmt:check` — all pass.
2. `git diff origin/main` — every changed line is a comment; no executable code in the diff.
