### PR TITLE
drop comments the code already says in app

### DIFF
--- a/packages/app/bookmarks.ts
+++ b/packages/app/bookmarks.ts
@@ -16,23 +16,15 @@ import { TitlebarPopup } from "./lib/titlebar-popup";
  *
  * A popup is the one surface that lists them, and the titlebar button that opens
  * it is always there — unlike the vertical tabs strip, which is gone in `New
- * Windows` mode and absent in `Tabs` mode until a second tab opens. The popup
- * stays reachable while empty, where it explains how to add a bookmark.
+ * Windows` mode and absent in `Tabs` mode until a second tab opens.
  */
 class Bookmarks {
   popup = new TitlebarPopup({
     page: "bookmarks",
     width: BASE_SPACING * 40,
-    // A list of saved URLs is as long as the account made it, so it takes the
-    // window rather than a height of its own and scrolls within it
     height: "fill",
   });
 
-  /**
-   * The popup comes up where it was asked for: beside the vertical tabs strip
-   * for the button that sits in the strip, and at the end of the titlebar for
-   * the one that sits there.
-   */
   togglePopup(parentWindow: BrowserWindow, placement: BookmarksPopupPlacement) {
     return this.popup.toggle(parentWindow, {
       anchorX:
@@ -68,10 +60,6 @@ class Bookmarks {
     return this.getAccountBookmarks(accountId).some((bookmark) => bookmark.url === url);
   }
 
-  /**
-   * Saves the given URL, or drops what is saved for it — the surfaces that
-   * offer bookmarking are toggles on the URL they are showing.
-   */
   toggle(accountId: AccountConfig["id"], { app, url, title }: Omit<Bookmark, "id">) {
     const accountBookmarks = this.getAccountBookmarks(accountId);
 

--- a/packages/app/dialogs.ts
+++ b/packages/app/dialogs.ts
@@ -18,10 +18,6 @@ export async function showRestartDialog() {
   }
 }
 
-/**
- * Only one tab per app can take that app's links, so designating a new one
- * takes it away from the tab holding it. Asks before doing so.
- */
 export async function confirmAppLinksTabHandover(
   workspaceApp: SupportedWorkspaceApp,
   appLinksTabTitle: string,

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -348,9 +348,7 @@ class Ipc {
 
       const tabApp = tab.app;
 
-      // A designated tab keeps offering the app it was designated for even
-      // after browsing on, so that the designation stays visible and removable
-      // from the tab holding it.
+      // The designation stays visible and removable from the tab holding it.
       const appLinksApp = tab.opensLinksForApp ?? tabApp;
 
       const hasOtherClosableTabs = account.instance.tabs.tabs.some(

--- a/packages/app/lib/linux.ts
+++ b/packages/app/lib/linux.ts
@@ -22,7 +22,6 @@ async function getGtkDecorationLayout() {
     // gsettings not available or schema not installed
   }
 
-  // Fallback
   const settingsFiles = [
     join(homedir(), ".config", "gtk-3.0", "settings.ini"),
     join(homedir(), ".config", "gtk-4.0", "settings.ini"),
@@ -38,9 +37,7 @@ async function getGtkDecorationLayout() {
       if (match?.[1]) {
         return match[1].trim();
       }
-    } catch {
-      // File doesn't exist or can't be read
-    }
+    } catch {}
   }
 
   return null;

--- a/packages/app/lib/notifications.test.ts
+++ b/packages/app/lib/notifications.test.ts
@@ -79,14 +79,14 @@ describe("checkWithinNotificationTimes", () => {
   });
 
   test("returns true when current day matches a day-specific window", () => {
-    const times = [makeTime("09:00", "17:00", [1, 2, 3, 4, 5])]; // weekdays Mon–Fri
-    const monday = makeDate(1, 12, 0); // Jan 1 2024 = Monday
+    const times = [makeTime("09:00", "17:00", [1, 2, 3, 4, 5])];
+    const monday = makeDate(1, 12, 0);
     expect(checkWithinNotificationTimes(times, monday)).toBe(true);
   });
 
   test("returns false when current day does not match a day-specific window", () => {
-    const times = [makeTime("09:00", "17:00", [1, 2, 3, 4, 5])]; // weekdays Mon–Fri
-    const saturday = makeDate(6, 12, 0); // Jan 6 2024 = Saturday
+    const times = [makeTime("09:00", "17:00", [1, 2, 3, 4, 5])];
+    const saturday = makeDate(6, 12, 0);
     expect(checkWithinNotificationTimes(times, saturday)).toBe(false);
   });
 
@@ -97,12 +97,12 @@ describe("checkWithinNotificationTimes", () => {
   });
 
   test("day-agnostic and day-specific windows are independent (no precedence)", () => {
-    const everyDay = makeTime("09:00", "17:00"); // no days = every day
-    const mondayOnly = makeTime("10:00", "12:00", [1]); // Monday only
+    const everyDay = makeTime("09:00", "17:00");
+    const mondayOnly = makeTime("10:00", "12:00", [1]);
     const times = [everyDay, mondayOnly];
 
     // Monday 9:30 — everyDay matches even though mondayOnly does not cover 9:30
-    const monday930 = makeDate(1, 9, 30); // Jan 1 2024 = Monday
+    const monday930 = makeDate(1, 9, 30);
     expect(checkWithinNotificationTimes(times, monday930)).toBe(true);
   });
 

--- a/packages/app/lib/titlebar-popup.ts
+++ b/packages/app/lib/titlebar-popup.ts
@@ -116,8 +116,7 @@ export class TitlebarPopup {
 
   /**
    * Returns whether the popup ended up open, so callers can refresh what it is
-   * about to show. Toggling from where it is already hanging closes it; from
-   * another window, or from a button that hangs it elsewhere, it moves there.
+   * about to show.
    */
   toggle(parentWindow: BrowserWindow, { anchorX }: { anchorX?: number } = {}) {
     if (this.view) {
@@ -153,7 +152,8 @@ export class TitlebarPopup {
     parentWindow.on("resize", this.setBounds);
 
     // A window closing out from under the popup — a workspace app window it was
-    // hung on, or the main window on quit — leaves the view attached to it
+    // hung on, or the main window on quit — leaves the view attached to
+    // something that is going away, so the popup comes down with it
     parentWindow.once("closed", this.close);
 
     this.view.setBorderRadius(BASE_SPACING * 2);

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -164,8 +164,7 @@ export class AppMenu {
 
     /**
      * The nth entry of the pinned section as the strip shows it, Gmail counting
-     * as the first: the numbers stand for what is on screen, so the filters the
-     * strip renders through decide what they land on.
+     * as the first.
      */
     const selectPinnedTab = (pinnedTabIndex: number) => {
       const selectedAccountTabs = accounts.getSelectedAccount().instance.tabs;

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -247,9 +247,8 @@ export class Tabs {
   }
 
   /**
-   * Wakes a saved tab up and brings it forward, optionally on a URL other than
-   * the one it was saved on — that is how a link lands in a designated tab that
-   * has not been opened yet.
+   * Wakes a saved tab up and brings it forward — that is how a link lands in a
+   * designated tab that has not been opened yet.
    */
   private openDormantTab(dormantTab: DormantTab, url?: string) {
     // A designated tab is woken on the link's app, which is not necessarily the
@@ -418,9 +417,8 @@ export class Tabs {
   }
 
   /**
-   * Opens a URL the way the configured mode dictates — in a window of its own,
-   * or in a tab that is activated right away. Apps that may not open inside
-   * Meru go to the default browser instead, leaving nothing to return.
+   * Apps that may not open inside Meru go to the default browser instead,
+   * leaving nothing to return.
    */
   openUrl(url: string) {
     if (!canOpenWorkspaceAppInApp(getWorkspaceAppFromUrl(url))) {
@@ -517,9 +515,10 @@ export class Tabs {
   }
 
   /**
-   * The tab every link to `app` opens in, if the user designated one. The tab
-   * holds the app it was designated for rather than the one it happens to be
-   * showing, so browsing on never hands the designation to another app.
+   * The tab every link to `app` opens in, if the user designated one. Only one
+   * tab per app can take that app's links. The tab holds the app it was
+   * designated for rather than the one it happens to be showing, so browsing on
+   * never hands the designation to another app.
    */
   getAppLinksTab(app: SupportedWorkspaceApp) {
     return this.tabs.find((tab) => tab.opensLinksForApp === app);

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -389,11 +389,6 @@ export class WorkspaceApp {
     return !this.isPopup && Boolean(this.app);
   }
 
-  /**
-   * A bookmark saves the URL it was created from, so the button reflects the
-   * URL on display rather than anything about the app holding it — browsing on
-   * from a bookmarked page leaves the button empty again.
-   */
   get bookmarkState(): WorkspaceAppBookmarkState {
     return {
       savable: this.isSavable,
@@ -425,10 +420,6 @@ export class WorkspaceApp {
 
   loadOnLaunch = false;
 
-  /**
-   * Whether every link to this tab's app opens here instead of in a new tab.
-   * Only one tab per app can hold it.
-   */
   opensLinksForApp: SupportedWorkspaceApp | null = null;
 
   /**
@@ -676,10 +667,6 @@ export class WorkspaceApp {
     this.view.webContents.off("did-stop-loading", this.broadcastLoadingState);
   }
 
-  /**
-   * The bookmark button is keyed on the URL on display, so it has to be redrawn
-   * wherever the window navigates, alongside the back and forward controls.
-   */
   private handleWindowedNavigation = () => {
     this.broadcastNavigationState();
 


### PR DESCRIPTION
Comment-only pass over `packages/app`, no executable code changed.

- Standard applied: a comment stays only if the next reader would otherwise have to work it out; anything restating the code below it goes, and repeated invariants get one canonical home.
- Deleted docs that narrate their own body or restate a name: `bookmarks.togglePopup`/`toggle`, `WorkspaceApp.bookmarkState`/`handleWindowedNavigation`, `confirmAppLinksTabHandover`, the `// Fallback` label in `lib/linux.ts`.
- The "only one tab per app can take that app's links" invariant now lives once, on `Tabs.getAppLinksTab`; the copies on `opensLinksForApp`, in `dialogs.ts` and in `ipc.ts` are gone, with the `?? tabApp` rationale kept where it is.
- Shrank docs to the half that carries something: `openDormantTab`, `openUrl`, `TitlebarPopup.toggle`, `selectPinnedTab`, and the calendar restatements in `notifications.test.ts` (the canonical statement at the top of the file stays).
- Completed the unfinished sentence on the `closed` listener in `titlebar-popup.ts`, which stated a cause and no consequence.
- Kept against the survey: the `// 6/8/4-digit codes` markers in `gmail/index.ts` (they group eight near-identical loops and name the split forms the regexes don't), the caller-falls-back half of `openInAppLinksTab`'s contract (it differs from `openUrl`, which handles it itself), and the assertion rationale in the no-precedence test.
- `lib/linux.ts` loses the comment inside the `readFile` catch, leaving a bare `catch {}` — if that reads as an accidental swallow rather than a deliberate one, say so and it goes back.

Test plan:
1. `bun run types && bun run lint && bun run fmt:check` — all pass.
2. `git diff origin/main -- packages/app` — every hunk is a comment or blank line, except `} catch { … }` collapsing to `} catch {}` in `lib/linux.ts`.
