### PR TITLE
always show vertical tabs width button, with a setting to hide it

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -120,6 +120,7 @@ export const config = new Store<Config>({
     "spellchecker.languages": [],
     "verticalTabs.showWindows": true,
     "verticalTabs.width": "auto",
+    "verticalTabs.showWidthToggle": true,
     "verticalTabs.hideUnreadBadgeWhenActive": false,
     "verticalTabs.showAppLinksBadge": true,
   },

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -339,10 +339,8 @@ function VerticalTabsBookmarks({ isWide }: { isWide: boolean }) {
  * with the strip the click has already resized, so the transition names its
  * properties instead.
  *
- * Opacity is the one of them the button does animate: a width the app is
- * unlikely to be asked for twice in a sitting has no business holding an arrow
- * at the foot of the strip for good. An auto margin is what puts it at the
- * foot: the tabs and the controls under them take only the height they need.
+ * An auto margin is what puts it at the foot: the tabs and the controls under
+ * them take only the height they need.
  */
 function VerticalTabsWidthToggle({
   accountId,
@@ -356,7 +354,7 @@ function VerticalTabsWidthToggle({
       variant="ghost"
       size={isWide ? "default" : "icon"}
       className={cn(
-        "mt-auto text-muted-foreground opacity-0 transition-[color,background-color,opacity] group-hover/vertical-tabs:opacity-100 focus-visible:opacity-100",
+        "mt-auto text-muted-foreground transition-[color,background-color]",
         isWide && "w-full",
       )}
       title={isWide ? "Narrow Tabs" : "Wide Tabs"}
@@ -434,6 +432,8 @@ export function VerticalTabs() {
 
   const shouldShowWorkspaceAppsLauncher = isLicenseKeyValid && launcherApps.length > 0;
 
+  const showsWidthToggle = config?.["verticalTabs.showWidthToggle"] ?? true;
+
   // Gmail is already in front while its tab is active, so the count can be
   // taken as read there. Attention is still flagged either way.
   const hidesUnreadCount =
@@ -451,12 +451,6 @@ export function VerticalTabs() {
   return (
     <div
       className={cn(
-        // The group is named so that pointing at the strip reaches the width
-        // toggle at its foot and nothing else: every tab row is an unnamed
-        // group already, and an unnamed one here would hand each of them its
-        // hover state at once, opening every close button in the column
-        // together.
-        //
         // The one gutter on every edge of both widths is the narrow strip's own
         // measure: it leaves exactly an icon button's width between its sides,
         // which is what a 32px button centred in a 64px strip already sat on.
@@ -465,7 +459,7 @@ export function VerticalTabs() {
         // the resizing — stay put rather than stepping out from under the
         // pointer. The scrolling sections reach past that gutter and lay it out
         // again themselves, so a scrollbar can never take it from the column.
-        "group/vertical-tabs flex flex-col border-r p-4 select-none",
+        "flex flex-col border-r p-4 select-none",
         isWide ? "gap-1" : "items-center gap-2",
       )}
       style={{ width: verticalTabsWidth, minWidth: verticalTabsWidth }}
@@ -589,7 +583,9 @@ export function VerticalTabs() {
         </div>
       )}
       <VerticalTabsBookmarks isWide={isWide} />
-      <VerticalTabsWidthToggle accountId={selectedAccount.config.id} isWide={isWide} />
+      {showsWidthToggle && (
+        <VerticalTabsWidthToggle accountId={selectedAccount.config.id} isWide={isWide} />
+      )}
     </div>
   );
 }

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -333,11 +333,11 @@ function VerticalTabsBookmarks({ isWide }: { isWide: boolean }) {
  * widened or narrowed where it stands rather than through settings. It leaves
  * the setting alone: the width is this account's for this run of the app.
  *
- * `default` rather than the `sm` its neighbours widen into, because that is the
- * one size that matches `icon`'s height and glyph. That width lands at once
- * too — the button's default `transition-all` would animate the box out of step
- * with the strip the click has already resized, so the transition names its
- * properties instead.
+ * The same square button at both widths, rather than one that widens with its
+ * neighbours: the wide strip sends it to its right edge instead, which is the
+ * side the arrow points at and the side the strip grows from. The button's
+ * default `transition-all` would animate that box out of step with the strip
+ * the click has already resized, so the transition names its properties.
  *
  * An auto margin is what puts it at the foot: the tabs and the controls under
  * them take only the height they need.
@@ -352,10 +352,10 @@ function VerticalTabsWidthToggle({
   return (
     <Button
       variant="ghost"
-      size={isWide ? "default" : "icon"}
+      size="icon"
       className={cn(
         "mt-auto text-muted-foreground transition-[color,background-color]",
-        isWide && "w-full",
+        isWide && "self-end",
       )}
       title={isWide ? "Narrow Tabs" : "Wide Tabs"}
       onClick={() => {

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -246,6 +246,12 @@ export function WorkspaceAppsSettings() {
                   }))}
                 />
                 <ConfigSwitchField
+                  label="Show Width Button"
+                  description="Show the button at the bottom of the sidebar that switches between narrow and wide. With this off, use Reset Width from the sidebar's context menu or the Width setting above."
+                  configKey="verticalTabs.showWidthToggle"
+                  licenseKeyRequired
+                />
+                <ConfigSwitchField
                   label="Hide Gmail Unread Badge When Active"
                   description="Hide the unread badge on the Gmail tab while it is the active tab, since the inbox is already in front. Accounts that need attention are still flagged."
                   configKey="verticalTabs.hideUnreadBadgeWhenActive"

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -156,6 +156,7 @@ export type Config = {
   "spellchecker.languages": string[];
   "verticalTabs.showWindows": boolean;
   "verticalTabs.width": VerticalTabsWidth;
+  "verticalTabs.showWidthToggle": boolean;
   "verticalTabs.hideUnreadBadgeWhenActive": boolean;
   "verticalTabs.showAppLinksBadge": boolean;
 };


### PR DESCRIPTION
- The width toggle at the foot of the vertical tabs sidebar is now visible at rest instead of fading in on strip hover.
- It stays the same square icon button at both widths; the wide strip aligns it to the right edge rather than stretching it full-width.
- New `verticalTabs.showWidthToggle` setting (default on) hides the button; it sits under Settings → Workspace Apps → Vertical Tabs, next to Width.
- Dropped the now-unused `group/vertical-tabs` name from the strip and the opacity transition on the button.

Not verified in the running app — only types, format and lint.

Test plan:
1. With the setting on and the sidebar wide, the chevron button sits bottom-right at icon size; clicking it narrows the strip and the button stays put under the pointer.
2. Turn Show Width Button off: the button disappears; Reset Width in the sidebar context menu and the Width setting still work.