### PR TITLE
expand view over app shell in HTML fullscreen

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -57,16 +57,6 @@ Two things are waiting on it. The nine `Ctrl+Shift+1..9` jumps to pinned tabs ar
 
 Surfaced by the comment audit. `Accounts.init` (`packages/app/accounts.ts:116`) blindly calls `refreshSelectedAccountView()` on the main window's `show` and `restore` events because the account views sometimes don't render after the window comes back — the view just doesn't paint sometimes when only `main.window.contentView.addChildView()` is called. The suspicion is a bug in Electron itself, but that is unconfirmed; the root cause was never found, and the refresh is the workaround. To investigate: pin down a reproduction, check whether a minimal Electron app shows it, search/file an upstream issue, and either link the issue at the workaround or replace it with a real fix.
 
-## HTML fullscreen leaves the app shell visible (2026-08-12)
-
-Found while testing PR #723. Presenting in Slides and going fullscreen in Meet both enter fullscreen inside the view, but the titlebar and the vertical tabs strip stay on screen — the page fills only the region its `WebContentsView` already occupied instead of the whole window.
-
-Nothing in the app listens for `enter-html-full-screen` / `leave-html-full-screen` on a view's `webContents`; the only fullscreen handling is `main.ts:150`, a `leave-full-screen` listener on the `BrowserWindow` for window-level fullscreen. So a page entering HTML fullscreen changes nothing about how the shell is laid out.
-
-Newly reachable rather than newly broken, confirmed by testing on main: before #723 the `fullscreen` permission request fell through the request handler's `switch` without ever invoking `callback`, so it never settled and pages could not enter fullscreen at all.
-
-To decide when picking this up: whether HTML fullscreen should take over the whole window (hide titlebar and strip, resize the view to the full content bounds) or also put the `BrowserWindow` itself into fullscreen, and how that interacts with a workspace app that is already in its own window.
-
 ## Google Docs menu paste wants a Chrome extension (2026-08-12)
 
 Found while testing PR #723. Edit → Paste in Docs shows a dialog asking for the Google Docs extension to be installed instead of pasting. Menu Copy works, and Cmd/Ctrl+V is unaffected.

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -252,6 +252,8 @@ export class Gmail {
 
   private pageTitle = "";
 
+  private htmlFullscreen = false;
+
   get title() {
     return WorkspaceApp.resolveTitle(this.pageTitle, this.app);
   }
@@ -423,6 +425,14 @@ export class Gmail {
       this.pageTitle = explicitSet ? pageTitle : "";
     });
 
+    this.view.webContents.on("enter-html-full-screen", () => {
+      this.setHtmlFullscreen(true);
+    });
+
+    this.view.webContents.on("leave-html-full-screen", () => {
+      this.setHtmlFullscreen(false);
+    });
+
     registerTabBroadcasts(this.view);
 
     openViewDevToolsOnLaunch(this.view);
@@ -472,8 +482,20 @@ export class Gmail {
     });
   }
 
+  private setHtmlFullscreen(htmlFullscreen: boolean) {
+    this.htmlFullscreen = htmlFullscreen;
+
+    this.updateViewBounds();
+  }
+
   updateViewBounds() {
     const { width, height } = main.getWindowBounds();
+
+    if (this.htmlFullscreen) {
+      this.view.setBounds({ x: 0, y: 0, width, height });
+
+      return;
+    }
 
     const verticalTabsWidth = accounts.getVerticalTabsWidth();
 

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -440,6 +440,8 @@ export class WorkspaceApp {
 
   private isClosing = false;
 
+  private htmlFullscreen = false;
+
   constructor({
     accountId,
     url,
@@ -640,6 +642,8 @@ export class WorkspaceApp {
     this.view.webContents.on("did-navigate", this.handleDidNavigate);
     this.view.webContents.on("will-redirect", this.handleGoogleRedirect);
     this.view.webContents.on("page-title-updated", this.handlePageTitleUpdated);
+    this.view.webContents.on("enter-html-full-screen", this.handleEnterHtmlFullscreen);
+    this.view.webContents.on("leave-html-full-screen", this.handleLeaveHtmlFullscreen);
 
     if (this._window) {
       this.registerWindowedViewListeners();
@@ -781,6 +785,18 @@ export class WorkspaceApp {
     WorkspaceApp.handleRedirect(event, url, this.view.webContents);
   };
 
+  private handleEnterHtmlFullscreen = () => {
+    this.htmlFullscreen = true;
+
+    this.updateViewBounds();
+  };
+
+  private handleLeaveHtmlFullscreen = () => {
+    this.htmlFullscreen = false;
+
+    this.updateViewBounds();
+  };
+
   get navigationHistory() {
     return {
       canGoBack: this.view.webContents.navigationHistory.canGoBack(),
@@ -852,27 +868,22 @@ export class WorkspaceApp {
   };
 
   updateViewBounds = () => {
-    if (!this._window) {
-      const { width, height } = main.getWindowBounds();
+    const { width, height } = this._window
+      ? this.window.getContentBounds()
+      : main.getWindowBounds();
 
-      const verticalTabsWidth = accounts.getVerticalTabsWidth();
-
-      this.view.setBounds({
-        x: verticalTabsWidth,
-        y: APP_TITLEBAR_HEIGHT,
-        width: width - verticalTabsWidth,
-        height: height - APP_TITLEBAR_HEIGHT,
-      });
+    if (this.htmlFullscreen) {
+      this.view.setBounds({ x: 0, y: 0, width, height });
 
       return;
     }
 
-    const { width, height } = this.window.getContentBounds();
+    const verticalTabsWidth = this._window ? 0 : accounts.getVerticalTabsWidth();
 
     this.view.setBounds({
-      x: 0,
+      x: verticalTabsWidth,
       y: APP_TITLEBAR_HEIGHT,
-      width,
+      width: width - verticalTabsWidth,
       height: height - APP_TITLEBAR_HEIGHT,
     });
   };


### PR DESCRIPTION
- A view entering HTML fullscreen (presenting in Slides, fullscreen in Meet) now lays out at the full window content bounds instead of keeping its titlebar and vertical-tabs offsets, so the shell is covered — child `WebContentsView`s paint above the main window's HTML, so no renderer change is needed.
- `enter-html-full-screen` / `leave-html-full-screen` listeners on each view's `webContents` flip a flag that `updateViewBounds` branches on, in both `Gmail` and `WorkspaceApp`; everything that can move a view already routes through those two methods.
- `WorkspaceApp.updateViewBounds` collapses its embedded and windowed branches into one — a windowed app is the embedded layout with a zero-width strip — rather than growing a third copy for fullscreen. Windowed apps get the same takeover, covering their own HTML titlebar.
- The window itself going into OS fullscreen is Electron's own doing (`disableHtmlFullscreenWindowResize` defaults to `false`, and a child view has an owner window), left as-is: that is the Chrome behaviour.

Not verified: I have no display in this environment, so nothing here was run — the bounds behaviour, the macOS fullscreen transition (bounds may land mid-animation and need a re-apply on the window's `enter-full-screen`), and the Windows `titleBarOverlay` caption buttons, which are drawn in the non-client area above child views, are all untested.

Left out: `main.saveWindowState()` records `fullscreen: isFullScreen()`, so quitting mid-presentation restores the app fullscreen on next launch. Pre-existing, but only reachable now.

## Test plan

1. Present a deck in Slides in an embedded tab — the slide fills the whole window, titlebar and vertical tabs gone; Esc restores both and the view returns to its previous bounds.
2. Do the same in a workspace app opened in its own window — the page covers that window's titlebar too.
3. While presenting, switch to another tab and back — the other tab lays out normally, and the presenting tab is still fullscreen when you return.
4. On macOS, presenting should take the window into fullscreen and leaving should return it to its previous size and position.
