### PR TITLE
add a gathering procedure to the release notes skill

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -7,7 +7,7 @@ description: Write release notes for Meru. Use when drafting or updating GitHub 
 
 ## Gathering the changes
 
-- The range runs from the last published release to `HEAD`: check it with `gh release list -L 1`, then `git log --oneline v<latest>..HEAD`.
+- The release being written is the one the version commit at `HEAD` bumps to — a commit whose subject is the bare version number, matching `version` in `package.json` (e.g. `3.58.0`, tagged `v3.58.0`). The range runs from the previous release's tag to that commit; `gh release list -L 2` gives both tags.
 - Triage the log before opening a single diff. Drop on the commit subject alone: comment and docs edits, refactors and extractions, `TODO.md` notes, tests, CI, and dependency bumps other than Electron. A release of 40 commits usually has around 10 user-facing ones.
 - For the commits that survive, `gh pr view <number>` is the fastest read — the PR body states what changed for the user, the commit subject often doesn't. Fall back to `git show` when there is no PR.
 - Don't trust a commit message's scope — verify the actual fix from the diff. Messages often name a single platform or quote a GitHub issue title (e.g. "fix window position resetting after Windows reboot") when the underlying bug affects every platform. Only scope a note to a platform with `**macOS:**`/`**Windows:**` when the code confirms the fix is platform-specific.
@@ -39,5 +39,8 @@ description: Write release notes for Meru. Use when drafting or updating GitHub 
 
 ## Output
 
-- Release notes live only on GitHub Releases — do not commit a `RELEASE_NOTES.md` or `CHANGELOG.md` file, and do not write the notes to a file in the repo. Match the style of recent published releases at https://github.com/zoidsh/meru/releases.
-- Output the notes in chat wrapped in a fenced markdown code block, so the raw markdown can be copied straight into the GitHub release.
+- Release notes live only on GitHub Releases — do not commit a `RELEASE_NOTES.md` or `CHANGELOG.md` file, and do not write the notes anywhere inside the repo. Match the style of recent published releases at https://github.com/zoidsh/meru/releases.
+- Write the finished notes onto the release for the version commit's tag: `gh release edit v<version> --notes-file <path>`, with the notes in a temporary file outside the repo. Pass a file rather than `--notes` so the markdown, backticks and `<kbd>` tags survive the shell.
+- Read the current body first with `gh release view v<version> --json body -q .body`. Editing replaces it wholesale, so when it isn't empty, show the notes in chat and confirm before overwriting.
+- If no release exists for the tag yet, stop and ask — creating one triggers the build-and-publish workflow, which is not this skill's job.
+- Share the release URL after writing, and print the notes in chat as well.

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -41,6 +41,6 @@ description: Write release notes for Meru. Use when drafting or updating GitHub 
 
 - Release notes live only on GitHub Releases — do not commit a `RELEASE_NOTES.md` or `CHANGELOG.md` file, and do not write the notes anywhere inside the repo. Match the style of recent published releases at https://github.com/zoidsh/meru/releases.
 - Write the finished notes onto the release for the version commit's tag: `gh release edit v<version> --notes-file <path>`, with the notes in a temporary file outside the repo. Pass a file rather than `--notes` so the markdown, backticks and `<kbd>` tags survive the shell.
-- Read the current body first with `gh release view v<version> --json body -q .body`. Editing replaces it wholesale, so when it isn't empty, show the notes in chat and confirm before overwriting.
+- Read the current body first with `gh release view v<version> --json body -q .body`. When the release already has notes, fold the changes into them and overwrite without asking — editing replaces the body wholesale, so always pass the complete set of notes, never just the new bullets.
 - If no release exists for the tag yet, stop and ask — creating one triggers the build-and-publish workflow, which is not this skill's job.
 - Share the release URL after writing, and print the notes in chat as well.

--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -5,22 +5,39 @@ description: Write release notes for Meru. Use when drafting or updating GitHub 
 
 # Release Notes
 
-- Release notes live only on GitHub Releases — do not commit a `RELEASE_NOTES.md` or `CHANGELOG.md` file. Match the style of recent published releases at https://github.com/zoidsh/meru/releases.
-- Output the release notes in chat for pasting into the GitHub release — do not write them to a file in the repo. Wrap the notes in a fenced markdown code block so the raw markdown can be copied directly into the GitHub release.
-- Structure: use `## Added`, `## Changed`, `## Fixed`, `## Internal Changes` sections (in that order, omit unused ones). Skip `## Internal Changes` entirely when nothing affects end users (e.g. CI, CLAUDE.md, repo tooling).
-- `## Internal Changes` is essentially only for Electron upgrades — bumping Electron pulls in a new Chromium, which carries performance and security improvements users benefit from. Other dependency or tooling upgrades (e.g. TypeScript, dnd-kit, electron-builder, build config) are not user-observable, so omit them; if Electron wasn't upgraded, there's usually no `## Internal Changes` section at all.
+## Gathering the changes
+
+- The range runs from the last published release to `HEAD`: check it with `gh release list -L 1`, then `git log --oneline v<latest>..HEAD`.
+- Triage the log before opening a single diff. Drop on the commit subject alone: comment and docs edits, refactors and extractions, `TODO.md` notes, tests, CI, and dependency bumps other than Electron. A release of 40 commits usually has around 10 user-facing ones.
+- For the commits that survive, `gh pr view <number>` is the fastest read — the PR body states what changed for the user, the commit subject often doesn't. Fall back to `git show` when there is no PR.
+- Don't trust a commit message's scope — verify the actual fix from the diff. Messages often name a single platform or quote a GitHub issue title (e.g. "fix window position resetting after Windows reboot") when the underlying bug affects every platform. Only scope a note to a platform with `**macOS:**`/`**Windows:**` when the code confirms the fix is platform-specific.
+- Describe the end state at the tag, not the journey. A feature that landed and was then renamed, redesigned, or extended over several commits in the same release gets one bullet describing how it works now.
+- Drop fixes to code newly introduced in the same release — a bug that only existed between merge and tag is invisible to users upgrading from the previous public release.
+- Skip changes that aren't user-observable given existing constraints (e.g. don't mention gating a feature behind Pro if free-tier limits already made it inaccessible).
+
+## Structure
+
+- Sections are `## Added`, `## Changed`, `## Fixed`, `## Internal Changes`, in that order, omitting unused ones. Lead with `## Changed` when a change is needed to understand `## Added` — v3.58.0 opened with the Google Apps → Workspace Apps rename because every new tab bullet below it says "Workspace Apps".
 - Classify each change correctly:
   - `Added` — new feature or capability
   - `Changed` — intentional change to existing behavior, rename, or default
   - `Fixed` — resolves a bug or unintended behavior (e.g. windows stacking awkwardly)
-- Write user-facing, not commit-facing. Describe what changed for the user, not the commit history or implementation. Merge multiple commits for one feature into a single bullet.
-- Don't trust a commit message's scope — verify the actual fix from the diff. Messages often name a single platform or quote a GitHub issue title (e.g. "fix window position resetting after Windows reboot") when the underlying bug affects every platform. Only scope a note to a platform with `**macOS:**`/`**Windows:**` when the code confirms the fix is platform-specific.
-- Lead with outcome, not mechanism. "New windows no longer stack on top of each other" beats "Added cascading window positioning". Avoid internal jargon like "patch-burst" or "debounce".
-- Prefix Pro-only features with `**Meru Pro:**`.
-- Skip changes that aren't user-observable given existing constraints (e.g. don't mention gating a feature behind Pro if free-tier limits already made it inaccessible).
-- Reference settings paths as `Settings... → Section → Option`.
+- `## Internal Changes` is essentially only for Electron upgrades — bumping Electron pulls in a new Chromium, which carries performance and security improvements users benefit from. Other dependency, CI, or tooling upgrades (e.g. TypeScript, dnd-kit, electron-builder, build config, `CLAUDE.md`) are not user-observable, so omit them; if Electron wasn't upgraded, there's no `## Internal Changes` section at all.
 - Group related bullets next to each other (e.g. all Workspace Apps changes together).
 - Use sub-bullets for details: options list, defaults, keyboard shortcuts, behavior nuances. Always state the default for new options.
-- Drop fixes to code newly introduced in the same release — a bug that only existed between merge and tag is invisible to users upgrading from the previous public release.
-- Wrap keyboard shortcuts in `<kbd>` tags and write them per platform: `<kbd>Cmd</kbd>+<kbd>F</kbd> on macOS, <kbd>Ctrl</kbd>+<kbd>F</kbd> on Windows/Linux`.
+
+## Writing
+
+- Write user-facing, not commit-facing. Describe what changed for the user, not the commit history or implementation. Merge multiple commits for one feature into a single bullet.
+- Lead with outcome, not mechanism. "New windows no longer stack on top of each other" beats "Added cascading window positioning". Avoid internal jargon like "patch-burst" or "debounce".
+- Never reference PR numbers, issue numbers, commit hashes, or contributor handles. Commit subjects carry a trailing `(#792)` — drop it.
+- Say what carries over whenever a rename, move, or behavior change could read as lost settings or data: "Your existing settings carry over automatically", "Your existing Gmail zoom level is preserved".
 - When reverting or removing a previously released feature, include the reason inline so users who relied on it understand the change.
+- Prefix Pro-only features with `**Meru Pro:**`.
+- Reference settings paths in backticks, with an ellipsis character rather than three dots: `` `Settings… → Section → Option` ``.
+- Wrap keyboard shortcuts in `<kbd>` tags and write them per platform: `<kbd>Cmd</kbd>+<kbd>F</kbd> on macOS, <kbd>Ctrl</kbd>+<kbd>F</kbd> on Windows/Linux`.
+
+## Output
+
+- Release notes live only on GitHub Releases — do not commit a `RELEASE_NOTES.md` or `CHANGELOG.md` file, and do not write the notes to a file in the repo. Match the style of recent published releases at https://github.com/zoidsh/meru/releases.
+- Output the notes in chat wrapped in a fenced markdown code block, so the raw markdown can be copied straight into the GitHub release.


### PR DESCRIPTION
- Adds a **Gathering the changes** section: the release is the one the version commit at `HEAD` bumps to, the range is the previous tag to that commit, which commit subjects to drop unread, and `gh pr view` as the fastest read on user-facing intent.
- **Output now writes to GitHub** — `gh release edit v<version> --notes-file` onto the version commit's tag, instead of printing markdown in chat to paste by hand. Existing notes are folded into and overwritten without asking, so the skill always passes the complete set of notes rather than just new bullets. Stops and asks only if no release exists for the tag, since creating one triggers the build-and-publish workflow.
- New rule to describe the end state at the tag, not the journey — a feature that was renamed or redesigned across several commits in the same release gets one bullet.
- Bans PR/issue numbers, commit hashes and contributor handles, which no published release has ever carried but every commit subject supplies.
- Captures the "your existing settings carry over" reassurance used for renames and moves.
- Section order now allows leading with `## Changed` when a change is needed to understand `## Added`, as v3.58.0 did with the Workspace Apps rename.
- Fixes `Settings...` → `Settings…`, merges the two `## Internal Changes` rules, and groups the rules under headings.

Nothing here is verified against an actual release — the next one drafted with the skill is the first test, and that run is also the first time the skill edits a public release body unprompted.

## Test plan

1. Run the skill with `HEAD` on a version commit — expect it to resolve the tag from `package.json`, gather from the previous tag, and land the notes on that release rather than in chat.
2. Run it against `v3.57.0..v3.58.0` (~40 commits, mostly comment and refactor churn) — expect roughly 10 user-facing bullets and no `(#NNN)` refs surviving.
3. Re-run it on a release that already has a body — expect the published notes to still contain the earlier bullets, not just the newly changed ones.