### PR TITLE
enable workspace app notifications by default

### DIFF
--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -10,6 +10,7 @@ import { Gmail } from "./gmail";
 import { createBrowserWindow, getPreloadPath, loadRenderer } from "./lib/window";
 import { licenseKey } from "./license-key";
 import { main } from "./main";
+import { areWorkspaceAppNotificationsAllowed } from "./notifications";
 import { Tabs } from "./tabs";
 import { WorkspaceApp } from "./workspace-app";
 
@@ -95,7 +96,7 @@ export class Account {
           break;
         }
         case "notifications": {
-          callback(config.get("notifications.allowFromWorkspaceApps"));
+          callback(areWorkspaceAppNotificationsAllowed());
           break;
         }
         default: {
@@ -108,7 +109,7 @@ export class Account {
   private registerSessionPermissionsCheckHandler() {
     this.session.setPermissionCheckHandler((_webContents, permission) => {
       if (permission === "notifications") {
-        return config.get("notifications.allowFromWorkspaceApps");
+        return areWorkspaceAppNotificationsAllowed();
       }
 
       return true;

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -60,7 +60,7 @@ export const config = new Store<Config>({
     "notifications.showSubject": true,
     "notifications.showSummary": true,
     "notifications.playSound": true,
-    "notifications.allowFromWorkspaceApps": false,
+    "notifications.allowFromWorkspaceApps": true,
     "notifications.sound": "linen",
     "notifications.volume": 1,
     "notifications.downloadCompleted": true,
@@ -406,6 +406,10 @@ export const config = new Store<Config>({
       store.delete("gmail.fullDarkTheme");
     },
     ">3.58.0": (store) => {
+      // Workspace app notifications are on by default now, so everyone who
+      // never turned them on gets them and opts out instead.
+      store.set("notifications.allowFromWorkspaceApps", true);
+
       // @ts-expect-error: `workspaceApps.openBehavior` is now 'workspaceApps.mode'
       const openBehavior = store.get("workspaceApps.openBehavior");
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -40,7 +40,11 @@ import { DoNotDisturb, doNotDisturb } from "./do-not-disturb";
 import { downloads } from "./downloads";
 import { GMAIL_USER_STYLES_PATH } from "./gmail";
 import { log } from "./lib/log";
-import { createNewEmailNotification, createNotification } from "./notifications";
+import {
+  areWorkspaceAppNotificationsAllowed,
+  createNewEmailNotification,
+  createNotification,
+} from "./notifications";
 import { MAILTO_PROTOCOL } from "./protocol";
 import { appUpdater } from "./updater";
 import { openExternalUrl } from "./url";
@@ -716,7 +720,7 @@ class Ipc {
     });
 
     ipc.main.on("workspaceApp.showNotification", (event, notification) => {
-      if (!config.get("notifications.allowFromWorkspaceApps")) {
+      if (!areWorkspaceAppNotificationsAllowed()) {
         return;
       }
 

--- a/packages/app/notifications.ts
+++ b/packages/app/notifications.ts
@@ -28,6 +28,10 @@ export function isWithinNotificationTimes() {
   return checkWithinNotificationTimes(config.get("notifications.times"), new Date());
 }
 
+export function areWorkspaceAppNotificationsAllowed() {
+  return licenseKey.isValid && config.get("notifications.allowFromWorkspaceApps");
+}
+
 export function createNewEmailNotification({
   click,
   action,


### PR DESCRIPTION
- `notifications.allowFromWorkspaceApps` now defaults to `true`, so workspace app notifications are opt-out
- Migration `>3.58.0` sets the key to `true` for existing configs, including for anyone who had turned it off before
- The permission request/check handlers and the `workspaceApp.showNotification` IPC now go through `areWorkspaceAppNotificationsAllowed()`, which also requires a valid license — previously only the settings switch was Pro-gated, so a default of `true` would have let free users receive notifications while their switch read off and disabled

The migration forces the value on rather than only filling in an unset one, so a user who deliberately turned it off before upgrading gets it back on once.

Test plan:
1. Launch with a pre-3.58.0 config that has `notifications.allowFromWorkspaceApps: false` and a valid license — the Notifications settings switch reads on, and a Calendar/Chat notification is delivered.
2. Launch without a license — the switch reads off and disabled, and no workspace app notification is delivered (previously the config value would have been honored regardless).