### PR TITLE
split ci and build workflows, skip build for markdown-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: main
+name: build
 
 on:
   push:
@@ -11,10 +11,7 @@ on:
       - "**.md"
 
 jobs:
-  ci:
-    uses: ./.github/workflows/ci.yml
   build:
-    needs: ci
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: ci
 
 on:
+  push:
+    branches:
+      - main
+  pull_request:
   workflow_call:
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
+    paths-ignore:
+      - "**.md"
 
 jobs:
   ci:


### PR DESCRIPTION
- `main.yml` is gone; its build job now lives in `build.yml` with `paths-ignore: ["**.md"]` on `push` and `pull_request`, so docs, README and skill markdown changes no longer trigger the three-platform app build.
- `ci.yml` gains its own `push`/`pull_request` triggers alongside `workflow_call`, so fmt/lint/types/test run on every change (markdown included) and `release.yml` still calls it unchanged.

`build` no longer runs behind `needs: ci` — that dependency can't cross workflow files. Builds now start in parallel with the checks, so a PR that fails lint will still build all three platforms.

Test plan:
1. Open a PR touching only a `.md` file — `ci` runs, no `build` run appears.
2. Open a PR touching a `.ts` file — both `ci` and `build` run, concurrently rather than in sequence.