### PR TITLE
Make the titlebar popup a generic popup that fades in

### DIFF
--- a/packages/app/bookmarks.ts
+++ b/packages/app/bookmarks.ts
@@ -7,7 +7,7 @@ import type { BrowserWindow } from "electron";
 import { accounts } from "./accounts";
 import { config } from "./config";
 import { ipc } from "./ipc";
-import { TitlebarPopup } from "./lib/titlebar-popup";
+import { Popup } from "./lib/popup";
 
 /**
  * The URLs an account has saved. A bookmark keeps the URL, title and app it was
@@ -19,7 +19,7 @@ import { TitlebarPopup } from "./lib/titlebar-popup";
  * Windows` mode and absent in `Tabs` mode until a second tab opens.
  */
 class Bookmarks {
-  popup = new TitlebarPopup({
+  popup = new Popup({
     page: "bookmarks",
     width: BASE_SPACING * 40,
     height: "fill",

--- a/packages/app/downloads.ts
+++ b/packages/app/downloads.ts
@@ -9,7 +9,7 @@ import electronDl from "electron-dl";
 import { config } from "@/config";
 import { createNotification } from "@/notifications";
 import { fileExists } from "./lib/fs";
-import { TitlebarPopup } from "./lib/titlebar-popup";
+import { Popup } from "./lib/popup";
 
 const FILE_MANAGER_NAME = platform.isMacOS
   ? "Finder"
@@ -18,7 +18,7 @@ const FILE_MANAGER_NAME = platform.isMacOS
     : "your file manager";
 
 class Downloads {
-  recentDownloadHistoryPopup = new TitlebarPopup({
+  recentDownloadHistoryPopup = new Popup({
     page: "recent-download-history",
     width: BASE_SPACING * 48,
     height: BASE_SPACING * 44,

--- a/packages/app/lib/popup.ts
+++ b/packages/app/lib/popup.ts
@@ -8,10 +8,15 @@ import { getPreloadPath, loadRenderer, type RendererPage } from "./window";
  * A renderer page drawn over the window it was opened from, as a child view
  * rather than renderer-drawn markup: child views paint above the main window's
  * HTML, so a dropdown would be covered wherever a workspace app view sits.
+ *
+ * The view spans `BASE_SPACING` past the popup on every side and the page pads
+ * itself by the same amount, so the popup sits where the gaps put it and its
+ * entrance animation has room to move without being cut off at the view edge.
  */
 export class Popup {
   private page: RendererPage;
 
+  /** The size of the popup itself, without the gaps the view spans. */
   private width: number;
 
   /** `fill` reaches the bottom of the window, leaving the gap it hangs by. */
@@ -62,13 +67,16 @@ export class Popup {
       ? this.parentWindow.getContentBounds()
       : this.parentWindow.getBounds();
 
-    const y = APP_TITLEBAR_HEIGHT + BASE_SPACING;
+    const y = APP_TITLEBAR_HEIGHT;
+
+    const width = this.width + BASE_SPACING * 2;
 
     this.view.setBounds({
-      x: this.anchorX ?? parentWindowBounds.width - this.width - BASE_SPACING,
+      x: this.anchorX === null ? parentWindowBounds.width - width : this.anchorX - BASE_SPACING,
       y,
-      width: this.width,
-      height: this.height === "fill" ? parentWindowBounds.height - y - BASE_SPACING : this.height,
+      width,
+      height:
+        this.height === "fill" ? parentWindowBounds.height - y : this.height + BASE_SPACING * 2,
     });
   };
 
@@ -158,8 +166,6 @@ export class Popup {
     // hung on, or the main window on quit — leaves the view attached to
     // something that is going away, so the popup comes down with it
     parentWindow.once("closed", this.close);
-
-    this.view.setBorderRadius(BASE_SPACING * 2);
 
     return true;
   }

--- a/packages/app/lib/popup.ts
+++ b/packages/app/lib/popup.ts
@@ -5,12 +5,11 @@ import { WebContentsView } from "electron";
 import { getPreloadPath, loadRenderer, type RendererPage } from "./window";
 
 /**
- * A renderer page hung under the titlebar of the window it was opened from, as
- * a child view rather than renderer-drawn markup: child views paint above the
- * main window's HTML, so a dropdown would be covered wherever a workspace app
- * view sits.
+ * A renderer page drawn over the window it was opened from, as a child view
+ * rather than renderer-drawn markup: child views paint above the main window's
+ * HTML, so a dropdown would be covered wherever a workspace app view sits.
  */
-export class TitlebarPopup {
+export class Popup {
   private page: RendererPage;
 
   private width: number;
@@ -136,6 +135,10 @@ export class TitlebarPopup {
         preload: getPreloadPath("renderer"),
       },
     });
+
+    // The page paints its own background as it fades in, so the view stays clear
+    // instead of flashing white until the first frame lands
+    this.view.setBackgroundColor("#00000000");
 
     this.parentWindow = parentWindow;
 

--- a/packages/renderer/bookmarks.html
+++ b/packages/renderer/bookmarks.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="./globals.css" />
   </head>
-  <body>
+  <body class="bg-transparent">
     <div id="root"></div>
     <script type="module" src="./bookmarks.tsx"></script>
   </body>

--- a/packages/renderer/bookmarks.tsx
+++ b/packages/renderer/bookmarks.tsx
@@ -15,7 +15,7 @@ import { ScrollArea } from "@meru/ui/components/scroll-area";
 import { cn } from "@meru/ui/lib/utils";
 import { BookOpenIcon, XIcon } from "lucide-react";
 import type { Ref } from "react";
-import { PopupWindow } from "@/components/popup-window";
+import { Popup } from "@/components/popup";
 import { TabIcon } from "@/components/tab-icon";
 import { sortablePlugins, sortableSensors } from "@/lib/dnd";
 import { renderApp } from "@/lib/react";
@@ -158,7 +158,7 @@ function BookmarkList() {
 
 function Bookmarks() {
   return (
-    <div className="flex h-screen flex-col rounded-2xl border">
+    <>
       <div className="p-4 font-semibold">Bookmarks</div>
       <Button
         size="icon"
@@ -174,15 +174,15 @@ function Bookmarks() {
           <BookmarkList />
         </div>
       </ScrollArea>
-    </div>
+    </>
   );
 }
 
 function BookmarksPopup() {
   return (
-    <PopupWindow onClose={closePopup}>
+    <Popup onClose={closePopup}>
       <Bookmarks />
-    </PopupWindow>
+    </Popup>
   );
 }
 

--- a/packages/renderer/components/popup.tsx
+++ b/packages/renderer/components/popup.tsx
@@ -10,10 +10,11 @@ export function Popup({ children, onClose }: { children: React.ReactNode; onClos
     <PopupWindow onClose={onClose}>
       <div
         className="h-screen p-2"
-        onClick={(event) => {
-          // The view covers the gaps, so a click on one lands in the popup
-          // instead of blurring it — closing here is the blur that would
-          // have been
+        onPointerDown={(event) => {
+          // The view covers the gaps, so a press on one lands in the popup
+          // instead of blurring it — closing here is the blur that would have
+          // been. On the press, not the click: a click that only ends on a gap
+          // — a text selection dragged past the frame — lands here too
           if (event.target === event.currentTarget) {
             onClose();
           }

--- a/packages/renderer/components/popup.tsx
+++ b/packages/renderer/components/popup.tsx
@@ -1,0 +1,15 @@
+import { PopupWindow } from "@/components/popup-window";
+
+/**
+ * The frame of a page shown in a popup view drawn over a window. The view it
+ * fills is transparent, so the frame is what paints and fades the popup in.
+ */
+export function Popup({ children, onClose }: { children: React.ReactNode; onClose: () => void }) {
+  return (
+    <PopupWindow onClose={onClose}>
+      <div className="flex h-screen animate-in flex-col rounded-2xl border bg-background duration-100 fade-in-0 zoom-in-95 slide-in-from-top-2">
+        {children}
+      </div>
+    </PopupWindow>
+  );
+}

--- a/packages/renderer/components/popup.tsx
+++ b/packages/renderer/components/popup.tsx
@@ -2,13 +2,26 @@ import { PopupWindow } from "@/components/popup-window";
 
 /**
  * The frame of a page shown in a popup view drawn over a window. The view it
- * fills is transparent, so the frame is what paints and fades the popup in.
+ * fills is transparent and spans the gaps the popup keeps from the window
+ * edges, so the frame is what paints, pads and fades the popup in.
  */
 export function Popup({ children, onClose }: { children: React.ReactNode; onClose: () => void }) {
   return (
     <PopupWindow onClose={onClose}>
-      <div className="flex h-screen animate-in flex-col rounded-2xl border bg-background duration-100 fade-in-0 zoom-in-95 slide-in-from-top-2">
-        {children}
+      <div
+        className="h-screen p-2"
+        onClick={(event) => {
+          // The view covers the gaps, so a click on one lands in the popup
+          // instead of blurring it — closing here is the blur that would
+          // have been
+          if (event.target === event.currentTarget) {
+            onClose();
+          }
+        }}
+      >
+        <div className="relative flex h-full animate-in flex-col overflow-hidden rounded-2xl border bg-background duration-100 fade-in-0 zoom-in-95 slide-in-from-top-2">
+          {children}
+        </div>
       </div>
     </PopupWindow>
   );

--- a/packages/renderer/recent-download-history.html
+++ b/packages/renderer/recent-download-history.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="./globals.css" />
   </head>
-  <body>
+  <body class="bg-transparent">
     <div id="root"></div>
     <script type="module" src="./recent-download-history.tsx"></script>
   </body>

--- a/packages/renderer/recent-download-history.tsx
+++ b/packages/renderer/recent-download-history.tsx
@@ -4,12 +4,12 @@ import { Button } from "@meru/ui/components/button";
 import { ScrollArea } from "@meru/ui/components/scroll-area";
 import { SquareArrowOutUpRightIcon, XIcon } from "lucide-react";
 import { DownloadHistoryList } from "@/components/download-history";
-import { PopupWindow } from "@/components/popup-window";
+import { Popup } from "@/components/popup";
 import { renderApp } from "@/lib/react";
 
 function RecentDownloadHistory() {
   return (
-    <div className="flex h-screen flex-col rounded-2xl border">
+    <>
       <div className="p-4 font-semibold">Recent Download History</div>
       <Button
         size="icon"
@@ -38,19 +38,19 @@ function RecentDownloadHistory() {
           <SquareArrowOutUpRightIcon /> Full Download History
         </Button>
       </div>
-    </div>
+    </>
   );
 }
 
 function RecentDownloadHistoryPopup() {
   return (
-    <PopupWindow
+    <Popup
       onClose={() => {
         ipc.main.send("downloads.closeRecentDownloadHistoryPopup");
       }}
     >
       <RecentDownloadHistory />
-    </PopupWindow>
+    </Popup>
   );
 }
 


### PR DESCRIPTION
- Renames `TitlebarPopup` to `Popup` (`packages/app/lib/popup.ts`) — it's a page drawn over the window it was opened from, not something the titlebar owns. The optional `anchorX` still says where the popup starts.
- The view is created with a transparent background, so opening no longer flashes white before the first frame lands.
- The view now spans `BASE_SPACING` past the popup on every side (up to the window edges) and the page pads itself by the same amount, so the popup stays exactly where it was but its entrance animation isn't cut off at the view edge. The view's border radius is gone with it — the page's frame paints and clips its own corners.
- New `Popup` renderer component (`packages/renderer/components/popup.tsx`) carries the frame both popup pages used to repeat — padding, rounded border, `bg-background`, and the entrance animation (`animate-in fade-in-0 zoom-in-95 slide-in-from-top-2 duration-100`, matching dropdown-menu/popover in `packages/ui`). The two popup pages set `bg-transparent` on `<body>` so the frame is what paints.
- Because the view covers the gaps, a click there lands in the popup instead of blurring it, so the page closes itself on a gap click. Those gaps no longer pass clicks through to what's underneath.

Not verified in the running app — this sandbox has no display, so the transparency, the animation and the gap-click close were only checked by building.

## Test plan

1. Open the bookmarks popup from the titlebar and from the vertical tabs strip — it fades and slides in from the top with nothing clipped, sits in the same place as before, and shows no white flash.
2. Open the recent downloads popup — same, and its footer bar stays inside the rounded bottom corners.
3. Close each popup with Esc, the X button, a click on the ~8px gap around it, and a click further away — all still close it.