### PR TITLE
ignore docs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,4 @@ dist
 
 # Meru
 build-js
+docs/


### PR DESCRIPTION
- Ignores `docs/` so a privately-hosted docs repo can live inside the checkout without ever landing in this public repo.

Test plan:
1. Clone any repo (or `mkdir docs && touch docs/x.md`) at `docs/` — `git status` stays clean.