### PR TITLE
document the dev loop and a rename-grep rule in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,24 @@
 bun install --frozen-lockfile
 ```
 
+## Commands
+
+```sh
+bun run dev        # run the app in development
+bun run types      # type check every package (CI runs `bun run types:ci`)
+bun run lint       # oxlint
+bun run fmt:check  # oxfmt check; `bun run fmt` writes
+bun test           # tests across every package
+```
+
+- `bun run types`, `bun run lint` and `bun run fmt:check` must pass before pushing.
+
 ## Docs
 
 - `docs/` is a separately cloned private docs repo, gitignored here; it may be absent on fresh checkouts. When present, read `docs/README.md` for what lives where.
 - Check `docs/decisions.md` before reopening a settled design decision.
 - Keep `docs/architecture/` current when changing the app's structure; larger features start as a design doc in `docs/features/` before implementation.
+- When renaming a main-process class or file, grep `docs/` for the old name and fix every reference — the docs repo has no other mechanism to catch renames.
 
 ## Dependencies
 


### PR DESCRIPTION
- Add a `## Commands` section after Setup with the dev, type, lint, format-check and test commands, plus a line that types/lint/fmt:check must pass before pushing. Every fresh session currently rediscovers these from package.json.
- Add a `## Docs` bullet: grep `docs/` for the old name when renaming a main-process class or file, since nothing else catches renames there.

Commands were taken from `package.json` and cross-checked against `.github/workflows/ci.yml`, and each was run in a clean worktree: `fmt:check`, `lint`, `types` and `bun test` (127 tests) all passed. `bun run dev` and `types:ci` are the two documented commands not executed.

## Test plan

1. `bun run types && bun run lint && bun run fmt:check` — all exit 0.
2. `bun test` — 127 tests pass across 10 files.
3. Read the rendered `CLAUDE.md` — `## Commands` sits between Setup and Docs, and the new Docs bullet is last in its section.