### PR TITLE
put Meru settings on Cmd+, and Gmail Settings on Cmd+Shift+,

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -255,13 +255,14 @@ export class AppMenu {
           },
           {
             label: "Settings...",
+            accelerator: "CommandOrControl+,",
             click: () => {
               main.navigate("/settings/general");
             },
           },
           {
             label: "Gmail Settings...",
-            accelerator: "Command+,",
+            accelerator: "Command+Shift+,",
             click: () => {
               ipc.renderer.send(
                 selectedAccount.instance.gmail.view.webContents,


### PR DESCRIPTION
- `Cmd+,` / `Ctrl+,` now opens Meru's own Settings (`CommandOrControl+,` on the existing "Settings..." app-menu item), matching native app conventions.
- Gmail Settings moves to `Command+Shift+,`, keeping its existing macOS-only scope (the accelerator string still starts with `Command`, which Electron only binds on macOS) — Windows/Linux gain no Gmail Settings shortcut, as before.

No other accelerator in the app used a comma, so nothing was displaced. I can't run the Electron app here, so neither shortcut was verified live — only that types, lint and format pass.

Test plan
1. On macOS press `Cmd+,` from the main window — Meru's Settings (General) opens.
2. Press `Cmd+Shift+,` — Gmail's own settings load in the active account's Gmail view and the window is shown.
3. On Windows/Linux press `Ctrl+,` — Meru's Settings opens; the Gmail Settings menu item shows no accelerator.
