### PR TITLE
make Docs' Edit menu cut, copy and paste work

### DIFF
--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -5,7 +5,6 @@ import type { AccountConfig } from "@meru/shared/schemas";
 import { clamp } from "@meru/shared/utils";
 import {
   type SupportedWorkspaceApp,
-  WORKSPACE_APP_PRELOAD_ARGUMENTS,
   type WorkspaceAppBookmarkState,
   type WorkspaceAppOpenBehavior,
   workspaceApps,
@@ -539,23 +538,16 @@ export class WorkspaceApp {
     url: string;
     options?: WebContentsViewConstructorOptions;
   }) {
-    const isDocsView = this.app === "docs";
-
     const view = createChildWebContentsView({
       session: this.account.instance.session,
       preload: getPreloadPath("workspace-app"),
-      ...(isDocsView && {
-        additionalArguments: [WORKSPACE_APP_PRELOAD_ARGUMENTS.docsMenuClipboard],
-      }),
       viewOptions: {
         ...options,
         webPreferences: {
           ...options?.webPreferences,
           // Docs cuts, copies and pastes from its Edit menu through
-          // `document.execCommand`, which Electron gates behind this preference.
-          // The argument above tells the Docs preload the grant exists — the
-          // two must always travel together.
-          enableDeprecatedPaste: isDocsView,
+          // `document.execCommand`, which Electron gates behind this preference
+          enableDeprecatedPaste: true,
         },
       },
       attachView: (createdView) => {

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -5,6 +5,7 @@ import type { AccountConfig } from "@meru/shared/schemas";
 import { clamp } from "@meru/shared/utils";
 import {
   type SupportedWorkspaceApp,
+  WORKSPACE_APP_PRELOAD_ARGUMENTS,
   type WorkspaceAppBookmarkState,
   type WorkspaceAppOpenBehavior,
   workspaceApps,
@@ -538,16 +539,23 @@ export class WorkspaceApp {
     url: string;
     options?: WebContentsViewConstructorOptions;
   }) {
+    const isDocsView = this.app === "docs";
+
     const view = createChildWebContentsView({
       session: this.account.instance.session,
       preload: getPreloadPath("workspace-app"),
+      ...(isDocsView && {
+        additionalArguments: [WORKSPACE_APP_PRELOAD_ARGUMENTS.docsMenuClipboard],
+      }),
       viewOptions: {
         ...options,
         webPreferences: {
           ...options?.webPreferences,
           // Docs cuts, copies and pastes from its Edit menu through
-          // `document.execCommand`, which Electron gates behind this preference
-          enableDeprecatedPaste: true,
+          // `document.execCommand`, which Electron gates behind this preference.
+          // The argument above tells the Docs preload the grant exists — the
+          // two must always travel together.
+          enableDeprecatedPaste: isDocsView,
         },
       },
       attachView: (createdView) => {

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -541,7 +541,15 @@ export class WorkspaceApp {
     const view = createChildWebContentsView({
       session: this.account.instance.session,
       preload: getPreloadPath("workspace-app"),
-      viewOptions: options,
+      viewOptions: {
+        ...options,
+        webPreferences: {
+          ...options?.webPreferences,
+          // Docs cuts, copies and pastes from its Edit menu through
+          // `document.execCommand`, which Electron gates behind this preference
+          enableDeprecatedPaste: true,
+        },
+      },
       attachView: (createdView) => {
         if (this._window) {
           this._window.contentView.addChildView(createdView);

--- a/packages/preload-workspace-app/apps/docs.ts
+++ b/packages/preload-workspace-app/apps/docs.ts
@@ -1,0 +1,29 @@
+import { webFrame } from "electron";
+
+declare global {
+  interface Window {
+    _docs_chrome_extension_exists: boolean;
+    _docs_chrome_extension_permissions: string[];
+  }
+}
+
+/**
+ * The "Docs Offline" Chrome extension injects a `page_embed_script.js` into
+ * every Docs page that does nothing but set these globals, telling Docs which
+ * clipboard permissions the extension grants the page. Without them the Edit
+ * menu's cut, copy and paste items only offer to install the extension. Meru
+ * grants the clipboard access itself through the view's `enableDeprecatedPaste`
+ * preference, so only the globals are missing.
+ */
+function markDocsOfflineExtensionAsInstalled() {
+  window._docs_chrome_extension_exists = true;
+  window._docs_chrome_extension_permissions = ["clipboardRead", "clipboardWrite"];
+}
+
+export function initDocsPreload() {
+  webFrame
+    .executeJavaScript(`(${markDocsOfflineExtensionAsInstalled.toString()})()`)
+    .catch((error) => {
+      console.error("Failed to mark the Docs Offline extension as installed:", error);
+    });
+}

--- a/packages/preload-workspace-app/apps/docs.ts
+++ b/packages/preload-workspace-app/apps/docs.ts
@@ -1,3 +1,4 @@
+import { WORKSPACE_APP_PRELOAD_ARGUMENTS } from "@meru/shared/workspace-apps";
 import { webFrame } from "electron";
 
 declare global {
@@ -21,6 +22,14 @@ function markDocsOfflineExtensionAsInstalled() {
 }
 
 export function initDocsPreload() {
+  // Only views created for the Docs app carry `enableDeprecatedPaste`. A view
+  // that navigated here in place has no paste grant, so advertising the
+  // extension would make Docs' menu paste fail silently — keep the install
+  // prompt there instead.
+  if (!process.argv.includes(WORKSPACE_APP_PRELOAD_ARGUMENTS.docsMenuClipboard)) {
+    return;
+  }
+
   webFrame
     .executeJavaScript(`(${markDocsOfflineExtensionAsInstalled.toString()})()`)
     .catch((error) => {

--- a/packages/preload-workspace-app/apps/docs.ts
+++ b/packages/preload-workspace-app/apps/docs.ts
@@ -1,4 +1,3 @@
-import { WORKSPACE_APP_PRELOAD_ARGUMENTS } from "@meru/shared/workspace-apps";
 import { webFrame } from "electron";
 
 declare global {
@@ -22,14 +21,6 @@ function markDocsOfflineExtensionAsInstalled() {
 }
 
 export function initDocsPreload() {
-  // Only views created for the Docs app carry `enableDeprecatedPaste`. A view
-  // that navigated here in place has no paste grant, so advertising the
-  // extension would make Docs' menu paste fail silently — keep the install
-  // prompt there instead.
-  if (!process.argv.includes(WORKSPACE_APP_PRELOAD_ARGUMENTS.docsMenuClipboard)) {
-    return;
-  }
-
   webFrame
     .executeJavaScript(`(${markDocsOfflineExtensionAsInstalled.toString()})()`)
     .catch((error) => {

--- a/packages/preload-workspace-app/index.ts
+++ b/packages/preload-workspace-app/index.ts
@@ -1,10 +1,12 @@
 import "@meru/shared/electron-api";
 import "./ipc";
+import { initDocsPreload } from "./apps/docs";
 import { initMailPreload } from "./apps/mail";
 import { initMeetPreload } from "./apps/meet";
 import { initServiceWorkerNotifications } from "./service-worker-notifications";
 
 const appPreloadScripts: Record<string, () => void> = {
+  "docs.google.com": initDocsPreload,
   "mail.google.com": initMailPreload,
   "meet.google.com": initMeetPreload,
 };

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -42,6 +42,10 @@ export type LauncherWorkspaceApp = {
 export const workspaceApps: Record<SupportedWorkspaceApp, WorkspaceAppDefinition> =
   workspaceAppDefinitions;
 
+export const WORKSPACE_APP_PRELOAD_ARGUMENTS = {
+  docsMenuClipboard: "--meru-docs-menu-clipboard",
+};
+
 export const launcherWorkspaceApps = Object.fromEntries(
   Object.entries(workspaceApps)
     .filter(([, workspaceAppDefinition]) => workspaceAppDefinition.availableInLauncher !== false)

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -42,10 +42,6 @@ export type LauncherWorkspaceApp = {
 export const workspaceApps: Record<SupportedWorkspaceApp, WorkspaceAppDefinition> =
   workspaceAppDefinitions;
 
-export const WORKSPACE_APP_PRELOAD_ARGUMENTS = {
-  docsMenuClipboard: "--meru-docs-menu-clipboard",
-};
-
 export const launcherWorkspaceApps = Object.fromEntries(
   Object.entries(workspaceApps)
     .filter(([, workspaceAppDefinition]) => workspaceAppDefinition.availableInLauncher !== false)


### PR DESCRIPTION
Google Docs' own Edit menu offers to install the "Docs Offline" Chrome extension instead of cutting, copying or pasting. Two things are missing in Meru, both addressed here:

- The extension's `page_embed_script.js` (339 bytes, fetched from the Web Store CRX) only sets `window._docs_chrome_extension_exists` and friends — a marker for the clipboard permissions the extension's `content_capabilities` grant the page. The workspace app preload now sets that marker on `docs.google.com` in the main world, with only the two clipboard permissions listed so Docs doesn't take it as an offer of offline storage.
- The clipboard access itself: Docs cuts, copies and pastes through `document.execCommand`, which Electron gates behind the `enableDeprecatedPaste` web preference (off by default) plus the `deprecated-sync-clipboard-read` permission. Workspace app views now set the preference; the session's permission check handler already grants the permission.

Loading the real extension via `session.loadExtension` was the other route and is a dead end: Electron implements neither `content_capabilities` — the mechanism that grants Docs its clipboard access in Chrome — nor `web_accessible_resources`, and it would mean shipping Google's 135 KB service worker.

Risks: I can't run the app against real Google Docs from here, so none of this is verified end to end — in particular whether today's Docs is happy with the two globals alone (Wavebox shipped exactly these two, but years ago) or also wants `_docs_chrome_extension_features_version`. If it isn't, the menu keeps offering the extension, as it does today. Claiming the extension exists may also make Docs surface offline options that can't work, since there is no `chrome.runtime` to talk to. `enableDeprecatedPaste` is deprecated in Electron and will eventually be removed, which puts the paste back where it is today.

Test plan:
1. Open a document in Docs in-app, select some text, and use Edit → Copy, then Edit → Paste — both should act on the clipboard instead of showing the "install the Docs Offline extension" prompt.
2. Paste something copied from outside Meru through Edit → Paste; it should land in the document.
3. In the same document, check the File menu's offline entry — Docs now believes an extension is installed, so watch for an offline toggle that errors or hangs.
