### PR TITLE
add a setting to pin the launcher and bookmarks to the titlebar

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -123,6 +123,7 @@ export const config = new Store<Config>({
     "verticalTabs.showWidthToggle": true,
     "verticalTabs.hideUnreadBadgeWhenActive": false,
     "verticalTabs.showAppLinksBadge": true,
+    "verticalTabs.launcherAndBookmarksHost": "auto",
   },
   migrations: {
     ">=3.4.0": (store) => {

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -223,10 +223,12 @@ export function AppTitlebar() {
   const shouldShowWorkspaceAppsLauncher =
     isLicenseKeyValid && config["workspaceApps.launcherApps"].length > 0;
 
-  // The vertical tabs strip hosts the launcher and the bookmarks button
-  // whenever it is there, so that opening another app or a bookmarked page
-  // stays in the same place as switching between tabs.
-  const areLauncherAndBookmarksHostedByVerticalTabs = verticalTabsWidth > 0;
+  // On `auto` the vertical tabs strip hosts the launcher and the bookmarks
+  // button whenever it is there, so that opening another app or a bookmarked
+  // page stays in the same place as switching between tabs. `titlebar` keeps
+  // them here whatever the strip does.
+  const areLauncherAndBookmarksHostedByVerticalTabs =
+    config["verticalTabs.launcherAndBookmarksHost"] === "auto" && verticalTabsWidth > 0;
 
   const shouldShowUnifiedInboxButton =
     isLicenseKeyValid && config["unifiedInbox.enabled"] && accounts.length > 1;

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -430,7 +430,11 @@ export function VerticalTabs() {
 
   const launcherApps = config?.["workspaceApps.launcherApps"] ?? [];
 
-  const shouldShowWorkspaceAppsLauncher = isLicenseKeyValid && launcherApps.length > 0;
+  const hostsLauncherAndBookmarks =
+    (config?.["verticalTabs.launcherAndBookmarksHost"] ?? "auto") === "auto";
+
+  const shouldShowWorkspaceAppsLauncher =
+    hostsLauncherAndBookmarks && isLicenseKeyValid && launcherApps.length > 0;
 
   const showsWidthToggle = config?.["verticalTabs.showWidthToggle"] ?? true;
 
@@ -582,7 +586,7 @@ export function VerticalTabs() {
           <VerticalTabsWorkspaceAppsLauncher launcherApps={launcherApps} isWide={isWide} />
         </div>
       )}
-      <VerticalTabsBookmarks isWide={isWide} />
+      {hostsLauncherAndBookmarks && <VerticalTabsBookmarks isWide={isWide} />}
       {showsWidthToggle && (
         <VerticalTabsWidthToggle accountId={selectedAccount.config.id} isWide={isWide} />
       )}

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -1,7 +1,11 @@
 import { move } from "@dnd-kit/helpers";
 import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
-import { GMAIL_TAB_ID, verticalTabsWidths } from "@meru/shared/tabs";
+import {
+  GMAIL_TAB_ID,
+  verticalTabsLauncherAndBookmarksHosts,
+  verticalTabsWidths,
+} from "@meru/shared/tabs";
 import {
   type LauncherWorkspaceApp,
   launcherWorkspaceApps,
@@ -250,6 +254,19 @@ export function WorkspaceAppsSettings() {
                   description="Show the button at the bottom of the sidebar that switches between narrow and wide. With this off, use Reset Width from the sidebar's context menu or the Width setting above."
                   configKey="verticalTabs.showWidthToggle"
                   licenseKeyRequired
+                />
+                <ConfigSelectField
+                  label="Launcher and Bookmarks"
+                  description="Where the Workspace Apps launcher and the bookmarks button sit. Follow Sidebar moves them to the bottom of the sidebar while it is shown, Titlebar keeps them in the titlebar at all times."
+                  configKey="verticalTabs.launcherAndBookmarksHost"
+                  placeholder="Select host"
+                  licenseKeyRequired
+                  items={Object.entries(verticalTabsLauncherAndBookmarksHosts).map(
+                    ([value, label]) => ({
+                      value,
+                      label,
+                    }),
+                  )}
                 />
                 <ConfigSwitchField
                   label="Hide Gmail Unread Badge When Active"

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -19,6 +19,14 @@ export type VerticalTabsWidth = keyof typeof verticalTabsWidths;
  */
 export type VerticalTabsSessionWidth = Exclude<VerticalTabsWidth, "auto">;
 
+export const verticalTabsLauncherAndBookmarksHosts = {
+  auto: "Follow Sidebar",
+  titlebar: "Titlebar",
+} as const;
+
+export type VerticalTabsLauncherAndBookmarksHost =
+  keyof typeof verticalTabsLauncherAndBookmarksHosts;
+
 export type TabState = {
   id: string;
   app: SupportedWorkspaceApp | undefined;

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -11,7 +11,12 @@ import type {
   GmailLabelColors,
   GmailSavedSearches,
 } from "./schemas";
-import type { AccountTabsState, VerticalTabsSessionWidth, VerticalTabsWidth } from "./tabs";
+import type {
+  AccountTabsState,
+  VerticalTabsLauncherAndBookmarksHost,
+  VerticalTabsSessionWidth,
+  VerticalTabsWidth,
+} from "./tabs";
 import type {
   LauncherWorkspaceApp,
   SupportedWorkspaceApp,
@@ -159,6 +164,7 @@ export type Config = {
   "verticalTabs.showWidthToggle": boolean;
   "verticalTabs.hideUnreadBadgeWhenActive": boolean;
   "verticalTabs.showAppLinksBadge": boolean;
+  "verticalTabs.launcherAndBookmarksHost": VerticalTabsLauncherAndBookmarksHost;
 };
 
 export type IpcMainEvents =


### PR DESCRIPTION
- Adds `verticalTabs.launcherAndBookmarksHost` (`"auto" | "titlebar"`, default `"auto"`), with the label map `verticalTabsLauncherAndBookmarksHosts` next to `verticalTabsWidths` in `packages/shared/tabs.ts`.
- `"auto"` keeps today's behavior: the sidebar hosts the Workspace Apps launcher and the bookmarks button whenever it is visible, with the existing handover fade in the titlebar.
- `"titlebar"` keeps both in the titlebar at all times, and the sidebar stops rendering its launcher and bookmarks entries at the foot.
- New "Launcher and Bookmarks" `ConfigSelectField` in the Vertical Tabs fieldset of Workspace Apps settings, `licenseKeyRequired` like its siblings, `Follow Sidebar` listed first.
- No migration — new key with a default.

Not verified in the running app; I could not launch Electron here. `bun run types`, `bun run lint`, `bun run fmt:check` and `bun test` pass.

Test plan

1. With more than one tab open so the sidebar is visible, set Launcher and Bookmarks to Titlebar in Settings → Workspace Apps → Vertical Tabs. The launcher and bookmarks button should leave the foot of the sidebar and fade in at the right of the titlebar, with the width toggle still at the foot.
2. Switch back to Follow Sidebar. Both should return to the sidebar and disappear from the titlebar with the existing fade.
3. On Follow Sidebar, close tabs until the sidebar hides. Both should hand back to the titlebar as before.
4. On Titlebar, open the bookmarks popup from the titlebar button. It should hang at the end of the titlebar (the sidebar placement is no longer reachable).
