### PR TITLE
group the launcher and bookmarks into one fade per host

### DIFF
--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -41,10 +41,9 @@ import {
   useTrialStore,
 } from "../lib/stores";
 
-function BookmarksButton({ className }: { className?: string }) {
+function BookmarksButton() {
   return (
     <TitlebarIconButton
-      className={className}
       onClick={() => {
         ipc.main.send("bookmarks.togglePopup", "titlebar");
       }}
@@ -382,26 +381,21 @@ export function AppTitlebar() {
           <div className="flex items-center gap-2">
             <Trial />
             <FindInPage />
-            {shouldShowWorkspaceAppsLauncher && (
-              <TitlebarButtonGroup
-                className={cn(
-                  HOST_HANDOVER_FADE_CLASS_NAME,
-                  areLauncherAndBookmarksHostedByVerticalTabs && "hidden opacity-0",
-                )}
-              >
+            <TitlebarButtonGroup
+              className={cn(
+                HOST_HANDOVER_FADE_CLASS_NAME,
+                areLauncherAndBookmarksHostedByVerticalTabs && "hidden opacity-0",
+              )}
+            >
+              {shouldShowWorkspaceAppsLauncher && (
                 <WorkspaceAppsLauncher
                   launcherApps={config["workspaceApps.launcherApps"]}
                   display={config["workspaceApps.launcherDisplay"]}
                   disabled={isUnifiedInboxLocation}
                 />
-              </TitlebarButtonGroup>
-            )}
-            <BookmarksButton
-              className={cn(
-                HOST_HANDOVER_FADE_CLASS_NAME,
-                areLauncherAndBookmarksHostedByVerticalTabs && "hidden opacity-0",
               )}
-            />
+              <BookmarksButton />
+            </TitlebarButtonGroup>
             {shouldShowSavedSearchesButton && (
               <TitlebarDropdownMenu
                 title="Saved Searches"

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -433,8 +433,7 @@ export function VerticalTabs() {
   const hostsLauncherAndBookmarks =
     (config?.["verticalTabs.launcherAndBookmarksHost"] ?? "auto") === "auto";
 
-  const shouldShowWorkspaceAppsLauncher =
-    hostsLauncherAndBookmarks && isLicenseKeyValid && launcherApps.length > 0;
+  const shouldShowWorkspaceAppsLauncher = isLicenseKeyValid && launcherApps.length > 0;
 
   const showsWidthToggle = config?.["verticalTabs.showWidthToggle"] ?? true;
 
@@ -581,12 +580,26 @@ export function VerticalTabs() {
           </DragDropProvider>
         )}
       </div>
-      {shouldShowWorkspaceAppsLauncher && (
-        <div className={cn(HOST_HANDOVER_FADE_CLASS_NAME, isWide && "w-full")}>
-          <VerticalTabsWorkspaceAppsLauncher launcherApps={launcherApps} isWide={isWide} />
+      {/*
+       * One group, so the handover to and from the titlebar fades the two
+       * controls together rather than each on its own. It sets out again the
+       * spacing and alignment they took from the strip, which they no longer
+       * sit directly in.
+       */}
+      {hostsLauncherAndBookmarks && (
+        <div
+          className={cn(
+            HOST_HANDOVER_FADE_CLASS_NAME,
+            "flex flex-col",
+            isWide ? "w-full gap-1" : "items-center gap-2",
+          )}
+        >
+          {shouldShowWorkspaceAppsLauncher && (
+            <VerticalTabsWorkspaceAppsLauncher launcherApps={launcherApps} isWide={isWide} />
+          )}
+          <VerticalTabsBookmarks isWide={isWide} />
         </div>
       )}
-      {hostsLauncherAndBookmarks && <VerticalTabsBookmarks isWide={isWide} />}
       {showsWidthToggle && (
         <VerticalTabsWidthToggle accountId={selectedAccount.config.id} isWide={isWide} />
       )}


### PR DESCRIPTION
- Titlebar: the launcher and the bookmarks button now sit in one `TitlebarButtonGroup` that carries the host-handover fade, instead of each carrying its own copy; `BookmarksButton` loses its now-unused `className` prop.
- Vertical tabs strip: one wrapper div gated on the host setting holds both controls and carries the fade — the strip's bookmarks button previously had no fade at all and popped in on handover. The wrapper reproduces the spacing/alignment the controls took from the strip root (wide: `w-full gap-1`, narrow: `items-center gap-2`).
- Grouping tightens the titlebar launcher↔bookmarks gap from `gap-2` to `gap-1`, matching the other titlebar groups.

Not verified visually in a running app — only types/lint/fmt/tests.

Test plan:
1. With vertical tabs visible and host on `auto`, open a second tab to trigger a handover: launcher and bookmarks should fade in together in the strip (bookmarks no longer pops in), and fade out together in the titlebar.
2. Close down to one tab: the pair fades back into the titlebar together, sitting as one group.
3. Toggle the strip between narrow and wide: the pair stays centred (narrow) / full-width left-aligned (wide) with unchanged spacing to the width toggle below.