### PR TITLE
skip the passkey sign-in intercept on windows

### DIFF
--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { platform } from "@electron-toolkit/utils";
 import { APP_TITLEBAR_HEIGHT, GOOGLE_ACCOUNTS_URL } from "@meru/shared/constants";
 import { getWorkspaceAppFromUrl, getWorkspaceAppUrl } from "@meru/shared/google";
 import type { AccountConfig } from "@meru/shared/schemas";
@@ -149,10 +150,16 @@ export class WorkspaceApp {
       return;
     }
 
+    // Windows handles Google's platform passkeys natively via webauthn.dll.
+    if (platform.isWindows) {
+      return;
+    }
+
     dialog.showMessageBox({
       type: "info",
-      message: "Passkey sign-in not supported yet",
-      detail: "Please use password to sign in.",
+      message: "Passkey sign-in isn't supported on this platform yet",
+      detail:
+        "Sign in with your password or another available second factor. If the account has no password, add one at myaccount.google.com in a browser first, then sign in here.",
     });
   }
 


### PR DESCRIPTION
- `WorkspaceApp.handleNavigate` now returns early on Windows, so Google's passkey challenge proceeds natively (Electron 43 goes through `webauthn.dll`) instead of being intercepted.
- macOS and Linux still show the dialog, with copy that no longer dead-ends passkey-only accounts: it points at another factor, or adding a password at myaccount.google.com in a browser first.

Not verified: the Windows native passkey flow against a live passkey-only Google account (no Windows machine available); the macOS/Linux dialog was checked by code review only.

Test plan
1. On Windows, sign into a Google account that has a passkey — expect the Windows Hello / passkey prompt, not Meru's dialog.
2. On macOS or Linux, hit the same sign-in flow — expect the updated dialog ("Passkey sign-in isn't supported on this platform yet") and a working password sign-in afterwards.
