### PR TITLE
enable macos touch id passkey enrollment in gmail views

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -12,5 +12,9 @@
     <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
+    <key>keychain-access-groups</key>
+    <array>
+      <string>$(AppIdentifierPrefix)sh.zoid.meru.webauthn</string>
+    </array>
   </dict>
 </plist>

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -59,6 +59,16 @@ async function init() {
     app.setAppUserModelId(APP_ID);
   }
 
+  // The team id is only known to signed builds, and without it the keychain
+  // access group can't match the `keychain-access-groups` entitlement
+  if (platform.isMacOS && process.env.APPLE_TEAM_ID) {
+    app.configureWebAuthn({
+      touchID: {
+        keychainAccessGroup: `${process.env.APPLE_TEAM_ID}.${APP_ID}.webauthn`,
+      },
+    });
+  }
+
   setMeruProtocolClient();
 
   if (!app.requestSingleInstanceLock()) {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -41,6 +41,11 @@ function buildAppFiles() {
                   "process.env.MERU_API_URL": JSON.stringify(process.env.MERU_API_URL),
                 }
               : {}),
+            ...(process.env.APPLE_TEAM_ID
+              ? {
+                  "process.env.APPLE_TEAM_ID": JSON.stringify(process.env.APPLE_TEAM_ID),
+                }
+              : {}),
           }
         : undefined,
     },


### PR DESCRIPTION
- Calls `app.configureWebAuthn({ touchID: { keychainAccessGroup } })` early in `init()` (before `app.whenReady`, so it lands before any view exists), gated on macOS — until it's called, `isUserVerifyingPlatformAuthenticatorAvailable()` stays `false` and Google won't offer in-app passkey creation.
- Access group is `<APPLE_TEAM_ID>.sh.zoid.meru.webauthn`. Electron exposes no runtime API for the team id, so it's inlined at build time from `APPLE_TEAM_ID` (already set for the mac build steps in `build.yml`/`release.yml`), reusing the existing `MERU_API_URL` define in `scripts/build.ts`. Unsigned/dev builds have no team id and simply skip the call.
- Adds the matching `keychain-access-groups` entitlement with `$(AppIdentifierPrefix)sh.zoid.meru.webauthn`, expanded by `codesign` at signing time.

Not verified: exercising Touch ID enrollment needs a signed macOS build, which this Linux sandbox can't produce. Note this only enables creating and using *new* platform passkeys in the Secure Enclave — existing iCloud Keychain or phone passkeys are unaffected.

Test plan

1. Produce a signed macOS build with `APPLE_TEAM_ID` set, launch it, and in a Gmail view run `PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()` — expect `true` (it is `false` on main).
2. In that build, open Google account security settings → Passkeys → create a passkey — expect the native Touch ID prompt and a passkey listed afterwards.
3. Sign out and back in choosing that passkey — expect the Touch ID prompt again and a successful sign-in.