### PR TITLE
clear Gmail's interval and store subscriptions on destroy

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -296,6 +296,10 @@ export class Gmail {
 
   private previousNewMessages: Map<string, number> = new Map();
 
+  private previousNewMessagesPruneInterval: NodeJS.Timeout;
+
+  private storeUnsubscribers: (() => void)[] = [];
+
   constructor({
     accountId,
     session,
@@ -373,7 +377,7 @@ export class Gmail {
 
     this.subscribeToStore();
 
-    setInterval(() => {
+    this.previousNewMessagesPruneInterval = setInterval(() => {
       for (const [messageId, timestamp] of this.previousNewMessages) {
         if (Date.now() - timestamp > ms("5m")) {
           this.previousNewMessages.delete(messageId);
@@ -555,6 +559,16 @@ export class Gmail {
     this.view.removeAllListeners();
 
     main.window.contentView.removeChildView(this.view);
+
+    clearInterval(this.previousNewMessagesPruneInterval);
+
+    for (const unsubscribe of this.storeUnsubscribers) {
+      unsubscribe();
+    }
+
+    this.storeUnsubscribers = [];
+
+    this._view = undefined;
   }
 
   private setDelegatedAccountId(delegatedAccountId: string | null) {
@@ -887,54 +901,60 @@ export class Gmail {
   }
 
   subscribeToStore() {
-    this.store.subscribe(
-      (state) => state.attentionRequired,
-      () => {
-        accounts.sendAccountsChangedToRenderer();
+    this.storeUnsubscribers.push(
+      this.store.subscribe(
+        (state) => state.attentionRequired,
+        () => {
+          accounts.sendAccountsChangedToRenderer();
 
-        accounts.sendTabsChangedToRenderer();
-      },
+          accounts.sendTabsChangedToRenderer();
+        },
+      ),
     );
 
     if (this.getIsUnreadCountEnabled()) {
       const dockUnreadBadge = config.get("dock.unreadBadge");
 
-      this.store.subscribe(
-        (state) => state.unreadCount,
-        () => {
-          const totalUnreadCount = accounts.getTotalUnreadCount();
+      this.storeUnsubscribers.push(
+        this.store.subscribe(
+          (state) => state.unreadCount,
+          () => {
+            const totalUnreadCount = accounts.getTotalUnreadCount();
 
-          if (dockUnreadBadge) {
-            if (platform.isMacOS && app.dock) {
-              app.dock.setBadge(totalUnreadCount ? totalUnreadCount.toString() : "");
-            } else if (platform.isLinux) {
-              app.badgeCount = totalUnreadCount;
-            } else if (platform.isWindows) {
-              if (totalUnreadCount) {
-                ipc.renderer.send(
-                  main.window.webContents,
-                  "taskbar.setOverlayIcon",
-                  totalUnreadCount,
-                );
-              } else {
-                main.window.setOverlayIcon(null, "");
+            if (dockUnreadBadge) {
+              if (platform.isMacOS && app.dock) {
+                app.dock.setBadge(totalUnreadCount ? totalUnreadCount.toString() : "");
+              } else if (platform.isLinux) {
+                app.badgeCount = totalUnreadCount;
+              } else if (platform.isWindows) {
+                if (totalUnreadCount) {
+                  ipc.renderer.send(
+                    main.window.webContents,
+                    "taskbar.setOverlayIcon",
+                    totalUnreadCount,
+                  );
+                } else {
+                  main.window.setOverlayIcon(null, "");
+                }
               }
             }
-          }
 
-          appTray.updateUnreadStatus(totalUnreadCount);
+            appTray.updateUnreadStatus(totalUnreadCount);
 
-          accounts.sendAccountsChangedToRenderer();
-        },
+            accounts.sendAccountsChangedToRenderer();
+          },
+        ),
       );
     }
 
     if (licenseKey.isValid && config.get("unifiedInbox.enabled") && this.unifiedInboxEnabled) {
-      this.store.subscribe(
-        (state) => state.unreadInbox,
-        () => {
-          accounts.sendAccountsChangedToRenderer();
-        },
+      this.storeUnsubscribers.push(
+        this.store.subscribe(
+          (state) => state.unreadInbox,
+          () => {
+            accounts.sendAccountsChangedToRenderer();
+          },
+        ),
       );
     }
   }


### PR DESCRIPTION
- `Gmail`'s 5-minute `previousNewMessages` prune interval is now stored on the instance and cleared in `destroy()` — its closure captured `this`, so the timer kept the whole `Gmail` graph (store, view wrapper, session, preload arguments) alive after account removal.
- `subscribeToStore()` collects the unsubscribe functions from its up-to-three `store.subscribe` calls; `destroy()` calls them all and empties the array.
- `destroy()` ends by setting `_view = undefined`, so the `WebContentsView` wrapper can be collected and any use-after-destroy hits the existing throwing `view` getter instead of a stale view.

Heap verification is not done: no snapshot run of N add/remove cycles asserting zero retained `Gmail` instances. The full "Account is freed" check only passes once #813 lands too — the session's display-media handler is a second root into the same graph.

Test plan:
1. Add a second account, then remove it from settings — removal completes with no main-process error and the remaining account's view still renders.
2. With two accounts, remove one and let the app sit — unread badge/tray updates from the surviving account still fire (the store subscriptions of the live account were not torn down).
3. Remove an account and reopen settings — re-adding an account works and its Gmail view loads.
