### PR TITLE
detach session handlers when an account is removed

### DIFF
--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -60,6 +60,16 @@ export class Account {
     this.tabs.restoreSavedTabs(accountConfig.workspaceApps.savedTabs);
   }
 
+  destroy() {
+    this.session.setPermissionRequestHandler(null);
+
+    this.session.setPermissionCheckHandler(null);
+
+    this.session.setDisplayMediaRequestHandler(null);
+
+    blocker.teardownSession(this.session);
+  }
+
   setSpellCheckerLanguages() {
     if (platform.isMacOS || !licenseKey.isValid) {
       return;

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -336,6 +336,8 @@ class Accounts {
 
     account.instance.gmail.destroy();
 
+    account.instance.destroy();
+
     await account.instance.session.clearData();
 
     this.instances.delete(selectedAccountId);

--- a/packages/app/blocker/index.ts
+++ b/packages/app/blocker/index.ts
@@ -34,6 +34,10 @@ export class Blocker {
       session.webRequest.onBeforeRequest({ urls: ["<all_urls>"] }, this.onBeforeRequest);
     }
   }
+
+  teardownSession(session: Electron.Session) {
+    session.webRequest.onBeforeRequest(null);
+  }
 }
 
 export const blocker = new Blocker();


### PR DESCRIPTION
- Adds `Account.destroy()`, symmetric with what the constructor registers: nulls `setPermissionRequestHandler`, `setPermissionCheckHandler` and `setDisplayMediaRequestHandler` on the account's session, and tears down the blocker hook.
- Adds `Blocker.teardownSession(session)` calling `session.webRequest.onBeforeRequest(null)` — `onBeforeRequest` is private on `Blocker`, so `setupSession` needed a counterpart. Safe to call when `setupSession` registered nothing.
- `Accounts.removeAccount` calls `account.instance.destroy()` after `gmail.destroy()` and before the awaited `session.clearData()`, so a late permission/display-media callback can't fire against half-torn-down state.

Electron caches partition sessions for the process lifetime, so the `Session` object itself still can't be freed — this only cuts what its handler slots retained (the display-media handler captured `this`, and through it `Gmail` and `Tabs`). Heap verification is not done: no snapshot run of N add/remove cycles asserting zero retained `Account` instances, and that check only passes with #812 also landed.

Test plan:
1. With two accounts, remove one, then use Google Meet screen sharing on the surviving account — the source picker still opens (only the removed account's handler was nulled).
2. Remove an account and re-add the same address — permission prompts (notifications, media) and ad blocking behave as before on the fresh account.
