### PR TITLE
close popup workspace apps when an account is removed

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -334,6 +334,8 @@ class Accounts {
 
     account.instance.tabs.closeAll();
 
+    WorkspaceApp.closeAccountInstances(selectedAccountId);
+
     account.instance.gmail.destroy();
 
     account.instance.destroy();

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -144,6 +144,14 @@ export class WorkspaceApp {
     );
   }
 
+  static closeAccountInstances(accountId: AccountConfig["id"]) {
+    for (const instance of Array.from(WorkspaceApp.instances.values())) {
+      if (instance.accountId === accountId) {
+        instance.close();
+      }
+    }
+  }
+
   static handleNavigate(url: string) {
     if (!url.startsWith(`${GOOGLE_ACCOUNTS_URL}/v3/signin/challenge/pk/presend`)) {
       return;


### PR DESCRIPTION
- Adds `WorkspaceApp.closeAccountInstances(accountId)`, closing every instance in the static `instances` map that belongs to the account. It iterates a copied array because `close()` mutates the map via `teardown()`; double-closing tabs already handled by `Tabs.closeAll` is safe via `isClosing`.
- `Accounts.removeAccount` calls it alongside `tabs.closeAll()`, before `this.instances.delete(...)` and the `config.set("accounts", ...)` — `close()` ends in `this.account.instance.tabs.removeTab(this.id)`, which must still resolve.

Popup `WorkspaceApp`s (compose pop-outs, PDF viewers) live only in the static map and were never in any `Tabs` array, so they survived account removal with a window plus view each — and closing one by hand afterwards threw uncaught in the main process, because `handleClose` dereferences `this.account` before `teardown()`. Not verified with a heap snapshot or an `app.getAppMetrics()` process count across N add/remove cycles.

Test plan:
1. On account B, open a compose pop-out, then remove account B from settings — the pop-out window closes and no uncaught main-process error appears.
2. Same with a PDF attachment opened in its own window on account B — that window closes too.
3. Remove account B while it has both a windowed tab and a popup open — the windowed tab closes once (no double-close error) and the remaining account's tab strip is intact.
