### PR TITLE
sign macos builds on prs from contributors and members

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ jobs:
       - if: startsWith(matrix.os, 'macos')
         run: bun run build:mac -- --publish never
         env:
+          # electron-builder skips signing on PR builds unless this is true; forks never receive the secrets.
+          CSC_FOR_PULL_REQUEST: ${{ github.event_name != 'pull_request' || contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association) }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,9 @@ jobs:
       - if: startsWith(matrix.os, 'macos')
         run: bun run build:mac -- --publish never
         env:
-          # electron-builder skips signing on PR builds unless this is true; forks never receive the secrets.
-          CSC_FOR_PULL_REQUEST: ${{ github.event_name != 'pull_request' || contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.pull_request.author_association) }}
+          # electron-builder skips signing on PR builds unless this is true; fork PRs never
+          # receive the secrets, so they still fall back to an unsigned build.
+          CSC_FOR_PULL_REQUEST: "true"
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}


### PR DESCRIPTION
- Sets `CSC_FOR_PULL_REQUEST: true` on the macOS build step: electron-builder skips signing whenever it detects a PR build, even though the secrets are already in the step's env — this is why only main builds came out signed.
- No author gate needed: fork PRs never receive the secrets, so they fall back to an unsigned build on their own.

Signing also triggers notarization, so PR macOS builds will take a few minutes longer. Not verified beyond this PR's own build.

Test plan:
1. This PR's macos build log should show signing/notarization steps instead of "Current build is a part of pull request, code signing will be skipped".
2. Download the macos artifact and confirm the app is signed (`codesign -dv Meru.app`).