### PR TITLE
upload one uncompressed artifact per installer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,72 @@ jobs:
         run: bun run build:linux -- --publish never
       - if: startsWith(matrix.os, 'windows')
         run: bun run build:win -- --publish never
-      - uses: actions/upload-artifact@v7
+      # One artifact per installer, uncompressed: installers are already compressed, and a
+      # bundled artifact forces downloading every file to test one. Auto-update zips and
+      # blockmaps are omitted — only the release publish flow needs them.
+      - if: startsWith(matrix.os, 'macos')
+        uses: actions/upload-artifact@v7
         with:
-          name: ${{ github.event.repository.name }}-${{ matrix.os }}
+          name: Meru-mac-x64.dmg
+          compression-level: 0
           path: |
-            dist/*.*
-            !dist/*.yml
+            dist/*.dmg
+            !dist/*-arm64.dmg
+      - if: startsWith(matrix.os, 'macos')
+        uses: actions/upload-artifact@v7
+        with:
+          name: Meru-mac-arm64.dmg
+          compression-level: 0
+          path: dist/*-arm64.dmg
+      - if: startsWith(matrix.os, 'windows')
+        uses: actions/upload-artifact@v7
+        with:
+          name: Meru-win-setup.exe
+          compression-level: 0
+          path: dist/Meru-Setup-*.exe
+      - if: startsWith(matrix.os, 'windows')
+        uses: actions/upload-artifact@v7
+        with:
+          name: Meru-win-portable.exe
+          compression-level: 0
+          path: |
+            dist/*.exe
+            !dist/Meru-Setup-*.exe
+      - if: startsWith(matrix.os, 'ubuntu')
+        uses: actions/upload-artifact@v7
+        with:
+          name: Meru-linux-x64.AppImage
+          compression-level: 0
+          path: |
+            dist/*.AppImage
+            !dist/*-arm64.AppImage
+      - if: startsWith(matrix.os, 'ubuntu')
+        uses: actions/upload-artifact@v7
+        with:
+          name: Meru-linux-arm64.AppImage
+          compression-level: 0
+          path: dist/*-arm64.AppImage
+      - if: startsWith(matrix.os, 'ubuntu')
+        uses: actions/upload-artifact@v7
+        with:
+          name: Meru-linux-amd64.deb
+          compression-level: 0
+          path: dist/*_amd64.deb
+      - if: startsWith(matrix.os, 'ubuntu')
+        uses: actions/upload-artifact@v7
+        with:
+          name: Meru-linux-arm64.deb
+          compression-level: 0
+          path: dist/*_arm64.deb
+      - if: startsWith(matrix.os, 'ubuntu')
+        uses: actions/upload-artifact@v7
+        with:
+          name: Meru-linux-x86_64.rpm
+          compression-level: 0
+          path: dist/*.x86_64.rpm
+      - if: startsWith(matrix.os, 'ubuntu')
+        uses: actions/upload-artifact@v7
+        with:
+          name: Meru-linux-aarch64.rpm
+          compression-level: 0
+          path: dist/*.aarch64.rpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: Meru-mac-x64.dmg
+          if-no-files-found: error
           compression-level: 0
           path: |
             dist/*.dmg
@@ -51,26 +52,31 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: Meru-mac-arm64.dmg
+          if-no-files-found: error
           compression-level: 0
           path: dist/*-arm64.dmg
       - if: startsWith(matrix.os, 'windows')
         uses: actions/upload-artifact@v7
         with:
           name: Meru-win-setup.exe
+          if-no-files-found: error
           compression-level: 0
-          path: dist/Meru-Setup-*.exe
+          # The NSIS installer has spaces in its filename; the dashed name only exists on release assets.
+          path: dist/* Setup *.exe
       - if: startsWith(matrix.os, 'windows')
         uses: actions/upload-artifact@v7
         with:
           name: Meru-win-portable.exe
+          if-no-files-found: error
           compression-level: 0
           path: |
             dist/*.exe
-            !dist/Meru-Setup-*.exe
+            !dist/* Setup *.exe
       - if: startsWith(matrix.os, 'ubuntu')
         uses: actions/upload-artifact@v7
         with:
           name: Meru-linux-x64.AppImage
+          if-no-files-found: error
           compression-level: 0
           path: |
             dist/*.AppImage
@@ -79,29 +85,34 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: Meru-linux-arm64.AppImage
+          if-no-files-found: error
           compression-level: 0
           path: dist/*-arm64.AppImage
       - if: startsWith(matrix.os, 'ubuntu')
         uses: actions/upload-artifact@v7
         with:
           name: Meru-linux-amd64.deb
+          if-no-files-found: error
           compression-level: 0
           path: dist/*_amd64.deb
       - if: startsWith(matrix.os, 'ubuntu')
         uses: actions/upload-artifact@v7
         with:
           name: Meru-linux-arm64.deb
+          if-no-files-found: error
           compression-level: 0
           path: dist/*_arm64.deb
       - if: startsWith(matrix.os, 'ubuntu')
         uses: actions/upload-artifact@v7
         with:
           name: Meru-linux-x86_64.rpm
+          if-no-files-found: error
           compression-level: 0
           path: dist/*.x86_64.rpm
       - if: startsWith(matrix.os, 'ubuntu')
         uses: actions/upload-artifact@v7
         with:
           name: Meru-linux-aarch64.rpm
+          if-no-files-found: error
           compression-level: 0
           path: dist/*.aarch64.rpm


### PR DESCRIPTION
- Replaces the single per-OS artifact (which bundled every dist file) with one artifact per installer, named after the file (e.g. `Meru-mac-arm64.dmg`), so testing a build means downloading only that file.
- `compression-level: 0` — the installers are already compressed, so zipping them again only wasted CI time.
- Auto-update zips and blockmaps are no longer uploaded; only the release publish flow needs them.
- `if-no-files-found: error` on every upload, so a filename drift breaks the build instead of silently dropping an artifact (the first run of this PR caught exactly that: the NSIS installer's dist filename has spaces, unlike its release asset name).

GitHub still wraps each artifact download in a zip — that's unavoidable — but it's now a thin container around a single file.

Test plan:
1. This PR's build run should list 10 artifacts (2 mac, 2 win, 6 linux), each roughly the size of its installer.
2. Download one (e.g. `Meru-linux-amd64.deb`) and confirm the zip contains exactly that file.