### PR TITLE
correct the passkey dialog for touch id builds and let it be dismissed

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -91,7 +91,6 @@ export const config = new Store<Config>({
     "gmail.extendDarkTheme": false,
     "gmail.inboxCategoriesToMonitor": "primary",
     "screenShare.useSystemPicker": true,
-    "passkeys.hideSignInDialog": false,
     "window.lastState": {
       bounds: DEFAULT_WINDOW_STATE_BOUNDS,
       fullscreen: false,
@@ -108,6 +107,7 @@ export const config = new Store<Config>({
     "workspaceApps.showAccountLabel": true,
     "workspaceApps.persistZoom": true,
     "workspaceApps.zoomFactors": {},
+    "workspaceApps.hidePasskeyDialog": false,
     "verificationCodes.autoCopy": false,
     "verificationCodes.autoDelete": false,
     "verificationCodes.autoMarkAsRead": false,

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -91,7 +91,7 @@ export const config = new Store<Config>({
     "gmail.extendDarkTheme": false,
     "gmail.inboxCategoriesToMonitor": "primary",
     "screenShare.useSystemPicker": true,
-    "signIn.hidePasskeyDialog": false,
+    "passkeys.hideSignInDialog": false,
     "window.lastState": {
       bounds: DEFAULT_WINDOW_STATE_BOUNDS,
       fullscreen: false,

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -91,6 +91,7 @@ export const config = new Store<Config>({
     "gmail.extendDarkTheme": false,
     "gmail.inboxCategoriesToMonitor": "primary",
     "screenShare.useSystemPicker": true,
+    "signIn.hidePasskeyDialog": false,
     "window.lastState": {
       bounds: DEFAULT_WINDOW_STATE_BOUNDS,
       fullscreen: false,

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -153,7 +153,7 @@ export class WorkspaceApp {
     }
   }
 
-  static handleNavigate(url: string) {
+  static async handleNavigate(url: string) {
     if (!url.startsWith(`${GOOGLE_ACCOUNTS_URL}/v3/signin/challenge/pk/presend`)) {
       return;
     }
@@ -163,12 +163,28 @@ export class WorkspaceApp {
       return;
     }
 
-    dialog.showMessageBox({
+    if (config.get("signIn.hidePasskeyDialog")) {
+      return;
+    }
+
+    // The team id is only inlined into signed builds, which are the only ones
+    // where Touch ID passkeys are configured (see `init` in index.ts).
+    const touchIdAvailable = platform.isMacOS && Boolean(process.env.APPLE_TEAM_ID);
+
+    const { checkboxChecked } = await dialog.showMessageBox({
       type: "info",
-      message: "Passkey sign-in isn't supported on this platform yet",
-      detail:
-        "Sign in with your password or another available second factor. If the account has no password, add one at myaccount.google.com in a browser first, then sign in here.",
+      message: touchIdAvailable
+        ? "Only passkeys created in Meru work here"
+        : "Passkey sign-in isn't supported on this platform yet",
+      detail: touchIdAvailable
+        ? "Continue with Touch ID if you've created a passkey in Meru. Passkeys from Chrome, iCloud or your phone can't be used here — sign in with your password or another second factor, then create a passkey for Meru in your Google account's security settings."
+        : "Sign in with your password or another available second factor. If the account has no password, add one at myaccount.google.com in a browser first, then sign in here.",
+      checkboxLabel: "Don't show again",
     });
+
+    if (checkboxChecked) {
+      config.set("signIn.hidePasskeyDialog", true);
+    }
   }
 
   static handleRedirect(event: Electron.Event, url: string, webContents: WebContents) {

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -163,7 +163,7 @@ export class WorkspaceApp {
       return;
     }
 
-    if (config.get("signIn.hidePasskeyDialog")) {
+    if (config.get("passkeys.hideSignInDialog")) {
       return;
     }
 
@@ -183,7 +183,7 @@ export class WorkspaceApp {
     });
 
     if (checkboxChecked) {
-      config.set("signIn.hidePasskeyDialog", true);
+      config.set("passkeys.hideSignInDialog", true);
     }
   }
 

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -163,7 +163,7 @@ export class WorkspaceApp {
       return;
     }
 
-    if (config.get("passkeys.hideSignInDialog")) {
+    if (config.get("workspaceApps.hidePasskeyDialog")) {
       return;
     }
 
@@ -183,7 +183,7 @@ export class WorkspaceApp {
     });
 
     if (checkboxChecked) {
-      config.set("passkeys.hideSignInDialog", true);
+      config.set("workspaceApps.hidePasskeyDialog", true);
     }
   }
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -127,7 +127,6 @@ export type Config = {
   "gmail.extendDarkTheme": boolean;
   "gmail.inboxCategoriesToMonitor": "primary" | "all";
   "screenShare.useSystemPicker": boolean;
-  "passkeys.hideSignInDialog": boolean;
   "window.lastState": {
     bounds: {
       width: number;
@@ -149,6 +148,7 @@ export type Config = {
   "workspaceApps.showAccountLabel": boolean;
   "workspaceApps.persistZoom": boolean;
   "workspaceApps.zoomFactors": Partial<Record<SupportedWorkspaceApp, number>>;
+  "workspaceApps.hidePasskeyDialog": boolean;
   "verificationCodes.autoCopy": boolean;
   "verificationCodes.autoDelete": boolean;
   "verificationCodes.autoMarkAsRead": boolean;

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -127,6 +127,7 @@ export type Config = {
   "gmail.extendDarkTheme": boolean;
   "gmail.inboxCategoriesToMonitor": "primary" | "all";
   "screenShare.useSystemPicker": boolean;
+  "signIn.hidePasskeyDialog": boolean;
   "window.lastState": {
     bounds: {
       width: number;

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -127,7 +127,7 @@ export type Config = {
   "gmail.extendDarkTheme": boolean;
   "gmail.inboxCategoriesToMonitor": "primary" | "all";
   "screenShare.useSystemPicker": boolean;
-  "signIn.hidePasskeyDialog": boolean;
+  "passkeys.hideSignInDialog": boolean;
   "window.lastState": {
     bounds: {
       width: number;


### PR DESCRIPTION
- On macOS signed builds (where Touch ID passkeys are configured), the sign-in dialog no longer claims passkeys are unsupported — it now says only Meru-created passkeys work and how to get one; Linux and unsigned macOS builds keep the existing copy.
- Adds a "Don't show again" checkbox, persisted as `workspaceApps.hidePasskeyDialog` (no settings UI — it's a dialog dismissal, not a preference to browse).
- Touch ID availability is detected the same way `init` gates `configureWebAuthn`: the build-time-inlined `APPLE_TEAM_ID`.

Dialog copy verified only by reading; no macOS signed build was run.

Test plan:
1. On a signed macOS build, hit the passkey challenge: expect the "Only passkeys created in Meru work here" dialog over the (working) Touch ID prompt.
2. Check "Don't show again", sign in again: expect no dialog.
3. On Linux, expect the old "not supported" copy with the same checkbox.