### PR TITLE
add a sidebar option that keeps the launcher and bookmarks in an always visible sidebar

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -65,13 +65,13 @@ class Accounts {
       accounts.updateAllViewBounds();
     });
 
-    // `sidebar` holds the strip open where the other hosts let it go, so
-    // switching between them moves every view sideways.
-    config.onDidChange("verticalTabs.launcherAndBookmarksHost", () => {
+    config.onDidChange("workspaceApps.mode", () => {
       accounts.updateAllViewBounds();
     });
 
-    config.onDidChange("workspaceApps.mode", () => {
+    // `sidebar` holds the strip open where the other hosts let it go, so
+    // switching between them moves every view sideways.
+    config.onDidChange("workspaceApps.launcherAndBookmarksHost", () => {
       accounts.updateAllViewBounds();
     });
 
@@ -140,7 +140,7 @@ class Accounts {
       {
         configuredWidth: config.get("verticalTabs.width"),
         sessionWidth: selectedAccount.instance.verticalTabsWidth,
-        launcherAndBookmarksHost: config.get("verticalTabs.launcherAndBookmarksHost"),
+        launcherAndBookmarksHost: config.get("workspaceApps.launcherAndBookmarksHost"),
       },
     );
   }

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -69,9 +69,9 @@ class Accounts {
       accounts.updateAllViewBounds();
     });
 
-    // `sidebar` holds the strip open where the other hosts let it go, so
+    // `sidebar` holds the strip open where the other placements let it go, so
     // switching between them moves every view sideways.
-    config.onDidChange("workspaceApps.launcherAndBookmarksHost", () => {
+    config.onDidChange("workspaceApps.launcherAndBookmarksPlacement", () => {
       accounts.updateAllViewBounds();
     });
 
@@ -140,7 +140,7 @@ class Accounts {
       {
         configuredWidth: config.get("verticalTabs.width"),
         sessionWidth: selectedAccount.instance.verticalTabsWidth,
-        launcherAndBookmarksHost: config.get("workspaceApps.launcherAndBookmarksHost"),
+        launcherAndBookmarksPlacement: config.get("workspaceApps.launcherAndBookmarksPlacement"),
       },
     );
   }

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -65,6 +65,12 @@ class Accounts {
       accounts.updateAllViewBounds();
     });
 
+    // `sidebar` holds the strip open where the other hosts let it go, so
+    // switching between them moves every view sideways.
+    config.onDidChange("verticalTabs.launcherAndBookmarksHost", () => {
+      accounts.updateAllViewBounds();
+    });
+
     config.onDidChange("workspaceApps.mode", () => {
       accounts.updateAllViewBounds();
     });
@@ -134,6 +140,7 @@ class Accounts {
       {
         configuredWidth: config.get("verticalTabs.width"),
         sessionWidth: selectedAccount.instance.verticalTabsWidth,
+        launcherAndBookmarksHost: config.get("verticalTabs.launcherAndBookmarksHost"),
       },
     );
   }

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -103,6 +103,7 @@ export const config = new Store<Config>({
     "workspaceApps.mode": "tabs",
     "workspaceApps.launcherApps": [],
     "workspaceApps.launcherDisplay": "auto",
+    "workspaceApps.launcherAndBookmarksHost": "auto",
     "workspaceApps.showAccountColor": true,
     "workspaceApps.showAccountLabel": true,
     "workspaceApps.persistZoom": true,
@@ -124,7 +125,6 @@ export const config = new Store<Config>({
     "verticalTabs.showWidthToggle": true,
     "verticalTabs.hideUnreadBadgeWhenActive": false,
     "verticalTabs.showAppLinksBadge": true,
-    "verticalTabs.launcherAndBookmarksHost": "auto",
   },
   migrations: {
     ">=3.4.0": (store) => {

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -103,7 +103,7 @@ export const config = new Store<Config>({
     "workspaceApps.mode": "tabs",
     "workspaceApps.launcherApps": [],
     "workspaceApps.launcherDisplay": "auto",
-    "workspaceApps.launcherAndBookmarksHost": "auto",
+    "workspaceApps.launcherAndBookmarksPlacement": "auto",
     "workspaceApps.showAccountColor": true,
     "workspaceApps.showAccountLabel": true,
     "workspaceApps.persistZoom": true,

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -228,7 +228,7 @@ export function AppTitlebar() {
   // strip there for them, so the width is never 0; `titlebar` keeps them here
   // whatever the strip does.
   const areLauncherAndBookmarksHostedByVerticalTabs =
-    config["verticalTabs.launcherAndBookmarksHost"] !== "titlebar" && verticalTabsWidth > 0;
+    config["workspaceApps.launcherAndBookmarksHost"] !== "titlebar" && verticalTabsWidth > 0;
 
   const shouldShowUnifiedInboxButton =
     isLicenseKeyValid && config["unifiedInbox.enabled"] && accounts.length > 1;

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -224,10 +224,11 @@ export function AppTitlebar() {
 
   // On `auto` the vertical tabs strip hosts the launcher and the bookmarks
   // button whenever it is there, so that opening another app or a bookmarked
-  // page stays in the same place as switching between tabs. `titlebar` keeps
-  // them here whatever the strip does.
+  // page stays in the same place as switching between tabs. `sidebar` keeps the
+  // strip there for them, so the width is never 0; `titlebar` keeps them here
+  // whatever the strip does.
   const areLauncherAndBookmarksHostedByVerticalTabs =
-    config["verticalTabs.launcherAndBookmarksHost"] === "auto" && verticalTabsWidth > 0;
+    config["verticalTabs.launcherAndBookmarksHost"] !== "titlebar" && verticalTabsWidth > 0;
 
   const shouldShowUnifiedInboxButton =
     isLicenseKeyValid && config["unifiedInbox.enabled"] && accounts.length > 1;

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -227,8 +227,8 @@ export function AppTitlebar() {
   // page stays in the same place as switching between tabs. `sidebar` keeps the
   // strip there for them, so the width is never 0; `titlebar` keeps them here
   // whatever the strip does.
-  const areLauncherAndBookmarksHostedByVerticalTabs =
-    config["workspaceApps.launcherAndBookmarksHost"] !== "titlebar" && verticalTabsWidth > 0;
+  const areLauncherAndBookmarksPlacementedByVerticalTabs =
+    config["workspaceApps.launcherAndBookmarksPlacement"] !== "titlebar" && verticalTabsWidth > 0;
 
   const shouldShowUnifiedInboxButton =
     isLicenseKeyValid && config["unifiedInbox.enabled"] && accounts.length > 1;
@@ -385,7 +385,7 @@ export function AppTitlebar() {
             <TitlebarButtonGroup
               className={cn(
                 HOST_HANDOVER_FADE_CLASS_NAME,
-                areLauncherAndBookmarksHostedByVerticalTabs && "hidden opacity-0",
+                areLauncherAndBookmarksPlacementedByVerticalTabs && "hidden opacity-0",
               )}
             >
               {shouldShowWorkspaceAppsLauncher && (

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -431,7 +431,7 @@ export function VerticalTabs() {
   const launcherApps = config?.["workspaceApps.launcherApps"] ?? [];
 
   const hostsLauncherAndBookmarks =
-    (config?.["verticalTabs.launcherAndBookmarksHost"] ?? "auto") !== "titlebar";
+    (config?.["workspaceApps.launcherAndBookmarksHost"] ?? "auto") !== "titlebar";
 
   const shouldShowWorkspaceAppsLauncher = isLicenseKeyValid && launcherApps.length > 0;
 

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -431,7 +431,7 @@ export function VerticalTabs() {
   const launcherApps = config?.["workspaceApps.launcherApps"] ?? [];
 
   const hostsLauncherAndBookmarks =
-    (config?.["verticalTabs.launcherAndBookmarksHost"] ?? "auto") === "auto";
+    (config?.["verticalTabs.launcherAndBookmarksHost"] ?? "auto") !== "titlebar";
 
   const shouldShowWorkspaceAppsLauncher = isLicenseKeyValid && launcherApps.length > 0;
 

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -431,7 +431,7 @@ export function VerticalTabs() {
   const launcherApps = config?.["workspaceApps.launcherApps"] ?? [];
 
   const hostsLauncherAndBookmarks =
-    (config?.["workspaceApps.launcherAndBookmarksHost"] ?? "auto") !== "titlebar";
+    (config?.["workspaceApps.launcherAndBookmarksPlacement"] ?? "auto") !== "titlebar";
 
   const shouldShowWorkspaceAppsLauncher = isLicenseKeyValid && launcherApps.length > 0;
 

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -76,7 +76,7 @@ export function useVerticalTabs() {
   const width = getVerticalTabsWidth(tabs, {
     configuredWidth: config?.["verticalTabs.width"] ?? "auto",
     sessionWidth: selectedAccount?.verticalTabsWidth ?? null,
-    launcherAndBookmarksHost: config?.["verticalTabs.launcherAndBookmarksHost"] ?? "auto",
+    launcherAndBookmarksHost: config?.["workspaceApps.launcherAndBookmarksHost"] ?? "auto",
   });
 
   return { selectedAccount, tabs, width };

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -76,7 +76,8 @@ export function useVerticalTabs() {
   const width = getVerticalTabsWidth(tabs, {
     configuredWidth: config?.["verticalTabs.width"] ?? "auto",
     sessionWidth: selectedAccount?.verticalTabsWidth ?? null,
-    launcherAndBookmarksHost: config?.["workspaceApps.launcherAndBookmarksHost"] ?? "auto",
+    launcherAndBookmarksPlacement:
+      config?.["workspaceApps.launcherAndBookmarksPlacement"] ?? "auto",
   });
 
   return { selectedAccount, tabs, width };

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -76,6 +76,7 @@ export function useVerticalTabs() {
   const width = getVerticalTabsWidth(tabs, {
     configuredWidth: config?.["verticalTabs.width"] ?? "auto",
     sessionWidth: selectedAccount?.verticalTabsWidth ?? null,
+    launcherAndBookmarksHost: config?.["verticalTabs.launcherAndBookmarksHost"] ?? "auto",
   });
 
   return { selectedAccount, tabs, width };

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -1,12 +1,9 @@
 import { move } from "@dnd-kit/helpers";
 import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
+import { GMAIL_TAB_ID, verticalTabsWidths } from "@meru/shared/tabs";
 import {
-  GMAIL_TAB_ID,
-  verticalTabsLauncherAndBookmarksHosts,
-  verticalTabsWidths,
-} from "@meru/shared/tabs";
-import {
+  launcherAndBookmarksHosts,
   type LauncherWorkspaceApp,
   launcherWorkspaceApps,
   type SupportedWorkspaceApp,
@@ -255,19 +252,6 @@ export function WorkspaceAppsSettings() {
                   configKey="verticalTabs.showWidthToggle"
                   licenseKeyRequired
                 />
-                <ConfigSelectField
-                  label="Launcher and Bookmarks"
-                  description="Where the Workspace Apps launcher and the bookmarks button sit. Auto moves them to the bottom of the sidebar while it is shown, Sidebar keeps them there and holds the sidebar open even with a single tab, Titlebar keeps them in the titlebar at all times."
-                  configKey="verticalTabs.launcherAndBookmarksHost"
-                  placeholder="Select host"
-                  licenseKeyRequired
-                  items={Object.entries(verticalTabsLauncherAndBookmarksHosts).map(
-                    ([value, label]) => ({
-                      value,
-                      label,
-                    }),
-                  )}
-                />
                 <ConfigSwitchField
                   label="Hide Gmail Unread Badge When Active"
                   description="Hide the unread badge on the Gmail tab while it is the active tab, since the inbox is already in front. Accounts that need attention are still flagged."
@@ -307,93 +291,109 @@ export function WorkspaceAppsSettings() {
             licenseKeyRequired
           />
           <FieldSeparator />
-          <Field>
-            <FieldContent>
-              <FieldLabel className="flex items-center gap-2">
-                Launcher Apps
-                {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
-              </FieldLabel>
-              <FieldDescription>
-                Add Workspace Apps to the Workspace Apps launcher in the titlebar on the right.
-              </FieldDescription>
-            </FieldContent>
-            <div className="flex flex-col gap-4">
-              <div className="flex flex-col gap-2">
-                <div className="text-xs font-medium text-muted-foreground">In Launcher</div>
-                {launcherApps.length === 0 ? (
-                  <p className="rounded-lg border border-dashed px-3 py-4 text-center text-sm text-muted-foreground">
-                    No apps in the launcher. Add apps from Available below.
-                  </p>
-                ) : (
-                  <DragDropProvider
-                    onDragEnd={(event) => {
-                      if (event.canceled) {
-                        return;
-                      }
+          <FieldSet>
+            <FieldLegend>Launcher and Bookmarks</FieldLegend>
+            <Field>
+              <FieldContent>
+                <FieldLabel className="flex items-center gap-2">
+                  Launcher Apps
+                  {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
+                </FieldLabel>
+                <FieldDescription>
+                  Add Workspace Apps to the Workspace Apps launcher in the titlebar on the right.
+                </FieldDescription>
+              </FieldContent>
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-col gap-2">
+                  <div className="text-xs font-medium text-muted-foreground">In Launcher</div>
+                  {launcherApps.length === 0 ? (
+                    <p className="rounded-lg border border-dashed px-3 py-4 text-center text-sm text-muted-foreground">
+                      No apps in the launcher. Add apps from Available below.
+                    </p>
+                  ) : (
+                    <DragDropProvider
+                      onDragEnd={(event) => {
+                        if (event.canceled) {
+                          return;
+                        }
 
-                      configMutation.mutate({
-                        "workspaceApps.launcherApps": move(launcherApps, event),
-                      });
-                    }}
-                  >
+                        configMutation.mutate({
+                          "workspaceApps.launcherApps": move(launcherApps, event),
+                        });
+                      }}
+                    >
+                      <div className="flex flex-row flex-wrap gap-2">
+                        {launcherApps.map((app, index) => (
+                          <SortableLauncherAppItem
+                            key={app}
+                            app={app}
+                            index={index}
+                            onRemove={() => {
+                              configMutation.mutate({
+                                "workspaceApps.launcherApps": launcherApps.filter(
+                                  (value) => value !== app,
+                                ),
+                              });
+                            }}
+                            disabled={!isLicenseKeyValid}
+                          />
+                        ))}
+                      </div>
+                    </DragDropProvider>
+                  )}
+                </div>
+                {availableApps.length > 0 && (
+                  <div className="flex flex-col gap-2">
+                    <div className="text-xs font-medium text-muted-foreground">Available</div>
                     <div className="flex flex-row flex-wrap gap-2">
-                      {launcherApps.map((app, index) => (
-                        <SortableLauncherAppItem
+                      {availableApps.map((app) => (
+                        <Button
                           key={app}
-                          app={app}
-                          index={index}
-                          onRemove={() => {
+                          variant="outline"
+                          size="xs"
+                          onClick={() => {
                             configMutation.mutate({
-                              "workspaceApps.launcherApps": launcherApps.filter(
-                                (value) => value !== app,
-                              ),
+                              "workspaceApps.launcherApps": [...launcherApps, app],
                             });
                           }}
                           disabled={!isLicenseKeyValid}
-                        />
+                          aria-label={`Add ${launcherWorkspaceApps[app]} to launcher`}
+                        >
+                          <WorkspaceAppIcon app={app} className="size-3.5" />
+                          {launcherWorkspaceApps[app]}
+                          <PlusIcon />
+                        </Button>
                       ))}
                     </div>
-                  </DragDropProvider>
+                  </div>
                 )}
               </div>
-              {availableApps.length > 0 && (
-                <div className="flex flex-col gap-2">
-                  <div className="text-xs font-medium text-muted-foreground">Available</div>
-                  <div className="flex flex-row flex-wrap gap-2">
-                    {availableApps.map((app) => (
-                      <Button
-                        key={app}
-                        variant="outline"
-                        size="xs"
-                        onClick={() => {
-                          configMutation.mutate({
-                            "workspaceApps.launcherApps": [...launcherApps, app],
-                          });
-                        }}
-                        disabled={!isLicenseKeyValid}
-                        aria-label={`Add ${launcherWorkspaceApps[app]} to launcher`}
-                      >
-                        <WorkspaceAppIcon app={app} className="size-3.5" />
-                        {launcherWorkspaceApps[app]}
-                        <PlusIcon />
-                      </Button>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          </Field>
-          <ConfigSelectField
-            label="Launcher Display"
-            description="How launcher apps are shown in the titlebar. Auto expands up to three apps into individual buttons and collapses beyond that. Collapsed always keeps them behind a single button, Expanded always shows them as individual buttons."
-            configKey="workspaceApps.launcherDisplay"
-            placeholder="Select display"
-            licenseKeyRequired
-            items={Object.entries(workspaceAppsLauncherDisplays).map(([value, label]) => ({
-              value,
-              label,
-            }))}
-          />
+            </Field>
+            <ConfigSelectField
+              label="Launcher Display"
+              description="How launcher apps are shown in the titlebar. Auto expands up to three apps into individual buttons and collapses beyond that. Collapsed always keeps them behind a single button, Expanded always shows them as individual buttons."
+              configKey="workspaceApps.launcherDisplay"
+              placeholder="Select display"
+              licenseKeyRequired
+              items={Object.entries(workspaceAppsLauncherDisplays).map(([value, label]) => ({
+                value,
+                label,
+              }))}
+            />
+            {config["workspaceApps.mode"] === "tabs" && (
+              <ConfigSelectField
+                label="Host"
+                description="Where the launcher and the bookmarks button sit. Auto moves them to the bottom of the vertical tabs sidebar while it is shown, Sidebar keeps them there and holds the sidebar open even with a single tab, Titlebar keeps them in the titlebar at all times."
+                configKey="workspaceApps.launcherAndBookmarksHost"
+                placeholder="Select host"
+                licenseKeyRequired
+                items={Object.entries(launcherAndBookmarksHosts).map(([value, label]) => ({
+                  value,
+                  label,
+                }))}
+              />
+            )}
+          </FieldSet>
         </FieldGroup>
       </SettingsContent>
     </Settings>

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -257,7 +257,7 @@ export function WorkspaceAppsSettings() {
                 />
                 <ConfigSelectField
                   label="Launcher and Bookmarks"
-                  description="Where the Workspace Apps launcher and the bookmarks button sit. Follow Sidebar moves them to the bottom of the sidebar while it is shown, Titlebar keeps them in the titlebar at all times."
+                  description="Where the Workspace Apps launcher and the bookmarks button sit. Follow Sidebar moves them to the bottom of the sidebar while it is shown, Sidebar keeps them there and holds the sidebar open even with a single tab, Titlebar keeps them in the titlebar at all times."
                   configKey="verticalTabs.launcherAndBookmarksHost"
                   placeholder="Select host"
                   licenseKeyRequired

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -257,7 +257,7 @@ export function WorkspaceAppsSettings() {
                 />
                 <ConfigSelectField
                   label="Launcher and Bookmarks"
-                  description="Where the Workspace Apps launcher and the bookmarks button sit. Follow Sidebar moves them to the bottom of the sidebar while it is shown, Sidebar keeps them there and holds the sidebar open even with a single tab, Titlebar keeps them in the titlebar at all times."
+                  description="Where the Workspace Apps launcher and the bookmarks button sit. Auto moves them to the bottom of the sidebar while it is shown, Sidebar keeps them there and holds the sidebar open even with a single tab, Titlebar keeps them in the titlebar at all times."
                   configKey="verticalTabs.launcherAndBookmarksHost"
                   placeholder="Select host"
                   licenseKeyRequired

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -3,7 +3,7 @@ import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { GMAIL_TAB_ID, verticalTabsWidths } from "@meru/shared/tabs";
 import {
-  launcherAndBookmarksHosts,
+  launcherAndBookmarksPlacements,
   type LauncherWorkspaceApp,
   launcherWorkspaceApps,
   type SupportedWorkspaceApp,
@@ -382,12 +382,12 @@ export function WorkspaceAppsSettings() {
             />
             {config["workspaceApps.mode"] === "tabs" && (
               <ConfigSelectField
-                label="Host"
+                label="Placement"
                 description="Where the launcher and the bookmarks button sit. Auto moves them to the bottom of the vertical tabs sidebar while it is shown, Sidebar keeps them there and holds the sidebar open even with a single tab, Titlebar keeps them in the titlebar at all times."
-                configKey="workspaceApps.launcherAndBookmarksHost"
-                placeholder="Select host"
+                configKey="workspaceApps.launcherAndBookmarksPlacement"
+                placeholder="Select placement"
                 licenseKeyRequired
-                items={Object.entries(launcherAndBookmarksHosts).map(([value, label]) => ({
+                items={Object.entries(launcherAndBookmarksPlacements).map(([value, label]) => ({
                   value,
                   label,
                 }))}

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -1,6 +1,10 @@
 import { VERTICAL_TABS_NARROW_WIDTH, VERTICAL_TABS_WIDE_WIDTH } from "./constants";
 import type { AccountConfig } from "./schemas";
-import type { SupportedWorkspaceApp, WorkspaceAppsMode } from "./workspace-apps";
+import type {
+  LauncherAndBookmarksHost,
+  SupportedWorkspaceApp,
+  WorkspaceAppsMode,
+} from "./workspace-apps";
 
 export const GMAIL_TAB_ID = "gmail";
 
@@ -18,15 +22,6 @@ export type VerticalTabsWidth = keyof typeof verticalTabsWidths;
  * which is what picking by hand steps over.
  */
 export type VerticalTabsSessionWidth = Exclude<VerticalTabsWidth, "auto">;
-
-export const verticalTabsLauncherAndBookmarksHosts = {
-  auto: "Auto",
-  sidebar: "Sidebar",
-  titlebar: "Titlebar",
-} as const;
-
-export type VerticalTabsLauncherAndBookmarksHost =
-  keyof typeof verticalTabsLauncherAndBookmarksHosts;
 
 export type TabState = {
   id: string;
@@ -94,7 +89,7 @@ export function getVerticalTabsWidth(
   }: {
     configuredWidth: VerticalTabsWidth;
     sessionWidth: VerticalTabsSessionWidth | null;
-    launcherAndBookmarksHost: VerticalTabsLauncherAndBookmarksHost;
+    launcherAndBookmarksHost: LauncherAndBookmarksHost;
   },
 ) {
   // `sidebar` hands the strip the launcher and the bookmarks button for good,

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -21,6 +21,7 @@ export type VerticalTabsSessionWidth = Exclude<VerticalTabsWidth, "auto">;
 
 export const verticalTabsLauncherAndBookmarksHosts = {
   auto: "Follow Sidebar",
+  sidebar: "Sidebar",
   titlebar: "Titlebar",
 } as const;
 
@@ -89,9 +90,16 @@ export function getVerticalTabsWidth(
   {
     configuredWidth,
     sessionWidth,
-  }: { configuredWidth: VerticalTabsWidth; sessionWidth: VerticalTabsSessionWidth | null },
+    launcherAndBookmarksHost,
+  }: {
+    configuredWidth: VerticalTabsWidth;
+    sessionWidth: VerticalTabsSessionWidth | null;
+    launcherAndBookmarksHost: VerticalTabsLauncherAndBookmarksHost;
+  },
 ) {
-  if (tabs.length <= 1) {
+  // `sidebar` hands the strip the launcher and the bookmarks button for good,
+  // so it has to stay even with nothing to switch between.
+  if (tabs.length <= 1 && launcherAndBookmarksHost !== "sidebar") {
     return 0;
   }
 

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -1,7 +1,7 @@
 import { VERTICAL_TABS_NARROW_WIDTH, VERTICAL_TABS_WIDE_WIDTH } from "./constants";
 import type { AccountConfig } from "./schemas";
 import type {
-  LauncherAndBookmarksHost,
+  LauncherAndBookmarksPlacement,
   SupportedWorkspaceApp,
   WorkspaceAppsMode,
 } from "./workspace-apps";
@@ -85,16 +85,16 @@ export function getVerticalTabsWidth(
   {
     configuredWidth,
     sessionWidth,
-    launcherAndBookmarksHost,
+    launcherAndBookmarksPlacement,
   }: {
     configuredWidth: VerticalTabsWidth;
     sessionWidth: VerticalTabsSessionWidth | null;
-    launcherAndBookmarksHost: LauncherAndBookmarksHost;
+    launcherAndBookmarksPlacement: LauncherAndBookmarksPlacement;
   },
 ) {
   // `sidebar` hands the strip the launcher and the bookmarks button for good,
   // so it has to stay even with nothing to switch between.
-  if (tabs.length <= 1 && launcherAndBookmarksHost !== "sidebar") {
+  if (tabs.length <= 1 && launcherAndBookmarksPlacement !== "sidebar") {
     return 0;
   }
 

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -20,7 +20,7 @@ export type VerticalTabsWidth = keyof typeof verticalTabsWidths;
 export type VerticalTabsSessionWidth = Exclude<VerticalTabsWidth, "auto">;
 
 export const verticalTabsLauncherAndBookmarksHosts = {
-  auto: "Follow Sidebar",
+  auto: "Auto",
   sidebar: "Sidebar",
   titlebar: "Titlebar",
 } as const;

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -11,13 +11,9 @@ import type {
   GmailLabelColors,
   GmailSavedSearches,
 } from "./schemas";
+import type { AccountTabsState, VerticalTabsSessionWidth, VerticalTabsWidth } from "./tabs";
 import type {
-  AccountTabsState,
-  VerticalTabsLauncherAndBookmarksHost,
-  VerticalTabsSessionWidth,
-  VerticalTabsWidth,
-} from "./tabs";
-import type {
+  LauncherAndBookmarksHost,
   LauncherWorkspaceApp,
   SupportedWorkspaceApp,
   WorkspaceAppBookmarkState,
@@ -144,6 +140,7 @@ export type Config = {
   "workspaceApps.mode": WorkspaceAppsMode;
   "workspaceApps.launcherApps": LauncherWorkspaceApp[];
   "workspaceApps.launcherDisplay": WorkspaceAppsLauncherDisplay;
+  "workspaceApps.launcherAndBookmarksHost": LauncherAndBookmarksHost;
   "workspaceApps.showAccountColor": boolean;
   "workspaceApps.showAccountLabel": boolean;
   "workspaceApps.persistZoom": boolean;
@@ -165,7 +162,6 @@ export type Config = {
   "verticalTabs.showWidthToggle": boolean;
   "verticalTabs.hideUnreadBadgeWhenActive": boolean;
   "verticalTabs.showAppLinksBadge": boolean;
-  "verticalTabs.launcherAndBookmarksHost": VerticalTabsLauncherAndBookmarksHost;
 };
 
 export type IpcMainEvents =

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -13,7 +13,7 @@ import type {
 } from "./schemas";
 import type { AccountTabsState, VerticalTabsSessionWidth, VerticalTabsWidth } from "./tabs";
 import type {
-  LauncherAndBookmarksHost,
+  LauncherAndBookmarksPlacement,
   LauncherWorkspaceApp,
   SupportedWorkspaceApp,
   WorkspaceAppBookmarkState,
@@ -140,7 +140,7 @@ export type Config = {
   "workspaceApps.mode": WorkspaceAppsMode;
   "workspaceApps.launcherApps": LauncherWorkspaceApp[];
   "workspaceApps.launcherDisplay": WorkspaceAppsLauncherDisplay;
-  "workspaceApps.launcherAndBookmarksHost": LauncherAndBookmarksHost;
+  "workspaceApps.launcherAndBookmarksPlacement": LauncherAndBookmarksPlacement;
   "workspaceApps.showAccountColor": boolean;
   "workspaceApps.showAccountLabel": boolean;
   "workspaceApps.persistZoom": boolean;

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -69,6 +69,14 @@ export function resolveWorkspaceAppsLauncherDisplay(
   return launcherAppCount > LAUNCHER_EXPANDED_APPS_THRESHOLD ? "collapsed" : "expanded";
 }
 
+export const launcherAndBookmarksHosts = {
+  auto: "Auto",
+  sidebar: "Sidebar",
+  titlebar: "Titlebar",
+} as const;
+
+export type LauncherAndBookmarksHost = keyof typeof launcherAndBookmarksHosts;
+
 export const workspaceAppsModes = {
   tabs: "Tabs",
   windows: "New Windows",

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -69,13 +69,13 @@ export function resolveWorkspaceAppsLauncherDisplay(
   return launcherAppCount > LAUNCHER_EXPANDED_APPS_THRESHOLD ? "collapsed" : "expanded";
 }
 
-export const launcherAndBookmarksHosts = {
+export const launcherAndBookmarksPlacements = {
   auto: "Auto",
   sidebar: "Sidebar",
   titlebar: "Titlebar",
 } as const;
 
-export type LauncherAndBookmarksHost = keyof typeof launcherAndBookmarksHosts;
+export type LauncherAndBookmarksPlacement = keyof typeof launcherAndBookmarksPlacements;
 
 export const workspaceAppsModes = {
   tabs: "Tabs",


### PR DESCRIPTION
- Adds a third launcher-and-bookmarks placement, `sidebar`, which keeps the launcher and the bookmarks button in the vertical tabs sidebar and holds the sidebar open even when only the Gmail tab is there.
- `getVerticalTabsWidth` now takes the placement and skips its `tabs.length <= 1` early return on `sidebar`, so the width falls through to the session/configured logic; both call sites (`Accounts.getVerticalTabsWidth`, `useVerticalTabs`) pass it.
- The titlebar and the sidebar branch on `!== "titlebar"`, so `auto` and `sidebar` both put the controls in the sidebar.
- `Accounts.init` gets an `onDidChange` listener for the key that calls `updateAllViewBounds()`, since switching to or away from `sidebar` shifts every view sideways.
- The setting is `workspaceApps.launcherAndBookmarksPlacement`, alongside its siblings `workspaceApps.launcherApps` and `workspaceApps.launcherDisplay`; the map and type live in `shared/workspace-apps.ts` as `launcherAndBookmarksPlacements` / `LauncherAndBookmarksPlacement`.
- Settings gains a "Launcher and Bookmarks" fieldset at the bottom of the Workspace Apps page gathering Launcher Apps, Launcher Display and the new Placement select, which were floating unsectioned before. Placement only renders in Tabs mode; the other two show in both.
- No migration: the key never shipped in a release.

Not run visually — the width, bounds, placement and settings layout changes were only reasoned through and type-checked. The bookmarks popup anchor on `sidebar` follows `accounts.getVerticalTabsWidth()` and so should line up, but that was not observed either.

Test plan

1. With one account and only the Gmail tab open, set Workspace Apps → Launcher and Bookmarks → Placement to `Sidebar`. The sidebar should appear immediately at the narrow width with the launcher and bookmarks at its foot, and the Gmail view should reflow to the right without needing a window resize.
2. Switch Placement back to `Auto` while still on a single tab. The sidebar should disappear again and the launcher and bookmarks return to the titlebar, with the view reclaiming the space.
3. On `Sidebar` with a single tab, click the sidebar's bookmarks button. The popup should open flush beside the strip, not overlapping it.
4. Switch Workspace Apps Mode to New Windows. The Placement select should disappear from the fieldset while Launcher Apps and Launcher Display stay.
