### PR TITLE
add an extensions loader as a standalone package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,6 +76,10 @@
       "name": "@meru/dark-theme",
       "version": "0.0.0",
     },
+    "packages/electron-extensions": {
+      "name": "@meru/electron-extensions",
+      "version": "0.0.0",
+    },
     "packages/preload-gmail": {
       "name": "@meru/preload-gmail",
       "version": "0.0.0",
@@ -278,6 +282,8 @@
     "@meru/app": ["@meru/app@workspace:packages/app"],
 
     "@meru/dark-theme": ["@meru/dark-theme@workspace:packages/dark-theme"],
+
+    "@meru/electron-extensions": ["@meru/electron-extensions@workspace:packages/electron-extensions"],
 
     "@meru/preload-gmail": ["@meru/preload-gmail@workspace:packages/preload-gmail"],
 

--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -6,6 +6,7 @@ import type { SelectedDesktopSource } from "@meru/shared/types";
 import { app, type IpcMainEvent, ipcMain, type Session, session } from "electron";
 import { blocker } from "./blocker";
 import { config } from "./config";
+import { extensions } from "./extensions";
 import { Gmail } from "./gmail";
 import { createBrowserWindow, getPreloadPath, loadRenderer } from "./lib/window";
 import { licenseKey } from "./license-key";
@@ -45,6 +46,8 @@ export class Account {
 
     blocker.setupSession(this.session);
 
+    extensions.setupSession(this.session);
+
     this.setSpellCheckerLanguages();
 
     this.gmail = new Gmail({
@@ -68,6 +71,8 @@ export class Account {
     this.session.setDisplayMediaRequestHandler(null);
 
     blocker.teardownSession(this.session);
+
+    extensions.teardownSession(this.session);
   }
 
   setSpellCheckerLanguages() {

--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -100,7 +100,15 @@ export class Account {
   }
 
   private registerSessionPermissionsRequestsHandler() {
-    this.session.setPermissionRequestHandler((_webContents, permission, callback) => {
+    this.session.setPermissionRequestHandler((_webContents, permission, callback, details) => {
+      // Extensions are loaded deliberately and Chromium checks their requests
+      // against the permissions they declare, unlike web content
+      if (extensions.isLoadedExtensionUrl(this.session, details.requestingUrl)) {
+        callback(true);
+
+        return;
+      }
+
       switch (permission) {
         case "clipboard-read":
         case "clipboard-sanitized-write":

--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -1,0 +1,43 @@
+import path from "node:path";
+import { is } from "@electron-toolkit/utils";
+import { Extensions } from "@meru/electron-extensions";
+import { serializeError } from "serialize-error";
+import { log } from "@/lib/log";
+
+/**
+ * Unpacked extension directories to load into every account session, separated
+ * by the platform's path delimiter:
+ *
+ *   MERU_EXTENSIONS_DIRS=/path/to/1password bun run dev
+ *
+ * Until extensions are installed from the curated list, this is the only source
+ * of extensions, and it is read in development only — a packaged build has no
+ * way to turn extensions on, so nothing is loaded and account sessions stay
+ * exactly as they are today.
+ */
+const EXTENSION_DIRS_ENV_VAR = "MERU_EXTENSIONS_DIRS";
+
+function getExtensionDirs() {
+  const extensionDirs = is.dev ? process.env[EXTENSION_DIRS_ENV_VAR] : undefined;
+
+  if (!extensionDirs) {
+    return [];
+  }
+
+  return extensionDirs
+    .split(path.delimiter)
+    .filter(Boolean)
+    .map((extensionDir) => path.resolve(extensionDir));
+}
+
+export const extensions = new Extensions({
+  extensionDirs: getExtensionDirs(),
+  logger: {
+    info: (message, details) => {
+      log.info(message, details);
+    },
+    error: (message, { error, ...details }) => {
+      log.error(message, { ...details, error: serializeError(error) });
+    },
+  },
+});

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test";
+import type { Extension, Session } from "electron";
+import { Extensions } from "./extensions";
+
+function createExtension(id: string, extensionDir: string) {
+  return {
+    id,
+    name: `Extension ${id}`,
+    version: "1.0.0",
+    path: extensionDir,
+    url: `chrome-extension://${id}/`,
+    manifest: {},
+  } as Extension;
+}
+
+function createSession({
+  loadExtension = async (extensionDir: string) => createExtension("aaa", extensionDir),
+}: {
+  loadExtension?: (extensionDir: string) => Promise<Extension>;
+} = {}) {
+  const removedExtensionIds: string[] = [];
+
+  const session = {
+    extensions: {
+      loadExtension,
+      removeExtension: (extensionId: string) => {
+        removedExtensionIds.push(extensionId);
+      },
+    },
+  } as unknown as Session;
+
+  return { session, removedExtensionIds };
+}
+
+describe("Extensions", () => {
+  test("loads every directory into the session", async () => {
+    const loadedExtensionDirs: string[] = [];
+
+    const { session } = createSession({
+      loadExtension: async (extensionDir) => {
+        loadedExtensionDirs.push(extensionDir);
+
+        return createExtension(`id-${loadedExtensionDirs.length}`, extensionDir);
+      },
+    });
+
+    const extensions = new Extensions({ extensionDirs: ["/extensions/one", "/extensions/two"] });
+
+    await extensions.setupSession(session);
+
+    expect(loadedExtensionDirs).toEqual(["/extensions/one", "/extensions/two"]);
+  });
+
+  test("does nothing without extension directories", async () => {
+    let loadExtensionCalls = 0;
+
+    const { session } = createSession({
+      loadExtension: async (extensionDir) => {
+        loadExtensionCalls += 1;
+
+        return createExtension("aaa", extensionDir);
+      },
+    });
+
+    const extensions = new Extensions({ extensionDirs: [] });
+
+    await extensions.setupSession(session);
+
+    extensions.teardownSession(session);
+
+    expect(loadExtensionCalls).toBe(0);
+    expect(extensions.isLoadedExtensionUrl(session, "chrome-extension://aaa/popup.html")).toBe(
+      false,
+    );
+  });
+
+  test("keeps loading after a directory fails", async () => {
+    const loggedErrors: Record<string, unknown>[] = [];
+
+    const { session } = createSession({
+      loadExtension: async (extensionDir) => {
+        if (extensionDir === "/extensions/broken") {
+          throw new Error("Could not load extension");
+        }
+
+        return createExtension("aaa", extensionDir);
+      },
+    });
+
+    const extensions = new Extensions({
+      extensionDirs: ["/extensions/broken", "/extensions/one"],
+      logger: {
+        info: () => {},
+        error: (_message, details) => {
+          loggedErrors.push(details);
+        },
+      },
+    });
+
+    await extensions.setupSession(session);
+
+    expect(loggedErrors).toHaveLength(1);
+    expect(loggedErrors[0]?.extensionDir).toBe("/extensions/broken");
+    expect(extensions.isLoadedExtensionUrl(session, "chrome-extension://aaa/popup.html")).toBe(
+      true,
+    );
+  });
+
+  test("matches URLs of extensions loaded into that session only", async () => {
+    const { session: sessionWithExtension } = createSession();
+    const { session: sessionWithoutExtension } = createSession();
+
+    const extensions = new Extensions({ extensionDirs: ["/extensions/one"] });
+
+    await extensions.setupSession(sessionWithExtension);
+
+    expect(
+      extensions.isLoadedExtensionUrl(sessionWithExtension, "chrome-extension://aaa/popup.html"),
+    ).toBe(true);
+    expect(
+      extensions.isLoadedExtensionUrl(sessionWithExtension, "chrome-extension://bbb/popup.html"),
+    ).toBe(false);
+    expect(
+      extensions.isLoadedExtensionUrl(sessionWithExtension, "https://mail.google.com/mail/u/0"),
+    ).toBe(false);
+    expect(
+      extensions.isLoadedExtensionUrl(sessionWithoutExtension, "chrome-extension://aaa/popup.html"),
+    ).toBe(false);
+  });
+
+  test("unloads what it loaded and forgets the session", async () => {
+    const { session, removedExtensionIds } = createSession();
+
+    const extensions = new Extensions({ extensionDirs: ["/extensions/one"] });
+
+    await extensions.setupSession(session);
+
+    extensions.teardownSession(session);
+
+    expect(removedExtensionIds).toEqual(["aaa"]);
+    expect(extensions.isLoadedExtensionUrl(session, "chrome-extension://aaa/popup.html")).toBe(
+      false,
+    );
+
+    extensions.teardownSession(session);
+
+    expect(removedExtensionIds).toEqual(["aaa"]);
+  });
+
+  test("unloads an extension that finished loading after teardown", async () => {
+    const { promise: loadExtensionPromise, resolve: resolveLoadExtension } =
+      Promise.withResolvers<Extension>();
+
+    const { session, removedExtensionIds } = createSession({
+      loadExtension: () => loadExtensionPromise,
+    });
+
+    const extensions = new Extensions({ extensionDirs: ["/extensions/one", "/extensions/two"] });
+
+    const setupSessionPromise = extensions.setupSession(session);
+
+    extensions.teardownSession(session);
+
+    resolveLoadExtension(createExtension("aaa", "/extensions/one"));
+
+    await setupSessionPromise;
+
+    expect(removedExtensionIds).toEqual(["aaa"]);
+    expect(extensions.isLoadedExtensionUrl(session, "chrome-extension://aaa/popup.html")).toBe(
+      false,
+    );
+  });
+});

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -1,0 +1,106 @@
+import type { Session } from "electron";
+
+/** Where the loader reports what it did, since an embedder logs its own way. */
+export type ExtensionsLogger = {
+  info: (message: string, details: Record<string, unknown>) => void;
+  error: (message: string, details: Record<string, unknown>) => void;
+};
+
+export type ExtensionsOptions = {
+  /**
+   * Unpacked extension directories, loaded into every session handed to
+   * `setupSession`.
+   */
+  extensionDirs: string[];
+  logger?: ExtensionsLogger;
+};
+
+/**
+ * Loads unpacked extensions into Electron sessions and keeps track of what is
+ * loaded where, so an embedder can unload them again and can tell whether a
+ * `chrome-extension://` URL belongs to an extension it loaded itself.
+ *
+ * Chromium scopes an extension — content scripts, service worker, storage — to
+ * the session it is loaded into, so the same directory loaded into several
+ * sessions gives that many independent instances. Extensions are also forgotten
+ * between launches, which is why loading happens on every boot.
+ */
+export class Extensions {
+  private extensionDirs: string[];
+
+  private logger: ExtensionsLogger | undefined;
+
+  private loadedExtensionIdsBySession = new Map<Session, Set<string>>();
+
+  constructor({ extensionDirs, logger }: ExtensionsOptions) {
+    this.extensionDirs = extensionDirs;
+
+    this.logger = logger;
+  }
+
+  async setupSession(session: Session) {
+    if (this.extensionDirs.length === 0) {
+      return;
+    }
+
+    const loadedExtensionIds = new Set<string>();
+
+    this.loadedExtensionIdsBySession.set(session, loadedExtensionIds);
+
+    for (const extensionDir of this.extensionDirs) {
+      try {
+        const extension = await session.extensions.loadExtension(extensionDir);
+
+        // The session can be torn down while an extension is still loading
+        if (this.loadedExtensionIdsBySession.get(session) !== loadedExtensionIds) {
+          session.extensions.removeExtension(extension.id);
+
+          return;
+        }
+
+        loadedExtensionIds.add(extension.id);
+
+        this.logger?.info("Loaded extension", {
+          id: extension.id,
+          name: extension.name,
+          version: extension.version,
+          extensionDir,
+        });
+      } catch (error) {
+        this.logger?.error("Failed to load extension", { extensionDir, error });
+      }
+    }
+  }
+
+  teardownSession(session: Session) {
+    const loadedExtensionIds = this.loadedExtensionIdsBySession.get(session);
+
+    if (!loadedExtensionIds) {
+      return;
+    }
+
+    this.loadedExtensionIdsBySession.delete(session);
+
+    for (const extensionId of loadedExtensionIds) {
+      session.extensions.removeExtension(extensionId);
+
+      this.logger?.info("Unloaded extension", { id: extensionId });
+    }
+  }
+
+  isLoadedExtensionUrl(session: Session, url: string) {
+    const loadedExtensionIds = this.loadedExtensionIdsBySession.get(session);
+
+    if (!loadedExtensionIds) {
+      return false;
+    }
+
+    for (const extensionId of loadedExtensionIds) {
+      if (url.startsWith(`chrome-extension://${extensionId}/`)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/packages/electron-extensions/index.ts
+++ b/packages/electron-extensions/index.ts
@@ -1,0 +1,2 @@
+export { Extensions } from "./extensions";
+export type { ExtensionsLogger, ExtensionsOptions } from "./extensions";

--- a/packages/electron-extensions/package.json
+++ b/packages/electron-extensions/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@meru/electron-extensions",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    ".": "./index.ts"
+  },
+  "scripts": {
+    "test": "bun test",
+    "types": "tsc && tsc -p tsconfig.test.json"
+  }
+}

--- a/packages/electron-extensions/tsconfig.json
+++ b/packages/electron-extensions/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@total-typescript/tsconfig/bundler/no-dom",
+  "exclude": ["**/*.test.ts"]
+}

--- a/packages/electron-extensions/tsconfig.test.json
+++ b/packages/electron-extensions/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"]
+  },
+  "include": ["**/*.test.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
- New workspace package `@meru/electron-extensions`: loads unpacked extensions into Electron sessions, tracks what's loaded where for teardown and `chrome-extension://` URL ownership checks. Zero Meru imports (candidate for npm publication later); later slices (`chrome.*` bridge, CRX pipeline) land inside the same package.
- App glue in `packages/app/extensions.ts`: reads `MERU_EXTENSIONS_DIRS` (path-delimiter-separated unpacked dirs) in dev only — packaged builds cannot enable extensions, so the module is inert there.
- Accounts load extensions into their `persist:` session on construction, unload on destroy; the deny-by-default permission handler now allows requests from extensions loaded into that session (Chromium already checks them against declared permissions).

No config keys yet: `extensions.installed` has no reader or writer until the install pipeline, so it would be dead config — it lands with that slice. Not verified live: the permission carve-out (unit-tested only; 1Password's SW dies on missing `chrome.*` APIs before requesting anything — that's slice 3) and multiple dirs/Windows path delimiters. Known follow-up: account removal's `clearData()` does not wipe `Local Extension Settings`/extension IndexedDB — pre-existing gap, measured during verification, needs its own fix.

Test plan:
1. `MERU_EXTENSIONS_DIRS=<unpacked extension dir> bun run dev` → main log shows `Loaded extension` with the extension's real ID, and `Partitions/<accountId>/Local Extension Settings/<id>` appears.
2. Remove that account in settings → log shows `Unloaded extension`, no crash.
3. Run without the env var → no extension logs, no extension dirs under any partition.