### PR TITLE
clear extension storage when an account is removed

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -8,6 +8,7 @@ import {
 } from "@meru/shared/tabs";
 import { Account } from "./account";
 import { config } from "./config";
+import { extensions } from "./extensions";
 import { ipc } from "./ipc";
 import { licenseKey } from "./license-key";
 import { main } from "./main";
@@ -348,6 +349,8 @@ class Accounts {
     account.instance.destroy();
 
     await account.instance.session.clearData();
+
+    await extensions.clearSessionData(account.instance.session);
 
     this.instances.delete(selectedAccountId);
 

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -6,6 +6,7 @@ import { blocker } from "@/blocker";
 import { bookmarks } from "@/bookmarks";
 import { config } from "@/config";
 import { downloads } from "@/downloads";
+import { extensions } from "@/extensions";
 import { ipc } from "@/ipc";
 import { initLinuxWindowControls } from "@/lib/linux";
 import { licenseKey } from "@/license-key";
@@ -38,7 +39,11 @@ async function resetApp() {
     accounts.map((account) => {
       const accountSession = session.fromPartition(`persist:${account.id}`);
 
-      return Promise.all([accountSession.clearCache(), accountSession.clearStorageData()]);
+      return Promise.all([
+        accountSession.clearCache(),
+        accountSession.clearStorageData(),
+        extensions.clearSessionData(accountSession),
+      ]);
     }),
   );
 

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { Extension, Session } from "electron";
 import { Extensions } from "./extensions";
 
@@ -15,8 +18,10 @@ function createExtension(id: string, extensionDir: string) {
 
 function createSession({
   loadExtension = async (extensionDir: string) => createExtension("aaa", extensionDir),
+  storagePath = null,
 }: {
   loadExtension?: (extensionDir: string) => Promise<Extension>;
+  storagePath?: string | null;
 } = {}) {
   const removedExtensionIds: string[] = [];
 
@@ -27,9 +32,30 @@ function createSession({
         removedExtensionIds.push(extensionId);
       },
     },
+    getStoragePath: () => storagePath,
   } as unknown as Session;
 
   return { session, removedExtensionIds };
+}
+
+async function createPartitionDir(entryPaths: string[]) {
+  const partitionPath = await fs.mkdtemp(path.join(os.tmpdir(), "electron-extensions-"));
+
+  for (const entryPath of entryPaths) {
+    const filePath = path.join(partitionPath, entryPath);
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+
+    await fs.writeFile(filePath, "");
+  }
+
+  return partitionPath;
+}
+
+async function listPartitionDir(partitionPath: string) {
+  const entryPaths = await fs.readdir(partitionPath, { recursive: true });
+
+  return entryPaths.sort();
 }
 
 describe("Extensions", () => {
@@ -145,6 +171,79 @@ describe("Extensions", () => {
     extensions.teardownSession(session);
 
     expect(removedExtensionIds).toEqual(["aaa"]);
+  });
+
+  test("clears extension storage and leaves the rest of the partition alone", async () => {
+    const partitionPath = await createPartitionDir([
+      "Local Extension Settings/aaa/000003.log",
+      "Sync Extension Settings/aaa/000003.log",
+      "Managed Extension Settings/aaa/000003.log",
+      "Extension Rules/000003.log",
+      "Extension Scripts/000003.log",
+      "Extension State/000003.log",
+      "IndexedDB/chrome-extension_aaa_0.indexeddb.leveldb/000003.log",
+      "IndexedDB/https_mail.google.com_0.indexeddb.leveldb/000003.log",
+      "Local Storage/leveldb/000003.log",
+      "Cookies",
+    ]);
+
+    const { session } = createSession({ storagePath: partitionPath });
+
+    const extensions = new Extensions({ extensionDirs: ["/extensions/one"] });
+
+    await extensions.setupSession(session);
+
+    extensions.teardownSession(session);
+
+    await extensions.clearSessionData(session);
+
+    expect(await listPartitionDir(partitionPath)).toEqual([
+      "Cookies",
+      "IndexedDB",
+      path.join("IndexedDB", "https_mail.google.com_0.indexeddb.leveldb"),
+      path.join("IndexedDB", "https_mail.google.com_0.indexeddb.leveldb", "000003.log"),
+      "Local Storage",
+      path.join("Local Storage", "leveldb"),
+      path.join("Local Storage", "leveldb", "000003.log"),
+    ]);
+
+    await fs.rm(partitionPath, { recursive: true, force: true });
+  });
+
+  test("clears nothing for a session without a storage path", async () => {
+    const loggedErrors: Record<string, unknown>[] = [];
+
+    const { session } = createSession();
+
+    const extensions = new Extensions({
+      extensionDirs: ["/extensions/one"],
+      logger: {
+        info: () => {},
+        error: (_message, details) => {
+          loggedErrors.push(details);
+        },
+      },
+    });
+
+    await extensions.setupSession(session);
+
+    await extensions.clearSessionData(session);
+
+    expect(loggedErrors).toEqual([]);
+  });
+
+  test("clears a partition that holds no extension storage", async () => {
+    const partitionPath = await createPartitionDir(["Cookies"]);
+
+    const { session } = createSession({ storagePath: partitionPath });
+
+    const extensions = new Extensions({ extensionDirs: [] });
+
+    await extensions.clearSessionData(session);
+
+    expect(await listPartitionDir(partitionPath)).toEqual(["Cookies"]);
+
+    await fs.rm(partitionPath, { recursive: true, force: true });
   });
 
   test("unloads an extension that finished loading after teardown", async () => {

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -1,4 +1,22 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import type { Session } from "electron";
+
+/**
+ * Chromium keeps every `chrome.storage` area of every extension in its own
+ * directory inside the session's partition, next to the browsing data.
+ */
+const EXTENSION_STORAGE_DIR_NAMES = [
+  "Local Extension Settings",
+  "Sync Extension Settings",
+  "Managed Extension Settings",
+  "Extension Rules",
+  "Extension Scripts",
+  "Extension State",
+];
+
+/** `IndexedDB/chrome-extension_<extensionId>_0.indexeddb.leveldb` and friends. */
+const EXTENSION_INDEXED_DB_PREFIX = "chrome-extension_";
 
 /** Where the loader reports what it did, since an embedder logs its own way. */
 export type ExtensionsLogger = {
@@ -85,6 +103,62 @@ export class Extensions {
       session.extensions.removeExtension(extensionId);
 
       this.logger?.info("Unloaded extension", { id: extensionId });
+    }
+  }
+
+  /**
+   * Deletes what the extensions in this session wrote to disk. `chrome.storage`
+   * is none of the browsing data Chromium keeps per origin, and the one part
+   * that is — an extension's IndexedDB — `session.clearData()` walks past
+   * unless it is handed that extension's origin.
+   *
+   * Everything the partition holds for an extension goes, not just for the
+   * extensions loaded into this session, since an extension the embedder no
+   * longer loads left its storage behind all the same.
+   */
+  async clearSessionData(session: Session) {
+    const storagePath = session.getStoragePath();
+
+    if (!storagePath) {
+      return;
+    }
+
+    const extensionDataPaths = [
+      ...EXTENSION_STORAGE_DIR_NAMES.map((dirName) => path.join(storagePath, dirName)),
+      ...(await this.getExtensionIndexedDbPaths(storagePath)),
+    ];
+
+    await Promise.all(
+      extensionDataPaths.map(async (extensionDataPath) => {
+        try {
+          // Chromium can still hold the LevelDB files open right after
+          // unloading an extension, which fails the delete on Windows
+          await fs.rm(extensionDataPath, {
+            recursive: true,
+            force: true,
+            maxRetries: 5,
+            retryDelay: 100,
+          });
+        } catch (error) {
+          this.logger?.error("Failed to clear extension data", { path: extensionDataPath, error });
+        }
+      }),
+    );
+
+    this.logger?.info("Cleared extension data", { storagePath });
+  }
+
+  private async getExtensionIndexedDbPaths(storagePath: string) {
+    const indexedDbPath = path.join(storagePath, "IndexedDB");
+
+    try {
+      const entryNames = await fs.readdir(indexedDbPath);
+
+      return entryNames
+        .filter((entryName) => entryName.startsWith(EXTENSION_INDEXED_DB_PREFIX))
+        .map((entryName) => path.join(indexedDbPath, entryName));
+    } catch {
+      return [];
     }
   }
 


### PR DESCRIPTION
- `@meru/electron-extensions` gains `clearSessionData(session)`: deletes every extension storage dir under the session's partition (`Local Extension Settings` and the other `chrome.storage` areas) plus `IndexedDB/chrome-extension_*`, with retries for LevelDB files Chromium may still hold open. Id-independent, so storage from extensions no longer loaded is cleared too.
- `removeAccount` and `resetApp()` call it alongside their existing clearing — both leaked extension data identically.

No Electron session API covers `chrome.storage.local` on disk: measured on Electron 43, `clearData()`/`clearStorageData()` with the extension's origin clear its IndexedDB but never `Local Extension Settings`, so this is filesystem deletion by design. Verified headlessly on Linux with real 1Password data: partition holds nothing extension-owned after removal and nothing is recreated. Not verified: Windows/macOS (the locked-file retry path), and `resetApp()` (relaunches the app). Intentionally left: the SW registration record and the `extensions.settings.<id>` entry in `Preferences` — shared Chromium-owned files without user data.

Test plan:
1. `MERU_EXTENSIONS_DIRS=<unpacked extension> bun run dev`, let the extension write storage, remove the account → `Partitions/<accountId>/` has no `Local Extension Settings` and no `chrome-extension_*` IndexedDB dirs.
2. Settings → reset app with an extension loaded → same assertion for every account partition after relaunch.