### PR TITLE
give extension contexts a noop-first chrome.* facade

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { is } from "@electron-toolkit/utils";
 import { Extensions } from "@meru/electron-extensions";
+import { app } from "electron";
 import { serializeError } from "serialize-error";
 import { log } from "@/lib/log";
 
@@ -32,6 +33,8 @@ function getExtensionDirs() {
 
 export const extensions = new Extensions({
   extensionDirs: getExtensionDirs(),
+  facadeScriptPath: path.join(__dirname, "extensions-chrome-facade.js"),
+  derivedExtensionsDir: path.join(app.getPath("userData"), "derived-extensions"),
   logger: {
     info: (message, details) => {
       log.info(message, details);

--- a/packages/electron-extensions/derive/html.test.ts
+++ b/packages/electron-extensions/derive/html.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { injectFacadeScript } from "./html";
+
+describe("injectFacadeScript", () => {
+  test("runs the facade before the page's own scripts", () => {
+    const page = injectFacadeScript(
+      '<!doctype html><html><head><title>Popup</title><script src="/popup.js"></script></head></html>',
+      "/chrome-facade.js",
+    );
+
+    expect(page).toStartWith(
+      '<!doctype html><html><head><script src="/chrome-facade.js"></script>',
+    );
+    expect(page.indexOf("/chrome-facade.js")).toBeLessThan(page.indexOf("/popup.js"));
+  });
+
+  test("falls back to the html tag when there is no head", () => {
+    expect(injectFacadeScript("<html><body>Hi</body></html>", "/chrome-facade.js")).toBe(
+      '<html><script src="/chrome-facade.js"></script><body>Hi</body></html>',
+    );
+  });
+
+  test("prepends when there is no markup to anchor to", () => {
+    expect(injectFacadeScript("Hi", "/chrome-facade.js")).toBe(
+      '<script src="/chrome-facade.js"></script>Hi',
+    );
+  });
+
+  test("injects once", () => {
+    const page = injectFacadeScript("<html><head></head></html>", "/chrome-facade.js");
+
+    expect(injectFacadeScript(page, "/chrome-facade.js")).toBe(page);
+  });
+});

--- a/packages/electron-extensions/derive/html.ts
+++ b/packages/electron-extensions/derive/html.ts
@@ -1,0 +1,27 @@
+const HEAD_TAG = /<head\b[^>]*>/i;
+
+const HTML_TAG = /<html\b[^>]*>/i;
+
+/**
+ * Puts the facade in front of every script an extension page runs. Extension
+ * pages get the same incomplete `chrome` object the service worker does, and a
+ * page has no preload of its own that reliably reaches its main world, so the
+ * script tag is written into the page when the extension is derived.
+ */
+export function injectFacadeScript(html: string, facadeUrl: string) {
+  if (html.includes(facadeUrl)) {
+    return html;
+  }
+
+  const scriptTag = `<script src="${facadeUrl}"></script>`;
+
+  const openingTag = HEAD_TAG.exec(html) ?? HTML_TAG.exec(html);
+
+  if (!openingTag) {
+    return `${scriptTag}${html}`;
+  }
+
+  const insertAt = openingTag.index + openingTag[0].length;
+
+  return `${html.slice(0, insertAt)}${scriptTag}${html.slice(insertAt)}`;
+}

--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { deriveExtension } from "./index";
+
+let workDir: string;
+
+let sourceDir: string;
+
+let derivedExtensionsDir: string;
+
+let facadeScriptPath: string;
+
+const manifest = {
+  name: "Test Extension",
+  version: "1.0.0",
+  manifest_version: 3,
+  key: "MIIBIjANBgkq",
+  background: { service_worker: "background/background.js", type: "module" },
+};
+
+async function writeManifest(manifestSource: Record<string, unknown>) {
+  await writeFile(path.join(sourceDir, "manifest.json"), JSON.stringify(manifestSource));
+}
+
+beforeEach(async () => {
+  workDir = await mkdtemp(path.join(tmpdir(), "electron-extensions-"));
+
+  sourceDir = path.join(workDir, "source");
+
+  derivedExtensionsDir = path.join(workDir, "derived");
+
+  facadeScriptPath = path.join(workDir, "facade.js");
+
+  await mkdir(path.join(sourceDir, "background"), { recursive: true });
+
+  await writeManifest(manifest);
+
+  await writeFile(path.join(sourceDir, "background", "background.js"), "// background\n");
+
+  await writeFile(path.join(sourceDir, "popup.html"), "<html><head></head></html>");
+
+  await writeFile(facadeScriptPath, "// facade\n");
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+function derive() {
+  return deriveExtension({ sourceDir, derivedExtensionsDir, facadeScriptPath });
+}
+
+describe("deriveExtension", () => {
+  test("copies the extension and adds the facade to its contexts", async () => {
+    const derivedDir = await derive();
+
+    const derivedManifest = JSON.parse(
+      await readFile(path.join(derivedDir, "manifest.json"), "utf8"),
+    );
+
+    expect(derivedManifest.background.service_worker).toBe("chrome-facade-service-worker.js");
+    expect(derivedManifest.key).toBe(manifest.key);
+
+    expect(
+      await readFile(path.join(derivedDir, "chrome-facade-service-worker.js"), "utf8"),
+    ).toContain('import "./chrome-facade.js";');
+
+    expect(await readFile(path.join(derivedDir, "chrome-facade.js"), "utf8")).toBe("// facade\n");
+
+    expect(await readFile(path.join(derivedDir, "popup.html"), "utf8")).toContain(
+      '<script src="/chrome-facade.js"></script>',
+    );
+
+    expect(await readFile(path.join(derivedDir, "background", "background.js"), "utf8")).toBe(
+      "// background\n",
+    );
+  });
+
+  test("never writes to the directory it was handed", async () => {
+    await derive();
+
+    expect((await readdir(sourceDir)).sort()).toEqual([
+      "background",
+      "manifest.json",
+      "popup.html",
+    ]);
+
+    expect(JSON.parse(await readFile(path.join(sourceDir, "manifest.json"), "utf8"))).toEqual(
+      manifest,
+    );
+
+    expect(await readFile(path.join(sourceDir, "popup.html"), "utf8")).toBe(
+      "<html><head></head></html>",
+    );
+  });
+
+  test("derives the same directory every time, so a generated id stays stable", async () => {
+    expect(await derive()).toBe(await derive());
+  });
+
+  test("derives a directory of its own per extension", async () => {
+    const otherSourceDir = path.join(workDir, "other-source");
+
+    await mkdir(otherSourceDir);
+
+    await writeFile(path.join(otherSourceDir, "manifest.json"), JSON.stringify(manifest));
+
+    const otherDerivedDir = await deriveExtension({
+      sourceDir: otherSourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+    });
+
+    expect(otherDerivedDir).not.toBe(await derive());
+  });
+
+  test("keeps the copy but refreshes the facade when nothing changed", async () => {
+    const derivedDir = await derive();
+
+    await writeFile(path.join(derivedDir, "background", "background.js"), "// stale\n");
+
+    await writeFile(facadeScriptPath, "// rebuilt facade\n");
+
+    await derive();
+
+    expect(await readFile(path.join(derivedDir, "background", "background.js"), "utf8")).toBe(
+      "// stale\n",
+    );
+    expect(await readFile(path.join(derivedDir, "chrome-facade.js"), "utf8")).toBe(
+      "// rebuilt facade\n",
+    );
+  });
+
+  test("copies again when the extension changed", async () => {
+    const derivedDir = await derive();
+
+    await writeFile(path.join(derivedDir, "background", "background.js"), "// stale\n");
+
+    await writeManifest({ ...manifest, version: "2.0.0" });
+
+    await derive();
+
+    expect(await readFile(path.join(derivedDir, "background", "background.js"), "utf8")).toBe(
+      "// background\n",
+    );
+    expect(JSON.parse(await readFile(path.join(derivedDir, "manifest.json"), "utf8")).version).toBe(
+      "2.0.0",
+    );
+  });
+
+  test("injects the facade into a page only once", async () => {
+    const derivedDir = await derive();
+
+    await derive();
+
+    const page = await readFile(path.join(derivedDir, "popup.html"), "utf8");
+
+    expect(page.split('<script src="/chrome-facade.js"></script>')).toHaveLength(2);
+  });
+});

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -1,0 +1,109 @@
+import { createHash } from "node:crypto";
+import { cp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { injectFacadeScript } from "./html";
+import { deriveManifest, type ExtensionManifest } from "./manifest";
+
+const MANIFEST_FILE_NAME = "manifest.json";
+
+const FACADE_FILE_NAME = "chrome-facade.js";
+
+const SERVICE_WORKER_FILE_NAME = "chrome-facade-service-worker.js";
+
+/** Bump whenever what is written into a derived copy changes. */
+const DERIVE_VERSION = 1;
+
+export type DeriveExtensionOptions = {
+  /** The unpacked extension the embedder handed over, never written to. */
+  sourceDir: string;
+  derivedExtensionsDir: string;
+  facadeScriptPath: string;
+};
+
+function hash(value: string) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function readStamp(stampPath: string) {
+  try {
+    return await readFile(stampPath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+async function injectFacadeIntoPages(derivedDir: string) {
+  const fileNames = await readdir(derivedDir, { recursive: true });
+
+  for (const fileName of fileNames) {
+    if (!fileName.endsWith(".html")) {
+      continue;
+    }
+
+    const pagePath = path.join(derivedDir, fileName);
+
+    const page = await readFile(pagePath, "utf8");
+
+    await writeFile(pagePath, injectFacadeScript(page, `/${FACADE_FILE_NAME}`));
+  }
+}
+
+/**
+ * Copies an unpacked extension into a directory the loader owns and adds the
+ * `chrome.*` facade to it: the service worker gets a wrapper that pulls the
+ * facade in ahead of the extension's background script, and every extension
+ * page gets a script tag doing the same.
+ *
+ * The copy exists because the facade has to be part of the extension to run in
+ * its contexts, and the directory the embedder handed over is not the loader's
+ * to write to — it is a verified install, or a directory a developer is working
+ * in. The copy sits at a path derived from the source path, so an extension
+ * without a `manifest.key` keeps the same generated id across launches.
+ */
+export async function deriveExtension({
+  sourceDir,
+  derivedExtensionsDir,
+  facadeScriptPath,
+}: DeriveExtensionOptions) {
+  const manifestSource = await readFile(path.join(sourceDir, MANIFEST_FILE_NAME), "utf8");
+
+  const derivedDir = path.join(derivedExtensionsDir, hash(sourceDir).slice(0, 16));
+
+  const stampPath = `${derivedDir}.json`;
+
+  // The source is copied again when its manifest changes, which is what an
+  // installed extension moving to a new version does
+  const stamp = JSON.stringify({
+    deriveVersion: DERIVE_VERSION,
+    sourceDir,
+    manifest: hash(manifestSource),
+  });
+
+  if ((await readStamp(stampPath)) !== stamp) {
+    await rm(derivedDir, { recursive: true, force: true });
+
+    await rm(stampPath, { force: true });
+
+    await cp(sourceDir, derivedDir, { recursive: true });
+
+    const { manifest, serviceWorkerWrapper } = deriveManifest(
+      JSON.parse(manifestSource) as ExtensionManifest,
+      { facadeFileName: FACADE_FILE_NAME, serviceWorkerFileName: SERVICE_WORKER_FILE_NAME },
+    );
+
+    if (serviceWorkerWrapper) {
+      await writeFile(path.join(derivedDir, MANIFEST_FILE_NAME), JSON.stringify(manifest, null, 2));
+
+      await writeFile(path.join(derivedDir, SERVICE_WORKER_FILE_NAME), serviceWorkerWrapper);
+    }
+
+    await injectFacadeIntoPages(derivedDir);
+
+    await writeFile(stampPath, stamp);
+  }
+
+  // Always, so a rebuilt facade reaches copies that are otherwise up to date
+  await cp(facadeScriptPath, path.join(derivedDir, FACADE_FILE_NAME));
+
+  return derivedDir;
+}

--- a/packages/electron-extensions/derive/manifest.test.ts
+++ b/packages/electron-extensions/derive/manifest.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { deriveManifest } from "./manifest";
+
+const fileNames = {
+  facadeFileName: "chrome-facade.js",
+  serviceWorkerFileName: "chrome-facade-service-worker.js",
+};
+
+describe("deriveManifest", () => {
+  test("points the service worker at a wrapper importing the facade first", () => {
+    const { manifest, serviceWorkerWrapper } = deriveManifest(
+      {
+        name: "1Password",
+        background: { service_worker: "background/background.js", type: "module" },
+      },
+      fileNames,
+    );
+
+    expect(manifest.background).toEqual({
+      service_worker: "chrome-facade-service-worker.js",
+      type: "module",
+    });
+    expect(serviceWorkerWrapper).toContain('import "./chrome-facade.js";');
+    expect(serviceWorkerWrapper).toContain('import "./background/background.js";');
+    expect(serviceWorkerWrapper?.indexOf("chrome-facade.js")).toBeLessThan(
+      serviceWorkerWrapper?.indexOf("background/background.js") ?? 0,
+    );
+  });
+
+  test("imports with importScripts when the service worker is not a module", () => {
+    const { serviceWorkerWrapper } = deriveManifest(
+      { background: { service_worker: "background.js" } },
+      fileNames,
+    );
+
+    expect(serviceWorkerWrapper).toContain('importScripts("/chrome-facade.js", "/background.js");');
+  });
+
+  test("keeps the key so the extension id stays the one it was installed as", () => {
+    const { manifest } = deriveManifest(
+      { key: "MIIBIjANBgkq", background: { service_worker: "background.js" } },
+      fileNames,
+    );
+
+    expect(manifest.key).toBe("MIIBIjANBgkq");
+  });
+
+  test("leaves the source manifest alone", () => {
+    const sourceManifest = {
+      background: { service_worker: "background.js", type: "module" },
+    };
+
+    deriveManifest(sourceManifest, fileNames);
+
+    expect(sourceManifest.background.service_worker).toBe("background.js");
+  });
+
+  test("writes no wrapper for a manifest without a service worker", () => {
+    const { manifest, serviceWorkerWrapper } = deriveManifest({ name: "No background" }, fileNames);
+
+    expect(serviceWorkerWrapper).toBeNull();
+    expect(manifest.background).toBeUndefined();
+  });
+});

--- a/packages/electron-extensions/derive/manifest.ts
+++ b/packages/electron-extensions/derive/manifest.ts
@@ -1,0 +1,70 @@
+export type ExtensionManifest = {
+  name?: string;
+  version?: string;
+  key?: string;
+  background?: {
+    service_worker?: string;
+    type?: string;
+  };
+};
+
+export type DerivedManifest = {
+  manifest: ExtensionManifest;
+  serviceWorkerWrapper: string | null;
+};
+
+/**
+ * A service worker that pulls in the facade before the extension's own
+ * background script. Static imports are the only vehicle: `import()` is banned
+ * in service workers, and a script injected any other way runs too late or, on
+ * Electron 43, not at all (see the injection-vehicle notes in the feature doc).
+ */
+function createServiceWorkerWrapper(
+  facadeFileName: string,
+  backgroundFileName: string,
+  isModule: boolean,
+) {
+  const header =
+    "// Generated when the extension was derived, in place of its own service worker.\n";
+
+  if (isModule) {
+    return `${header}import "./${facadeFileName}";\nimport "./${backgroundFileName}";\n`;
+  }
+
+  return `${header}importScripts("/${facadeFileName}", "/${backgroundFileName}");\n`;
+}
+
+/**
+ * Points the manifest's service worker at a generated wrapper. Everything else
+ * is carried over untouched — `key` above all, since without it Chromium
+ * derives the extension id from the directory it was loaded from and the
+ * derived copy would answer to a different id than the extension it came from.
+ */
+export function deriveManifest(
+  manifest: ExtensionManifest,
+  {
+    facadeFileName,
+    serviceWorkerFileName,
+  }: {
+    facadeFileName: string;
+    serviceWorkerFileName: string;
+  },
+): DerivedManifest {
+  const backgroundFileName = manifest.background?.service_worker?.replace(/^\//, "");
+
+  if (!backgroundFileName) {
+    return { manifest, serviceWorkerWrapper: null };
+  }
+
+  return {
+    manifest: {
+      ...manifest,
+      background: { ...manifest.background, service_worker: serviceWorkerFileName },
+    },
+    serviceWorkerWrapper: createServiceWorkerWrapper(
+      facadeFileName,
+      backgroundFileName,
+      manifest.background?.type === "module",
+    ),
+  };
+}

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -1,9 +1,57 @@
-import { describe, expect, test } from "bun:test";
-import fs from "node:fs/promises";
-import os from "node:os";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import fs, { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os, { tmpdir } from "node:os";
 import path from "node:path";
 import type { Extension, Session } from "electron";
 import { Extensions } from "./extensions";
+
+let workDir: string;
+
+let facadeScriptPath: string;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(path.join(tmpdir(), "electron-extensions-"));
+
+  facadeScriptPath = path.join(workDir, "facade.js");
+
+  await writeFile(facadeScriptPath, "// facade\n");
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+async function createExtensionDir(name: string) {
+  const extensionDir = path.join(workDir, name);
+
+  await mkdir(extensionDir, { recursive: true });
+
+  await writeFile(
+    path.join(extensionDir, "manifest.json"),
+    JSON.stringify({
+      name,
+      version: "1.0.0",
+      manifest_version: 3,
+      background: { service_worker: "background.js", type: "module" },
+    }),
+  );
+
+  await writeFile(path.join(extensionDir, "background.js"), "// background\n");
+
+  return extensionDir;
+}
+
+function createExtensions(
+  extensionDirs: string[],
+  logger?: ConstructorParameters<typeof Extensions>[0]["logger"],
+) {
+  return new Extensions({
+    extensionDirs,
+    facadeScriptPath,
+    derivedExtensionsDir: path.join(workDir, "derived"),
+    logger,
+  });
+}
 
 function createExtension(id: string, extensionDir: string) {
   return {
@@ -59,7 +107,7 @@ async function listPartitionDir(partitionPath: string) {
 }
 
 describe("Extensions", () => {
-  test("loads every directory into the session", async () => {
+  test("loads a copy of every directory, with the facade in it", async () => {
     const loadedExtensionDirs: string[] = [];
 
     const { session } = createSession({
@@ -70,11 +118,35 @@ describe("Extensions", () => {
       },
     });
 
-    const extensions = new Extensions({ extensionDirs: ["/extensions/one", "/extensions/two"] });
+    const extensionDirs = [await createExtensionDir("one"), await createExtensionDir("two")];
 
-    await extensions.setupSession(session);
+    await createExtensions(extensionDirs).setupSession(session);
 
-    expect(loadedExtensionDirs).toEqual(["/extensions/one", "/extensions/two"]);
+    expect(loadedExtensionDirs).toHaveLength(2);
+    expect(loadedExtensionDirs).not.toContain(extensionDirs[0]);
+
+    for (const loadedExtensionDir of loadedExtensionDirs) {
+      expect(await readFile(path.join(loadedExtensionDir, "chrome-facade.js"), "utf8")).toBe(
+        "// facade\n",
+      );
+    }
+  });
+
+  test("loads the same copy into every session", async () => {
+    const loadedExtensionDirs: string[] = [];
+
+    const loadExtension = async (extensionDir: string) => {
+      loadedExtensionDirs.push(extensionDir);
+
+      return createExtension("aaa", extensionDir);
+    };
+
+    const extensions = createExtensions([await createExtensionDir("one")]);
+
+    await extensions.setupSession(createSession({ loadExtension }).session);
+    await extensions.setupSession(createSession({ loadExtension }).session);
+
+    expect(loadedExtensionDirs[0]).toBe(loadedExtensionDirs[1] as string);
   });
 
   test("does nothing without extension directories", async () => {
@@ -88,7 +160,7 @@ describe("Extensions", () => {
       },
     });
 
-    const extensions = new Extensions({ extensionDirs: [] });
+    const extensions = createExtensions([]);
 
     await extensions.setupSession(session);
 
@@ -103,30 +175,23 @@ describe("Extensions", () => {
   test("keeps loading after a directory fails", async () => {
     const loggedErrors: Record<string, unknown>[] = [];
 
-    const { session } = createSession({
-      loadExtension: async (extensionDir) => {
-        if (extensionDir === "/extensions/broken") {
-          throw new Error("Could not load extension");
-        }
+    const brokenExtensionDir = path.join(workDir, "broken");
 
-        return createExtension("aaa", extensionDir);
-      },
-    });
+    await mkdir(brokenExtensionDir);
 
-    const extensions = new Extensions({
-      extensionDirs: ["/extensions/broken", "/extensions/one"],
-      logger: {
-        info: () => {},
-        error: (_message, details) => {
-          loggedErrors.push(details);
-        },
+    const { session } = createSession();
+
+    const extensions = createExtensions([brokenExtensionDir, await createExtensionDir("one")], {
+      info: () => {},
+      error: (_message, details) => {
+        loggedErrors.push(details);
       },
     });
 
     await extensions.setupSession(session);
 
     expect(loggedErrors).toHaveLength(1);
-    expect(loggedErrors[0]?.extensionDir).toBe("/extensions/broken");
+    expect(loggedErrors[0]?.extensionDir).toBe(brokenExtensionDir);
     expect(extensions.isLoadedExtensionUrl(session, "chrome-extension://aaa/popup.html")).toBe(
       true,
     );
@@ -136,7 +201,7 @@ describe("Extensions", () => {
     const { session: sessionWithExtension } = createSession();
     const { session: sessionWithoutExtension } = createSession();
 
-    const extensions = new Extensions({ extensionDirs: ["/extensions/one"] });
+    const extensions = createExtensions([await createExtensionDir("one")]);
 
     await extensions.setupSession(sessionWithExtension);
 
@@ -157,7 +222,7 @@ describe("Extensions", () => {
   test("unloads what it loaded and forgets the session", async () => {
     const { session, removedExtensionIds } = createSession();
 
-    const extensions = new Extensions({ extensionDirs: ["/extensions/one"] });
+    const extensions = createExtensions([await createExtensionDir("one")]);
 
     await extensions.setupSession(session);
 
@@ -254,7 +319,10 @@ describe("Extensions", () => {
       loadExtension: () => loadExtensionPromise,
     });
 
-    const extensions = new Extensions({ extensionDirs: ["/extensions/one", "/extensions/two"] });
+    const extensions = createExtensions([
+      await createExtensionDir("one"),
+      await createExtensionDir("two"),
+    ]);
 
     const setupSessionPromise = extensions.setupSession(session);
 

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -254,7 +254,7 @@ describe("Extensions", () => {
 
     const { session } = createSession({ storagePath: partitionPath });
 
-    const extensions = new Extensions({ extensionDirs: ["/extensions/one"] });
+    const extensions = createExtensions([await createExtensionDir("one")]);
 
     await extensions.setupSession(session);
 
@@ -280,13 +280,10 @@ describe("Extensions", () => {
 
     const { session } = createSession();
 
-    const extensions = new Extensions({
-      extensionDirs: ["/extensions/one"],
-      logger: {
-        info: () => {},
-        error: (_message, details) => {
-          loggedErrors.push(details);
-        },
+    const extensions = createExtensions([await createExtensionDir("one")], {
+      info: () => {},
+      error: (_message, details) => {
+        loggedErrors.push(details);
       },
     });
 
@@ -302,7 +299,7 @@ describe("Extensions", () => {
 
     const { session } = createSession({ storagePath: partitionPath });
 
-    const extensions = new Extensions({ extensionDirs: [] });
+    const extensions = createExtensions([]);
 
     await extensions.clearSessionData(session);
 

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { Session } from "electron";
+import { deriveExtension } from "./derive";
 
 /**
  * Chromium keeps every `chrome.storage` area of every extension in its own
@@ -30,6 +31,13 @@ export type ExtensionsOptions = {
    * `setupSession`.
    */
   extensionDirs: string[];
+  /**
+   * The bundled `chrome.*` facade script, copied into every extension so it
+   * runs in the extension's own contexts.
+   */
+  facadeScriptPath: string;
+  /** A directory the loader owns, holding the copy it loads of each extension. */
+  derivedExtensionsDir: string;
   logger?: ExtensionsLogger;
 };
 
@@ -46,14 +54,50 @@ export type ExtensionsOptions = {
 export class Extensions {
   private extensionDirs: string[];
 
+  private facadeScriptPath: string;
+
+  private derivedExtensionsDir: string;
+
   private logger: ExtensionsLogger | undefined;
 
   private loadedExtensionIdsBySession = new Map<Session, Set<string>>();
 
-  constructor({ extensionDirs, logger }: ExtensionsOptions) {
+  private derivedExtensionDirs = new Map<string, Promise<string>>();
+
+  constructor({
+    extensionDirs,
+    facadeScriptPath,
+    derivedExtensionsDir,
+    logger,
+  }: ExtensionsOptions) {
     this.extensionDirs = extensionDirs;
 
+    this.facadeScriptPath = facadeScriptPath;
+
+    this.derivedExtensionsDir = derivedExtensionsDir;
+
     this.logger = logger;
+  }
+
+  /**
+   * The copy of an extension that carries the facade. Sessions share it the way
+   * they shared the source directory: one copy on disk, one instance per
+   * session.
+   */
+  private deriveExtensionDir(sourceDir: string) {
+    let derivedExtensionDir = this.derivedExtensionDirs.get(sourceDir);
+
+    if (!derivedExtensionDir) {
+      derivedExtensionDir = deriveExtension({
+        sourceDir,
+        derivedExtensionsDir: this.derivedExtensionsDir,
+        facadeScriptPath: this.facadeScriptPath,
+      });
+
+      this.derivedExtensionDirs.set(sourceDir, derivedExtensionDir);
+    }
+
+    return derivedExtensionDir;
   }
 
   async setupSession(session: Session) {
@@ -67,7 +111,9 @@ export class Extensions {
 
     for (const extensionDir of this.extensionDirs) {
       try {
-        const extension = await session.extensions.loadExtension(extensionDir);
+        const extension = await session.extensions.loadExtension(
+          await this.deriveExtensionDir(extensionDir),
+        );
 
         // The session can be torn down while an extension is still loading
         if (this.loadedExtensionIdsBySession.get(session) !== loadedExtensionIds) {

--- a/packages/electron-extensions/facade/api/commands.ts
+++ b/packages/electron-extensions/facade/api/commands.ts
@@ -1,0 +1,13 @@
+import type { ChromeNamespace } from "../lib/chrome";
+import { createNoopEvent } from "../lib/event";
+import { createNoopMethod } from "../lib/method";
+
+export function createCommands(): ChromeNamespace {
+  return {
+    // No command is bound to anything, so the extension is told about none
+    getAll: createNoopMethod(() => []),
+
+    onCommand: createNoopEvent(),
+    onChanged: createNoopEvent(),
+  };
+}

--- a/packages/electron-extensions/facade/api/context-menus.ts
+++ b/packages/electron-extensions/facade/api/context-menus.ts
@@ -1,0 +1,50 @@
+import type { ChromeNamespace } from "../lib/chrome";
+import { createNoopEvent } from "../lib/event";
+import { createNoopMethod } from "../lib/method";
+
+let createdMenuItemCount = 0;
+
+function takeMenuItemId(createProperties: unknown) {
+  if (createProperties !== null && typeof createProperties === "object") {
+    const { id } = createProperties as { id?: unknown };
+
+    if (typeof id === "string" || typeof id === "number") {
+      return id;
+    }
+  }
+
+  createdMenuItemCount += 1;
+
+  return createdMenuItemCount;
+}
+
+/**
+ * The one method here that answers synchronously with the id it assigned, using
+ * its optional callback only to signal that the item was created.
+ */
+function createMenuItem(...callArguments: unknown[]) {
+  const menuItemId = takeMenuItemId(callArguments[0]);
+
+  const callback = callArguments.at(-1);
+
+  if (typeof callback === "function") {
+    queueMicrotask(() => {
+      callback();
+    });
+  }
+
+  return menuItemId;
+}
+
+export function createContextMenus(): ChromeNamespace {
+  return {
+    ACTION_MENU_TOP_LEVEL_LIMIT: 6,
+
+    create: createMenuItem,
+    update: createNoopMethod(() => undefined),
+    remove: createNoopMethod(() => undefined),
+    removeAll: createNoopMethod(() => undefined),
+
+    onClicked: createNoopEvent(),
+  };
+}

--- a/packages/electron-extensions/facade/api/notifications.ts
+++ b/packages/electron-extensions/facade/api/notifications.ts
@@ -1,0 +1,39 @@
+import type { ChromeNamespace } from "../lib/chrome";
+import { createNoopEvent } from "../lib/event";
+import { createNoopMethod } from "../lib/method";
+
+let createdNotificationCount = 0;
+
+/**
+ * `create` takes the notification id as an optional first argument and answers
+ * with the id it used, so a caller that left it out gets a generated one back
+ * the way Chrome hands one out.
+ */
+function takeNotificationId(callArguments: unknown[]) {
+  const [notificationId] = callArguments;
+
+  if (typeof notificationId === "string") {
+    return notificationId;
+  }
+
+  createdNotificationCount += 1;
+
+  return `notification-${createdNotificationCount}`;
+}
+
+export function createNotifications(): ChromeNamespace {
+  return {
+    create: createNoopMethod(takeNotificationId),
+    // Nothing was ever shown, so nothing was updated or cleared
+    update: createNoopMethod(() => false),
+    clear: createNoopMethod(() => false),
+    getAll: createNoopMethod(() => ({})),
+    getPermissionLevel: createNoopMethod(() => "granted"),
+
+    onClosed: createNoopEvent(),
+    onClicked: createNoopEvent(),
+    onButtonClicked: createNoopEvent(),
+    onPermissionLevelChanged: createNoopEvent(),
+    onShowSettings: createNoopEvent(),
+  };
+}

--- a/packages/electron-extensions/facade/api/privacy.ts
+++ b/packages/electron-extensions/facade/api/privacy.ts
@@ -1,0 +1,59 @@
+import type { ChromeNamespace } from "../lib/chrome";
+import { createNoopEvent } from "../lib/event";
+import { createNoopMethod } from "../lib/method";
+
+/**
+ * Chrome's privacy settings describe browser features an embedder built on
+ * Electron does not have — password saving, autofill, safe browsing — so every
+ * setting reports itself as out of the extension's reach and writes go nowhere.
+ * The reported values are placeholders of the right type, not measurements.
+ */
+function createSetting(value: unknown): ChromeNamespace {
+  return {
+    get: createNoopMethod(() => ({ value, levelOfControl: "not_controllable" })),
+    set: createNoopMethod(() => undefined),
+    clear: createNoopMethod(() => undefined),
+    onChange: createNoopEvent(),
+  };
+}
+
+function createSettings(values: Record<string, unknown>): ChromeNamespace {
+  const settings: ChromeNamespace = {};
+
+  for (const [settingName, value] of Object.entries(values)) {
+    settings[settingName] = createSetting(value);
+  }
+
+  return settings;
+}
+
+export function createPrivacy(): ChromeNamespace {
+  return {
+    network: createSettings({
+      networkPredictionEnabled: false,
+      webRTCIPHandlingPolicy: "default",
+    }),
+    services: createSettings({
+      alternateErrorPagesEnabled: false,
+      autofillAddressEnabled: false,
+      autofillCreditCardEnabled: false,
+      passwordSavingEnabled: false,
+      safeBrowsingEnabled: false,
+      safeBrowsingExtendedReportingEnabled: false,
+      searchSuggestEnabled: false,
+      spellingServiceEnabled: false,
+      translationServiceEnabled: false,
+    }),
+    websites: createSettings({
+      adMeasurementEnabled: false,
+      doNotTrackEnabled: false,
+      fledgeEnabled: false,
+      hyperlinkAuditingEnabled: false,
+      protectedContentEnabled: false,
+      referrersEnabled: false,
+      relatedWebsiteSetsEnabled: false,
+      thirdPartyCookiesAllowed: false,
+      topicsEnabled: false,
+    }),
+  };
+}

--- a/packages/electron-extensions/facade/api/tabs.ts
+++ b/packages/electron-extensions/facade/api/tabs.ts
@@ -1,0 +1,12 @@
+import type { ChromeNamespace } from "../lib/chrome";
+
+/**
+ * Electron implements the tabs namespace itself, minus the two constants
+ * extensions compare ids against.
+ */
+export function createTabs(): ChromeNamespace {
+  return {
+    TAB_ID_NONE: -1,
+    TAB_INDEX_NONE: -1,
+  };
+}

--- a/packages/electron-extensions/facade/api/web-navigation.ts
+++ b/packages/electron-extensions/facade/api/web-navigation.ts
@@ -1,0 +1,21 @@
+import type { ChromeNamespace } from "../lib/chrome";
+import { createNoopEvent } from "../lib/event";
+import { createNoopMethod } from "../lib/method";
+
+export function createWebNavigation(): ChromeNamespace {
+  return {
+    // Chrome answers `null` for a frame it cannot find, and extensions handle it
+    getFrame: createNoopMethod(() => null),
+    getAllFrames: createNoopMethod(() => []),
+
+    onBeforeNavigate: createNoopEvent(),
+    onCommitted: createNoopEvent(),
+    onDOMContentLoaded: createNoopEvent(),
+    onCompleted: createNoopEvent(),
+    onErrorOccurred: createNoopEvent(),
+    onCreatedNavigationTarget: createNoopEvent(),
+    onReferenceFragmentUpdated: createNoopEvent(),
+    onTabReplaced: createNoopEvent(),
+    onHistoryStateUpdated: createNoopEvent(),
+  };
+}

--- a/packages/electron-extensions/facade/api/web-request.ts
+++ b/packages/electron-extensions/facade/api/web-request.ts
@@ -1,0 +1,29 @@
+import type { ChromeNamespace } from "../lib/chrome";
+import { createNoopEvent } from "../lib/event";
+import { createNoopMethod } from "../lib/method";
+
+/**
+ * The namespace Electron declares but cannot serve: its extension bindings ship
+ * no `webRequest` module, so every event on it is declared-but-`undefined` —
+ * feature detection with `in` passes and the dereference that follows takes the
+ * service worker down. Filling the events keeps that from happening; requests
+ * still only pass through the embedder's own `session.webRequest`.
+ */
+export function createWebRequest(): ChromeNamespace {
+  return {
+    MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES: 20,
+
+    handlerBehaviorChanged: createNoopMethod(() => undefined),
+
+    onBeforeRequest: createNoopEvent(),
+    onBeforeSendHeaders: createNoopEvent(),
+    onSendHeaders: createNoopEvent(),
+    onHeadersReceived: createNoopEvent(),
+    onAuthRequired: createNoopEvent(),
+    onResponseStarted: createNoopEvent(),
+    onBeforeRedirect: createNoopEvent(),
+    onCompleted: createNoopEvent(),
+    onErrorOccurred: createNoopEvent(),
+    onActionIgnored: createNoopEvent(),
+  };
+}

--- a/packages/electron-extensions/facade/api/windows.ts
+++ b/packages/electron-extensions/facade/api/windows.ts
@@ -1,0 +1,46 @@
+import type { ChromeNamespace } from "../lib/chrome";
+import { createNoopEvent } from "../lib/event";
+import { createNoopMethod } from "../lib/method";
+
+/**
+ * The one window every query answers with. An embedder promoting this namespace
+ * maps it onto its own windows; until then extensions only need a stable id
+ * that is neither `WINDOW_ID_NONE` nor `WINDOW_ID_CURRENT`.
+ */
+const WINDOW_ID = 1;
+
+function createWindow() {
+  return {
+    id: WINDOW_ID,
+    focused: true,
+    incognito: false,
+    alwaysOnTop: false,
+    state: "normal",
+    type: "normal",
+    top: 0,
+    left: 0,
+    width: 1280,
+    height: 800,
+    tabs: [],
+  };
+}
+
+export function createWindows(): ChromeNamespace {
+  return {
+    WINDOW_ID_NONE: -1,
+    WINDOW_ID_CURRENT: -2,
+
+    get: createNoopMethod(createWindow),
+    getCurrent: createNoopMethod(createWindow),
+    getLastFocused: createNoopMethod(createWindow),
+    getAll: createNoopMethod(() => [createWindow()]),
+    create: createNoopMethod(createWindow),
+    update: createNoopMethod(createWindow),
+    remove: createNoopMethod(() => undefined),
+
+    onCreated: createNoopEvent(),
+    onRemoved: createNoopEvent(),
+    onFocusChanged: createNoopEvent(),
+    onBoundsChanged: createNoopEvent(),
+  };
+}

--- a/packages/electron-extensions/facade/index.ts
+++ b/packages/electron-extensions/facade/index.ts
@@ -1,0 +1,27 @@
+import { createChromeFacade, installChromeFacade } from "./install";
+import type { ChromeNamespace } from "./lib/chrome";
+
+/**
+ * Entry point of the script that runs in extension contexts before any
+ * extension code. It is bundled on its own and copied into the derived
+ * extension directory, so it must stand alone: no Node, no DOM, no imports
+ * beyond this package.
+ *
+ * Electron puts the extension API under two globals, `chrome` and `browser`,
+ * as two separate objects with the same namespaces — measured 2026-08-16 in an
+ * extension service worker, and the reason 1Password crashed on
+ * `browser.windows.WINDOW_ID_NONE` while `chrome.windows` was already complete.
+ * Both are filled from one facade, so a namespace promoted to a real
+ * implementation later has one set of listeners, whichever global reached it.
+ */
+const extensionGlobals = globalThis as unknown as Record<string, ChromeNamespace | undefined>;
+
+const facade = createChromeFacade();
+
+for (const globalName of ["chrome", "browser"]) {
+  const extensionApi = extensionGlobals[globalName];
+
+  if (extensionApi) {
+    installChromeFacade(extensionApi, facade);
+  }
+}

--- a/packages/electron-extensions/facade/install.test.ts
+++ b/packages/electron-extensions/facade/install.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+import { createChromeFacade, installChromeFacade } from "./install";
+import type { ChromeEvent, ChromeNamespace } from "./lib/chrome";
+
+/**
+ * What Electron's extension bindings hand an extension, as the spike measured
+ * it: a handful of complete namespaces, `tabs` without its constants, and a
+ * `webRequest` whose events are declared but never defined.
+ */
+function createNativeChrome(): ChromeNamespace {
+  return {
+    runtime: { id: "aeblfdkhhhdcdjpifhhbdiojplfjncoa", getURL: (pathname: string) => pathname },
+    storage: { local: { get: () => Promise.resolve({}) } },
+    tabs: { query: () => Promise.resolve([]) },
+    webRequest: { onBeforeRequest: undefined, onAuthRequired: undefined },
+  };
+}
+
+function install() {
+  const chrome = createNativeChrome();
+
+  installChromeFacade(chrome);
+
+  return chrome;
+}
+
+function namespaceOf(chrome: ChromeNamespace, name: string) {
+  return chrome[name] as ChromeNamespace;
+}
+
+function eventOf(namespace: ChromeNamespace, name: string) {
+  return namespace[name] as ChromeEvent;
+}
+
+function methodOf(namespace: ChromeNamespace, name: string) {
+  return namespace[name] as (...callArguments: unknown[]) => Promise<unknown>;
+}
+
+describe("installChromeFacade", () => {
+  test("leaves everything Electron implements untouched", () => {
+    const chrome = createNativeChrome();
+
+    const { runtime, storage, tabs } = chrome;
+
+    const query = namespaceOf(chrome, "tabs").query;
+
+    installChromeFacade(chrome);
+
+    expect(chrome.runtime).toBe(runtime);
+    expect(chrome.storage).toBe(storage);
+    expect(chrome.tabs).toBe(tabs);
+    expect(namespaceOf(chrome, "tabs").query).toBe(query);
+  });
+
+  test("fills the namespaces Electron is missing", () => {
+    const chrome = install();
+
+    for (const namespace of [
+      "commands",
+      "contextMenus",
+      "notifications",
+      "privacy",
+      "webNavigation",
+      "windows",
+    ]) {
+      expect(chrome[namespace]).toBeObject();
+    }
+  });
+
+  test("adds the constants extensions compare ids against", () => {
+    const chrome = install();
+
+    expect(namespaceOf(chrome, "tabs").TAB_ID_NONE).toBe(-1);
+    expect(namespaceOf(chrome, "windows").WINDOW_ID_NONE).toBe(-1);
+    expect(namespaceOf(chrome, "windows").WINDOW_ID_CURRENT).toBe(-2);
+  });
+
+  test("defines the webRequest events Electron declares but never defines", () => {
+    const webRequest = namespaceOf(install(), "webRequest");
+
+    // The crash the spike hit: `"onAuthRequired" in chrome.webRequest` passes
+    // and the dereference that follows takes the service worker down
+    expect(eventOf(webRequest, "onAuthRequired").addListener).toBeFunction();
+    expect(eventOf(webRequest, "onBeforeRedirect").addListener).toBeFunction();
+    expect(eventOf(webRequest, "onBeforeRequest").addListener).toBeFunction();
+  });
+
+  test("accepts listeners on events that never fire", () => {
+    const onFocusChanged = eventOf(namespaceOf(install(), "windows"), "onFocusChanged");
+
+    let firedCount = 0;
+
+    const listener = () => {
+      firedCount += 1;
+    };
+
+    onFocusChanged.addListener(listener);
+
+    expect(onFocusChanged.hasListener(listener)).toBe(true);
+    expect(onFocusChanged.hasListeners()).toBe(true);
+
+    onFocusChanged.removeListener(listener);
+
+    expect(onFocusChanged.hasListener(listener)).toBe(false);
+    expect(firedCount).toBe(0);
+  });
+
+  test("answers a promise call with a window of the right shape", async () => {
+    const windows = namespaceOf(install(), "windows");
+
+    const currentWindow = (await methodOf(windows, "getCurrent")({ populate: true })) as Record<
+      string,
+      unknown
+    >;
+
+    expect(currentWindow.id).toBeNumber();
+    expect(currentWindow.id).not.toBe(-1);
+    expect(currentWindow.focused).toBe(true);
+    expect(currentWindow.tabs).toEqual([]);
+  });
+
+  test("answers a callback call instead of returning a promise", async () => {
+    const windows = namespaceOf(install(), "windows");
+
+    const { promise, resolve } = Promise.withResolvers<unknown>();
+
+    const returnValue = methodOf(windows, "getAll")({}, resolve);
+
+    expect(returnValue).toBeUndefined();
+    expect(await promise).toBeArrayOfSize(1);
+  });
+
+  test("hands out context menu ids the way Chrome does", () => {
+    const contextMenus = namespaceOf(install(), "contextMenus");
+
+    const create = contextMenus.create as (properties: unknown) => unknown;
+
+    expect(create({ id: "unlock", title: "Unlock" })).toBe("unlock");
+    expect(create({ title: "Fill" })).toBeNumber();
+  });
+
+  test("reports privacy settings as out of the extension's reach", async () => {
+    const services = namespaceOf(namespaceOf(install(), "privacy"), "services");
+
+    const passwordSavingEnabled = namespaceOf(services, "passwordSavingEnabled");
+
+    expect(await methodOf(passwordSavingEnabled, "set")({ value: true })).toBeUndefined();
+    expect(await methodOf(passwordSavingEnabled, "get")({})).toEqual({
+      value: false,
+      levelOfControl: "not_controllable",
+    });
+  });
+
+  test("shares one facade between the chrome and browser globals", () => {
+    const facade = createChromeFacade();
+
+    const chrome = createNativeChrome();
+    const browser = createNativeChrome();
+
+    installChromeFacade(chrome, facade);
+    installChromeFacade(browser, facade);
+
+    const listener = () => {};
+
+    eventOf(namespaceOf(browser, "windows"), "onFocusChanged").addListener(listener);
+
+    expect(eventOf(namespaceOf(chrome, "windows"), "onFocusChanged").hasListener(listener)).toBe(
+      true,
+    );
+  });
+
+  test("runs twice without replacing what the first run added", () => {
+    const chrome = install();
+
+    const { windows } = chrome;
+
+    installChromeFacade(chrome);
+
+    expect(chrome.windows).toBe(windows);
+  });
+});

--- a/packages/electron-extensions/facade/install.ts
+++ b/packages/electron-extensions/facade/install.ts
@@ -1,0 +1,44 @@
+import { createCommands } from "./api/commands";
+import { createContextMenus } from "./api/context-menus";
+import { createNotifications } from "./api/notifications";
+import { createPrivacy } from "./api/privacy";
+import { createTabs } from "./api/tabs";
+import { createWebNavigation } from "./api/web-navigation";
+import { createWebRequest } from "./api/web-request";
+import { createWindows } from "./api/windows";
+import type { ChromeNamespace } from "./lib/chrome";
+import { fillMissing } from "./lib/fill";
+
+/**
+ * Everything the facade has to offer, built without looking at what Electron
+ * implements: noop namespaces for what Electron is missing entirely, and the
+ * odd member for a namespace it ships half-finished. Promoting one of these to
+ * a real implementation later means backing it with an embedder transport —
+ * where the facade is installed and how it is merged stay the same.
+ */
+export function createChromeFacade(): ChromeNamespace {
+  return {
+    commands: createCommands(),
+    contextMenus: createContextMenus(),
+    notifications: createNotifications(),
+    privacy: createPrivacy(),
+    tabs: createTabs(),
+    webNavigation: createWebNavigation(),
+    webRequest: createWebRequest(),
+    windows: createWindows(),
+  };
+}
+
+/**
+ * Completes an extension API object in place — the `chrome` object of a service
+ * worker, a popup, an options page, any `chrome-extension://` frame. Nothing
+ * native is replaced or wrapped: every namespace and member Electron implements
+ * is left exactly as it is, and only the gaps around it are filled (see the
+ * noop-first decision in the feature docs).
+ */
+export function installChromeFacade(
+  extensionApi: ChromeNamespace,
+  facade: ChromeNamespace = createChromeFacade(),
+) {
+  fillMissing(extensionApi, facade);
+}

--- a/packages/electron-extensions/facade/lib/chrome.ts
+++ b/packages/electron-extensions/facade/lib/chrome.ts
@@ -1,0 +1,19 @@
+/**
+ * The facade never knows what Electron's own `chrome` object holds, so every
+ * namespace is treated as an opaque bag of values it may add to.
+ */
+export type ChromeNamespace = Record<string, unknown>;
+
+export type ChromeEventListener = (...eventArguments: unknown[]) => unknown;
+
+/**
+ * Chrome's event shape. The facade's events keep their listeners so
+ * `hasListener` answers truthfully and a promoted namespace has them to call,
+ * but nothing ever dispatches.
+ */
+export type ChromeEvent = {
+  addListener: (listener: ChromeEventListener, ...eventOptions: unknown[]) => void;
+  removeListener: (listener: ChromeEventListener) => void;
+  hasListener: (listener: ChromeEventListener) => boolean;
+  hasListeners: () => boolean;
+};

--- a/packages/electron-extensions/facade/lib/event.ts
+++ b/packages/electron-extensions/facade/lib/event.ts
@@ -1,0 +1,25 @@
+import type { ChromeEvent, ChromeEventListener } from "./chrome";
+
+/**
+ * An event that accepts listeners and never fires. Extensions register their
+ * listeners at startup and feature-detect by calling `addListener`, so the
+ * shape has to be complete even when nothing behind it exists yet.
+ */
+export function createNoopEvent(): ChromeEvent {
+  const listeners = new Set<ChromeEventListener>();
+
+  return {
+    addListener(listener) {
+      listeners.add(listener);
+    },
+    removeListener(listener) {
+      listeners.delete(listener);
+    },
+    hasListener(listener) {
+      return listeners.has(listener);
+    },
+    hasListeners() {
+      return listeners.size > 0;
+    },
+  };
+}

--- a/packages/electron-extensions/facade/lib/fill.ts
+++ b/packages/electron-extensions/facade/lib/fill.ts
@@ -1,0 +1,58 @@
+import type { ChromeNamespace } from "./chrome";
+
+/**
+ * Reads through whatever Electron put in the way. A namespace Chromium declares
+ * without shipping its module — `webRequest` is one — answers with a getter
+ * that logs and gives back `undefined`, and nothing here should ride on that
+ * staying an ordinary property.
+ */
+function read(target: ChromeNamespace, name: string) {
+  try {
+    return target[name];
+  } catch {
+    return undefined;
+  }
+}
+
+function define(target: ChromeNamespace, name: string, value: unknown) {
+  try {
+    Object.defineProperty(target, name, {
+      value,
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+  } catch {
+    target[name] = value;
+  }
+}
+
+function isNamespace(value: unknown): value is ChromeNamespace {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Adds what `facade` has and `target` lacks, and never anything else: an API
+ * Electron implements keeps the object it implemented, down to the individual
+ * members of a namespace it ships half-finished.
+ */
+export function fillMissing(target: ChromeNamespace, facade: ChromeNamespace) {
+  for (const [name, facadeValue] of Object.entries(facade)) {
+    try {
+      const nativeValue = read(target, name);
+
+      if (nativeValue === undefined) {
+        define(target, name, facadeValue);
+
+        continue;
+      }
+
+      if (isNamespace(nativeValue) && isNamespace(facadeValue)) {
+        fillMissing(nativeValue, facadeValue);
+      }
+    } catch (error) {
+      // What Chromium will not let us fill must not cost the extension the rest
+      console.error(`[chrome-facade] could not fill ${name}`, error);
+    }
+  }
+}

--- a/packages/electron-extensions/facade/lib/method.ts
+++ b/packages/electron-extensions/facade/lib/method.ts
@@ -1,0 +1,24 @@
+/**
+ * A method that does nothing and answers with `createResult`, the way Chrome
+ * would: extensions written against MV3 await a promise, while
+ * `webextension-polyfill` and older code pass a callback as the last argument
+ * and get `undefined` back. Both have to work, since an extension can use
+ * either style for the same method.
+ */
+export function createNoopMethod(createResult: (callArguments: unknown[]) => unknown) {
+  return (...callArguments: unknown[]) => {
+    const result = createResult(callArguments);
+
+    const callback = callArguments.at(-1);
+
+    if (typeof callback === "function") {
+      queueMicrotask(() => {
+        (callback as (callbackResult: unknown) => void)(result);
+      });
+
+      return undefined;
+    }
+
+    return Promise.resolve(result);
+  };
+}

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -88,6 +88,25 @@ function buildAppFiles() {
       }),
     );
 
+  // Runs inside extensions rather than in Meru, so it is bundled like a preload
+  // and copied into every extension the loader derives
+  const buildExtensionsChromeFacade = () =>
+    rolldown({
+      ...rolldownOptions,
+      input: "./packages/electron-extensions/facade/index.ts",
+      platform: "browser",
+      transform: {
+        ...rolldownOptions.transform,
+        target: browserTarget,
+      },
+    }).then((bundle) =>
+      bundle.write({
+        file: path.join(process.cwd(), "build-js", "extensions-chrome-facade.js"),
+        codeSplitting: false,
+        format: "iife",
+      }),
+    );
+
   return Promise.all([
     rolldown({
       ...rolldownOptions,
@@ -109,6 +128,7 @@ function buildAppFiles() {
     buildPreloadFile("preload-gmail"),
     buildPreloadFile("preload-workspace-app"),
     buildPreloadFile("preload-renderer"),
+    buildExtensionsChromeFacade(),
   ]);
 }
 


### PR DESCRIPTION
Review after #821 (both add to `packages/electron-extensions/extensions.ts`; this one gets rebased once #821 lands).

- Injection vehicle (SW preloads never run for extension service workers on Electron 43.2.0, rechecked): extensions load from a derived copy under `userData/derived-extensions` — manifest's service worker is rewritten to a wrapper that statically imports the facade before the original background module, every extension page gets the facade as its first script, and the source dir is never written to. Re-derives when the manifest changes; the facade file is refreshed on every launch.
- Noop-first `chrome.*` facade (rolldown IIFE, no Node/DOM assumptions), one file per namespace: `windows`, `webNavigation`, `notifications`, `contextMenus`, `commands`, `privacy` as never-firing events and harmlessly-resolving methods (callback and promise style both); patches the `webRequest` members whose absence crashed the stock SW, and the missing `tabs`/`windows` constants. Fills only what's `undefined` — natives are never wrapped or replaced. No IPC; promotion to real implementations comes per-API when sign-in testing demands it.
- Electron exposes the API as two separate globals, `chrome` **and** `browser` — not in the design doc's inventory (the spike's recorder masked it); 1Password crashes on `browser.windows.WINDOW_ID_NONE` with only `chrome` filled. Both are filled from one shared facade.

Verified headlessly: unmodified 1Password 8.12.32.33 boots to "Finished initializing 1Password" with no stubs and no errors, keeping its real extension id; popup/offscreen pages see the complete facade. Not verified: interactive flows (unlock, autofill, passkeys — need slice 4's action UI and a real machine), the `importScripts` wrapper for non-module SWs (unit-tested only), Windows/macOS. Derived copies aren't garbage-collected yet (~46 MB per 1Password version dir); that belongs to the install pipeline slice.

Test plan:
1. `MERU_EXTENSIONS_DIRS=<unpacked 1Password> bun run dev` → SW console reaches "Finished initializing 1Password", no `Service worker registration failed` and no `undefined (reading 'onClicked')` errors.
2. Same run → `userData/derived-extensions/<hash>/` exists with `chrome-facade.js` + rewritten manifest, and the source dir's mtimes are untouched.
3. Run with the env var unset → no derived-extensions dir created, app behaves as today.