### PR TITLE
show titlebar buttons and popups for loaded extensions

### DIFF
--- a/packages/app/bookmarks.ts
+++ b/packages/app/bookmarks.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { BASE_SPACING } from "@meru/shared/constants";
+import { APP_TITLEBAR_HEIGHT, BASE_SPACING } from "@meru/shared/constants";
 import type { AccountConfig, Bookmark, BookmarkState } from "@meru/shared/schemas";
 import type { BookmarksPopupPlacement } from "@meru/shared/types";
 import { clamp } from "@meru/shared/utils";
@@ -19,16 +19,21 @@ import { Popup } from "./lib/popup";
  * Windows` mode and absent in `Tabs` mode until a second tab opens.
  */
 class Bookmarks {
-  popup = new Popup({
-    page: "bookmarks",
-    width: BASE_SPACING * 40,
-    height: "fill",
-  });
+  popup = new Popup();
 
   togglePopup(parentWindow: BrowserWindow, placement: BookmarksPopupPlacement) {
     return this.popup.toggle(parentWindow, {
-      anchorX:
-        placement === "verticalTabs" ? accounts.getVerticalTabsWidth() + BASE_SPACING : undefined,
+      content: { page: "bookmarks" },
+      width: BASE_SPACING * 40,
+      height: "fill",
+      anchor:
+        placement === "verticalTabs"
+          ? {
+              x: accounts.getVerticalTabsWidth() + BASE_SPACING,
+              y: APP_TITLEBAR_HEIGHT + BASE_SPACING,
+              align: "start",
+            }
+          : undefined,
     });
   }
 

--- a/packages/app/downloads.ts
+++ b/packages/app/downloads.ts
@@ -4,7 +4,7 @@ import { platform } from "@electron-toolkit/utils";
 import { BASE_SPACING } from "@meru/shared/constants";
 import { ms } from "@meru/shared/ms";
 import type { DownloadItem } from "@meru/shared/types";
-import { shell } from "electron";
+import { type BrowserWindow, shell } from "electron";
 import electronDl from "electron-dl";
 import { config } from "@/config";
 import { createNotification } from "@/notifications";
@@ -18,11 +18,15 @@ const FILE_MANAGER_NAME = platform.isMacOS
     : "your file manager";
 
 class Downloads {
-  recentDownloadHistoryPopup = new Popup({
-    page: "recent-download-history",
-    width: BASE_SPACING * 48,
-    height: BASE_SPACING * 44,
-  });
+  recentDownloadHistoryPopup = new Popup();
+
+  toggleRecentDownloadHistoryPopup(parentWindow: BrowserWindow) {
+    return this.recentDownloadHistoryPopup.toggle(parentWindow, {
+      content: { page: "recent-download-history" },
+      width: BASE_SPACING * 48,
+      height: BASE_SPACING * 44,
+    });
+  }
 
   addDownloadHistoryItem({ fileName, filePath, createdAt, exists }: Omit<DownloadItem, "id">) {
     const item = {

--- a/packages/app/extension-actions.ts
+++ b/packages/app/extension-actions.ts
@@ -1,0 +1,96 @@
+import { APP_TITLEBAR_HEIGHT } from "@meru/shared/constants";
+import type { ExtensionActionAnchorRect } from "@meru/shared/types";
+import { BrowserWindow, type WebContents } from "electron";
+import { accounts } from "./accounts";
+import { extensions } from "./extensions";
+import { ipc } from "./ipc";
+import { Popup } from "./lib/popup";
+import { main } from "./main";
+import { WorkspaceApp } from "./workspace-app";
+
+/**
+ * The titlebar buttons of the extensions loaded into an account's session, and
+ * the popup a click on one opens.
+ *
+ * Extensions load into every account, so every titlebar shows the same buttons
+ * — the session a window belongs to only decides which of an extension's
+ * per-account instances the popup runs against.
+ */
+class ExtensionActions {
+  popup = new Popup();
+
+  init() {
+    extensions.onActionsChanged(() => {
+      this.broadcast();
+    });
+  }
+
+  /**
+   * The account a window shows: the one a workspace app window was opened for,
+   * and whichever is selected for the main window.
+   */
+  private getWindowSession(webContents: WebContents) {
+    const workspaceApp = WorkspaceApp.tryFromWebContents(webContents);
+
+    return workspaceApp
+      ? workspaceApp.account.instance.session
+      : accounts.getSelectedAccount().instance.session;
+  }
+
+  serialize(webContents: WebContents) {
+    return extensions
+      .getSessionActions(this.getWindowSession(webContents))
+      .map(({ extensionId, title, iconDataUrl }) => ({ extensionId, title, iconDataUrl }));
+  }
+
+  private broadcast() {
+    const windows = [
+      ...(main.window.isDestroyed() ? [] : [main.window]),
+      ...WorkspaceApp.getAllWindows(),
+    ];
+
+    for (const { webContents } of windows) {
+      ipc.renderer.send(webContents, "extensions.actionsChanged", this.serialize(webContents));
+    }
+  }
+
+  togglePopup(
+    webContents: WebContents,
+    extensionId: string,
+    anchorRect: ExtensionActionAnchorRect,
+  ) {
+    const parentWindow = BrowserWindow.fromWebContents(webContents);
+
+    if (!parentWindow) {
+      return;
+    }
+
+    const session = this.getWindowSession(webContents);
+
+    const action = extensions
+      .getSessionActions(session)
+      .find((sessionAction) => sessionAction.extensionId === extensionId);
+
+    if (!action?.popupUrl) {
+      // TODO: an extension that declares no popup expects `chrome.action.onClicked`
+      // in its service worker instead. Electron implements no part of
+      // `chrome.action` — it ships Chromium's schema for the namespace with
+      // every function marked unsupported — so there is no event to fire and no
+      // channel to fire it through short of the facade shadowing the namespace.
+      // Nothing Meru loads declares an action without a popup.
+      return;
+    }
+
+    this.popup.toggle(parentWindow, {
+      content: { url: action.popupUrl, session },
+      width: "preferred",
+      height: "preferred",
+      // The button sits in the titlebar, so the popup hangs from the bottom of
+      // it rather than from the button, whose own bottom edge is a few pixels
+      // short of it
+      anchor: { x: anchorRect.x + anchorRect.width, y: APP_TITLEBAR_HEIGHT, align: "end" },
+    });
+  }
+}
+
+export const extensionActions = new ExtensionActions();

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -6,6 +6,7 @@ import { blocker } from "@/blocker";
 import { bookmarks } from "@/bookmarks";
 import { config } from "@/config";
 import { downloads } from "@/downloads";
+import { extensionActions } from "@/extension-actions";
 import { extensions } from "@/extensions";
 import { ipc } from "@/ipc";
 import { initLinuxWindowControls } from "@/lib/linux";
@@ -124,6 +125,8 @@ async function init() {
 
   ipc.init();
 
+  extensionActions.init();
+
   theme.init();
 
   appMenu.init();
@@ -210,6 +213,8 @@ async function init() {
     bookmarks.popup.close();
 
     downloads.recentDownloadHistoryPopup.close();
+
+    extensionActions.popup.close();
   });
 }
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -38,6 +38,7 @@ import {
 import { confirmAppLinksTabHandover } from "./dialogs";
 import { DoNotDisturb, doNotDisturb } from "./do-not-disturb";
 import { downloads } from "./downloads";
+import { extensionActions } from "./extension-actions";
 import { GMAIL_USER_STYLES_PATH } from "./gmail";
 import { log } from "./lib/log";
 import {
@@ -996,6 +997,18 @@ class Ipc {
 
     ipc.main.on("bookmarks.moveBookmark", (_event, accountId, bookmarkId, targetIndex) => {
       bookmarks.move(accountId, bookmarkId, targetIndex);
+    });
+
+    ipc.main.handle("extensions.getActions", (event) => {
+      return extensionActions.serialize(event.sender);
+    });
+
+    ipc.main.on("extensions.toggleActionPopup", (event, extensionId, anchorRect) => {
+      extensionActions.togglePopup(event.sender, extensionId, anchorRect);
+    });
+
+    ipc.main.on("extensions.setActionPopupCloseOnBlurEnabled", (_event, enabled) => {
+      extensionActions.popup.closeOnBlurEnabled = enabled;
     });
 
     ipc.main.on("downloads.toggleRecentDownloadHistoryPopup", (event) => {

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -1005,7 +1005,7 @@ class Ipc {
         return;
       }
 
-      if (downloads.recentDownloadHistoryPopup.toggle(parentWindow)) {
+      if (downloads.toggleRecentDownloadHistoryPopup(parentWindow)) {
         downloads.checkDownloadHistoryItems(MAX_RECENT_DOWNLOAD_HISTORY_ITEMS);
       }
     });

--- a/packages/app/lib/popup.ts
+++ b/packages/app/lib/popup.ts
@@ -1,37 +1,76 @@
 import { platform } from "@electron-toolkit/utils";
 import { APP_TITLEBAR_HEIGHT, BASE_SPACING } from "@meru/shared/constants";
-import type { BrowserWindow } from "electron";
+import { clamp } from "@meru/shared/utils";
+import type { BrowserWindow, Event, Input, Session, Size } from "electron";
 import { WebContentsView } from "electron";
 import { getPreloadPath, loadRenderer, type RendererPage } from "./window";
 
+/** What a popup shows: a renderer page, or any URL loaded in a given session. */
+export type PopupContent = { page: RendererPage } | { url: string; session: Session };
+
 /**
- * A renderer page drawn over the window it was opened from, as a child view
- * rather than renderer-drawn markup: child views paint above the main window's
- * HTML, so a dropdown would be covered wherever a workspace app view sits.
+ * Where the popup hangs from, in the parent window's content coordinates: `y`
+ * is the popup's top edge and `x` the edge named by `align`. Left unset, the
+ * popup hangs from the end of the titlebar, where the buttons that open it sit.
+ */
+export type PopupAnchor = { x: number; y: number; align: "start" | "end" };
+
+export type PopupOptions = {
+  content: PopupContent;
+  /** The size of the popup itself, without the gaps the view spans. */
+  width: number | "preferred";
+  /** `fill` reaches the bottom of the window, leaving the gap it hangs by. */
+  height: number | "fill" | "preferred";
+  anchor?: PopupAnchor;
+};
+
+/** What a popup sized by its page gets until the page has reported a size. */
+const PREFERRED_SIZE_FALLBACK = { width: BASE_SPACING * 44, height: BASE_SPACING * 60 };
+
+/** Chrome's ceiling for an action popup, which is what sizes itself here. */
+const PREFERRED_SIZE_MAX = { width: 800, height: 600 };
+
+function isSameContent(content: PopupContent, otherContent: PopupContent) {
+  if ("page" in content) {
+    return "page" in otherContent && content.page === otherContent.page;
+  }
+
+  return (
+    !("page" in otherContent) &&
+    content.url === otherContent.url &&
+    content.session === otherContent.session
+  );
+}
+
+function isSameAnchor(anchor: PopupAnchor | undefined, otherAnchor: PopupAnchor | undefined) {
+  if (!anchor || !otherAnchor) {
+    return anchor === otherAnchor;
+  }
+
+  return (
+    anchor.x === otherAnchor.x && anchor.y === otherAnchor.y && anchor.align === otherAnchor.align
+  );
+}
+
+/**
+ * A page drawn over the window it was opened from, as a child view rather than
+ * renderer-drawn markup: child views paint above the main window's HTML, so a
+ * dropdown would be covered wherever a workspace app view sits.
  *
- * The view spans `BASE_SPACING` past the popup on every side and the page pads
- * itself by the same amount, so the popup sits where the gaps put it and its
+ * A renderer page pads itself by `BASE_SPACING`, and the view spans that much
+ * past the popup on every side, so the popup sits where the gaps put it and its
  * entrance animation has room to move without being cut off at the view edge.
+ * Any other page fills its view instead — an extension's popup knows nothing of
+ * Meru's gaps and would paint over them.
  */
 export class Popup {
-  private page: RendererPage;
+  private options: PopupOptions | null = null;
 
-  /** The size of the popup itself, without the gaps the view spans. */
-  private width: number;
-
-  /** `fill` reaches the bottom of the window, leaving the gap it hangs by. */
-  private height: number | "fill";
+  private preferredSize: { width: number; height: number } | null = null;
 
   private view: WebContentsView | null = null;
 
   private parentWindow: BrowserWindow | null = null;
-
-  /**
-   * Where the popup starts horizontally, for a caller that wants it somewhere
-   * other than the end of the titlebar — the bookmarks button in the vertical
-   * tabs strip hangs it beside the strip instead.
-   */
-  private anchorX: number | null = null;
 
   /**
    * Held off while the pointer is over the button that toggles the popup, so
@@ -40,48 +79,79 @@ export class Popup {
    */
   closeOnBlurEnabled = false;
 
-  constructor({
-    page,
-    width,
-    height,
-  }: {
-    page: RendererPage;
-    width: number;
-    height: number | "fill";
-  }) {
-    this.page = page;
-    this.width = width;
-    this.height = height;
-  }
-
   get webContents() {
     return this.view?.webContents ?? null;
   }
 
   private setBounds = () => {
-    if (!this.view || !this.parentWindow || this.parentWindow.isDestroyed()) {
+    const { view, parentWindow, options } = this;
+
+    if (!view || !parentWindow || !options || parentWindow.isDestroyed()) {
       return;
     }
 
     const parentWindowBounds = platform.isWindows
-      ? this.parentWindow.getContentBounds()
-      : this.parentWindow.getBounds();
+      ? parentWindow.getContentBounds()
+      : parentWindow.getBounds();
 
-    const y = APP_TITLEBAR_HEIGHT;
+    const padding = "page" in options.content ? BASE_SPACING : 0;
 
-    const width = this.width + BASE_SPACING * 2;
+    const width =
+      options.width === "preferred"
+        ? Math.min(
+            this.preferredSize?.width ?? PREFERRED_SIZE_FALLBACK.width,
+            PREFERRED_SIZE_MAX.width,
+          )
+        : options.width;
 
-    this.view.setBounds({
-      x: this.anchorX === null ? parentWindowBounds.width - width : this.anchorX - BASE_SPACING,
-      y,
-      width,
-      height:
-        this.height === "fill" ? parentWindowBounds.height - y : this.height + BASE_SPACING * 2,
+    const anchor = options.anchor ?? {
+      x: parentWindowBounds.width - padding,
+      y: APP_TITLEBAR_HEIGHT + padding,
+      align: "end" as const,
+    };
+
+    const viewWidth = width + padding * 2;
+
+    const viewY = anchor.y - padding;
+
+    const availableHeight = Math.max(parentWindowBounds.height - viewY, 0);
+
+    const viewHeight =
+      options.height === "fill"
+        ? availableHeight
+        : options.height === "preferred"
+          ? Math.min(
+              this.preferredSize?.height ?? PREFERRED_SIZE_FALLBACK.height,
+              PREFERRED_SIZE_MAX.height,
+            )
+          : options.height + padding * 2;
+
+    view.setBounds({
+      x: clamp(
+        (anchor.align === "start" ? anchor.x : anchor.x - width) - padding,
+        0,
+        Math.max(parentWindowBounds.width - viewWidth, 0),
+      ),
+      y: viewY,
+      width: viewWidth,
+      height: Math.min(viewHeight, availableHeight),
     });
+  };
+
+  private handlePreferredSizeChanged = (_event: Event, size: Size) => {
+    this.preferredSize = size;
+
+    this.setBounds();
   };
 
   private handleBlur = () => {
     if (this.closeOnBlurEnabled) {
+      this.close();
+    }
+  };
+
+  private handleInput = (_event: Event, input: Input) => {
+    if (input.type === "keyDown" && input.key === "Escape") {
       this.close();
     }
   };
@@ -97,7 +167,8 @@ export class Popup {
 
     this.view = null;
     this.parentWindow = null;
-    this.anchorX = null;
+    this.options = null;
+    this.preferredSize = null;
     this.closeOnBlurEnabled = false;
 
     if (!view || !parentWindow) {
@@ -113,9 +184,13 @@ export class Popup {
     }
 
     if (!view.webContents.isDestroyed()) {
-      // Only the listener this class added comes off: removing them all takes
+      // Only the listeners this class added come off: removing them all takes
       // Electron's own with it and leaves the webContents unable to tear down.
       view.webContents.off("blur", this.handleBlur);
+
+      view.webContents.off("before-input-event", this.handleInput);
+
+      view.webContents.off("preferred-size-changed", this.handlePreferredSizeChanged);
 
       view.webContents.close();
     }
@@ -123,24 +198,36 @@ export class Popup {
 
   /**
    * Returns whether the popup ended up open, so callers can refresh what it is
-   * about to show.
+   * about to show. Toggling it with the same window, content and anchor closes
+   * it; anything else about the popup changing reopens it.
    */
-  toggle(parentWindow: BrowserWindow, { anchorX }: { anchorX?: number } = {}) {
-    if (this.view) {
-      const wasSameWindow = this.parentWindow === parentWindow;
+  toggle(parentWindow: BrowserWindow, options: PopupOptions) {
+    const openOptions = this.options;
 
-      const wasSameAnchorX = this.anchorX === (anchorX ?? null);
+    if (this.view) {
+      const wasSamePopup =
+        this.parentWindow === parentWindow &&
+        openOptions !== null &&
+        isSameContent(openOptions.content, options.content) &&
+        isSameAnchor(openOptions.anchor, options.anchor);
 
       this.close();
 
-      if (wasSameWindow && wasSameAnchorX) {
+      if (wasSamePopup) {
         return false;
       }
     }
 
+    const { content } = options;
+
+    const isPage = "page" in content;
+
+    const followsPreferredSize = options.width === "preferred" || options.height === "preferred";
+
     this.view = new WebContentsView({
       webPreferences: {
-        preload: getPreloadPath("renderer"),
+        ...(isPage ? { preload: getPreloadPath("renderer") } : { session: content.session }),
+        enablePreferredSizeMode: followsPreferredSize,
       },
     });
 
@@ -150,15 +237,35 @@ export class Popup {
 
     this.parentWindow = parentWindow;
 
-    this.anchorX = anchorX ?? null;
+    this.options = options;
 
-    loadRenderer(this.view, { page: this.page });
+    if (isPage) {
+      loadRenderer(this.view, { page: content.page });
+    } else {
+      this.view.webContents.loadURL(content.url);
+    }
 
     parentWindow.contentView.addChildView(this.view);
 
     this.setBounds();
 
+    if (followsPreferredSize) {
+      this.view.webContents.on("preferred-size-changed", this.handlePreferredSizeChanged);
+    }
+
     this.view.webContents.once("blur", this.handleBlur);
+
+    if (!isPage) {
+      // A renderer page closes itself on Escape and calls the view's own way
+      // back here; an arbitrary page has neither, and neither can blur before
+      // the view has been given focus
+      this.view.webContents.on("before-input-event", this.handleInput);
+
+      this.view.webContents.focus();
+
+      // Extension popups end themselves with `window.close()` once they are done
+      this.view.webContents.once("destroyed", this.close);
+    }
 
     parentWindow.on("resize", this.setBounds);
 

--- a/packages/electron-extensions/action.test.ts
+++ b/packages/electron-extensions/action.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  type ActionExtension,
+  type ActionManifest,
+  createExtensionAction,
+  getActionPopupUrl,
+  readExtensionActionIcon,
+  resolveActionIconPath,
+} from "./action";
+
+let extensionDir: string;
+
+beforeEach(async () => {
+  extensionDir = await mkdtemp(path.join(tmpdir(), "electron-extensions-action-"));
+});
+
+afterEach(async () => {
+  await rm(extensionDir, { recursive: true, force: true });
+});
+
+function createExtension(manifest: ActionManifest): ActionExtension {
+  return {
+    id: "aeblfdkhhhdcdjpifhhbdiojplfjncoa",
+    name: "1Password",
+    path: extensionDir,
+    manifest,
+  };
+}
+
+describe("resolveActionIconPath", () => {
+  test("takes the action's own icon over the extension's", () => {
+    expect(
+      resolveActionIconPath({
+        action: { default_icon: { "32": "action-32.png" } },
+        icons: { "32": "icon-32.png" },
+      }),
+    ).toBe("action-32.png");
+  });
+
+  test("takes a single declared icon whatever its size", () => {
+    expect(resolveActionIconPath({ action: { default_icon: "action.png" } })).toBe("action.png");
+  });
+
+  test("falls back to the extension's icons, which is what 1Password leaves", () => {
+    expect(
+      resolveActionIconPath({
+        action: { default_title: "1Password", default_popup: "popup/index.html" },
+        icons: { "16": "onepassword-16.png", "48": "onepassword-48.png" },
+      }),
+    ).toBe("onepassword-48.png");
+  });
+
+  test("takes the smallest icon that covers the size it is drawn at", () => {
+    expect(
+      resolveActionIconPath({
+        icons: { "128": "128.png", "16": "16.png", "32": "32.png", "48": "48.png" },
+      }),
+    ).toBe("32.png");
+  });
+
+  test("takes the largest icon when none covers it", () => {
+    expect(resolveActionIconPath({ icons: { "16": "16.png", "24": "24.png" } })).toBe("24.png");
+  });
+
+  test("reads a manifest v2 browser action", () => {
+    expect(resolveActionIconPath({ browser_action: { default_icon: "browser-action.png" } })).toBe(
+      "browser-action.png",
+    );
+  });
+
+  test("has nothing to resolve without icons", () => {
+    expect(resolveActionIconPath({ action: { default_popup: "popup.html" } })).toBe(null);
+    expect(resolveActionIconPath({ icons: {} })).toBe(null);
+  });
+});
+
+describe("getActionPopupUrl", () => {
+  test("builds an extension URL from the declared page", () => {
+    expect(getActionPopupUrl("aaa", { action: { default_popup: "popup/index.html" } })).toBe(
+      "chrome-extension://aaa/popup/index.html",
+    );
+  });
+
+  test("keeps a page declared from the extension root", () => {
+    expect(getActionPopupUrl("aaa", { action: { default_popup: "/popup.html" } })).toBe(
+      "chrome-extension://aaa/popup.html",
+    );
+  });
+
+  test("keeps a query the page is opened with", () => {
+    expect(getActionPopupUrl("aaa", { action: { default_popup: "popup.html?view=list" } })).toBe(
+      "chrome-extension://aaa/popup.html?view=list",
+    );
+  });
+
+  test("is nothing for an extension without a popup", () => {
+    expect(getActionPopupUrl("aaa", { action: { default_title: "Title" } })).toBe(null);
+    expect(getActionPopupUrl("aaa", {})).toBe(null);
+  });
+});
+
+describe("createExtensionAction", () => {
+  test("assembles what a button is drawn from", () => {
+    expect(
+      createExtensionAction(
+        createExtension({
+          action: { default_title: "1Password", default_popup: "popup/index.html" },
+          icons: { "48": "onepassword-48.png" },
+        }),
+      ),
+    ).toEqual({
+      extensionId: "aeblfdkhhhdcdjpifhhbdiojplfjncoa",
+      name: "1Password",
+      title: "1Password",
+      popupUrl: "chrome-extension://aeblfdkhhhdcdjpifhhbdiojplfjncoa/popup/index.html",
+      iconDataUrl: null,
+    });
+  });
+
+  test("falls back to the extension name for the title", () => {
+    expect(createExtensionAction(createExtension({ action: {} })).title).toBe("1Password");
+  });
+
+  test("has no popup for an extension that expects a click instead", () => {
+    expect(createExtensionAction(createExtension({})).popupUrl).toBe(null);
+  });
+});
+
+describe("readExtensionActionIcon", () => {
+  test("reads the icon out of the extension as a data URL", async () => {
+    await mkdir(path.join(extensionDir, "images"), { recursive: true });
+
+    await writeFile(path.join(extensionDir, "images", "icon-48.png"), "icon");
+
+    expect(
+      await readExtensionActionIcon(createExtension({ icons: { "48": "images/icon-48.png" } })),
+    ).toBe(`data:image/png;base64,${Buffer.from("icon").toString("base64")}`);
+  });
+
+  test("has nothing to read without an icon", async () => {
+    expect(await readExtensionActionIcon(createExtension({}))).toBe(null);
+  });
+
+  test("skips an icon in a format a renderer would not draw", async () => {
+    expect(await readExtensionActionIcon(createExtension({ icons: { "48": "icon.ico" } }))).toBe(
+      null,
+    );
+  });
+
+  test("fails on an icon the manifest declares but the extension does not carry", () => {
+    expect(
+      readExtensionActionIcon(createExtension({ icons: { "48": "missing.png" } })),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/electron-extensions/action.ts
+++ b/packages/electron-extensions/action.ts
@@ -1,0 +1,146 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * The size the icon is picked for: browsers draw the toolbar button small, and
+ * a display at twice that density is the common case.
+ */
+const ICON_SIZE = 32;
+
+const ICON_MIME_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".gif": "image/gif",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".webp": "image/webp",
+  ".bmp": "image/bmp",
+};
+
+type ActionManifestEntry = {
+  default_icon?: string | Record<string, string>;
+  default_popup?: string;
+  default_title?: string;
+};
+
+/** The manifest keys the toolbar button is drawn from. */
+export type ActionManifest = {
+  /** Manifest v3. */
+  action?: ActionManifestEntry;
+  /** Manifest v2, where the same button was the browser action. */
+  browser_action?: ActionManifestEntry;
+  /** The extension's own icons, which the button falls back to. */
+  icons?: Record<string, string>;
+};
+
+/** As much of an Electron `Extension` as an action is built from. */
+export type ActionExtension = {
+  id: string;
+  name: string;
+  path: string;
+  manifest: ActionManifest;
+};
+
+/**
+ * What an embedder needs to draw one extension's toolbar button.
+ *
+ * Everything here comes from the manifest and never changes while the extension
+ * runs. Electron implements no part of `chrome.action`: it ships Chromium's
+ * schema for the namespace with every function marked unsupported, so an
+ * extension calling `setIcon`, `setBadgeText`, `setTitle` or `setPopup` changes
+ * nothing and produces no state — there is nothing to read, and no event to
+ * subscribe to. Dynamic action state would mean shadowing the namespace in the
+ * facade and routing it back over IPC, which is a slice of its own.
+ */
+export type ExtensionAction = {
+  extensionId: string;
+  name: string;
+  /** What the button says it is, which is what a tooltip shows. */
+  title: string;
+  /** The page the button opens, `null` for an extension that declares none. */
+  popupUrl: string | null;
+  /** The button's icon, ready for a renderer to draw. */
+  iconDataUrl: string | null;
+};
+
+function getActionManifestEntry(manifest: ActionManifest) {
+  return manifest.action ?? manifest.browser_action;
+}
+
+/**
+ * Icon maps are keyed by pixel size, and the smallest that still covers the
+ * size the icon is drawn at wins — scaling down beats scaling up — with the
+ * largest declared icon as the floor.
+ */
+function pickIconPath(icons: Record<string, string> | undefined) {
+  if (!icons) {
+    return null;
+  }
+
+  const sizedIcons = Object.entries(icons)
+    .map(([size, iconPath]) => ({ size: Number(size), iconPath }))
+    .filter(({ size }) => Number.isFinite(size) && size > 0)
+    .sort((a, b) => a.size - b.size);
+
+  const pickedIcon = sizedIcons.find(({ size }) => size >= ICON_SIZE) ?? sizedIcons.at(-1);
+
+  return pickedIcon?.iconPath ?? null;
+}
+
+/**
+ * The icon a browser would draw on the button: the action's own icon, or the
+ * extension's icons when the action declares none — which is what 1Password
+ * does.
+ */
+export function resolveActionIconPath(manifest: ActionManifest) {
+  const defaultIcon = getActionManifestEntry(manifest)?.default_icon;
+
+  if (typeof defaultIcon === "string") {
+    return defaultIcon;
+  }
+
+  return pickIconPath(defaultIcon) ?? pickIconPath(manifest.icons);
+}
+
+/** The extension URL of the page the button opens. */
+export function getActionPopupUrl(extensionId: string, manifest: ActionManifest) {
+  const defaultPopup = getActionManifestEntry(manifest)?.default_popup;
+
+  if (!defaultPopup) {
+    return null;
+  }
+
+  return new URL(defaultPopup, `chrome-extension://${extensionId}/`).href;
+}
+
+export function createExtensionAction(extension: ActionExtension): ExtensionAction {
+  return {
+    extensionId: extension.id,
+    name: extension.name,
+    title: getActionManifestEntry(extension.manifest)?.default_title ?? extension.name,
+    popupUrl: getActionPopupUrl(extension.id, extension.manifest),
+    iconDataUrl: null,
+  };
+}
+
+/**
+ * Reads the button's icon off disk as a data URL, so a renderer can draw it
+ * without a protocol handler or a file path it is allowed to read from.
+ */
+export async function readExtensionActionIcon(extension: ActionExtension) {
+  const iconPath = resolveActionIconPath(extension.manifest);
+
+  if (!iconPath) {
+    return null;
+  }
+
+  const mimeType = ICON_MIME_TYPES[path.extname(iconPath).toLowerCase()];
+
+  if (!mimeType) {
+    return null;
+  }
+
+  const icon = await readFile(path.join(extension.path, iconPath));
+
+  return `data:${mimeType};base64,${icon.toString("base64")}`;
+}

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -53,15 +53,26 @@ function createExtensions(
   });
 }
 
-function createExtension(id: string, extensionDir: string) {
+function createExtension(id: string, extensionDir: string, manifest: Record<string, unknown> = {}) {
   return {
     id,
     name: `Extension ${id}`,
     version: "1.0.0",
     path: extensionDir,
     url: `chrome-extension://${id}/`,
-    manifest: {},
+    manifest,
   } as Extension;
+}
+
+const ACTION_MANIFEST = {
+  action: { default_title: "Vault", default_popup: "popup/index.html" },
+  icons: { "48": "icon-48.png" },
+};
+
+async function createActionExtension(id: string, extensionDir: string) {
+  await writeFile(path.join(extensionDir, "icon-48.png"), "icon");
+
+  return createExtension(id, extensionDir, ACTION_MANIFEST);
 }
 
 function createSession({
@@ -306,6 +317,84 @@ describe("Extensions", () => {
     expect(await listPartitionDir(partitionPath)).toEqual(["Cookies"]);
 
     await fs.rm(partitionPath, { recursive: true, force: true });
+  });
+
+  test("assembles an action for every extension it loaded", async () => {
+    const { session } = createSession({
+      loadExtension: (extensionDir) => createActionExtension("aaa", extensionDir),
+    });
+
+    const extensions = createExtensions([await createExtensionDir("one")]);
+
+    await extensions.setupSession(session);
+
+    expect(extensions.getSessionActions(session)).toEqual([
+      {
+        extensionId: "aaa",
+        name: "Extension aaa",
+        title: "Vault",
+        popupUrl: "chrome-extension://aaa/popup/index.html",
+        iconDataUrl: `data:image/png;base64,${Buffer.from("icon").toString("base64")}`,
+      },
+    ]);
+  });
+
+  test("keeps the button of an extension whose icon cannot be read", async () => {
+    const loggedErrors: Record<string, unknown>[] = [];
+
+    const { session } = createSession({
+      loadExtension: async (extensionDir) =>
+        createExtension("aaa", extensionDir, { icons: { "48": "missing.png" } }),
+    });
+
+    const extensions = createExtensions([await createExtensionDir("one")], {
+      info: () => {},
+      error: (_message, details) => {
+        loggedErrors.push(details);
+      },
+    });
+
+    await extensions.setupSession(session);
+
+    expect(loggedErrors).toHaveLength(1);
+    expect(extensions.getSessionActions(session)).toHaveLength(1);
+    expect(extensions.getSessionActions(session)[0]?.iconDataUrl).toBe(null);
+  });
+
+  test("has no actions for a session it loaded nothing into", async () => {
+    const { session } = createSession();
+
+    const extensions = createExtensions([]);
+
+    await extensions.setupSession(session);
+
+    expect(extensions.getSessionActions(session)).toEqual([]);
+  });
+
+  test("reports the actions of a session whenever they change", async () => {
+    const changes: { sessionActions: number }[] = [];
+
+    const { session } = createSession({
+      loadExtension: (extensionDir) => createActionExtension("aaa", extensionDir),
+    });
+
+    const extensions = createExtensions([await createExtensionDir("one")]);
+
+    const unsubscribe = extensions.onActionsChanged((changedSession, actions) => {
+      expect(changedSession).toBe(session);
+
+      changes.push({ sessionActions: actions.length });
+    });
+
+    await extensions.setupSession(session);
+
+    extensions.teardownSession(session);
+
+    unsubscribe();
+
+    await extensions.setupSession(session);
+
+    expect(changes).toEqual([{ sessionActions: 1 }, { sessionActions: 0 }]);
   });
 
   test("unloads an extension that finished loading after teardown", async () => {

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -1,6 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { Session } from "electron";
+import {
+  type ActionExtension,
+  createExtensionAction,
+  type ExtensionAction,
+  readExtensionActionIcon,
+} from "./action";
 import { deriveExtension } from "./derive";
 
 /**
@@ -25,6 +31,8 @@ export type ExtensionsLogger = {
   error: (message: string, details: Record<string, unknown>) => void;
 };
 
+export type ActionsChangedListener = (session: Session, actions: ExtensionAction[]) => void;
+
 export type ExtensionsOptions = {
   /**
    * Unpacked extension directories, loaded into every session handed to
@@ -43,8 +51,9 @@ export type ExtensionsOptions = {
 
 /**
  * Loads unpacked extensions into Electron sessions and keeps track of what is
- * loaded where, so an embedder can unload them again and can tell whether a
- * `chrome-extension://` URL belongs to an extension it loaded itself.
+ * loaded where, so an embedder can unload them again, can tell whether a
+ * `chrome-extension://` URL belongs to an extension it loaded itself, and can
+ * draw a toolbar button for each of them.
  *
  * Chromium scopes an extension — content scripts, service worker, storage — to
  * the session it is loaded into, so the same directory loaded into several
@@ -61,6 +70,10 @@ export class Extensions {
   private logger: ExtensionsLogger | undefined;
 
   private loadedExtensionIdsBySession = new Map<Session, Set<string>>();
+
+  private actionsBySession = new Map<Session, ExtensionAction[]>();
+
+  private actionsChangedListeners = new Set<ActionsChangedListener>();
 
   private derivedExtensionDirs = new Map<string, Promise<string>>();
 
@@ -109,6 +122,10 @@ export class Extensions {
 
     this.loadedExtensionIdsBySession.set(session, loadedExtensionIds);
 
+    const actions: ExtensionAction[] = [];
+
+    this.actionsBySession.set(session, actions);
+
     for (const extensionDir of this.extensionDirs) {
       try {
         const extension = await session.extensions.loadExtension(
@@ -124,6 +141,8 @@ export class Extensions {
 
         loadedExtensionIds.add(extension.id);
 
+        actions.push(await this.createAction(extension));
+
         this.logger?.info("Loaded extension", {
           id: extension.id,
           name: extension.name,
@@ -134,6 +153,21 @@ export class Extensions {
         this.logger?.error("Failed to load extension", { extensionDir, error });
       }
     }
+
+    this.emitActionsChanged(session);
+  }
+
+  /** A broken icon costs the button its icon, not the extension its button. */
+  private async createAction(extension: ActionExtension) {
+    const action = createExtensionAction(extension);
+
+    try {
+      action.iconDataUrl = await readExtensionActionIcon(extension);
+    } catch (error) {
+      this.logger?.error("Failed to read extension action icon", { id: extension.id, error });
+    }
+
+    return action;
   }
 
   teardownSession(session: Session) {
@@ -145,10 +179,38 @@ export class Extensions {
 
     this.loadedExtensionIdsBySession.delete(session);
 
+    this.actionsBySession.delete(session);
+
     for (const extensionId of loadedExtensionIds) {
       session.extensions.removeExtension(extensionId);
 
       this.logger?.info("Unloaded extension", { id: extensionId });
+    }
+
+    this.emitActionsChanged(session);
+  }
+
+  /**
+   * The toolbar buttons an embedder draws for this session, in the order the
+   * extensions were loaded. Empty until the extensions have finished loading,
+   * which is what `onActionsChanged` is for.
+   */
+  getSessionActions(session: Session): ExtensionAction[] {
+    return this.actionsBySession.get(session) ?? [];
+  }
+
+  /** Fires whenever the extensions loaded into a session change. */
+  onActionsChanged(listener: ActionsChangedListener) {
+    this.actionsChangedListeners.add(listener);
+
+    return () => {
+      this.actionsChangedListeners.delete(listener);
+    };
+  }
+
+  private emitActionsChanged(session: Session) {
+    for (const listener of this.actionsChangedListeners) {
+      listener(session, this.getSessionActions(session));
     }
   }
 

--- a/packages/electron-extensions/index.ts
+++ b/packages/electron-extensions/index.ts
@@ -1,2 +1,3 @@
+export type { ExtensionAction } from "./action";
 export { Extensions } from "./extensions";
-export type { ExtensionsLogger, ExtensionsOptions } from "./extensions";
+export type { ActionsChangedListener, ExtensionsLogger, ExtensionsOptions } from "./extensions";

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -18,6 +18,7 @@ import {
 import { useState } from "react";
 import { useLocation } from "wouter";
 import { navigate } from "wouter/use-hash-location";
+import { ExtensionActions } from "@/components/extension-actions";
 import { FindInPage as UiFindInPage } from "@/components/find-in-page";
 import {
   Titlebar,
@@ -397,6 +398,7 @@ export function AppTitlebar() {
               )}
               <BookmarksButton />
             </TitlebarButtonGroup>
+            <ExtensionActions />
             {shouldShowSavedSearchesButton && (
               <TitlebarDropdownMenu
                 title="Saved Searches"

--- a/packages/renderer/components/extension-actions.tsx
+++ b/packages/renderer/components/extension-actions.tsx
@@ -1,0 +1,56 @@
+import { ipc } from "@meru/shared/renderer/ipc";
+import type { ExtensionActionState } from "@meru/shared/types";
+import { PuzzleIcon } from "lucide-react";
+import { TitlebarButtonGroup, TitlebarIconButton } from "@/components/titlebar";
+import { useExtensionActionsStore } from "@/lib/extension-actions";
+
+function ExtensionActionButton({ action }: { action: ExtensionActionState }) {
+  return (
+    <TitlebarIconButton
+      onClick={(event) => {
+        const { x, y, width, height } = event.currentTarget.getBoundingClientRect();
+
+        ipc.main.send("extensions.toggleActionPopup", action.extensionId, {
+          x: Math.round(x),
+          y: Math.round(y),
+          width: Math.round(width),
+          height: Math.round(height),
+        });
+      }}
+      onMouseEnter={() => {
+        ipc.main.send("extensions.setActionPopupCloseOnBlurEnabled", false);
+      }}
+      onMouseLeave={() => {
+        ipc.main.send("extensions.setActionPopupCloseOnBlurEnabled", true);
+      }}
+      title={action.title}
+    >
+      {action.iconDataUrl ? (
+        <img src={action.iconDataUrl} alt="" className="size-4" />
+      ) : (
+        <PuzzleIcon />
+      )}
+    </TitlebarIconButton>
+  );
+}
+
+/**
+ * One button per extension loaded into the account this window shows, drawing
+ * nothing at all while no extension is loaded — which is every window until
+ * extensions can be installed.
+ */
+export function ExtensionActions() {
+  const actions = useExtensionActionsStore((state) => state.actions);
+
+  if (actions.length === 0) {
+    return;
+  }
+
+  return (
+    <TitlebarButtonGroup>
+      {actions.map((action) => (
+        <ExtensionActionButton key={action.extensionId} action={action} />
+      ))}
+    </TitlebarButtonGroup>
+  );
+}

--- a/packages/renderer/lib/extension-actions.ts
+++ b/packages/renderer/lib/extension-actions.ts
@@ -1,0 +1,24 @@
+import { ipc } from "@meru/shared/renderer/ipc";
+import type { ExtensionActionState } from "@meru/shared/types";
+import { create } from "zustand";
+
+/**
+ * The extension buttons this window's titlebar shows. It lives outside
+ * `stores.ts` because the workspace app windows draw them too, and everything
+ * in there is the main window's.
+ */
+export const useExtensionActionsStore = create<{
+  actions: ExtensionActionState[];
+}>(() => ({
+  actions: [],
+}));
+
+ipc.renderer.on("extensions.actionsChanged", (_event, actions) => {
+  useExtensionActionsStore.setState({ actions });
+});
+
+// Extensions finish loading on their own schedule, and a window can open long
+// after they did, so what is already there is asked for rather than waited for
+ipc.main.invoke("extensions.getActions").then((actions) => {
+  useExtensionActionsStore.setState({ actions });
+});

--- a/packages/renderer/workspace-app.tsx
+++ b/packages/renderer/workspace-app.tsx
@@ -4,6 +4,7 @@ import { cn } from "@meru/ui/lib/utils";
 import { DownloadIcon, EllipsisVerticalIcon, StarIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { AccountBadge } from "@/components/account-badge";
+import { ExtensionActions } from "@/components/extension-actions";
 import { FindInPage } from "@/components/find-in-page";
 import {
   Titlebar,
@@ -204,6 +205,7 @@ function WorkspaceApp() {
       </TitlebarLeft>
       <TitlebarRight>
         <FindInPageControls />
+        <ExtensionActions />
         <TitlebarButtonGroup>
           <BookmarkButton workspaceAppId={workspaceAppId} />
           <RecentDownloadHistoryButton />

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -48,6 +48,21 @@ export type NotificationTime = {
 /** Which button asked for the bookmarks popup, and so where it hangs. */
 export type BookmarksPopupPlacement = "titlebar" | "verticalTabs";
 
+/**
+ * One loaded extension's titlebar button. Everything here comes from the
+ * extension's manifest and never changes while it runs — Electron implements no
+ * part of `chrome.action`, so an extension setting an icon, a badge or a title
+ * at runtime changes nothing and leaves no state to read.
+ */
+export type ExtensionActionState = {
+  extensionId: string;
+  title: string;
+  iconDataUrl: string | null;
+};
+
+/** A titlebar button's rect, in its window's content coordinates. */
+export type ExtensionActionAnchorRect = { x: number; y: number; width: number; height: number };
+
 export type WorkspaceAppNotification = {
   title: string;
   body?: string;
@@ -220,6 +235,8 @@ export type IpcMainEvents =
         bookmarkId: Bookmark["id"],
         targetIndex: number,
       ];
+      "extensions.toggleActionPopup": [extensionId: string, anchorRect: ExtensionActionAnchorRect];
+      "extensions.setActionPopupCloseOnBlurEnabled": [enabled: boolean];
       "doNotDisturb.toggle": [];
       "doNotDisturb.showOptions": [];
       "downloads.toggleRecentDownloadHistoryPopup": [];
@@ -249,6 +266,7 @@ export type IpcMainEvents =
       "workspaceApp.getLoadingState": (workspaceAppId?: string) => boolean;
       "workspaceApp.getBookmarkState": (workspaceAppId: string) => WorkspaceAppBookmarkState;
       "bookmarks.getBookmarks": () => BookmarkState[];
+      "extensions.getActions": () => ExtensionActionState[];
     };
 
 export type IpcRendererEvent = {
@@ -263,6 +281,7 @@ export type IpcRendererEvent = {
   "accounts.changed": [accounts: AccountInstances];
   "tabs.changed": [accountsTabs: AccountTabsState[]];
   "bookmarks.changed": [bookmarks: BookmarkState[]];
+  "extensions.actionsChanged": [actions: ExtensionActionState[]];
   "accounts.openAddAccountDialog": [];
   "findInPage.activate": [];
   "findInPage.result": [result: { activeMatch: number; totalMatches: number }];


### PR DESCRIPTION
- `@meru/electron-extensions` gains per-extension action data (title, popup URL, icon as data URL, MV3 `action` + MV2 `browser_action`, falling back to top-level `icons` — 1Password declares no `default_icon`, so the fallback is the live path) with `getSessionActions`/`onActionsChanged`.
- `Popup` generalized: content is a renderer page or any URL + session, anchor rect in window coordinates, size fixed / fill / page-driven via `preferred-size-changed` (clamped to Chrome's 800×600 popup ceiling). Existing bookmarks/downloads popups keep their exact geometry.
- One titlebar button per loaded extension in both the main and workspace-app titlebars, rendering nothing when no extensions are loaded; a click opens the extension's popup against that window's account session.

Finding that shrinks scope: Electron 43 implements **no part of `chrome.action`** — it ships the schema with every method marked unsupported, so `setIcon`/`setBadgeText`/`onClicked` are inert and nothing is readable by the embedder. Buttons render from manifest defaults; there is no badge and no dynamic icon until the facade shadows the namespace (noted in code, doc being corrected). Not verified (needs a display): blur/Escape/re-click dismissal, popup in a workspace-app window, live resize as the popup's content changes; headless evidence covers button rendering, popup view creation at the anchor with preferred size, and 1Password's popup page loading with `chrome.runtime` present.

Test plan:
1. `MERU_EXTENSIONS_DIRS=<unpacked 1Password> bun run dev` → a 1Password icon button appears at the end of the titlebar; click opens its popup under the button; click again / Escape / clicking elsewhere closes it.
2. Open a workspace app as a window → same button in that titlebar, popup opens against that account.
3. Bookmarks and recent-downloads popups look and behave exactly as before.
4. Without the env var → titlebar unchanged.