### PR TITLE
run native messaging hosts for extension contexts

### DIFF
--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -4,10 +4,12 @@ import type { AccountConfig } from "@meru/shared/schemas";
 import type { VerticalTabsSessionWidth } from "@meru/shared/tabs";
 import type { SelectedDesktopSource } from "@meru/shared/types";
 import { app, type IpcMainEvent, ipcMain, type Session, session } from "electron";
+import { serializeError } from "serialize-error";
 import { blocker } from "./blocker";
 import { config } from "./config";
 import { extensions } from "./extensions";
 import { Gmail } from "./gmail";
+import { log } from "./lib/log";
 import { createBrowserWindow, getPreloadPath, loadRenderer } from "./lib/window";
 import { licenseKey } from "./license-key";
 import { main } from "./main";
@@ -46,7 +48,9 @@ export class Account {
 
     blocker.setupSession(this.session);
 
-    extensions.setupSession(this.session);
+    const extensionsLoaded = extensions.setupSession(this.session).catch((error: unknown) => {
+      log.error("Failed to set up extensions", { error: serializeError(error) });
+    });
 
     this.setSpellCheckerLanguages();
 
@@ -56,6 +60,7 @@ export class Account {
       unreadCountEnabled: accountConfig.gmail.unreadBadge,
       unifiedInboxEnabled: accountConfig.gmail.unifiedInbox,
       delegatedAccountId: accountConfig.gmail.delegatedAccountId,
+      extensionsLoaded,
     });
 
     this.tabs = new Tabs(accountConfig.id, this.gmail);

--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -1,6 +1,10 @@
 import path from "node:path";
 import { is } from "@electron-toolkit/utils";
-import { Extensions, findExtensionDirs } from "@meru/electron-extensions";
+import {
+  Extensions,
+  findExtensionDirs,
+  registerNativeMessagingScheme,
+} from "@meru/electron-extensions";
 import { app } from "electron";
 import { serializeError } from "serialize-error";
 import { log } from "@/lib/log";
@@ -26,6 +30,10 @@ function getExtensionDirs() {
 
   return findExtensionDirs(path.join(app.getAppPath(), "extensions"));
 }
+
+// Extension contexts reach the native messaging bridge over a custom scheme,
+// and Electron only takes scheme privileges while modules are still loading
+registerNativeMessagingScheme();
 
 export const extensions = new Extensions({
   extensionDirs: getExtensionDirs(),

--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -31,6 +31,23 @@ function getExtensionDirs() {
   return findExtensionDirs(path.join(app.getAppPath(), "extensions"));
 }
 
+/**
+ * `MERU_EXTENSIONS_STRIP=content_scripts,declarative_net_request` derives every
+ * extension without those manifest keys, so a run can tell which part of an
+ * extension a page is reacting to. Development only, like the extensions
+ * themselves.
+ */
+function getStrippedManifestKeys() {
+  if (!is.dev) {
+    return [];
+  }
+
+  return (process.env.MERU_EXTENSIONS_STRIP ?? "")
+    .split(",")
+    .map((manifestKey) => manifestKey.trim())
+    .filter(Boolean);
+}
+
 // Extension contexts reach the native messaging bridge over a custom scheme,
 // and Electron only takes scheme privileges while modules are still loading
 registerNativeMessagingScheme();
@@ -39,6 +56,7 @@ export const extensions = new Extensions({
   extensionDirs: getExtensionDirs(),
   facadeScriptPath: path.join(__dirname, "extensions-chrome-facade.js"),
   derivedExtensionsDir: path.join(app.getPath("userData"), "derived-extensions"),
+  strippedManifestKeys: getStrippedManifestKeys(),
   logger: {
     info: (message, details) => {
       log.info(message, details);

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -32,6 +32,7 @@ import { ipc } from "@/ipc";
 import { log } from "@/lib/log";
 import {
   createChildWebContentsView,
+  loadUrl,
   openViewDevToolsOnLaunch,
   removeWebContentsListeners,
 } from "@/lib/web-contents";
@@ -441,7 +442,7 @@ export class Gmail {
 
     openViewDevToolsOnLaunch(this.view);
 
-    return this.view.webContents.loadURL(this.url);
+    return loadUrl(this.view.webContents, this.url);
   }
 
   async applyLabelColors() {
@@ -598,7 +599,7 @@ export class Gmail {
         const gmailDelegatedAccountId = url.match(GMAIL_DELEGATED_ACCOUNT_URL_REGEXP)?.[1];
 
         if (gmailDelegatedAccountId) {
-          window.webContents.loadURL(url);
+          loadUrl(window.webContents, url);
 
           this.setDelegatedAccountId(gmailDelegatedAccountId);
 
@@ -606,7 +607,7 @@ export class Gmail {
         }
 
         if (url === `${GMAIL_URL}/`) {
-          window.webContents.loadURL(url);
+          loadUrl(window.webContents, url);
 
           const account = accounts.getAccount(this.accountId);
 

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -455,11 +455,19 @@ export class Gmail {
     // makes Chromium abort that navigation, leaving the view empty
     await this.extensionsLoaded;
 
-    if (!this._view) {
+    if (!this._view || this._view.webContents.isDestroyed()) {
       return;
     }
 
-    return loadUrl(this.view.webContents, this.url);
+    const loaded = await loadUrl(this.view.webContents, this.url);
+
+    if (loaded || !this._view || this._view.webContents.isDestroyed()) {
+      return;
+    }
+
+    log.info("Retrying Gmail load", { url: this.url });
+
+    await loadUrl(this.view.webContents, this.url);
   }
 
   async applyLabelColors() {

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -33,6 +33,7 @@ import { log } from "@/lib/log";
 import {
   createChildWebContentsView,
   loadUrl,
+  logLoadFailures,
   openViewDevToolsOnLaunch,
   removeWebContentsListeners,
 } from "@/lib/web-contents";
@@ -403,6 +404,8 @@ export class Gmail {
     });
 
     this.registerNavigationHandler(this.view);
+
+    logLoadFailures(this.view.webContents, "Gmail view");
 
     this.updateViewBounds();
 

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -302,18 +302,22 @@ export class Gmail {
 
   private storeUnsubscribers: (() => void)[] = [];
 
+  private extensionsLoaded: Promise<void> | undefined;
+
   constructor({
     accountId,
     session,
     unreadCountEnabled,
     unifiedInboxEnabled,
     delegatedAccountId,
+    extensionsLoaded,
   }: {
     accountId: string;
     session: Session;
     unreadCountEnabled: boolean;
     unifiedInboxEnabled: boolean;
     delegatedAccountId: string | null;
+    extensionsLoaded?: Promise<void>;
   }) {
     const additionalArguments: string[] = [];
 
@@ -373,6 +377,8 @@ export class Gmail {
 
     this.additionalArguments = additionalArguments;
 
+    this.extensionsLoaded = extensionsLoaded;
+
     this.unreadCountEnabled = unreadCountEnabled;
 
     this.unifiedInboxEnabled = unifiedInboxEnabled;
@@ -388,7 +394,7 @@ export class Gmail {
     }, ms("5m"));
   }
 
-  createView(options?: WebContentsViewConstructorOptions) {
+  async createView(options?: WebContentsViewConstructorOptions) {
     this.view = createChildWebContentsView({
       session: this.session,
       preload: getPreloadPath("gmail"),
@@ -444,6 +450,14 @@ export class Gmail {
     registerTabBroadcasts(this.view);
 
     openViewDevToolsOnLaunch(this.view);
+
+    // An extension that finishes loading while a navigation is still provisional
+    // makes Chromium abort that navigation, leaving the view empty
+    await this.extensionsLoaded;
+
+    if (!this._view) {
+      return;
+    }
 
     return loadUrl(this.view.webContents, this.url);
   }

--- a/packages/app/lib/web-contents.ts
+++ b/packages/app/lib/web-contents.ts
@@ -4,9 +4,23 @@ import {
   WebContentsView,
   type WebContentsViewConstructorOptions,
 } from "electron";
+import { serializeError } from "serialize-error";
 import { setupWindowContextMenu } from "@/context-menu";
 import { ipc } from "@/ipc";
 import { shouldOpenDevToolsOnLaunch } from "./dev-tools";
+import { log } from "./log";
+
+/**
+ * `loadURL` rejects when the load never commits — a renderer that went away
+ * mid-navigation, a network stack that gave up — and nothing waits on the
+ * promise, which turns every such load into an unhandled rejection. There is
+ * nothing to do about a failed load beyond saying what happened.
+ */
+export function loadUrl(webContents: WebContents, url: string) {
+  return webContents.loadURL(url).catch((error: unknown) => {
+    log.error("Failed to load URL", { url, error: serializeError(error) });
+  });
+}
 
 export function applyViewZoomLimits(view: WebContentsView) {
   view.webContents.on("dom-ready", () => {

--- a/packages/app/lib/web-contents.ts
+++ b/packages/app/lib/web-contents.ts
@@ -13,13 +13,18 @@ import { log } from "./log";
 /**
  * `loadURL` rejects when the load never commits — a renderer that went away
  * mid-navigation, a network stack that gave up — and nothing waits on the
- * promise, which turns every such load into an unhandled rejection. There is
- * nothing to do about a failed load beyond saying what happened.
+ * promise, which turns every such load into an unhandled rejection. Says what
+ * happened and answers whether the page arrived.
  */
 export function loadUrl(webContents: WebContents, url: string) {
-  return webContents.loadURL(url).catch((error: unknown) => {
-    log.error("Failed to load URL", { url, error: serializeError(error) });
-  });
+  return webContents
+    .loadURL(url)
+    .then(() => true)
+    .catch((error: unknown) => {
+      log.error("Failed to load URL", { url, error: serializeError(error) });
+
+      return false;
+    });
 }
 
 /**

--- a/packages/app/lib/web-contents.ts
+++ b/packages/app/lib/web-contents.ts
@@ -22,6 +22,41 @@ export function loadUrl(webContents: WebContents, url: string) {
   });
 }
 
+/**
+ * Says why a view is empty. A load that never arrives leaves nothing behind on
+ * its own: the renderer that died, the frame that was refused and the error the
+ * network stack gave up with are all only in these events.
+ */
+export function logLoadFailures(webContents: WebContents, name: string) {
+  webContents.on("render-process-gone", (_event, { reason, exitCode }) => {
+    log.error(`${name} renderer is gone`, { reason, exitCode });
+  });
+
+  webContents.on(
+    "did-fail-load",
+    (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+      log.error(`${name} failed to load`, {
+        errorCode,
+        errorDescription,
+        validatedURL,
+        isMainFrame,
+      });
+    },
+  );
+
+  webContents.on(
+    "did-fail-provisional-load",
+    (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+      log.error(`${name} failed to start loading`, {
+        errorCode,
+        errorDescription,
+        validatedURL,
+        isMainFrame,
+      });
+    },
+  );
+}
+
 export function applyViewZoomLimits(view: WebContentsView) {
   view.webContents.on("dom-ready", () => {
     view.webContents.setVisualZoomLevelLimits(1, 3);

--- a/packages/electron-extensions/derive/extension-id.test.ts
+++ b/packages/electron-extensions/derive/extension-id.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { getExtensionIdFromManifestKey } from "./extension-id";
+
+/** 1Password 8.12.32.33, whose Chrome Web Store id this key has to derive. */
+const ONE_PASSWORD_KEY =
+  "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnHpaUll4uWujpAdbIXOQY2WE6hk8PllsYsnoUaj5qHXwv4IB6A9pONqGaTL2KL20u6E6XVhncY6Ae6SQSBQqiIkgjPsiG0NDNsDlju/kzBnfimKFC/bpzOrqFqbhswQHifnet5uHlpG97whTzLO3ka0M5aqB9V9mD/0qVXvNgAVVnSTULH254YqpeCcAhmsKiFZSL6OrOZmCp8kZ/OeOUK9iYWYylL7VcOXVrZf10EPrlaCNXzVk7K35dPuQ7svhA0Pgju3kngB4RLa5Iojhw3IT+B5+m8pisjOSd1oKMrRmhGs7rDhF5IEtAiVxqVp7uOOMPQj3vrbMDAzf7vqLtQIDAQAB";
+
+describe("getExtensionIdFromManifestKey", () => {
+  test("derives the id Chromium gives the extension", () => {
+    expect(getExtensionIdFromManifestKey(ONE_PASSWORD_KEY)).toBe(
+      "aeblfdkhhhdcdjpifhhbdiojplfjncoa",
+    );
+  });
+
+  test("writes the id in the a-p alphabet only", () => {
+    expect(getExtensionIdFromManifestKey("dGVzdC1rZXk=")).toBe("gckpihaehgepkpiokicpmgbmojmemdja");
+  });
+
+  test("has no id for a manifest without a key", () => {
+    expect(getExtensionIdFromManifestKey(undefined)).toBeUndefined();
+  });
+});

--- a/packages/electron-extensions/derive/extension-id.ts
+++ b/packages/electron-extensions/derive/extension-id.ts
@@ -1,0 +1,25 @@
+import { createHash } from "node:crypto";
+
+const ID_ALPHABET_OFFSET = "a".charCodeAt(0);
+
+/**
+ * The id Chromium gives an extension whose manifest carries a `key`: the first
+ * 16 bytes of the key's sha256, written in the a-p alphabet extension ids use
+ * instead of hexadecimal.
+ *
+ * Knowing the id before the extension is loaded is what lets the loader address
+ * the extension's own storage in a session. An extension without a `key` has no
+ * id until Chromium generates one from the directory it is loaded from, so it
+ * has none here.
+ */
+export function getExtensionIdFromManifestKey(key: string | undefined) {
+  if (!key) {
+    return undefined;
+  }
+
+  const digest = createHash("sha256").update(Buffer.from(key, "base64")).digest("hex").slice(0, 32);
+
+  return Array.from(digest, (digit) =>
+    String.fromCharCode(ID_ALPHABET_OFFSET + Number.parseInt(digit, 16)),
+  ).join("");
+}

--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -48,8 +48,8 @@ afterEach(async () => {
   await rm(workDir, { recursive: true, force: true });
 });
 
-function derive() {
-  return deriveExtension({ sourceDir, derivedExtensionsDir, facadeScriptPath });
+async function derive() {
+  return (await deriveExtension({ sourceDir, derivedExtensionsDir, facadeScriptPath })).derivedDir;
 }
 
 describe("deriveExtension", () => {
@@ -67,7 +67,9 @@ describe("deriveExtension", () => {
       await readFile(path.join(derivedDir, "chrome-facade-service-worker.js"), "utf8"),
     ).toContain('import "./chrome-facade.js";');
 
-    expect(await readFile(path.join(derivedDir, "chrome-facade.js"), "utf8")).toBe("// facade\n");
+    expect(await readFile(path.join(derivedDir, "chrome-facade.js"), "utf8")).toEndWith(
+      "// facade\n",
+    );
 
     expect(await readFile(path.join(derivedDir, "popup.html"), "utf8")).toContain(
       '<script src="/chrome-facade.js"></script>',
@@ -107,7 +109,7 @@ describe("deriveExtension", () => {
 
     await writeFile(path.join(otherSourceDir, "manifest.json"), JSON.stringify(manifest));
 
-    const otherDerivedDir = await deriveExtension({
+    const { derivedDir: otherDerivedDir } = await deriveExtension({
       sourceDir: otherSourceDir,
       derivedExtensionsDir,
       facadeScriptPath,
@@ -128,7 +130,7 @@ describe("deriveExtension", () => {
     expect(await readFile(path.join(derivedDir, "background", "background.js"), "utf8")).toBe(
       "// stale\n",
     );
-    expect(await readFile(path.join(derivedDir, "chrome-facade.js"), "utf8")).toBe(
+    expect(await readFile(path.join(derivedDir, "chrome-facade.js"), "utf8")).toEndWith(
       "// rebuilt facade\n",
     );
   });
@@ -148,6 +150,22 @@ describe("deriveExtension", () => {
     expect(JSON.parse(await readFile(path.join(derivedDir, "manifest.json"), "utf8")).version).toBe(
       "2.0.0",
     );
+  });
+
+  test("gives every derived copy of the facade a bridge token of its own", async () => {
+    const { bridgeToken, derivedDir } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+    });
+
+    expect(await readFile(path.join(derivedDir, "chrome-facade.js"), "utf8")).toContain(
+      JSON.stringify(bridgeToken),
+    );
+
+    const rederived = await deriveExtension({ sourceDir, derivedExtensionsDir, facadeScriptPath });
+
+    expect(rederived.bridgeToken).not.toBe(bridgeToken);
   });
 
   test("injects the facade into a page only once", async () => {

--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -168,6 +168,28 @@ describe("deriveExtension", () => {
     expect(rederived.bridgeToken).not.toBe(bridgeToken);
   });
 
+  test("reports the id the extension will be loaded as", async () => {
+    const { extensionId } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+    });
+
+    expect(extensionId).toBe("gkodpobagfoadfbnehppbpmagfgmimpa");
+  });
+
+  test("reports no id for an extension without a key", async () => {
+    await writeManifest({ ...manifest, key: undefined });
+
+    const { extensionId } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+    });
+
+    expect(extensionId).toBeUndefined();
+  });
+
   test("injects the facade into a page only once", async () => {
     const derivedDir = await derive();
 

--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -178,6 +178,27 @@ describe("deriveExtension", () => {
     expect(extensionId).toBe("gkodpobagfoadfbnehppbpmagfgmimpa");
   });
 
+  test("derives the copy again when the keys it strips change", async () => {
+    await writeManifest({ ...manifest, content_scripts: [{ js: ["content.js"] }] });
+
+    const derivedDir = await derive();
+
+    expect(
+      JSON.parse(await readFile(path.join(derivedDir, "manifest.json"), "utf8")),
+    ).toHaveProperty("content_scripts");
+
+    await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      strippedManifestKeys: ["content_scripts"],
+    });
+
+    expect(
+      JSON.parse(await readFile(path.join(derivedDir, "manifest.json"), "utf8")),
+    ).not.toHaveProperty("content_scripts");
+  });
+
   test("reports no id for an extension without a key", async () => {
     await writeManifest({ ...manifest, key: undefined });
 

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -16,7 +16,7 @@ const FACADE_FILE_NAME = "chrome-facade.js";
 const SERVICE_WORKER_FILE_NAME = "chrome-facade-service-worker.js";
 
 /** Bump whenever what is written into a derived copy changes. */
-const DERIVE_VERSION = 2;
+const DERIVE_VERSION = 3;
 
 export type DeriveExtensionOptions = {
   /** The unpacked extension the embedder handed over, never written to. */

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -1,6 +1,10 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { cp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
+import {
+  NATIVE_MESSAGING_SCHEME,
+  NATIVE_MESSAGING_TOKEN_GLOBAL,
+} from "../native-messaging/bridge-protocol";
 import { injectFacadeScript } from "./html";
 import { deriveManifest, type ExtensionManifest } from "./manifest";
 
@@ -11,7 +15,7 @@ const FACADE_FILE_NAME = "chrome-facade.js";
 const SERVICE_WORKER_FILE_NAME = "chrome-facade-service-worker.js";
 
 /** Bump whenever what is written into a derived copy changes. */
-const DERIVE_VERSION = 1;
+const DERIVE_VERSION = 2;
 
 export type DeriveExtensionOptions = {
   /** The unpacked extension the embedder handed over, never written to. */
@@ -59,6 +63,9 @@ async function injectFacadeIntoPages(derivedDir: string) {
  * to write to — it is a verified install, or a directory a developer is working
  * in. The copy sits at a path derived from the source path, so an extension
  * without a `manifest.key` keeps the same generated id across launches.
+ *
+ * The facade is written rather than copied so that this extension's copy can
+ * carry the token its native messaging bridge requests are recognised by.
  */
 export async function deriveExtension({
   sourceDir,
@@ -88,12 +95,16 @@ export async function deriveExtension({
 
     const { manifest, serviceWorkerWrapper } = deriveManifest(
       JSON.parse(manifestSource) as ExtensionManifest,
-      { facadeFileName: FACADE_FILE_NAME, serviceWorkerFileName: SERVICE_WORKER_FILE_NAME },
+      {
+        facadeFileName: FACADE_FILE_NAME,
+        serviceWorkerFileName: SERVICE_WORKER_FILE_NAME,
+        bridgeConnectSource: `${NATIVE_MESSAGING_SCHEME}:`,
+      },
     );
 
-    if (serviceWorkerWrapper) {
-      await writeFile(path.join(derivedDir, MANIFEST_FILE_NAME), JSON.stringify(manifest, null, 2));
+    await writeFile(path.join(derivedDir, MANIFEST_FILE_NAME), JSON.stringify(manifest, null, 2));
 
+    if (serviceWorkerWrapper) {
       await writeFile(path.join(derivedDir, SERVICE_WORKER_FILE_NAME), serviceWorkerWrapper);
     }
 
@@ -103,7 +114,15 @@ export async function deriveExtension({
   }
 
   // Always, so a rebuilt facade reaches copies that are otherwise up to date
-  await cp(facadeScriptPath, path.join(derivedDir, FACADE_FILE_NAME));
+  const bridgeToken = randomUUID();
 
-  return derivedDir;
+  await writeFile(
+    path.join(derivedDir, FACADE_FILE_NAME),
+    `globalThis.${NATIVE_MESSAGING_TOKEN_GLOBAL} = ${JSON.stringify(bridgeToken)};\n${await readFile(
+      facadeScriptPath,
+      "utf8",
+    )}`,
+  );
+
+  return { derivedDir, bridgeToken };
 }

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -23,6 +23,12 @@ export type DeriveExtensionOptions = {
   sourceDir: string;
   derivedExtensionsDir: string;
   facadeScriptPath: string;
+  /**
+   * Manifest keys the copy is derived without, to run an extension with one of
+   * its parts taken away — `content_scripts`, `declarative_net_request` — and
+   * see what changes.
+   */
+  strippedManifestKeys?: string[];
 };
 
 function hash(value: string) {
@@ -72,6 +78,7 @@ export async function deriveExtension({
   sourceDir,
   derivedExtensionsDir,
   facadeScriptPath,
+  strippedManifestKeys = [],
 }: DeriveExtensionOptions) {
   const manifestSource = await readFile(path.join(sourceDir, MANIFEST_FILE_NAME), "utf8");
 
@@ -82,11 +89,13 @@ export async function deriveExtension({
   const stampPath = `${derivedDir}.json`;
 
   // The source is copied again when its manifest changes, which is what an
-  // installed extension moving to a new version does
+  // installed extension moving to a new version does, and when what the derive
+  // makes of it changes
   const stamp = JSON.stringify({
     deriveVersion: DERIVE_VERSION,
     sourceDir,
     manifest: hash(manifestSource),
+    strippedManifestKeys,
   });
 
   if ((await readStamp(stampPath)) !== stamp) {
@@ -100,6 +109,7 @@ export async function deriveExtension({
       facadeFileName: FACADE_FILE_NAME,
       serviceWorkerFileName: SERVICE_WORKER_FILE_NAME,
       bridgeConnectSource: `${NATIVE_MESSAGING_SCHEME}:`,
+      strippedManifestKeys,
     });
 
     await writeFile(path.join(derivedDir, MANIFEST_FILE_NAME), JSON.stringify(manifest, null, 2));

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -5,6 +5,7 @@ import {
   NATIVE_MESSAGING_SCHEME,
   NATIVE_MESSAGING_TOKEN_GLOBAL,
 } from "../native-messaging/bridge-protocol";
+import { getExtensionIdFromManifestKey } from "./extension-id";
 import { injectFacadeScript } from "./html";
 import { deriveManifest, type ExtensionManifest } from "./manifest";
 
@@ -74,6 +75,8 @@ export async function deriveExtension({
 }: DeriveExtensionOptions) {
   const manifestSource = await readFile(path.join(sourceDir, MANIFEST_FILE_NAME), "utf8");
 
+  const sourceManifest = JSON.parse(manifestSource) as ExtensionManifest;
+
   const derivedDir = path.join(derivedExtensionsDir, hash(sourceDir).slice(0, 16));
 
   const stampPath = `${derivedDir}.json`;
@@ -93,14 +96,11 @@ export async function deriveExtension({
 
     await cp(sourceDir, derivedDir, { recursive: true });
 
-    const { manifest, serviceWorkerWrapper } = deriveManifest(
-      JSON.parse(manifestSource) as ExtensionManifest,
-      {
-        facadeFileName: FACADE_FILE_NAME,
-        serviceWorkerFileName: SERVICE_WORKER_FILE_NAME,
-        bridgeConnectSource: `${NATIVE_MESSAGING_SCHEME}:`,
-      },
-    );
+    const { manifest, serviceWorkerWrapper } = deriveManifest(sourceManifest, {
+      facadeFileName: FACADE_FILE_NAME,
+      serviceWorkerFileName: SERVICE_WORKER_FILE_NAME,
+      bridgeConnectSource: `${NATIVE_MESSAGING_SCHEME}:`,
+    });
 
     await writeFile(path.join(derivedDir, MANIFEST_FILE_NAME), JSON.stringify(manifest, null, 2));
 
@@ -124,5 +124,9 @@ export async function deriveExtension({
     )}`,
   );
 
-  return { derivedDir, bridgeToken };
+  return {
+    derivedDir,
+    bridgeToken,
+    extensionId: getExtensionIdFromManifestKey(sourceManifest.key),
+  };
 }

--- a/packages/electron-extensions/derive/manifest.test.ts
+++ b/packages/electron-extensions/derive/manifest.test.ts
@@ -103,6 +103,31 @@ describe("deriveManifest", () => {
 
     expect(manifest.permissions).toBeUndefined();
   });
+
+  test("derives the copy without the manifest keys it was told to strip", () => {
+    const { manifest } = deriveManifest(
+      {
+        name: "1Password",
+        content_scripts: [{ js: ["inline/inject-content-scripts.js"] }],
+        declarative_net_request: { rule_resources: [] },
+      },
+      { ...fileNames, strippedManifestKeys: ["content_scripts", "declarative_net_request"] },
+    );
+
+    expect(manifest).toEqual({ name: "1Password" });
+  });
+
+  test("strips nothing an extension does not have", () => {
+    const { manifest } = deriveManifest(
+      { name: "1Password" },
+      {
+        ...fileNames,
+        strippedManifestKeys: ["content_scripts"],
+      },
+    );
+
+    expect(manifest).toEqual({ name: "1Password" });
+  });
 });
 
 describe("allowConnectSource", () => {

--- a/packages/electron-extensions/derive/manifest.test.ts
+++ b/packages/electron-extensions/derive/manifest.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { deriveManifest } from "./manifest";
+import { allowConnectSource, deriveManifest } from "./manifest";
 
 const fileNames = {
   facadeFileName: "chrome-facade.js",
   serviceWorkerFileName: "chrome-facade-service-worker.js",
+  bridgeConnectSource: "extension-native-messaging:",
 };
 
 describe("deriveManifest", () => {
@@ -60,5 +61,63 @@ describe("deriveManifest", () => {
 
     expect(serviceWorkerWrapper).toBeNull();
     expect(manifest.background).toBeUndefined();
+  });
+
+  test("lets the content security policy reach the bridge", () => {
+    const { manifest } = deriveManifest(
+      {
+        content_security_policy: {
+          extension_pages: "default-src 'none'; connect-src https://1password.com",
+          sandbox: "sandbox allow-scripts",
+        },
+      },
+      fileNames,
+    );
+
+    expect(manifest.content_security_policy).toEqual({
+      extension_pages:
+        "default-src 'none'; connect-src https://1password.com extension-native-messaging:",
+      sandbox: "sandbox allow-scripts",
+    });
+  });
+
+  test("leaves a manifest without a content security policy alone", () => {
+    const { manifest } = deriveManifest({ name: "No policy" }, fileNames);
+
+    expect(manifest.content_security_policy).toBeUndefined();
+  });
+});
+
+describe("allowConnectSource", () => {
+  const source = "extension-native-messaging:";
+
+  test("appends to an existing connect-src", () => {
+    expect(allowConnectSource("script-src 'self'; connect-src https://a.test", source)).toBe(
+      "script-src 'self'; connect-src https://a.test extension-native-messaging:",
+    );
+  });
+
+  test("adds nothing twice", () => {
+    const contentSecurityPolicy = `connect-src https://a.test ${source}`;
+
+    expect(allowConnectSource(contentSecurityPolicy, source)).toBe(contentSecurityPolicy);
+  });
+
+  test("derives connect-src from default-src, dropping 'none'", () => {
+    expect(allowConnectSource("default-src 'none'; script-src 'self'", source)).toBe(
+      "default-src 'none'; script-src 'self'; connect-src extension-native-messaging:",
+    );
+  });
+
+  test("carries the other default-src sources over", () => {
+    expect(allowConnectSource("default-src 'self' https://a.test", source)).toBe(
+      "default-src 'self' https://a.test; connect-src 'self' https://a.test extension-native-messaging:",
+    );
+  });
+
+  test("leaves a policy that restricts neither alone", () => {
+    expect(allowConnectSource("script-src 'self'; object-src 'self'", source)).toBe(
+      "script-src 'self'; object-src 'self'",
+    );
   });
 });

--- a/packages/electron-extensions/derive/manifest.test.ts
+++ b/packages/electron-extensions/derive/manifest.test.ts
@@ -86,6 +86,23 @@ describe("deriveManifest", () => {
 
     expect(manifest.content_security_policy).toBeUndefined();
   });
+
+  test("drops the permissions Electron declares but cannot serve", () => {
+    const { manifest } = deriveManifest(
+      {
+        permissions: ["storage", "webRequest", "nativeMessaging", "webRequestAuthProvider", "tabs"],
+      },
+      fileNames,
+    );
+
+    expect(manifest.permissions).toEqual(["storage", "nativeMessaging", "tabs"]);
+  });
+
+  test("leaves a manifest without permissions alone", () => {
+    const { manifest } = deriveManifest({ name: "No permissions" }, fileNames);
+
+    expect(manifest.permissions).toBeUndefined();
+  });
 });
 
 describe("allowConnectSource", () => {

--- a/packages/electron-extensions/derive/manifest.ts
+++ b/packages/electron-extensions/derive/manifest.ts
@@ -1,4 +1,6 @@
+/** Only what the derive reads or rewrites is spelled out; the rest is carried. */
 export type ExtensionManifest = {
+  [manifestKey: string]: unknown;
   name?: string;
   version?: string;
   key?: string;
@@ -142,10 +144,13 @@ export function deriveManifest(
     facadeFileName,
     serviceWorkerFileName,
     bridgeConnectSource,
+    strippedManifestKeys = [],
   }: {
     facadeFileName: string;
     serviceWorkerFileName: string;
     bridgeConnectSource: string;
+    /** Manifest keys to leave out of the copy, e.g. `content_scripts`. */
+    strippedManifestKeys?: string[];
   },
 ): DerivedManifest {
   const derivedManifest: ExtensionManifest = {
@@ -153,6 +158,10 @@ export function deriveManifest(
     permissions: derivePermissions(manifest.permissions),
     content_security_policy: deriveContentSecurityPolicy(manifest, bridgeConnectSource),
   };
+
+  for (const strippedManifestKey of strippedManifestKeys) {
+    delete derivedManifest[strippedManifestKey];
+  }
 
   const backgroundFileName = manifest.background?.service_worker?.replace(/^\//, "");
 

--- a/packages/electron-extensions/derive/manifest.ts
+++ b/packages/electron-extensions/derive/manifest.ts
@@ -2,6 +2,7 @@ export type ExtensionManifest = {
   name?: string;
   version?: string;
   key?: string;
+  permissions?: string[];
   background?: {
     service_worker?: string;
     type?: string;
@@ -36,6 +37,24 @@ function createServiceWorkerWrapper(
   }
 
   return `${header}importScripts("/${facadeFileName}", "/${backgroundFileName}");\n`;
+}
+
+/**
+ * Permissions whose bindings Electron declares but ships no implementation for.
+ * Chromium builds the namespace from the schema the moment anything touches it,
+ * looks for the JavaScript module behind it, finds none and hits a NOTREACHED —
+ * once for `webRequest` and once per event on it, in every extension context.
+ * That is a `DumpWithoutCrashing` in the builds Meru ships and a fatal check in
+ * others, and it costs the extension nothing to avoid: extension-side
+ * `webRequest` listeners never see a request in Electron, measured in the spike.
+ *
+ * Dropped from the derived copy, the namespace is missing rather than broken,
+ * and the facade's noop `webRequest` stands in for it.
+ */
+const DROPPED_PERMISSIONS = new Set(["webRequest", "webRequestAuthProvider"]);
+
+function derivePermissions(permissions: ExtensionManifest["permissions"]) {
+  return permissions?.filter((permission) => !DROPPED_PERMISSIONS.has(permission));
 }
 
 function parseDirectives(contentSecurityPolicy: string) {
@@ -110,11 +129,12 @@ function deriveContentSecurityPolicy(
 }
 
 /**
- * Points the manifest's service worker at a generated wrapper and lets its
- * content security policy reach the native messaging bridge. Everything else is
- * carried over untouched — `key` above all, since without it Chromium derives
- * the extension id from the directory it was loaded from and the derived copy
- * would answer to a different id than the extension it came from.
+ * Points the manifest's service worker at a generated wrapper, lets its content
+ * security policy reach the native messaging bridge and drops the permissions
+ * Electron cannot serve. Everything else is carried over untouched — `key`
+ * above all, since without it Chromium derives the extension id from the
+ * directory it was loaded from and the derived copy would answer to a different
+ * id than the extension it came from.
  */
 export function deriveManifest(
   manifest: ExtensionManifest,
@@ -130,6 +150,7 @@ export function deriveManifest(
 ): DerivedManifest {
   const derivedManifest: ExtensionManifest = {
     ...manifest,
+    permissions: derivePermissions(manifest.permissions),
     content_security_policy: deriveContentSecurityPolicy(manifest, bridgeConnectSource),
   };
 

--- a/packages/electron-extensions/derive/manifest.ts
+++ b/packages/electron-extensions/derive/manifest.ts
@@ -6,6 +6,10 @@ export type ExtensionManifest = {
     service_worker?: string;
     type?: string;
   };
+  content_security_policy?: {
+    extension_pages?: string;
+    sandbox?: string;
+  };
 };
 
 export type DerivedManifest = {
@@ -34,31 +38,110 @@ function createServiceWorkerWrapper(
   return `${header}importScripts("/${facadeFileName}", "/${backgroundFileName}");\n`;
 }
 
+function parseDirectives(contentSecurityPolicy: string) {
+  return contentSecurityPolicy
+    .split(";")
+    .map((directive) => directive.trim())
+    .filter(Boolean);
+}
+
+function findDirective(directives: string[], name: string) {
+  return directives.findIndex((directive) => new RegExp(`^${name}(\\s|$)`, "i").test(directive));
+}
+
 /**
- * Points the manifest's service worker at a generated wrapper. Everything else
- * is carried over untouched — `key` above all, since without it Chromium
- * derives the extension id from the directory it was loaded from and the
- * derived copy would answer to a different id than the extension it came from.
+ * Widens `connect-src` so the facade can reach the bridge. An extension's own
+ * policy governs its service worker as much as its pages, and one that pins
+ * `connect-src` — 1Password pins it to its own hosts — would otherwise block
+ * the only transport extension contexts have into the main process.
+ *
+ * Only `connect-src` moves, and only by this one scheme: what the extension
+ * may load, execute or frame is left exactly as its author wrote it.
+ */
+export function allowConnectSource(contentSecurityPolicy: string, source: string) {
+  const directives = parseDirectives(contentSecurityPolicy);
+
+  const connectIndex = findDirective(directives, "connect-src");
+
+  if (connectIndex !== -1) {
+    const connectDirective = directives[connectIndex] as string;
+
+    if (connectDirective.split(/\s+/).includes(source)) {
+      return contentSecurityPolicy;
+    }
+
+    directives[connectIndex] = `${connectDirective} ${source}`;
+
+    return directives.join("; ");
+  }
+
+  const defaultIndex = findDirective(directives, "default-src");
+
+  // Without either directive nothing restricts connections in the first place
+  if (defaultIndex === -1) {
+    return contentSecurityPolicy;
+  }
+
+  const inheritedSources = (directives[defaultIndex] as string)
+    .split(/\s+/)
+    .slice(1)
+    // `'none'` alongside another source is ignored rather than obeyed
+    .filter((inheritedSource) => inheritedSource !== "'none'");
+
+  directives.push(`connect-src ${[...inheritedSources, source].join(" ")}`);
+
+  return directives.join("; ");
+}
+
+function deriveContentSecurityPolicy(
+  manifest: ExtensionManifest,
+  bridgeConnectSource: string,
+): ExtensionManifest["content_security_policy"] {
+  const extensionPages = manifest.content_security_policy?.extension_pages;
+
+  if (!extensionPages) {
+    return manifest.content_security_policy;
+  }
+
+  return {
+    ...manifest.content_security_policy,
+    extension_pages: allowConnectSource(extensionPages, bridgeConnectSource),
+  };
+}
+
+/**
+ * Points the manifest's service worker at a generated wrapper and lets its
+ * content security policy reach the native messaging bridge. Everything else is
+ * carried over untouched — `key` above all, since without it Chromium derives
+ * the extension id from the directory it was loaded from and the derived copy
+ * would answer to a different id than the extension it came from.
  */
 export function deriveManifest(
   manifest: ExtensionManifest,
   {
     facadeFileName,
     serviceWorkerFileName,
+    bridgeConnectSource,
   }: {
     facadeFileName: string;
     serviceWorkerFileName: string;
+    bridgeConnectSource: string;
   },
 ): DerivedManifest {
+  const derivedManifest: ExtensionManifest = {
+    ...manifest,
+    content_security_policy: deriveContentSecurityPolicy(manifest, bridgeConnectSource),
+  };
+
   const backgroundFileName = manifest.background?.service_worker?.replace(/^\//, "");
 
   if (!backgroundFileName) {
-    return { manifest, serviceWorkerWrapper: null };
+    return { manifest: derivedManifest, serviceWorkerWrapper: null };
   }
 
   return {
     manifest: {
-      ...manifest,
+      ...derivedManifest,
       background: { ...manifest.background, service_worker: serviceWorkerFileName },
     },
     serviceWorkerWrapper: createServiceWorkerWrapper(

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -2,8 +2,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import fs, { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os, { tmpdir } from "node:os";
 import path from "node:path";
-import type { Extension, Session } from "electron";
+import type { ClearStorageDataOptions, Extension, Session } from "electron";
 import { Extensions } from "./extensions";
+import {
+  NATIVE_MESSAGING_ORIGIN,
+  NATIVE_MESSAGING_PATHS,
+} from "./native-messaging/bridge-protocol";
 
 let workDir: string;
 
@@ -21,7 +25,7 @@ afterEach(async () => {
   await rm(workDir, { recursive: true, force: true });
 });
 
-async function createExtensionDir(name: string) {
+async function createExtensionDir(name: string, key?: string) {
   const extensionDir = path.join(workDir, name);
 
   await mkdir(extensionDir, { recursive: true });
@@ -32,6 +36,7 @@ async function createExtensionDir(name: string) {
       name,
       version: "1.0.0",
       manifest_version: 3,
+      ...(key && { key }),
       background: { service_worker: "background.js", type: "module" },
     }),
   );
@@ -86,25 +91,56 @@ function createSession({
 
   const handledSchemes: string[] = [];
 
+  const sessionEvents: string[] = [];
+
+  let requestHandler: ((request: GlobalRequest) => Promise<Response>) | undefined;
+
   const session = {
     extensions: {
-      loadExtension,
+      loadExtension: async (extensionDir: string) => {
+        sessionEvents.push("loadExtension");
+
+        return loadExtension(extensionDir);
+      },
       removeExtension: (extensionId: string) => {
         removedExtensionIds.push(extensionId);
       },
     },
     protocol: {
-      handle: (scheme: string) => {
+      handle: (scheme: string, handler: (request: GlobalRequest) => Promise<Response>) => {
         handledSchemes.push(scheme);
+
+        requestHandler = handler;
       },
       unhandle: (scheme: string) => {
         handledSchemes.splice(handledSchemes.indexOf(scheme), 1);
       },
     },
+    clearStorageData: async ({ origin, storages }: ClearStorageDataOptions) => {
+      sessionEvents.push(`clearStorageData ${origin} ${storages?.join()}`);
+    },
     getStoragePath: () => storagePath,
   } as unknown as Session;
 
-  return { session, removedExtensionIds, handledSchemes };
+  return {
+    session,
+    removedExtensionIds,
+    handledSchemes,
+    sessionEvents,
+    request: (body: Record<string, unknown>) =>
+      requestHandler?.({
+        url: `${NATIVE_MESSAGING_ORIGIN}${NATIVE_MESSAGING_PATHS.connect}`,
+        headers: new Headers(),
+        json: async () => body,
+      } as unknown as GlobalRequest) as Promise<Response>,
+  };
+}
+
+/** The token the derived copy of the facade carries into the extension. */
+async function readBridgeToken(derivedDir: string) {
+  const facade = await readFile(path.join(derivedDir, "chrome-facade.js"), "utf8");
+
+  return facade.match(/"(.+)"/)?.[1];
 }
 
 async function createPartitionDir(entryPaths: string[]) {
@@ -168,6 +204,57 @@ describe("Extensions", () => {
     await extensions.setupSession(createSession({ loadExtension }).session);
 
     expect(loadedExtensionDirs[0]).toBe(loadedExtensionDirs[1] as string);
+  });
+
+  test("drops the cached service worker before loading an extension", async () => {
+    const { session, sessionEvents } = createSession();
+
+    // Chromium serves the worker it cached on first registration forever, so a
+    // copy of the facade older than this launch would run without it
+    await createExtensions([await createExtensionDir("one", "dGVzdC1rZXk=")]).setupSession(session);
+
+    expect(sessionEvents).toEqual([
+      "clearStorageData chrome-extension://gckpihaehgepkpiokicpmgbmojmemdja serviceworkers",
+      "loadExtension",
+    ]);
+  });
+
+  test("keeps the service worker of an extension it has no id for", async () => {
+    const { session, sessionEvents } = createSession();
+
+    await createExtensions([await createExtensionDir("one")]).setupSession(session);
+
+    expect(sessionEvents).toEqual(["loadExtension"]);
+  });
+
+  test("answers the bridge in every session sharing a derived copy", async () => {
+    const derivedDirs: string[] = [];
+
+    const loadExtension = async (extensionDir: string) => {
+      derivedDirs.push(extensionDir);
+
+      return createExtension("aaa", extensionDir);
+    };
+
+    const first = createSession({ loadExtension });
+    const second = createSession({ loadExtension });
+
+    const extensions = createExtensions([await createExtensionDir("one")]);
+
+    await extensions.setupSession(first.session);
+    await extensions.setupSession(second.session);
+
+    const bridgeToken = await readBridgeToken(derivedDirs[0] as string);
+
+    const connect = (
+      request: ReturnType<typeof createSession>["request"],
+      token: string | undefined,
+      portId: string,
+    ) => request({ token, portId, hostName: "com.meru.test" });
+
+    expect((await connect(first.request, bridgeToken, "first")).status).not.toBe(403);
+    expect((await connect(second.request, bridgeToken, "second")).status).not.toBe(403);
+    expect((await connect(first.request, "not-a-token", "third")).status).toBe(403);
   });
 
   test("does nothing without extension directories", async () => {

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -84,6 +84,8 @@ function createSession({
 } = {}) {
   const removedExtensionIds: string[] = [];
 
+  const handledSchemes: string[] = [];
+
   const session = {
     extensions: {
       loadExtension,
@@ -91,10 +93,18 @@ function createSession({
         removedExtensionIds.push(extensionId);
       },
     },
+    protocol: {
+      handle: (scheme: string) => {
+        handledSchemes.push(scheme);
+      },
+      unhandle: (scheme: string) => {
+        handledSchemes.splice(handledSchemes.indexOf(scheme), 1);
+      },
+    },
     getStoragePath: () => storagePath,
   } as unknown as Session;
 
-  return { session, removedExtensionIds };
+  return { session, removedExtensionIds, handledSchemes };
 }
 
 async function createPartitionDir(entryPaths: string[]) {
@@ -137,7 +147,7 @@ describe("Extensions", () => {
     expect(loadedExtensionDirs).not.toContain(extensionDirs[0]);
 
     for (const loadedExtensionDir of loadedExtensionDirs) {
-      expect(await readFile(path.join(loadedExtensionDir, "chrome-facade.js"), "utf8")).toBe(
+      expect(await readFile(path.join(loadedExtensionDir, "chrome-facade.js"), "utf8")).toEndWith(
         "// facade\n",
       );
     }

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -46,6 +46,12 @@ export type ExtensionsOptions = {
   /** A directory the loader owns, holding the copy it loads of each extension. */
   derivedExtensionsDir: string;
   /**
+   * Manifest keys every extension is derived without, for taking a part of an
+   * extension away — `content_scripts`, `declarative_net_request` — to find out
+   * which one is behind a misbehaving page.
+   */
+  strippedManifestKeys?: string[];
+  /**
    * Narrows which native messaging hosts an extension may drive. Without it any
    * host that lists the extension in its own `allowed_origins` is reachable.
    */
@@ -71,6 +77,8 @@ export class Extensions {
 
   private derivedExtensionsDir: string;
 
+  private strippedManifestKeys: string[] | undefined;
+
   private logger: ExtensionsLogger | undefined;
 
   private loadedExtensionIdsBySession = new Map<Session, Set<string>>();
@@ -87,6 +95,7 @@ export class Extensions {
     extensionDirs,
     facadeScriptPath,
     derivedExtensionsDir,
+    strippedManifestKeys,
     isNativeMessagingHostAllowed,
     logger,
   }: ExtensionsOptions) {
@@ -95,6 +104,8 @@ export class Extensions {
     this.facadeScriptPath = facadeScriptPath;
 
     this.derivedExtensionsDir = derivedExtensionsDir;
+
+    this.strippedManifestKeys = strippedManifestKeys;
 
     this.logger = logger;
 
@@ -117,6 +128,7 @@ export class Extensions {
         sourceDir,
         derivedExtensionsDir: this.derivedExtensionsDir,
         facadeScriptPath: this.facadeScriptPath,
+        strippedManifestKeys: this.strippedManifestKeys,
       });
 
       this.derivedExtensions.set(sourceDir, derivedExtension);

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -8,6 +8,11 @@ import {
   readExtensionActionIcon,
 } from "./action";
 import { deriveExtension } from "./derive";
+import type { ExtensionsLogger } from "./logger";
+import {
+  NativeMessaging,
+  type NativeMessagingHostPolicy,
+} from "./native-messaging/native-messaging";
 
 /**
  * Chromium keeps every `chrome.storage` area of every extension in its own
@@ -25,12 +30,6 @@ const EXTENSION_STORAGE_DIR_NAMES = [
 /** `IndexedDB/chrome-extension_<extensionId>_0.indexeddb.leveldb` and friends. */
 const EXTENSION_INDEXED_DB_PREFIX = "chrome-extension_";
 
-/** Where the loader reports what it did, since an embedder logs its own way. */
-export type ExtensionsLogger = {
-  info: (message: string, details: Record<string, unknown>) => void;
-  error: (message: string, details: Record<string, unknown>) => void;
-};
-
 export type ActionsChangedListener = (session: Session, actions: ExtensionAction[]) => void;
 
 export type ExtensionsOptions = {
@@ -46,6 +45,11 @@ export type ExtensionsOptions = {
   facadeScriptPath: string;
   /** A directory the loader owns, holding the copy it loads of each extension. */
   derivedExtensionsDir: string;
+  /**
+   * Narrows which native messaging hosts an extension may drive. Without it any
+   * host that lists the extension in its own `allowed_origins` is reachable.
+   */
+  isNativeMessagingHostAllowed?: NativeMessagingHostPolicy;
   logger?: ExtensionsLogger;
 };
 
@@ -75,12 +79,15 @@ export class Extensions {
 
   private actionsChangedListeners = new Set<ActionsChangedListener>();
 
-  private derivedExtensionDirs = new Map<string, Promise<string>>();
+  private derivedExtensions = new Map<string, ReturnType<typeof deriveExtension>>();
+
+  private nativeMessaging: NativeMessaging;
 
   constructor({
     extensionDirs,
     facadeScriptPath,
     derivedExtensionsDir,
+    isNativeMessagingHostAllowed,
     logger,
   }: ExtensionsOptions) {
     this.extensionDirs = extensionDirs;
@@ -90,6 +97,11 @@ export class Extensions {
     this.derivedExtensionsDir = derivedExtensionsDir;
 
     this.logger = logger;
+
+    this.nativeMessaging = new NativeMessaging({
+      isHostAllowed: isNativeMessagingHostAllowed,
+      logger,
+    });
   }
 
   /**
@@ -97,20 +109,20 @@ export class Extensions {
    * they shared the source directory: one copy on disk, one instance per
    * session.
    */
-  private deriveExtensionDir(sourceDir: string) {
-    let derivedExtensionDir = this.derivedExtensionDirs.get(sourceDir);
+  private deriveExtension(sourceDir: string) {
+    let derivedExtension = this.derivedExtensions.get(sourceDir);
 
-    if (!derivedExtensionDir) {
-      derivedExtensionDir = deriveExtension({
+    if (!derivedExtension) {
+      derivedExtension = deriveExtension({
         sourceDir,
         derivedExtensionsDir: this.derivedExtensionsDir,
         facadeScriptPath: this.facadeScriptPath,
       });
 
-      this.derivedExtensionDirs.set(sourceDir, derivedExtensionDir);
+      this.derivedExtensions.set(sourceDir, derivedExtension);
     }
 
-    return derivedExtensionDir;
+    return derivedExtension;
   }
 
   async setupSession(session: Session) {
@@ -126,11 +138,17 @@ export class Extensions {
 
     this.actionsBySession.set(session, actions);
 
+    const extensionIdsByBridgeToken = new Map<string, string>();
+
+    this.nativeMessaging.setupSession(session, {
+      getExtensionId: (bridgeToken) => extensionIdsByBridgeToken.get(bridgeToken),
+    });
+
     for (const extensionDir of this.extensionDirs) {
       try {
-        const extension = await session.extensions.loadExtension(
-          await this.deriveExtensionDir(extensionDir),
-        );
+        const { derivedDir, bridgeToken } = await this.deriveExtension(extensionDir);
+
+        const extension = await session.extensions.loadExtension(derivedDir);
 
         // The session can be torn down while an extension is still loading
         if (this.loadedExtensionIdsBySession.get(session) !== loadedExtensionIds) {
@@ -140,6 +158,8 @@ export class Extensions {
         }
 
         loadedExtensionIds.add(extension.id);
+
+        extensionIdsByBridgeToken.set(bridgeToken, extension.id);
 
         actions.push(await this.createAction(extension));
 
@@ -180,6 +200,8 @@ export class Extensions {
     this.loadedExtensionIdsBySession.delete(session);
 
     this.actionsBySession.delete(session);
+
+    this.nativeMessaging.teardownSession(session);
 
     for (const extensionId of loadedExtensionIds) {
       session.extensions.removeExtension(extensionId);

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -146,7 +146,9 @@ export class Extensions {
 
     for (const extensionDir of this.extensionDirs) {
       try {
-        const { derivedDir, bridgeToken } = await this.deriveExtension(extensionDir);
+        const { derivedDir, bridgeToken, extensionId } = await this.deriveExtension(extensionDir);
+
+        await this.dropServiceWorkerRegistration(session, extensionId);
 
         const extension = await session.extensions.loadExtension(derivedDir);
 
@@ -175,6 +177,31 @@ export class Extensions {
     }
 
     this.emitActionsChanged(session);
+  }
+
+  /**
+   * Chromium stores an extension's service worker script when the worker first
+   * registers and serves that copy for as long as the partition exists: it
+   * never fetches the script again, not on a later launch and not when the file
+   * on disk has changed. Everything the derive writes into the worker — the
+   * facade above all, and the bridge token it carries — would therefore be a
+   * copy from the launch the partition was created in, which is what answered
+   * every native messaging call with 403 (measured 2026-08-16).
+   *
+   * Dropping the registration first makes Chromium fetch the script again.
+   * `clearData` walks past `chrome-extension://` origins, so `clearStorageData`
+   * is the way in; an extension without a `manifest.key` has no id to address
+   * its storage by and keeps the worker Chromium already has.
+   */
+  private async dropServiceWorkerRegistration(session: Session, extensionId: string | undefined) {
+    if (!extensionId) {
+      return;
+    }
+
+    await session.clearStorageData({
+      origin: `chrome-extension://${extensionId}`,
+      storages: ["serviceworkers"],
+    });
   }
 
   /** A broken icon costs the button its icon, not the extension its button. */

--- a/packages/electron-extensions/facade/api/native-messaging.ts
+++ b/packages/electron-extensions/facade/api/native-messaging.ts
@@ -1,0 +1,225 @@
+import {
+  NATIVE_MESSAGING_ORIGIN,
+  NATIVE_MESSAGING_PATHS,
+  NATIVE_MESSAGING_TOKEN_GLOBAL,
+  type NativeMessagingFrame,
+} from "../../native-messaging/bridge-protocol";
+import { NativeMessageDecoder } from "../../native-messaging/framing";
+import type { ChromeNamespace } from "../lib/chrome";
+import { createEvent } from "../lib/event";
+
+const DISCONNECTED_PORT_ERROR = "Attempting to use a disconnected port object";
+
+const BRIDGE_CLOSED_ERROR = "The native messaging bridge closed the connection.";
+
+type NativeMessagingPort = {
+  name: string;
+  postMessage: (message: unknown) => void;
+  disconnect: () => void;
+  onMessage: ReturnType<typeof createEvent>;
+  onDisconnect: ReturnType<typeof createEvent>;
+};
+
+function post(pathName: string, body: Record<string, unknown>) {
+  const token = (globalThis as unknown as Record<string, string | undefined>)[
+    NATIVE_MESSAGING_TOKEN_GLOBAL
+  ];
+
+  return fetch(`${NATIVE_MESSAGING_ORIGIN}${pathName}`, {
+    method: "POST",
+    // A safelisted content type keeps this a simple request, so no preflight
+    headers: { "content-type": "text/plain;charset=UTF-8" },
+    body: JSON.stringify({ ...body, token }),
+  });
+}
+
+/**
+ * `chrome.runtime.lastError` the way Chrome exposes it: set for the duration of
+ * the callback that has to see it, gone again afterwards.
+ */
+function withLastError(runtime: ChromeNamespace, error: string | undefined, run: () => void) {
+  if (error === undefined) {
+    run();
+
+    return;
+  }
+
+  runtime.lastError = { message: error };
+
+  try {
+    run();
+  } finally {
+    delete runtime.lastError;
+  }
+}
+
+function getLastErrorMessage(runtime: ChromeNamespace) {
+  return (runtime.lastError as { message?: string } | undefined)?.message;
+}
+
+function createPort(runtime: ChromeNamespace, hostName: string): NativeMessagingPort {
+  const portId = crypto.randomUUID();
+
+  const onMessage = createEvent();
+
+  const onDisconnect = createEvent();
+
+  let isDisconnected = false;
+
+  let markOpened = () => {};
+
+  /**
+   * Resolves once the bridge has answered the connect request, which is when it
+   * knows the port id. Extensions post the moment `connectNative` returns, and
+   * two fetches have no order between them, so everything sent waits here and
+   * then goes out in the order it was written.
+   */
+  const opened = new Promise<void>((resolve) => {
+    markOpened = resolve;
+  });
+
+  let sendChain: Promise<unknown> = opened;
+
+  const port: NativeMessagingPort = {
+    name: hostName,
+    onMessage,
+    onDisconnect,
+    postMessage(message) {
+      if (isDisconnected) {
+        throw new Error(DISCONNECTED_PORT_ERROR);
+      }
+
+      sendChain = sendChain
+        .then(() => post(NATIVE_MESSAGING_PATHS.post, { portId, message }))
+        .catch(() => undefined);
+    },
+    disconnect() {
+      if (isDisconnected) {
+        return;
+      }
+
+      isDisconnected = true;
+
+      markOpened();
+
+      void post(NATIVE_MESSAGING_PATHS.disconnect, { portId });
+    },
+  };
+
+  // Chrome stays quiet about a port the extension disconnected itself
+  const disconnected = (error?: string) => {
+    markOpened();
+
+    if (isDisconnected) {
+      return;
+    }
+
+    isDisconnected = true;
+
+    withLastError(runtime, error, () => {
+      onDisconnect.emit(port);
+    });
+  };
+
+  const readFrames = async () => {
+    const response = await post(NATIVE_MESSAGING_PATHS.connect, { portId, hostName });
+
+    if (!response.ok || !response.body) {
+      throw new Error(`The native messaging bridge answered ${response.status}`);
+    }
+
+    markOpened();
+
+    const reader = response.body.getReader();
+
+    const decoder = new NativeMessageDecoder();
+
+    for (;;) {
+      const { value, done } = await reader.read();
+
+      if (done) {
+        return;
+      }
+
+      for (const frame of decoder.push(value) as NativeMessagingFrame[]) {
+        if (frame.type === "message") {
+          onMessage.emit(frame.message, port);
+        } else {
+          disconnected(frame.error);
+
+          return;
+        }
+      }
+    }
+  };
+
+  readFrames().then(
+    () => {
+      disconnected(BRIDGE_CLOSED_ERROR);
+    },
+    (error: unknown) => {
+      disconnected(error instanceof Error ? error.message : String(error));
+    },
+  );
+
+  return port;
+}
+
+function createSendNativeMessage(runtime: ChromeNamespace) {
+  return (hostName: string, message: unknown, ...callArguments: unknown[]) => {
+    const callback = callArguments.at(-1);
+
+    const reply = new Promise<unknown>((resolve, reject) => {
+      const port = createPort(runtime, hostName);
+
+      port.onMessage.addListener((response) => {
+        resolve(response);
+
+        port.disconnect();
+      });
+
+      port.onDisconnect.addListener(() => {
+        reject(new Error(getLastErrorMessage(runtime) ?? BRIDGE_CLOSED_ERROR));
+      });
+
+      port.postMessage(message);
+    });
+
+    if (typeof callback !== "function") {
+      return reply;
+    }
+
+    reply.then(
+      (response) => {
+        (callback as (response: unknown) => void)(response);
+      },
+      (error: Error) => {
+        withLastError(runtime, error.message, () => {
+          (callback as (response: unknown) => void)(undefined);
+        });
+      },
+    );
+
+    return undefined;
+  };
+}
+
+/**
+ * Replaces Electron's `connectNative` and `sendNativeMessage` rather than
+ * filling in around them: both exist, and both refuse every host. Electron's
+ * `ElectronMessagingDelegate` answers `DISALLOW` to any host name and hands out
+ * no receiver, which is what turns 1Password's search for its desktop app into
+ * "Access to the native messaging host was disabled by the system
+ * administrator". The replacements reach the package's own bridge instead.
+ */
+export function installNativeMessaging(extensionApi: ChromeNamespace) {
+  const runtime = extensionApi.runtime as ChromeNamespace | undefined;
+
+  if (!runtime) {
+    return;
+  }
+
+  runtime.connectNative = (hostName: string) => createPort(runtime, hostName);
+
+  runtime.sendNativeMessage = createSendNativeMessage(runtime);
+}

--- a/packages/electron-extensions/facade/install.ts
+++ b/packages/electron-extensions/facade/install.ts
@@ -1,5 +1,6 @@
 import { createCommands } from "./api/commands";
 import { createContextMenus } from "./api/context-menus";
+import { installNativeMessaging } from "./api/native-messaging";
 import { createNotifications } from "./api/notifications";
 import { createPrivacy } from "./api/privacy";
 import { createTabs } from "./api/tabs";
@@ -31,14 +32,20 @@ export function createChromeFacade(): ChromeNamespace {
 
 /**
  * Completes an extension API object in place — the `chrome` object of a service
- * worker, a popup, an options page, any `chrome-extension://` frame. Nothing
- * native is replaced or wrapped: every namespace and member Electron implements
- * is left exactly as it is, and only the gaps around it are filled (see the
- * noop-first decision in the feature docs).
+ * worker, a popup, an options page, any `chrome-extension://` frame. Almost
+ * nothing native is replaced or wrapped: every namespace and member Electron
+ * implements is left exactly as it is, and only the gaps around it are filled
+ * (see the noop-first decision in the feature docs).
+ *
+ * Native messaging is the one exception, and it is one because filling gaps
+ * cannot help there: Electron implements `connectNative` and refuses every host
+ * from it (see `api/native-messaging.ts`).
  */
 export function installChromeFacade(
   extensionApi: ChromeNamespace,
   facade: ChromeNamespace = createChromeFacade(),
 ) {
   fillMissing(extensionApi, facade);
+
+  installNativeMessaging(extensionApi);
 }

--- a/packages/electron-extensions/facade/lib/event.ts
+++ b/packages/electron-extensions/facade/lib/event.ts
@@ -1,11 +1,14 @@
 import type { ChromeEvent, ChromeEventListener } from "./chrome";
 
+export type EmittableChromeEvent = ChromeEvent & {
+  emit: (...eventArguments: unknown[]) => void;
+};
+
 /**
- * An event that accepts listeners and never fires. Extensions register their
- * listeners at startup and feature-detect by calling `addListener`, so the
- * shape has to be complete even when nothing behind it exists yet.
+ * Chrome's event shape, with a way to dispatch. A listener that throws is the
+ * extension's problem and never the event's: the rest still hear about it.
  */
-export function createNoopEvent(): ChromeEvent {
+export function createEvent(): EmittableChromeEvent {
   const listeners = new Set<ChromeEventListener>();
 
   return {
@@ -21,5 +24,25 @@ export function createNoopEvent(): ChromeEvent {
     hasListeners() {
       return listeners.size > 0;
     },
+    emit(...eventArguments) {
+      for (const listener of listeners) {
+        try {
+          listener(...eventArguments);
+        } catch (error) {
+          console.error("[chrome-facade] event listener threw", error);
+        }
+      }
+    },
   };
+}
+
+/**
+ * An event that accepts listeners and never fires. Extensions register their
+ * listeners at startup and feature-detect by calling `addListener`, so the
+ * shape has to be complete even when nothing behind it exists yet.
+ */
+export function createNoopEvent(): ChromeEvent {
+  const { emit: _emit, ...event } = createEvent();
+
+  return event;
 }

--- a/packages/electron-extensions/index.ts
+++ b/packages/electron-extensions/index.ts
@@ -1,4 +1,7 @@
 export type { ExtensionAction } from "./action";
 export { Extensions } from "./extensions";
-export type { ActionsChangedListener, ExtensionsLogger, ExtensionsOptions } from "./extensions";
+export type { ActionsChangedListener, ExtensionsOptions } from "./extensions";
+export type { ExtensionsLogger } from "./logger";
+export type { NativeMessagingHostPolicy } from "./native-messaging/native-messaging";
+export { registerNativeMessagingScheme } from "./native-messaging/scheme";
 export { findExtensionDirs } from "./scan";

--- a/packages/electron-extensions/logger.ts
+++ b/packages/electron-extensions/logger.ts
@@ -1,0 +1,5 @@
+/** Where the package reports what it did, since an embedder logs its own way. */
+export type ExtensionsLogger = {
+  info: (message: string, details: Record<string, unknown>) => void;
+  error: (message: string, details: Record<string, unknown>) => void;
+};

--- a/packages/electron-extensions/native-messaging/bridge-protocol.ts
+++ b/packages/electron-extensions/native-messaging/bridge-protocol.ts
@@ -1,0 +1,68 @@
+/**
+ * The contract between the facade running inside an extension and the bridge
+ * running in the main process, shared by both sides.
+ *
+ * Extension contexts have no IPC of their own — service worker preload scripts
+ * never run for extension service workers on Electron 43 (see the injection
+ * notes in the feature docs) — but they do have `fetch`, and a custom scheme
+ * handled per session is something only the main process can answer. That is
+ * the whole transport: one request per call, and the connect request's response
+ * body left open to carry everything the host says back.
+ */
+
+export const NATIVE_MESSAGING_SCHEME = "extension-native-messaging";
+
+/** Every request goes to the one bridge, so only the path varies. */
+export const NATIVE_MESSAGING_ORIGIN = `${NATIVE_MESSAGING_SCHEME}://port`;
+
+export const NATIVE_MESSAGING_PATHS = {
+  connect: "/connect",
+  post: "/post",
+  disconnect: "/disconnect",
+} as const;
+
+/**
+ * Where the derived copy of an extension leaves the secret that says a request
+ * came from that extension.
+ *
+ * Something has to, because nothing else in the request does: Electron hands
+ * the handler no `Origin` header and no sender, and the scheme is reachable
+ * from any document in the session whose own policy allows it — a workspace app
+ * or any page a user navigates to. The secret is written into the extension's
+ * copy of the facade, which only the extension can read, and is new on every
+ * launch.
+ */
+export const NATIVE_MESSAGING_TOKEN_GLOBAL = "__electronExtensionsNativeMessagingToken";
+
+export type NativeMessagingRequest = {
+  token: string;
+};
+
+/**
+ * The port id is the extension's to choose so that it can post to a port the
+ * moment `connectNative` returns, the way Chrome lets it. The bridge still owns
+ * what the id may reach: a port answers only to the session and extension that
+ * opened it.
+ */
+export type NativeMessagingConnectRequest = NativeMessagingRequest & {
+  portId: string;
+  hostName: string;
+};
+
+export type NativeMessagingPostRequest = NativeMessagingRequest & {
+  portId: string;
+  message: unknown;
+};
+
+export type NativeMessagingDisconnectRequest = NativeMessagingRequest & {
+  portId: string;
+};
+
+/**
+ * Frames on the connect response body, in the same length-prefixed JSON the
+ * host's own stdio uses. A stream always ends with a disconnect frame, which
+ * carries the error Chrome would have put on `runtime.lastError`.
+ */
+export type NativeMessagingFrame =
+  | { type: "message"; message: unknown }
+  | { type: "disconnect"; error?: string };

--- a/packages/electron-extensions/native-messaging/framing.test.ts
+++ b/packages/electron-extensions/native-messaging/framing.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { encodeNativeMessage, MAX_NATIVE_MESSAGE_BYTES, NativeMessageDecoder } from "./framing";
+
+function decodeAll(chunks: Uint8Array[], maxMessageBytes?: number) {
+  const decoder = new NativeMessageDecoder(maxMessageBytes);
+
+  return chunks.flatMap((chunk) => decoder.push(chunk));
+}
+
+describe("encodeNativeMessage", () => {
+  test("puts the byte length in front, little-endian", () => {
+    const frame = encodeNativeMessage({ a: 1 });
+
+    expect(new DataView(frame.buffer).getUint32(0, true)).toBe(frame.byteLength - 4);
+    expect(Array.from(frame.subarray(0, 4))).toEqual([7, 0, 0, 0]);
+    expect(new TextDecoder().decode(frame.subarray(4))).toBe('{"a":1}');
+  });
+
+  test("counts bytes rather than characters", () => {
+    const frame = encodeNativeMessage("é");
+
+    expect(new DataView(frame.buffer).getUint32(0, true)).toBe(4);
+  });
+});
+
+describe("NativeMessageDecoder", () => {
+  test("reads several messages out of one chunk", () => {
+    const chunk = new Uint8Array([
+      ...encodeNativeMessage({ first: true }),
+      ...encodeNativeMessage({ second: true }),
+    ]);
+
+    expect(decodeAll([chunk])).toEqual([{ first: true }, { second: true }]);
+  });
+
+  test("waits for a message split across chunks", () => {
+    const frame = encodeNativeMessage({ split: "yes" });
+
+    const decoder = new NativeMessageDecoder();
+
+    expect(decoder.push(frame.subarray(0, 2))).toEqual([]);
+    expect(decoder.push(frame.subarray(2, 9))).toEqual([]);
+    expect(decoder.push(frame.subarray(9))).toEqual([{ split: "yes" }]);
+  });
+
+  test("keeps what is left of a chunk for the next message", () => {
+    const frame = encodeNativeMessage({ n: 1 });
+
+    const decoder = new NativeMessageDecoder();
+
+    expect(
+      decoder.push(new Uint8Array([...frame, ...encodeNativeMessage({ n: 2 }).subarray(0, 3)])),
+    ).toEqual([{ n: 1 }]);
+
+    expect(decoder.push(encodeNativeMessage({ n: 2 }).subarray(3))).toEqual([{ n: 2 }]);
+  });
+
+  test("refuses a message larger than the cap before buffering it", () => {
+    const announcement = new Uint8Array(4);
+
+    new DataView(announcement.buffer).setUint32(0, MAX_NATIVE_MESSAGE_BYTES + 1, true);
+
+    expect(() => decodeAll([announcement])).toThrow(
+      `Native message of ${MAX_NATIVE_MESSAGE_BYTES + 1} bytes exceeds the ${MAX_NATIVE_MESSAGE_BYTES} byte limit`,
+    );
+  });
+
+  test("accepts a message right at the cap", () => {
+    const message = "a".repeat(MAX_NATIVE_MESSAGE_BYTES - 2);
+
+    expect(decodeAll([encodeNativeMessage(message)])).toEqual([message]);
+  });
+
+  test("throws on a message that is not JSON", () => {
+    const body = new TextEncoder().encode("not json");
+
+    const frame = new Uint8Array(4 + body.byteLength);
+
+    new DataView(frame.buffer).setUint32(0, body.byteLength, true);
+
+    frame.set(body, 4);
+
+    expect(() => decodeAll([frame])).toThrow(/not valid JSON/);
+  });
+});

--- a/packages/electron-extensions/native-messaging/framing.ts
+++ b/packages/electron-extensions/native-messaging/framing.ts
@@ -1,0 +1,87 @@
+/**
+ * Chrome's native messaging wire format: a 4-byte little-endian byte length in
+ * the platform's native byte order, then that many bytes of UTF-8 JSON.
+ *
+ * The same framing carries messages twice — between Meru and the host over the
+ * host's stdio, and between Meru and the extension over the bridge stream — so
+ * this module stays free of Node built-ins and runs in both places.
+ */
+
+const LENGTH_PREFIX_BYTES = 4;
+
+/** What Chrome accepts from a host; anything larger kills the connection. */
+export const MAX_NATIVE_MESSAGE_BYTES = 1024 * 1024;
+
+const textEncoder = new TextEncoder();
+
+const textDecoder = new TextDecoder("utf-8", { fatal: true });
+
+export function encodeNativeMessage(message: unknown): Uint8Array {
+  const body = textEncoder.encode(JSON.stringify(message));
+
+  const frame = new Uint8Array(LENGTH_PREFIX_BYTES + body.byteLength);
+
+  new DataView(frame.buffer).setUint32(0, body.byteLength, true);
+
+  frame.set(body, LENGTH_PREFIX_BYTES);
+
+  return frame;
+}
+
+/**
+ * Reassembles messages from however the bytes arrive. A message that claims to
+ * be larger than the cap is refused before a byte of it is buffered, so a host
+ * cannot grow the decoder's memory by announcing a huge length.
+ */
+export class NativeMessageDecoder {
+  private buffered = new Uint8Array(0);
+
+  constructor(private maxMessageBytes = MAX_NATIVE_MESSAGE_BYTES) {}
+
+  /** Throws when the stream is unusable, which leaves the caller to end it. */
+  push(chunk: Uint8Array): unknown[] {
+    const combined = new Uint8Array(this.buffered.byteLength + chunk.byteLength);
+
+    combined.set(this.buffered);
+
+    combined.set(chunk, this.buffered.byteLength);
+
+    this.buffered = combined;
+
+    const messages: unknown[] = [];
+
+    while (this.buffered.byteLength >= LENGTH_PREFIX_BYTES) {
+      const messageBytes = new DataView(
+        this.buffered.buffer,
+        this.buffered.byteOffset,
+        LENGTH_PREFIX_BYTES,
+      ).getUint32(0, true);
+
+      if (messageBytes > this.maxMessageBytes) {
+        throw new Error(
+          `Native message of ${messageBytes} bytes exceeds the ${this.maxMessageBytes} byte limit`,
+        );
+      }
+
+      if (this.buffered.byteLength < LENGTH_PREFIX_BYTES + messageBytes) {
+        break;
+      }
+
+      const body = this.buffered.subarray(LENGTH_PREFIX_BYTES, LENGTH_PREFIX_BYTES + messageBytes);
+
+      messages.push(this.parse(body));
+
+      this.buffered = this.buffered.slice(LENGTH_PREFIX_BYTES + messageBytes);
+    }
+
+    return messages;
+  }
+
+  private parse(body: Uint8Array) {
+    try {
+      return JSON.parse(textDecoder.decode(body)) as unknown;
+    } catch (error) {
+      throw new Error(`Native message is not valid JSON: ${String(error)}`);
+    }
+  }
+}

--- a/packages/electron-extensions/native-messaging/host-manifest.test.ts
+++ b/packages/electron-extensions/native-messaging/host-manifest.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  findHostManifest,
+  getHostManifestSearchPaths,
+  isExtensionAllowed,
+  isValidHostName,
+  parseHostManifest,
+  resolveHostPath,
+} from "./host-manifest";
+
+const HOST_NAME = "com.1password.1password";
+
+const EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
+
+function manifestSource(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    name: HOST_NAME,
+    path: "/opt/1Password/1Password-BrowserSupport",
+    type: "stdio",
+    allowed_origins: [`chrome-extension://${EXTENSION_ID}/`],
+    ...overrides,
+  });
+}
+
+describe("getHostManifestSearchPaths", () => {
+  test("looks in the user directories before the system ones on Linux", () => {
+    const searchPaths = getHostManifestSearchPaths(HOST_NAME, {
+      platform: "linux",
+      homeDir: "/home/tim",
+    });
+
+    expect(searchPaths[0]).toBe(
+      `/home/tim/.config/google-chrome/NativeMessagingHosts/${HOST_NAME}.json`,
+    );
+    expect(searchPaths).toContain(
+      `/home/tim/.config/chromium/NativeMessagingHosts/${HOST_NAME}.json`,
+    );
+    expect(searchPaths.at(-1)).toBe(`/etc/opt/edge/native-messaging-hosts/${HOST_NAME}.json`);
+    expect(searchPaths.indexOf(`/etc/opt/chrome/native-messaging-hosts/${HOST_NAME}.json`)).toBe(
+      searchPaths.findIndex((searchPath) => searchPath.startsWith("/etc/")),
+    );
+  });
+
+  test("looks in the macOS locations on macOS", () => {
+    const searchPaths = getHostManifestSearchPaths(HOST_NAME, {
+      platform: "darwin",
+      homeDir: "/Users/tim",
+    });
+
+    expect(searchPaths[0]).toBe(
+      `/Users/tim/Library/Application Support/Google/Chrome/NativeMessagingHosts/${HOST_NAME}.json`,
+    );
+    expect(searchPaths).toContain(`/Library/Google/Chrome/NativeMessagingHosts/${HOST_NAME}.json`);
+  });
+
+  test("has no directories to walk on Windows, where the registry answers", () => {
+    expect(getHostManifestSearchPaths(HOST_NAME, { platform: "win32" })).toEqual([]);
+  });
+});
+
+describe("isValidHostName", () => {
+  test("takes what Chrome documents as a host name", () => {
+    expect(isValidHostName("com.1password.1password")).toBe(true);
+    expect(isValidHostName("host_name")).toBe(true);
+  });
+
+  test("refuses anything that could leave the directory it is joined to", () => {
+    expect(isValidHostName("../../etc/passwd")).toBe(false);
+    expect(isValidHostName("com/1password")).toBe(false);
+    expect(isValidHostName("com..1password")).toBe(false);
+    expect(isValidHostName(".com.1password")).toBe(false);
+    expect(isValidHostName("com.1password.")).toBe(false);
+    expect(isValidHostName("Com.1Password")).toBe(false);
+    expect(isValidHostName("")).toBe(false);
+  });
+});
+
+describe("parseHostManifest", () => {
+  test("reads a well-formed manifest", () => {
+    expect(parseHostManifest(manifestSource(), HOST_NAME)).toEqual({
+      name: HOST_NAME,
+      description: undefined,
+      path: "/opt/1Password/1Password-BrowserSupport",
+      type: "stdio",
+      allowed_origins: [`chrome-extension://${EXTENSION_ID}/`],
+    });
+  });
+
+  test("refuses a manifest that names a different host", () => {
+    expect(() => parseHostManifest(manifestSource({ name: "com.other" }), HOST_NAME)).toThrow(
+      /names "com.other"/,
+    );
+  });
+
+  test("refuses a transport it cannot speak", () => {
+    expect(() => parseHostManifest(manifestSource({ type: "native" }), HOST_NAME)).toThrow(
+      /type "native"/,
+    );
+  });
+
+  test("refuses a manifest without a path or allowed_origins", () => {
+    expect(() => parseHostManifest(manifestSource({ path: "" }), HOST_NAME)).toThrow(/no path/);
+    expect(() =>
+      parseHostManifest(manifestSource({ allowed_origins: undefined }), HOST_NAME),
+    ).toThrow(/no allowed_origins/);
+  });
+});
+
+describe("isExtensionAllowed", () => {
+  const manifest = parseHostManifest(manifestSource(), HOST_NAME);
+
+  test("allows an extension the host listed", () => {
+    expect(isExtensionAllowed(manifest, EXTENSION_ID)).toBe(true);
+  });
+
+  test("refuses every extension the host did not list", () => {
+    expect(isExtensionAllowed(manifest, "b".repeat(32))).toBe(false);
+    expect(isExtensionAllowed({ ...manifest, allowed_origins: [] }, EXTENSION_ID)).toBe(false);
+  });
+
+  test("matches the whole origin, not a prefix of it", () => {
+    expect(isExtensionAllowed(manifest, EXTENSION_ID.slice(0, 20))).toBe(false);
+  });
+});
+
+describe("resolveHostPath", () => {
+  test("resolves a relative path against the manifest's directory", () => {
+    expect(
+      resolveHostPath("/etc/opt/chrome/native-messaging-hosts/host.json", {
+        name: HOST_NAME,
+        path: "./bin/host",
+        type: "stdio",
+        allowed_origins: [],
+      }),
+    ).toBe("/etc/opt/chrome/native-messaging-hosts/bin/host");
+  });
+});
+
+describe("findHostManifest", () => {
+  test("takes the first readable manifest, passing over a broken one", async () => {
+    const homeDir = await mkdtemp(path.join(tmpdir(), "native-messaging-"));
+
+    const firstDir = path.join(homeDir, ".config/google-chrome/NativeMessagingHosts");
+
+    const secondDir = path.join(homeDir, ".config/chromium/NativeMessagingHosts");
+
+    await mkdir(firstDir, { recursive: true });
+
+    await mkdir(secondDir, { recursive: true });
+
+    await writeFile(path.join(firstDir, `${HOST_NAME}.json`), "{ not json");
+
+    await writeFile(path.join(secondDir, `${HOST_NAME}.json`), manifestSource());
+
+    const found = await findHostManifest(HOST_NAME, { platform: "linux", homeDir });
+
+    expect(found?.manifestPath).toBe(path.join(secondDir, `${HOST_NAME}.json`));
+    expect(found?.manifest.path).toBe("/opt/1Password/1Password-BrowserSupport");
+
+    expect(await findHostManifest("com.missing", { platform: "linux", homeDir })).toBeUndefined();
+
+    await rm(homeDir, { recursive: true, force: true });
+  });
+
+  test("never looks up a host name that is not one", async () => {
+    expect(
+      await findHostManifest("../../../etc/passwd", { platform: "linux", homeDir: "/home/tim" }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/electron-extensions/native-messaging/host-manifest.ts
+++ b/packages/electron-extensions/native-messaging/host-manifest.ts
@@ -1,0 +1,192 @@
+import { readFile } from "node:fs/promises";
+import { homedir, platform } from "node:os";
+import path from "node:path";
+import { queryWindowsRegistryHostManifestPaths } from "./windows-registry";
+
+/**
+ * The manifest a native messaging host installs so browsers can find it:
+ * https://developer.chrome.com/docs/apps/nativeMessaging.
+ */
+export type NativeMessagingHostManifest = {
+  name: string;
+  description?: string;
+  path: string;
+  type: string;
+  allowed_origins: string[];
+};
+
+export type FoundNativeMessagingHost = {
+  manifestPath: string;
+  manifest: NativeMessagingHostManifest;
+};
+
+/**
+ * Where the Chromium browsers keep host manifests, user-level directory first
+ * the way Chromium searches. Hosts install themselves for the browsers they
+ * find, and Meru is not one of them, so what it reads are other browsers'
+ * registrations — the manifests 1Password's desktop app wrote for Chrome are
+ * how Meru reaches it at all.
+ */
+const CHROMIUM_HOST_DIRECTORIES: Record<string, { user: string[]; system: string[] }> = {
+  linux: {
+    user: [
+      ".config/google-chrome/NativeMessagingHosts",
+      ".config/chromium/NativeMessagingHosts",
+      ".config/microsoft-edge/NativeMessagingHosts",
+      ".config/BraveSoftware/Brave-Browser/NativeMessagingHosts",
+      ".config/vivaldi/NativeMessagingHosts",
+    ],
+    system: [
+      "/etc/opt/chrome/native-messaging-hosts",
+      "/etc/chromium/native-messaging-hosts",
+      "/etc/opt/edge/native-messaging-hosts",
+    ],
+  },
+  darwin: {
+    user: [
+      "Library/Application Support/Google/Chrome/NativeMessagingHosts",
+      "Library/Application Support/Chromium/NativeMessagingHosts",
+      "Library/Application Support/Microsoft Edge/NativeMessagingHosts",
+      "Library/Application Support/BraveSoftware/Brave-Browser/NativeMessagingHosts",
+      "Library/Application Support/Vivaldi/NativeMessagingHosts",
+    ],
+    system: [
+      "/Library/Google/Chrome/NativeMessagingHosts",
+      "/Library/Application Support/Chromium/NativeMessagingHosts",
+      "/Library/Microsoft/Edge/NativeMessagingHosts",
+    ],
+  },
+};
+
+/**
+ * Windows keeps no manifest directories: the registry holds the path to each
+ * manifest, under the same per-browser split of user and machine scope.
+ */
+export const WINDOWS_HOST_REGISTRY_KEYS = [
+  "HKCU\\Software\\Google\\Chrome\\NativeMessagingHosts",
+  "HKCU\\Software\\Chromium\\NativeMessagingHosts",
+  "HKCU\\Software\\Microsoft\\Edge\\NativeMessagingHosts",
+  "HKCU\\Software\\BraveSoftware\\Brave-Browser\\NativeMessagingHosts",
+  "HKCU\\Software\\Vivaldi\\NativeMessagingHosts",
+  "HKLM\\Software\\Google\\Chrome\\NativeMessagingHosts",
+  "HKLM\\Software\\Chromium\\NativeMessagingHosts",
+  "HKLM\\Software\\Microsoft\\Edge\\NativeMessagingHosts",
+];
+
+export type HostManifestSearchOptions = {
+  platform?: string;
+  homeDir?: string;
+};
+
+/**
+ * The manifest paths to try, in order. Empty on Windows, where the paths come
+ * out of the registry instead.
+ */
+export function getHostManifestSearchPaths(
+  hostName: string,
+  { platform: osPlatform = platform(), homeDir = homedir() }: HostManifestSearchOptions = {},
+) {
+  const directories = CHROMIUM_HOST_DIRECTORIES[osPlatform];
+
+  if (!directories) {
+    return [];
+  }
+
+  return [
+    ...directories.user.map((directory) => path.join(homeDir, directory)),
+    ...directories.system,
+  ].map((directory) => path.join(directory, `${hostName}.json`));
+}
+
+/**
+ * A host name is a file name and a registry key on the way to a manifest, so
+ * only what Chrome documents as a host name is ever looked up: lowercase
+ * alphanumerics, underscores and dots, no leading, trailing or doubled dot.
+ */
+export function isValidHostName(hostName: string) {
+  return /^[a-z0-9_]+(\.[a-z0-9_]+)*$/.test(hostName);
+}
+
+export function parseHostManifest(source: string, hostName: string): NativeMessagingHostManifest {
+  const manifest = JSON.parse(source) as Partial<NativeMessagingHostManifest>;
+
+  if (manifest.name !== hostName) {
+    throw new Error(`Host manifest names "${manifest.name}", not "${hostName}"`);
+  }
+
+  if (manifest.type !== "stdio") {
+    throw new Error(`Host manifest type "${manifest.type}" is not supported`);
+  }
+
+  if (typeof manifest.path !== "string" || manifest.path.length === 0) {
+    throw new Error("Host manifest has no path");
+  }
+
+  if (!Array.isArray(manifest.allowed_origins)) {
+    throw new Error("Host manifest has no allowed_origins");
+  }
+
+  return {
+    name: manifest.name,
+    description: manifest.description,
+    // Chrome resolves a relative path against the manifest's own directory
+    path: manifest.path,
+    type: manifest.type,
+    allowed_origins: manifest.allowed_origins,
+  };
+}
+
+export function getExtensionOrigin(extensionId: string) {
+  return `chrome-extension://${extensionId}/`;
+}
+
+/**
+ * Whether the host itself accepts this extension. The check is the host's, not
+ * the browser's — it is how a host decides which extensions may drive it, and
+ * skipping it would hand every loaded extension every host on the machine.
+ */
+export function isExtensionAllowed(manifest: NativeMessagingHostManifest, extensionId: string) {
+  return manifest.allowed_origins.includes(getExtensionOrigin(extensionId));
+}
+
+/** Absolute, so the host is spawned from where its manifest says it lives. */
+export function resolveHostPath(manifestPath: string, manifest: NativeMessagingHostManifest) {
+  return path.resolve(path.dirname(manifestPath), manifest.path);
+}
+
+async function readHostManifest(manifestPath: string, hostName: string) {
+  try {
+    return parseHostManifest(await readFile(manifestPath, "utf8"), hostName);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * The first readable manifest for this host name, or nothing. A manifest that
+ * fails to parse is passed over rather than thrown on, so one broken
+ * registration in an early directory cannot hide a working one behind it.
+ */
+export async function findHostManifest(
+  hostName: string,
+  options: HostManifestSearchOptions = {},
+): Promise<FoundNativeMessagingHost | undefined> {
+  if (!isValidHostName(hostName)) {
+    return undefined;
+  }
+
+  const manifestPaths =
+    (options.platform ?? platform()) === "win32"
+      ? await queryWindowsRegistryHostManifestPaths(hostName, WINDOWS_HOST_REGISTRY_KEYS)
+      : getHostManifestSearchPaths(hostName, options);
+
+  for (const manifestPath of manifestPaths) {
+    const manifest = await readHostManifest(manifestPath, hostName);
+
+    if (manifest) {
+      return { manifestPath, manifest };
+    }
+  }
+
+  return undefined;
+}

--- a/packages/electron-extensions/native-messaging/host.ts
+++ b/packages/electron-extensions/native-messaging/host.ts
@@ -1,0 +1,150 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import path from "node:path";
+import { encodeNativeMessage, NativeMessageDecoder } from "./framing";
+
+export type NativeMessagingHostHandlers = {
+  onMessage: (message: unknown) => void;
+  /** The host is gone, and nothing more will be read from or written to it. */
+  onClose: (error?: Error) => void;
+};
+
+export type NativeMessagingHostOptions = {
+  hostPath: string;
+  /** `chrome-extension://<id>/`, which is how a host knows who is calling. */
+  extensionOrigin: string;
+  handlers: NativeMessagingHostHandlers;
+  onStderr?: (output: string) => void;
+};
+
+/**
+ * One native messaging host process for the lifetime of one port, spoken to the
+ * way Chrome does it: the calling extension's origin as the first argument, and
+ * length-prefixed JSON over the host's stdio.
+ */
+export class NativeMessagingHost {
+  private process: ChildProcess;
+
+  private decoder = new NativeMessageDecoder();
+
+  private handlers: NativeMessagingHostHandlers;
+
+  private isClosed = false;
+
+  constructor({ hostPath, extensionOrigin, handlers, onStderr }: NativeMessagingHostOptions) {
+    this.handlers = handlers;
+
+    this.process = spawn(hostPath, this.getArguments(extensionOrigin), {
+      // Hosts are shipped next to the files they read, and Chrome starts them
+      // from their own directory
+      cwd: path.dirname(hostPath),
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+
+    this.process.stdout?.on("data", (chunk: Buffer) => {
+      this.readMessages(chunk);
+    });
+
+    this.process.stderr?.on("data", (chunk: Buffer) => {
+      onStderr?.(chunk.toString("utf8").trimEnd());
+    });
+
+    this.process.on("error", (error) => {
+      this.close(error);
+    });
+
+    this.process.on("exit", (code, signal) => {
+      // A host closing the connection by quitting is what Chrome reports as
+      // this, and the extension has no other way of hearing about it
+      this.close(
+        new Error(
+          code === null
+            ? `Native host has exited (${signal}).`
+            : `Native host has exited with code ${code}.`,
+        ),
+      );
+    });
+
+    // A host that never reads stdin still must not take Meru down with it
+    this.process.stdin?.on("error", (error) => {
+      this.close(error);
+    });
+  }
+
+  get pid() {
+    return this.process.pid;
+  }
+
+  private getArguments(extensionOrigin: string) {
+    if (process.platform === "win32") {
+      // Chrome passes the calling window's handle on Windows, and hosts that
+      // parent a dialog on it expect the argument to be there
+      return [extensionOrigin, "--parent-window=0"];
+    }
+
+    return [extensionOrigin];
+  }
+
+  private readMessages(chunk: Buffer) {
+    if (this.isClosed) {
+      return;
+    }
+
+    let messages: unknown[];
+
+    try {
+      messages = this.decoder.push(chunk);
+    } catch (error) {
+      this.kill();
+
+      this.close(error instanceof Error ? error : new Error(String(error)));
+
+      return;
+    }
+
+    for (const message of messages) {
+      this.handlers.onMessage(message);
+    }
+  }
+
+  /** Backpressure: a host that talks faster than the extension reads waits. */
+  pauseReading() {
+    this.process.stdout?.pause();
+  }
+
+  resumeReading() {
+    this.process.stdout?.resume();
+  }
+
+  postMessage(message: unknown) {
+    if (this.isClosed) {
+      return;
+    }
+
+    this.process.stdin?.write(encodeNativeMessage(message));
+  }
+
+  /**
+   * Ends the host. Closing stdin is how a host is told to shut down, and the
+   * kill is what covers hosts that ignore it.
+   */
+  kill() {
+    if (this.isClosed) {
+      return;
+    }
+
+    this.process.stdin?.end();
+
+    this.process.kill();
+  }
+
+  private close(error?: Error) {
+    if (this.isClosed) {
+      return;
+    }
+
+    this.isClosed = true;
+
+    this.handlers.onClose(error);
+  }
+}

--- a/packages/electron-extensions/native-messaging/native-messaging.test.ts
+++ b/packages/electron-extensions/native-messaging/native-messaging.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Session } from "electron";
+import {
+  NATIVE_MESSAGING_ORIGIN,
+  NATIVE_MESSAGING_PATHS,
+  NATIVE_MESSAGING_SCHEME,
+  type NativeMessagingFrame,
+} from "./bridge-protocol";
+import { NativeMessageDecoder } from "./framing";
+import { getHostManifestSearchPaths } from "./host-manifest";
+import { NativeMessaging } from "./native-messaging";
+
+const EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
+
+const BRIDGE_TOKEN = "bridge-token";
+
+const HOST_NAME = "com.meru.test";
+
+/** Echoes every message back, so a round trip proves the whole path. */
+const HOST_SOURCE = `
+let buffered = Buffer.alloc(0);
+process.stdin.on("data", (chunk) => {
+  buffered = Buffer.concat([buffered, chunk]);
+  while (buffered.byteLength >= 4) {
+    const length = buffered.readUInt32LE(0);
+    if (buffered.byteLength < 4 + length) return;
+    const body = JSON.parse(buffered.subarray(4, 4 + length).toString("utf8"));
+    buffered = buffered.subarray(4 + length);
+    const reply = Buffer.from(JSON.stringify({ echo: body, origin: process.argv[2] }), "utf8");
+    const prefix = Buffer.alloc(4);
+    prefix.writeUInt32LE(reply.byteLength, 0);
+    process.stdout.write(Buffer.concat([prefix, reply]));
+  }
+});
+`;
+
+let workDir: string;
+
+let requestHandler: ((request: GlobalRequest) => Promise<Response>) | undefined;
+
+let session: Session;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(path.join(tmpdir(), "native-messaging-"));
+
+  const hostScriptPath = path.join(workDir, "host.js");
+
+  await writeFile(hostScriptPath, HOST_SOURCE);
+
+  await writeFile(
+    path.join(workDir, "host"),
+    `#!/bin/sh\nexec "${process.execPath}" "${hostScriptPath}" "$@"\n`,
+  );
+
+  await chmod(path.join(workDir, "host"), 0o755);
+
+  requestHandler = undefined;
+
+  session = {
+    protocol: {
+      handle: (_scheme: string, handler: (request: GlobalRequest) => Promise<Response>) => {
+        requestHandler = handler;
+      },
+      unhandle: () => {
+        requestHandler = undefined;
+      },
+    },
+  } as unknown as Session;
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+async function writeHostManifest(allowedExtensionId = EXTENSION_ID) {
+  const manifestPath = getHostManifestSearchPaths(HOST_NAME, { homeDir: workDir })[0] as string;
+
+  await mkdir(path.dirname(manifestPath), { recursive: true });
+
+  await writeFile(
+    manifestPath,
+    JSON.stringify({
+      name: HOST_NAME,
+      path: path.join(workDir, "host"),
+      type: "stdio",
+      allowed_origins: [`chrome-extension://${allowedExtensionId}/`],
+    }),
+  );
+}
+
+function createRequest(pathName: string, body: Record<string, unknown>) {
+  return {
+    url: `${NATIVE_MESSAGING_ORIGIN}${pathName}`,
+    headers: new Headers(),
+    json: async () => body,
+  } as unknown as GlobalRequest;
+}
+
+function connect(portId = "port-1") {
+  return requestHandler?.(
+    createRequest(NATIVE_MESSAGING_PATHS.connect, {
+      token: BRIDGE_TOKEN,
+      portId,
+      hostName: HOST_NAME,
+    }),
+  ) as Promise<Response>;
+}
+
+function createNativeMessaging(options: ConstructorParameters<typeof NativeMessaging>[0] = {}) {
+  const nativeMessaging = new NativeMessaging({
+    ...options,
+    hostManifestSearch: { homeDir: workDir },
+  });
+
+  nativeMessaging.setupSession(session, {
+    getExtensionId: (bridgeToken) => (bridgeToken === BRIDGE_TOKEN ? EXTENSION_ID : undefined),
+  });
+
+  return nativeMessaging;
+}
+
+/** Reads frames off a connect response until one has arrived. */
+async function readFrame(response: Response) {
+  const reader = (response.body as ReadableStream<Uint8Array>).getReader();
+
+  const decoder = new NativeMessageDecoder();
+
+  for (;;) {
+    const { value, done } = await reader.read();
+
+    if (done) {
+      return undefined;
+    }
+
+    const [frame] = decoder.push(value) as NativeMessagingFrame[];
+
+    if (frame) {
+      return frame;
+    }
+  }
+}
+
+describe("NativeMessaging", () => {
+  test("carries messages both ways and tells the host who is calling", async () => {
+    await writeHostManifest();
+
+    const nativeMessaging = createNativeMessaging();
+
+    const response = await connect();
+
+    expect(response.status).toBe(200);
+
+    await requestHandler?.(
+      createRequest(NATIVE_MESSAGING_PATHS.post, {
+        token: BRIDGE_TOKEN,
+        portId: "port-1",
+        message: { hello: "host" },
+      }),
+    );
+
+    expect(await readFrame(response)).toEqual({
+      type: "message",
+      message: { echo: { hello: "host" }, origin: `chrome-extension://${EXTENSION_ID}/` },
+    });
+
+    nativeMessaging.teardownSession(session);
+  });
+
+  test("refuses a request without the token of a loaded extension", async () => {
+    await writeHostManifest();
+
+    createNativeMessaging();
+
+    const response = await requestHandler?.(
+      createRequest(NATIVE_MESSAGING_PATHS.connect, {
+        token: "guessed",
+        portId: "port-1",
+        hostName: HOST_NAME,
+      }),
+    );
+
+    expect(response?.status).toBe(403);
+  });
+
+  test("disconnects when the host does not list the extension", async () => {
+    await writeHostManifest("b".repeat(32));
+
+    createNativeMessaging();
+
+    expect(await readFrame(await connect())).toEqual({
+      type: "disconnect",
+      error: "Access to the specified native messaging host is forbidden.",
+    });
+  });
+
+  test("disconnects when no manifest names the host", async () => {
+    createNativeMessaging();
+
+    expect(await readFrame(await connect())).toEqual({
+      type: "disconnect",
+      error: "Specified native messaging host not found.",
+    });
+  });
+
+  test("lets an embedder refuse a host the manifest allows", async () => {
+    await writeHostManifest();
+
+    createNativeMessaging({ isHostAllowed: () => false });
+
+    expect(await readFrame(await connect())).toEqual({
+      type: "disconnect",
+      error: "Access to the specified native messaging host is forbidden.",
+    });
+  });
+
+  test("takes the session's ports down with the session", async () => {
+    await writeHostManifest();
+
+    const nativeMessaging = createNativeMessaging();
+
+    const response = await connect();
+
+    nativeMessaging.teardownSession(session);
+
+    expect(requestHandler).toBeUndefined();
+    expect(await readFrame(response)).toEqual({ type: "disconnect", error: undefined });
+  });
+
+  test("handles the scheme on the session it is set up for", () => {
+    const handledSchemes: string[] = [];
+
+    new NativeMessaging().setupSession(
+      {
+        protocol: {
+          handle: (scheme: string) => {
+            handledSchemes.push(scheme);
+          },
+          unhandle: () => undefined,
+        },
+      } as unknown as Session,
+      { getExtensionId: () => undefined },
+    );
+
+    expect(handledSchemes).toEqual([NATIVE_MESSAGING_SCHEME]);
+  });
+});

--- a/packages/electron-extensions/native-messaging/native-messaging.ts
+++ b/packages/electron-extensions/native-messaging/native-messaging.ts
@@ -1,0 +1,333 @@
+import type { Session } from "electron";
+import type { ExtensionsLogger } from "../logger";
+import {
+  NATIVE_MESSAGING_PATHS,
+  NATIVE_MESSAGING_SCHEME,
+  type NativeMessagingConnectRequest,
+  type NativeMessagingDisconnectRequest,
+  type NativeMessagingFrame,
+  type NativeMessagingPostRequest,
+  type NativeMessagingRequest,
+} from "./bridge-protocol";
+import { encodeNativeMessage } from "./framing";
+import { NativeMessagingHost } from "./host";
+import {
+  findHostManifest,
+  type HostManifestSearchOptions,
+  isExtensionAllowed,
+  resolveHostPath,
+} from "./host-manifest";
+
+/** The errors Chrome hands the extension, kept word for word. */
+const HOST_NOT_FOUND_ERROR = "Specified native messaging host not found.";
+
+const HOST_FORBIDDEN_ERROR = "Access to the specified native messaging host is forbidden.";
+
+/**
+ * Whether an extension may drive this host. The host's own `allowed_origins`
+ * has already said yes by the time this is asked; an embedder that wants a
+ * narrower rule than "whatever the host trusts" says no here.
+ */
+export type NativeMessagingHostPolicy = (details: {
+  session: Session;
+  extensionId: string;
+  hostName: string;
+  manifestPath: string;
+  hostPath: string;
+}) => boolean | Promise<boolean>;
+
+export type NativeMessagingOptions = {
+  isHostAllowed?: NativeMessagingHostPolicy;
+  /**
+   * Where host manifests are looked up, defaulting to the locations the running
+   * platform's Chromium browsers use.
+   */
+  hostManifestSearch?: HostManifestSearchOptions;
+  logger?: ExtensionsLogger;
+};
+
+type NativeMessagingSession = {
+  /** The extension whose copy of the facade carries this token, if any. */
+  getExtensionId: (bridgeToken: string) => string | undefined;
+};
+
+type NativeMessagingPort = {
+  id: string;
+  session: Session;
+  extensionId: string;
+  hostName: string;
+  controller: ReadableStreamDefaultController<Uint8Array>;
+  host?: NativeMessagingHost;
+  isClosed: boolean;
+};
+
+/**
+ * `chrome.runtime.connectNative` and `sendNativeMessage` for extensions loaded
+ * into Electron sessions.
+ *
+ * Electron ships Chromium's native messaging plumbing with the door nailed
+ * shut: `ElectronMessagingDelegate::IsNativeMessagingHostAllowed` returns
+ * `DISALLOW` and `CreateReceiverForNativeApp` returns nullptr, so the built-in
+ * `connectNative` disconnects every port with "Access to the native messaging
+ * host was disabled by the system administrator" no matter where a host
+ * manifest sits. The facade therefore replaces both methods and they land here,
+ * which finds the host manifest the way Chromium would, honours its
+ * `allowed_origins`, and runs one host process per port.
+ */
+export class NativeMessaging {
+  private options: NativeMessagingOptions;
+
+  private sessions = new Map<Session, NativeMessagingSession>();
+
+  private ports = new Map<string, NativeMessagingPort>();
+
+  constructor(options: NativeMessagingOptions = {}) {
+    this.options = options;
+
+    // Host processes are children of this process and outlive an abrupt exit,
+    // and every path out of the app passes through here
+    process.once("exit", () => {
+      for (const port of this.ports.values()) {
+        port.host?.kill();
+      }
+    });
+  }
+
+  setupSession(session: Session, sessionOptions: NativeMessagingSession) {
+    this.sessions.set(session, sessionOptions);
+
+    session.protocol.handle(NATIVE_MESSAGING_SCHEME, (request) =>
+      this.handleRequest(session, request),
+    );
+  }
+
+  teardownSession(session: Session) {
+    if (!this.sessions.delete(session)) {
+      return;
+    }
+
+    session.protocol.unhandle(NATIVE_MESSAGING_SCHEME);
+
+    for (const port of this.ports.values()) {
+      if (port.session === session) {
+        this.closePort(port);
+      }
+    }
+  }
+
+  private async handleRequest(session: Session, request: GlobalRequest) {
+    const headers = {
+      "access-control-allow-origin": request.headers.get("origin") ?? "*",
+      "cache-control": "no-store",
+    };
+
+    const { pathname } = new URL(request.url);
+
+    try {
+      const body = (await request.json()) as NativeMessagingRequest;
+
+      // Everything else in the session — Gmail, workspace apps, any page a user
+      // navigated to — can reach this scheme just as well, and only the loaded
+      // extensions know a token
+      const extensionId = this.sessions.get(session)?.getExtensionId(body.token);
+
+      if (!extensionId) {
+        return new Response(null, { status: 403, headers });
+      }
+
+      if (pathname === NATIVE_MESSAGING_PATHS.connect) {
+        return this.handleConnect(
+          session,
+          extensionId,
+          body as NativeMessagingConnectRequest,
+          headers,
+        );
+      }
+
+      if (pathname === NATIVE_MESSAGING_PATHS.post) {
+        this.handlePost(session, extensionId, body as NativeMessagingPostRequest);
+
+        return new Response(null, { status: 204, headers });
+      }
+
+      if (pathname === NATIVE_MESSAGING_PATHS.disconnect) {
+        const port = this.getPort(
+          session,
+          extensionId,
+          (body as NativeMessagingDisconnectRequest).portId,
+        );
+
+        if (port) {
+          this.closePort(port);
+        }
+
+        return new Response(null, { status: 204, headers });
+      }
+    } catch (error) {
+      this.options.logger?.error("Native messaging request failed", { pathname, error });
+
+      return new Response(null, { status: 400, headers });
+    }
+
+    return new Response(null, { status: 404, headers });
+  }
+
+  /**
+   * The response is held back until the host is running or has failed to start,
+   * because the extension takes it as the sign that the port exists and posts
+   * the moment it arrives. A message that overtook the host process would have
+   * nowhere to go.
+   */
+  private async handleConnect(
+    session: Session,
+    extensionId: string,
+    { portId, hostName }: NativeMessagingConnectRequest,
+    headers: Record<string, string>,
+  ) {
+    if (typeof portId !== "string" || typeof hostName !== "string" || this.ports.has(portId)) {
+      return new Response(null, { status: 400, headers });
+    }
+
+    let port: NativeMessagingPort | undefined;
+
+    const body = new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        port = { id: portId, session, extensionId, hostName, controller, isClosed: false };
+
+        this.ports.set(portId, port);
+      },
+      pull: () => {
+        port?.host?.resumeReading();
+      },
+      cancel: () => {
+        // The extension context went away — a closed page, a restarted service
+        // worker — and its host has to go with it
+        if (port) {
+          this.closePort(port);
+        }
+      },
+    });
+
+    if (port) {
+      await this.startHost(port);
+    }
+
+    return new Response(body, {
+      headers: { ...headers, "content-type": "application/octet-stream" },
+    });
+  }
+
+  private async startHost(port: NativeMessagingPort) {
+    const found = await findHostManifest(port.hostName, this.options.hostManifestSearch);
+
+    if (!found) {
+      this.closePort(port, HOST_NOT_FOUND_ERROR);
+
+      return;
+    }
+
+    const hostPath = resolveHostPath(found.manifestPath, found.manifest);
+
+    const isAllowed =
+      isExtensionAllowed(found.manifest, port.extensionId) &&
+      (await (this.options.isHostAllowed?.({
+        session: port.session,
+        extensionId: port.extensionId,
+        hostName: port.hostName,
+        manifestPath: found.manifestPath,
+        hostPath,
+      }) ?? true));
+
+    if (!isAllowed) {
+      this.closePort(port, HOST_FORBIDDEN_ERROR);
+
+      return;
+    }
+
+    // Awaiting the manifest and the policy gave the extension time to disconnect
+    if (port.isClosed) {
+      return;
+    }
+
+    port.host = new NativeMessagingHost({
+      hostPath,
+      extensionOrigin: `chrome-extension://${port.extensionId}/`,
+      onStderr: (output) => {
+        this.options.logger?.error("Native messaging host wrote to stderr", {
+          hostName: port.hostName,
+          output,
+        });
+      },
+      handlers: {
+        onMessage: (message) => {
+          this.sendFrame(port, { type: "message", message });
+        },
+        onClose: (error) => {
+          this.closePort(port, error?.message);
+        },
+      },
+    });
+
+    this.options.logger?.info("Connected native messaging host", {
+      hostName: port.hostName,
+      extensionId: port.extensionId,
+      manifestPath: found.manifestPath,
+      hostPath,
+      pid: port.host.pid,
+    });
+  }
+
+  private handlePost(session: Session, extensionId: string, request: NativeMessagingPostRequest) {
+    this.getPort(session, extensionId, request.portId)?.host?.postMessage(request.message);
+  }
+
+  private getPort(session: Session, extensionId: string, portId: string) {
+    const port = this.ports.get(portId);
+
+    if (!port || port.session !== session || port.extensionId !== extensionId) {
+      return undefined;
+    }
+
+    return port;
+  }
+
+  private sendFrame(port: NativeMessagingPort, frame: NativeMessagingFrame) {
+    if (port.isClosed) {
+      return;
+    }
+
+    port.controller.enqueue(encodeNativeMessage(frame));
+
+    // Stop reading the host until the extension has taken what it was sent
+    if ((port.controller.desiredSize ?? 1) <= 0) {
+      port.host?.pauseReading();
+    }
+  }
+
+  private closePort(port: NativeMessagingPort, error?: string) {
+    if (port.isClosed) {
+      return;
+    }
+
+    this.sendFrame(port, { type: "disconnect", error });
+
+    port.isClosed = true;
+
+    this.ports.delete(port.id);
+
+    port.host?.kill();
+
+    try {
+      port.controller.close();
+    } catch {
+      // The stream is already gone when the extension cancelled it
+    }
+
+    this.options.logger?.info("Disconnected native messaging host", {
+      hostName: port.hostName,
+      extensionId: port.extensionId,
+      pid: port.host?.pid,
+      error,
+    });
+  }
+}

--- a/packages/electron-extensions/native-messaging/scheme.ts
+++ b/packages/electron-extensions/native-messaging/scheme.ts
@@ -1,0 +1,29 @@
+import { protocol } from "electron";
+import { NATIVE_MESSAGING_SCHEME } from "./bridge-protocol";
+
+/**
+ * Registers the scheme the native messaging bridge answers on. Electron only
+ * takes scheme privileges before the app is ready, so an embedder has to call
+ * this while its modules are still loading.
+ *
+ * `supportFetchAPI` and `corsEnabled` are what let an extension context fetch
+ * the scheme at all, and `allowServiceWorkers` is what extends that to service
+ * workers: without it a fetch from an extension's service worker — the context
+ * that matters here — fails with "Failed to fetch" before the handler is ever
+ * asked (measured on Electron 43.2.0). Nothing can navigate to the scheme, so
+ * the workers it allows to be registered on it are hypothetical.
+ */
+export function registerNativeMessagingScheme() {
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: NATIVE_MESSAGING_SCHEME,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        corsEnabled: true,
+        allowServiceWorkers: true,
+      },
+    },
+  ]);
+}

--- a/packages/electron-extensions/native-messaging/windows-registry.test.ts
+++ b/packages/electron-extensions/native-messaging/windows-registry.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { WINDOWS_HOST_REGISTRY_KEYS } from "./host-manifest";
+import { parseRegistryQueryOutput } from "./windows-registry";
+
+describe("parseRegistryQueryOutput", () => {
+  test("reads the manifest path out of a default string value", () => {
+    expect(
+      parseRegistryQueryOutput(
+        [
+          "",
+          "HKEY_CURRENT_USER\\Software\\Google\\Chrome\\NativeMessagingHosts\\com.1password.1password",
+          "    (Default)    REG_SZ    C:\\Users\\Tim\\AppData\\Local\\1Password\\com.1password.1password.json",
+          "",
+        ].join("\r\n"),
+      ),
+    ).toBe("C:\\Users\\Tim\\AppData\\Local\\1Password\\com.1password.1password.json");
+  });
+
+  test("reads an expandable string value too", () => {
+    expect(
+      parseRegistryQueryOutput("    (Default)    REG_EXPAND_SZ    %LOCALAPPDATA%\\host.json\r\n"),
+    ).toBe("%LOCALAPPDATA%\\host.json");
+  });
+
+  test("keeps a path with spaces in it whole", () => {
+    expect(
+      parseRegistryQueryOutput("    (Default)    REG_SZ    C:\\Program Files\\1Password\\h.json"),
+    ).toBe("C:\\Program Files\\1Password\\h.json");
+  });
+
+  test("ignores a value that is not a string", () => {
+    expect(parseRegistryQueryOutput("    (Default)    REG_DWORD    0x1")).toBeUndefined();
+  });
+
+  test("answers with nothing when the key has no default value", () => {
+    expect(
+      parseRegistryQueryOutput(
+        "\r\nHKEY_CURRENT_USER\\Software\\Google\\Chrome\\NativeMessagingHosts\r\n",
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("WINDOWS_HOST_REGISTRY_KEYS", () => {
+  test("asks the user hive before the machine hive", () => {
+    const firstMachineKey = WINDOWS_HOST_REGISTRY_KEYS.findIndex((key) => key.startsWith("HKLM"));
+
+    expect(
+      WINDOWS_HOST_REGISTRY_KEYS.slice(0, firstMachineKey).every((key) => key.startsWith("HKCU")),
+    ).toBe(true);
+    expect(WINDOWS_HOST_REGISTRY_KEYS).toContain(
+      "HKCU\\Software\\Google\\Chrome\\NativeMessagingHosts",
+    );
+    expect(WINDOWS_HOST_REGISTRY_KEYS).toContain(
+      "HKLM\\Software\\Google\\Chrome\\NativeMessagingHosts",
+    );
+  });
+});

--- a/packages/electron-extensions/native-messaging/windows-registry.ts
+++ b/packages/electron-extensions/native-messaging/windows-registry.ts
@@ -1,0 +1,59 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * The manifest path out of `reg query <key> /ve`, which prints the key it read
+ * and then the default value as name, type and data separated by runs of
+ * spaces. Only a string value is a path; anything else is a registration this
+ * code has no business following.
+ *
+ *     HKEY_CURRENT_USER\Software\Google\Chrome\NativeMessagingHosts\com.1password.1password
+ *         (Default)    REG_SZ    C:\Users\me\AppData\Local\1Password\com.1password.1password.json
+ */
+export function parseRegistryQueryOutput(output: string) {
+  for (const line of output.split(/\r?\n/)) {
+    const value = /^\s+\(Default\)\s+REG_(?:SZ|EXPAND_SZ)\s+(.+?)\s*$/.exec(line);
+
+    if (value?.[1]) {
+      return value[1];
+    }
+  }
+
+  return undefined;
+}
+
+async function queryRegistryValue(key: string) {
+  try {
+    const { stdout } = await execFileAsync("reg.exe", ["query", key, "/ve"], {
+      windowsHide: true,
+    });
+
+    return parseRegistryQueryOutput(stdout);
+  } catch {
+    // An unregistered host is a missing key, which `reg` reports as an error
+    return undefined;
+  }
+}
+
+/**
+ * Windows has no manifest directories to walk: each registered host is a
+ * registry key whose default value holds the path of its manifest.
+ */
+export async function queryWindowsRegistryHostManifestPaths(
+  hostName: string,
+  registryKeys: string[],
+) {
+  const manifestPaths: string[] = [];
+
+  for (const registryKey of registryKeys) {
+    const manifestPath = await queryRegistryValue(`${registryKey}\\${hostName}`);
+
+    if (manifestPath) {
+      manifestPaths.push(manifestPath);
+    }
+  }
+
+  return manifestPaths;
+}


### PR DESCRIPTION
- Electron's built-in `connectNative` is a categorical refusal, not a discovery problem: `ElectronMessagingDelegate::IsNativeMessagingHostAllowed` returns `DISALLOW` unconditionally (verified in Electron 43 source and empirically against 7 manifest locations), so the facade replaces `runtime.connectNative`/`sendNativeMessage` on both `chrome` and `browser`.
- The bridge to main is a per-session privileged custom scheme (`protocol.handle`): extension contexts fetch it, the connect response streams framed messages back. `allowServiceWorkers` is required or SW fetches die before the handler; extension-page CSP gets `connect-src` extended at derive time. Since `protocol.handle` receives no `Origin` and any page in the session can reach the scheme, calls carry a per-extension bearer token regenerated each launch and written into that extension's derived facade copy — not web-reachable for 1Password (its `web_accessible_resources` doesn't cover the facade file).
- Host side matches Chrome: per-OS manifest discovery (Linux/macOS dirs for Chrome/Chromium/Edge/Brave/Vivaldi, Windows via `reg query`), `allowed_origins` enforcement, one host process per port with origin as argv[1], 4-byte-LE framing with the 1MB inbound cap, Chrome's error strings verbatim. Port disconnect, oversize, session teardown, and process exit all kill host processes (verified by PID).
- From real-machine (macOS) testing: Chromium never re-fetches an extension SW's script once registered, so later launches ran a stale facade with a dead token → every call 403'd. The loader now drops the extension's SW registration before each load (`clearStorageData` scoped to the extension's origin; id derived from `manifest.key`). Without this, no facade change ever reached an existing profile's SW.
- Also from that testing: derived copies drop `webRequest`/`webRequestAuthProvider` from permissions (inert in Electron; removes the renderer's `NOTREACHED "webRequest" not found` bursts entirely), and Gmail's `loadURL` rejections are caught and logged (`Failed to load URL`) instead of surfacing unhandled.
- The blank-Gmail `ERR_FAILED` is root-caused and fixed: `loadExtension` completing while Gmail's navigation was still provisional made Chromium abort that navigation (both failing runs died ~90ms after `Loaded extension`; successful runs had committed before it). Gmail's first navigation now waits for the session's extension loads (a failed extension setup logs and never blocks Gmail), and the initial load retries once if it still never commits.
- Diagnostics for any future empty view stay in: `render-process-gone` / `did-fail-load` / `did-fail-provisional-load` are logged for the Gmail view, and `MERU_EXTENSIONS_STRIP=<manifest keys>` (dev-only) derives extensions without the listed keys for bisecting.

Not verified: the race fix and retry against a real failing launch (the race is timing-dependent — several clean starts are the signal); the real 1Password host (it verifies the calling browser's code signature — a dev build may be refused until Add Browser sees a signed build); Touch ID; macOS/Windows manifest lookup paths (unit-tested as data only). Onboarding UI for Add Browser is a later slice.

Test plan (needs a machine with the 1Password desktop app):
1. `bun run extensions:download`, then `bun run dev` repeatedly (5+ starts) on an existing profile → Gmail renders every time; a `Retrying Gmail load` line, if it appears, means the abort happened and the retry covered it.
2. Log shows no 403s; 1Password's desktop-app probe either connects or fails on the host's own trust check, not on the bridge.
3. 1Password → Settings → Browser → Add Browser → watch for `Connected native messaging host` in Meru's log and 1Password reporting the desktop-app link (may require a signed build).
4. Quit Meru with the extension connected → no orphaned `1Password-BrowserSupport` process.
