### PR TITLE
log failed loads and quiet native messaging stderr

### DIFF
--- a/packages/app/lib/popup.ts
+++ b/packages/app/lib/popup.ts
@@ -3,6 +3,7 @@ import { APP_TITLEBAR_HEIGHT, BASE_SPACING } from "@meru/shared/constants";
 import { clamp } from "@meru/shared/utils";
 import type { BrowserWindow, Event, Input, Session, Size } from "electron";
 import { WebContentsView } from "electron";
+import { loadUrl } from "./web-contents";
 import { getPreloadPath, loadRenderer, type RendererPage } from "./window";
 
 /** What a popup shows: a renderer page, or any URL loaded in a given session. */
@@ -242,7 +243,7 @@ export class Popup {
     if (isPage) {
       loadRenderer(this.view, { page: content.page });
     } else {
-      this.view.webContents.loadURL(content.url);
+      loadUrl(this.view.webContents, content.url);
     }
 
     parentWindow.contentView.addChildView(this.view);

--- a/packages/app/lib/window.ts
+++ b/packages/app/lib/window.ts
@@ -11,6 +11,7 @@ import {
 } from "electron";
 import { shouldOpenDevToolsOnLaunch } from "./dev-tools";
 import { isLinuxWindowControlsEnabled } from "./linux";
+import { loadUrl } from "./web-contents";
 
 const CASCADE_OFFSET = 30;
 
@@ -150,7 +151,7 @@ export function loadRenderer(
   searchParams.set("darkMode", nativeTheme.shouldUseDarkColors ? "true" : "false");
 
   if (is.dev) {
-    window.webContents.loadURL(`http://localhost:3000/${pageFileName}?${searchParams.toString()}`);
+    loadUrl(window.webContents, `http://localhost:3000/${pageFileName}?${searchParams.toString()}`);
 
     if (shouldOpenDevToolsOnLaunch) {
       window.webContents.openDevTools({ mode: "detach" });

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -28,6 +28,7 @@ import { config } from "./config";
 import { ipc } from "./ipc";
 import {
   createChildWebContentsView,
+  loadUrl,
   openViewDevToolsOnLaunch,
   removeWebContentsListeners,
 } from "./lib/web-contents";
@@ -197,7 +198,7 @@ export class WorkspaceApp {
 
     event.preventDefault();
 
-    webContents.loadURL(`${GOOGLE_ACCOUNTS_URL}/ServiceLogin?service=mail`);
+    loadUrl(webContents, `${GOOGLE_ACCOUNTS_URL}/ServiceLogin?service=mail`);
   }
 
   static handleWindowOpen({
@@ -594,7 +595,7 @@ export class WorkspaceApp {
       },
     });
 
-    view.webContents.loadURL(url);
+    loadUrl(view.webContents, url);
 
     openViewDevToolsOnLaunch(view);
 
@@ -936,7 +937,7 @@ export class WorkspaceApp {
   }
 
   navigate(url: string) {
-    this.view.webContents.loadURL(url);
+    loadUrl(this.view.webContents, url);
   }
 
   reload() {

--- a/packages/electron-extensions/native-messaging/native-messaging.ts
+++ b/packages/electron-extensions/native-messaging/native-messaging.ts
@@ -253,7 +253,7 @@ export class NativeMessaging {
       hostPath,
       extensionOrigin: `chrome-extension://${port.extensionId}/`,
       onStderr: (output) => {
-        this.options.logger?.error("Native messaging host wrote to stderr", {
+        this.options.logger?.info("Native messaging host wrote to stderr", {
           hostName: port.hostName,
           output,
         });


### PR DESCRIPTION
- Routes the five remaining fire-and-forget `webContents.loadURL` calls (workspace-app redirect/child-view/navigate, popup URL content, dev-mode `loadRenderer`) through the `loadUrl` wrapper from #824, so a load that never commits logs `Failed to load URL` instead of surfacing as an unhandled rejection. Call sites stay fire-and-forget — no retries, no awaiting.
- Logs the native-messaging host's stderr at info instead of error: 1Password's helper writes routine diagnostics there, which showed up as error-level noise on every launch.

Behavior is unchanged on the happy path; only failure logging moves. Not exercised against a real failing load.

Test plan:
1. `bun run dev` → app starts and workspace tabs/popups load as before.
2. Trigger a 1Password native-messaging connect (press the titlebar action) → any host stderr chatter appears in the log at info level, not error.
