### PR TITLE
derive an extension again when any of its source files changed

### DIFF
--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { deriveExtension } from "./index";
@@ -20,8 +20,26 @@ const manifest = {
   background: { service_worker: "background/background.js", type: "module" },
 };
 
+let writeCount = 0;
+
+/**
+ * Gives every write an mtime of its own, so a rewrite is a change the derive
+ * can see whatever the filesystem's timestamp granularity is.
+ */
+async function writeSourceFile(fileName: string, content: string) {
+  const filePath = path.join(sourceDir, fileName);
+
+  await writeFile(filePath, content);
+
+  writeCount += 1;
+
+  const writtenAt = new Date(Date.now() + writeCount * 1000);
+
+  await utimes(filePath, writtenAt, writtenAt);
+}
+
 async function writeManifest(manifestSource: Record<string, unknown>) {
-  await writeFile(path.join(sourceDir, "manifest.json"), JSON.stringify(manifestSource));
+  await writeSourceFile("manifest.json", JSON.stringify(manifestSource));
 }
 
 beforeEach(async () => {
@@ -37,9 +55,9 @@ beforeEach(async () => {
 
   await writeManifest(manifest);
 
-  await writeFile(path.join(sourceDir, "background", "background.js"), "// background\n");
+  await writeSourceFile(path.join("background", "background.js"), "// background\n");
 
-  await writeFile(path.join(sourceDir, "popup.html"), "<html><head></head></html>");
+  await writeSourceFile("popup.html", "<html><head></head></html>");
 
   await writeFile(facadeScriptPath, "// facade\n");
 });
@@ -150,6 +168,28 @@ describe("deriveExtension", () => {
     expect(JSON.parse(await readFile(path.join(derivedDir, "manifest.json"), "utf8")).version).toBe(
       "2.0.0",
     );
+  });
+
+  test("copies again when a file other than the manifest changed", async () => {
+    const derivedDir = await derive();
+
+    await writeSourceFile(path.join("background", "background.js"), "// edited\n");
+
+    await derive();
+
+    expect(await readFile(path.join(derivedDir, "background", "background.js"), "utf8")).toBe(
+      "// edited\n",
+    );
+  });
+
+  test("copies again when the source gained a file", async () => {
+    const derivedDir = await derive();
+
+    await writeSourceFile("content.js", "// content\n");
+
+    await derive();
+
+    expect(await readFile(path.join(derivedDir, "content.js"), "utf8")).toBe("// content\n");
   });
 
   test("gives every derived copy of the facade a bridge token of its own", async () => {

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { cp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { cp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
   NATIVE_MESSAGING_SCHEME,
@@ -33,6 +33,31 @@ export type DeriveExtensionOptions = {
 
 function hash(value: string) {
   return createHash("sha256").update(value).digest("hex");
+}
+
+/**
+ * Digests the source tree from each file's path, size and mtime — never its
+ * contents, since an extension runs to tens of megabytes and this happens on
+ * every launch, and an edit always moves one of the two.
+ */
+async function hashSourceTree(sourceDir: string) {
+  const entryNames = await readdir(sourceDir, { recursive: true });
+
+  const fileEntries: string[] = [];
+
+  for (const entryName of entryNames) {
+    const stats = await stat(path.join(sourceDir, entryName));
+
+    if (!stats.isFile()) {
+      continue;
+    }
+
+    const relativePath = entryName.split(path.sep).join("/");
+
+    fileEntries.push(`${relativePath}\0${stats.size}\0${stats.mtimeMs}`);
+  }
+
+  return hash(fileEntries.sort().join("\n"));
 }
 
 async function readStamp(stampPath: string) {
@@ -88,13 +113,14 @@ export async function deriveExtension({
 
   const stampPath = `${derivedDir}.json`;
 
-  // The source is copied again when its manifest changes, which is what an
-  // installed extension moving to a new version does, and when what the derive
-  // makes of it changes
+  // The source is copied again when any of its files changes, which is what an
+  // installed extension moving to a new version does and what a developer
+  // working in an unpacked one does, and when what the derive makes of it
+  // changes
   const stamp = JSON.stringify({
     deriveVersion: DERIVE_VERSION,
     sourceDir,
-    manifest: hash(manifestSource),
+    sourceTree: await hashSourceTree(sourceDir),
     strippedManifestKeys,
   });
 


### PR DESCRIPTION
- The derive stamp digested only `manifest.json`, so editing any other file in an unpacked extension dir never refreshed the derived copy the loader loads — the dev-mode footgun noted in the feature doc after #824.
- The stamp now digests the whole source tree from each file's path, size and mtime (no content reads — an extension runs to tens of MB and this runs every launch).

Launch-time cost of stat-ing a large real tree wasn't measured, only unit-tested.

Test plan:
1. `bun run extensions:download`, `bun run dev` once, then edit a comment into `extensions/1password/inline/injected/webauthn-listeners.js` and relaunch — the derived copy under `userData/derived-extensions` picks up the edit.
2. Relaunch again untouched — startup shows no noticeable extra delay from the stat pass.