### PR TITLE
skip the passkey dialog when 1password is loaded

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -9,6 +9,10 @@ import { app } from "electron";
 import { serializeError } from "serialize-error";
 import { log } from "@/lib/log";
 
+// 1Password overrides `navigator.credentials` in the page, which is what lets a
+// passkey sign-in go through in Electron and makes the passkey dialog moot
+export const ONEPASSWORD_EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
+
 /**
  * Unpacked extensions to load into every account session, one directory holding
  * a `manifest.json` per extension:

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -494,7 +494,7 @@ export class Gmail {
 
   private registerNavigationHandler(window: BrowserWindow | WebContentsView) {
     window.webContents.on("did-navigate", (_event, url) => {
-      WorkspaceApp.handleNavigate(url);
+      WorkspaceApp.handleNavigate(url, this.session);
 
       if (window === this.view) {
         this.store.setState({

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -18,6 +18,7 @@ import {
   dialog,
   globalShortcut,
   powerSaveBlocker,
+  type Session,
   type WebContents,
   type WebContentsView,
   type WebContentsViewConstructorOptions,
@@ -25,6 +26,7 @@ import {
 import { accounts } from "./accounts";
 import { bookmarks } from "./bookmarks";
 import { config } from "./config";
+import { extensions, ONEPASSWORD_EXTENSION_ID } from "./extensions";
 import { ipc } from "./ipc";
 import {
   createChildWebContentsView,
@@ -154,7 +156,7 @@ export class WorkspaceApp {
     }
   }
 
-  static async handleNavigate(url: string) {
+  static async handleNavigate(url: string, session: Session) {
     if (!url.startsWith(`${GOOGLE_ACCOUNTS_URL}/v3/signin/challenge/pk/presend`)) {
       return;
     }
@@ -165,6 +167,10 @@ export class WorkspaceApp {
     }
 
     if (config.get("workspaceApps.hidePasskeyDialog")) {
+      return;
+    }
+
+    if (extensions.isExtensionLoaded(session, ONEPASSWORD_EXTENSION_ID)) {
       return;
     }
 
@@ -818,7 +824,7 @@ export class WorkspaceApp {
   private handleDidNavigate = (_event: Electron.Event, url: string) => {
     this.updateAppFromNavigation(url);
 
-    WorkspaceApp.handleNavigate(url);
+    WorkspaceApp.handleNavigate(url, this.account.instance.session);
   };
 
   private handleGoogleRedirect = (event: Electron.Event, url: string) => {

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -327,6 +327,23 @@ describe("Extensions", () => {
     ).toBe(false);
   });
 
+  test("reports an extension as loaded in that session only", async () => {
+    const { session: sessionWithExtension } = createSession();
+    const { session: sessionWithoutExtension } = createSession();
+
+    const extensions = createExtensions([await createExtensionDir("one")]);
+
+    await extensions.setupSession(sessionWithExtension);
+
+    expect(extensions.isExtensionLoaded(sessionWithExtension, "aaa")).toBe(true);
+    expect(extensions.isExtensionLoaded(sessionWithExtension, "bbb")).toBe(false);
+    expect(extensions.isExtensionLoaded(sessionWithoutExtension, "aaa")).toBe(false);
+
+    extensions.teardownSession(sessionWithExtension);
+
+    expect(extensions.isExtensionLoaded(sessionWithExtension, "aaa")).toBe(false);
+  });
+
   test("unloads what it loaded and forgets the session", async () => {
     const { session, removedExtensionIds } = createSession();
 

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -331,6 +331,15 @@ export class Extensions {
     }
   }
 
+  /**
+   * Whether one particular extension is loaded into this session, for stepping
+   * a behavior of the embedder's own aside while the extension takes it over —
+   * a password manager overriding WebAuthn in the page, say.
+   */
+  isExtensionLoaded(session: Session, extensionId: string) {
+    return this.loadedExtensionIdsBySession.get(session)?.has(extensionId) ?? false;
+  }
+
   isLoadedExtensionUrl(session: Session, url: string) {
     const loadedExtensionIds = this.loadedExtensionIdsBySession.get(session);
 


### PR DESCRIPTION
- Adds `Extensions.isExtensionLoaded(session, extensionId)` to the extensions package (unit-tested), for stepping embedder behavior aside while an extension takes it over.
- `WorkspaceApp.handleNavigate` now takes the navigating view's session and skips the passkey info dialog when 1Password is loaded into it — its MAIN-world `navigator.credentials` override handles the challenge instead (slice 8 of the chrome-extensions feature doc). Both callers (workspace apps and the Gmail view) updated.

The suppression path wasn't exercised with 1Password actually loaded — only the accessor is unit-tested.

Test plan:
1. `bun run extensions:download`, `bun run dev`, hit a Google passkey challenge in a signed-out account — Meru's dialog stays away and 1Password's intercept appears.
2. Same flow without the `extensions/` folder — the dialog behaves exactly as before.