### PR TITLE
verify crx packages against the id they are curated under

### DIFF
--- a/packages/electron-extensions/crx/crx.test.ts
+++ b/packages/electron-extensions/crx/crx.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, test } from "bun:test";
+import { createHash, createSign, generateKeyPairSync, type KeyPairSyncResult } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { unzipSync, zipSync } from "fflate";
+import { EXTENSION_ID_BYTE_LENGTH, getExtensionIdFromPublicKey } from "../derive/extension-id";
+import { verifyCrx } from "./crx";
+
+const SHA256_WITH_RSA_FIELD_NUMBER = 2;
+
+const SIGNED_HEADER_DATA_FIELD_NUMBER = 10000;
+
+const PUBLIC_KEY_FIELD_NUMBER = 1;
+
+const SIGNATURE_FIELD_NUMBER = 2;
+
+const CRX_ID_FIELD_NUMBER = 1;
+
+const ARCHIVE_FILES = { "manifest.json": new TextEncoder().encode('{"name":"Extension"}\n') };
+
+type KeyPair = KeyPairSyncResult<Buffer, Buffer>;
+
+function createKeyPair(): KeyPair {
+  return generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: "spki", format: "der" },
+    privateKeyEncoding: { type: "pkcs8", format: "der" },
+  });
+}
+
+const signingKeyPair = createKeyPair();
+
+const otherKeyPair = createKeyPair();
+
+const extensionId = getExtensionIdFromPublicKey(signingKeyPair.publicKey);
+
+/** The form a key is compared in here, which is the form a manifest carries. */
+function toBase64(key: Uint8Array) {
+  return Buffer.from(key).toString("base64");
+}
+
+function encodeVarint(value: number) {
+  const bytes: number[] = [];
+
+  let remaining = value;
+
+  do {
+    const byte = remaining % 0x80;
+
+    remaining = Math.floor(remaining / 0x80);
+
+    bytes.push(remaining > 0 ? byte | 0x80 : byte);
+  } while (remaining > 0);
+
+  return Buffer.from(bytes);
+}
+
+function encodeField(fieldNumber: number, bytes: Uint8Array) {
+  return Buffer.concat([
+    encodeVarint(fieldNumber * 8 + 2),
+    encodeVarint(bytes.byteLength),
+    Buffer.from(bytes),
+  ]);
+}
+
+function encodeUint32Le(value: number) {
+  const bytes = Buffer.alloc(4);
+
+  bytes.writeUInt32LE(value);
+
+  return bytes;
+}
+
+function sign(privateKey: Buffer, signedContent: Buffer) {
+  return createSign("sha256")
+    .update(signedContent)
+    .sign({ key: privateKey, format: "der", type: "pkcs8" });
+}
+
+type CrxOptions = {
+  /** Every key the header carries a proof for, each signing with its own key. */
+  keyPairs?: KeyPair[];
+  /** The id the header is signed for, by default the signing key's. */
+  crxId?: Buffer;
+  archive?: Buffer;
+  formatVersion?: number;
+  omitSignature?: boolean;
+};
+
+function createCrx({
+  keyPairs = [signingKeyPair],
+  crxId = createHash("sha256")
+    .update(signingKeyPair.publicKey)
+    .digest()
+    .subarray(0, EXTENSION_ID_BYTE_LENGTH),
+  archive = Buffer.from(zipSync(ARCHIVE_FILES)),
+  formatVersion = 3,
+  omitSignature = false,
+}: CrxOptions = {}) {
+  const signedHeaderData = encodeField(CRX_ID_FIELD_NUMBER, crxId);
+
+  const signedContent = Buffer.concat([
+    Buffer.from("CRX3 SignedData", "utf8"),
+    Buffer.from([0]),
+    encodeUint32Le(signedHeaderData.byteLength),
+    signedHeaderData,
+    archive,
+  ]);
+
+  const proofs = keyPairs.map((keyPair) =>
+    encodeField(
+      SHA256_WITH_RSA_FIELD_NUMBER,
+      Buffer.concat([
+        encodeField(PUBLIC_KEY_FIELD_NUMBER, keyPair.publicKey),
+        ...(omitSignature
+          ? []
+          : [encodeField(SIGNATURE_FIELD_NUMBER, sign(keyPair.privateKey, signedContent))]),
+      ]),
+    ),
+  );
+
+  const header = Buffer.concat([
+    ...proofs,
+    encodeField(SIGNED_HEADER_DATA_FIELD_NUMBER, signedHeaderData),
+  ]);
+
+  return Buffer.concat([
+    Buffer.from("Cr24", "ascii"),
+    encodeUint32Le(formatVersion),
+    encodeUint32Le(header.byteLength),
+    header,
+    archive,
+  ]);
+}
+
+describe("verifyCrx", () => {
+  test("returns the archive of a package signed for the pinned id", () => {
+    const crx = createCrx();
+
+    const { archive, publicKey, headerByteLength } = verifyCrx(crx, extensionId);
+
+    expect(Object.keys(unzipSync(archive))).toEqual(["manifest.json"]);
+    expect(toBase64(publicKey)).toBe(toBase64(signingKeyPair.publicKey));
+    expect(headerByteLength).toBe(crx.byteLength - archive.byteLength - 12);
+  });
+
+  test("picks the proof deriving the pinned id over the one that comes first", () => {
+    const { publicKey } = verifyCrx(
+      createCrx({ keyPairs: [otherKeyPair, signingKeyPair] }),
+      extensionId,
+    );
+
+    expect(toBase64(publicKey)).toBe(toBase64(signingKeyPair.publicKey));
+  });
+
+  test("refuses a package whose archive was changed after signing", () => {
+    const crx = createCrx();
+
+    const tamperedByteOffset = crx.byteLength - 8;
+
+    crx[tamperedByteOffset] = (crx[tamperedByteOffset] as number) ^ 0xff;
+
+    expect(() => verifyCrx(crx, extensionId)).toThrow(
+      `No signature by the key deriving ${extensionId} verifies the CRX`,
+    );
+  });
+
+  test("refuses a package signed for another id", () => {
+    const otherExtensionId = getExtensionIdFromPublicKey(otherKeyPair.publicKey);
+
+    expect(() => verifyCrx(createCrx(), otherExtensionId)).toThrow(
+      `CRX is signed for ${extensionId} instead of ${otherExtensionId}`,
+    );
+  });
+
+  test("refuses a package whose keys do not derive the id it is signed for", () => {
+    const crx = createCrx({
+      keyPairs: [otherKeyPair],
+    });
+
+    expect(() => verifyCrx(crx, extensionId)).toThrow(
+      `None of the 1 keys in the CRX derives ${extensionId}`,
+    );
+  });
+
+  test("refuses a proof without a signature", () => {
+    expect(() => verifyCrx(createCrx({ omitSignature: true }), extensionId)).toThrow(
+      `None of the 0 keys in the CRX derives ${extensionId}`,
+    );
+  });
+
+  test("refuses a corrupted signature", () => {
+    const crx = createCrx();
+
+    const signatureByteOffset = crx.indexOf(signingKeyPair.publicKey) + 300;
+
+    crx[signatureByteOffset] = (crx[signatureByteOffset] as number) ^ 0xff;
+
+    expect(() => verifyCrx(crx, extensionId)).toThrow(
+      `No signature by the key deriving ${extensionId} verifies the CRX`,
+    );
+  });
+
+  test("refuses a buffer too short to hold a header", () => {
+    expect(() => verifyCrx(createCrx().subarray(0, 8), extensionId)).toThrow(
+      "CRX of 8 bytes is too short to hold a header",
+    );
+  });
+
+  test("refuses a package truncated in the middle of its header", () => {
+    expect(() => verifyCrx(createCrx().subarray(0, 32), extensionId)).toThrow(
+      "does not fit in 32 bytes",
+    );
+  });
+
+  test("refuses a header claiming more bytes than the package has", () => {
+    const crx = createCrx();
+
+    crx.writeUInt32LE(crx.byteLength, 8);
+
+    expect(() => verifyCrx(crx, extensionId)).toThrow(/does not fit in/);
+  });
+
+  test("refuses something that is not a CRX", () => {
+    expect(() => verifyCrx(Buffer.from(zipSync(ARCHIVE_FILES)), extensionId)).toThrow(
+      'instead of "Cr24"',
+    );
+  });
+
+  test("refuses a CRX2 package", () => {
+    expect(() => verifyCrx(createCrx({ formatVersion: 2 }), extensionId)).toThrow(
+      "CRX format version 2 is not supported",
+    );
+  });
+});
+
+/**
+ * The package `bun run extensions:download` leaves behind, which is a real Web
+ * Store CRX carrying three proofs. It is absent on a fresh checkout and in CI.
+ */
+const onePasswordCrxPath = path.join(
+  import.meta.dirname,
+  "..",
+  "..",
+  "..",
+  "extensions",
+  "1password.crx",
+);
+
+describe("verifyCrx with a Web Store package", () => {
+  test.skipIf(!existsSync(onePasswordCrxPath))("verifies the 1Password package", () => {
+    const { archive, publicKey } = verifyCrx(
+      readFileSync(onePasswordCrxPath),
+      "aeblfdkhhhdcdjpifhhbdiojplfjncoa",
+    );
+
+    expect(getExtensionIdFromPublicKey(publicKey)).toBe("aeblfdkhhhdcdjpifhhbdiojplfjncoa");
+    expect(Object.keys(unzipSync(archive))).toContain("manifest.json");
+  });
+});

--- a/packages/electron-extensions/crx/crx.ts
+++ b/packages/electron-extensions/crx/crx.ts
@@ -1,0 +1,212 @@
+import { createPublicKey, createVerify, type KeyObject } from "node:crypto";
+import {
+  encodeExtensionId,
+  EXTENSION_ID_BYTE_LENGTH,
+  getExtensionIdFromPublicKey,
+} from "../derive/extension-id";
+import { readLengthDelimitedFields } from "./protobuf";
+
+const CRX_MAGIC = "Cr24";
+
+/** The magic, the format version and the header size, four bytes each. */
+const CRX_PREFIX_BYTE_LENGTH = 12;
+
+const CRX_FORMAT_VERSION = 3;
+
+/**
+ * What a CRX3 signature is taken over, ahead of the signed header data and the
+ * archive. The trailing NUL is part of it.
+ */
+const SIGNED_DATA_MAGIC = Uint8Array.from([...new TextEncoder().encode("CRX3 SignedData"), 0]);
+
+const SHA256_WITH_RSA_FIELD_NUMBER = 2;
+
+const SHA256_WITH_ECDSA_FIELD_NUMBER = 3;
+
+const SIGNED_HEADER_DATA_FIELD_NUMBER = 10000;
+
+const PUBLIC_KEY_FIELD_NUMBER = 1;
+
+const SIGNATURE_FIELD_NUMBER = 2;
+
+const CRX_ID_FIELD_NUMBER = 1;
+
+type CrxProof = {
+  /** The key type the proof's field number declares, which its key has to be. */
+  keyType: "rsa" | "ec";
+  publicKey: Uint8Array;
+  signature: Uint8Array;
+};
+
+export type VerifiedCrx = {
+  /** The zip archive the CRX wraps, which is what an install unpacks. */
+  archive: Uint8Array;
+  /**
+   * The DER SPKI public key of the proof that verified. Base64 of it is the
+   * `manifest.key` an unpacked install has to carry to load under the pinned
+   * id instead of one Chromium derives from its directory.
+   */
+  publicKey: Uint8Array;
+  headerByteLength: number;
+};
+
+function readUint32Le(bytes: Uint8Array, offset: number) {
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(offset, true);
+}
+
+function encodeUint32Le(value: number) {
+  const bytes = new Uint8Array(4);
+
+  new DataView(bytes.buffer).setUint32(0, value, true);
+
+  return bytes;
+}
+
+function readProof(proofBytes: Uint8Array, keyType: CrxProof["keyType"]): CrxProof | undefined {
+  const fields = readLengthDelimitedFields(proofBytes);
+
+  const publicKey = fields.find((field) => field.fieldNumber === PUBLIC_KEY_FIELD_NUMBER)?.bytes;
+
+  const signature = fields.find((field) => field.fieldNumber === SIGNATURE_FIELD_NUMBER)?.bytes;
+
+  if (!publicKey || !signature) {
+    return undefined;
+  }
+
+  return { keyType, publicKey, signature };
+}
+
+function readPublicKey(proof: CrxProof): KeyObject | undefined {
+  try {
+    const publicKey = createPublicKey({
+      key: Buffer.from(proof.publicKey),
+      format: "der",
+      type: "spki",
+    });
+
+    return publicKey.asymmetricKeyType === proof.keyType ? publicKey : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function verifyProof(proof: CrxProof, signedContent: Uint8Array[]) {
+  const publicKey = readPublicKey(proof);
+
+  if (!publicKey) {
+    return false;
+  }
+
+  const verifier = createVerify("sha256");
+
+  for (const part of signedContent) {
+    verifier.update(part);
+  }
+
+  return verifier.verify(publicKey, proof.signature);
+}
+
+/**
+ * Checks a CRX3 package against the id Meru pinned for the extension and hands
+ * back what installing it takes. Every failure throws, because this is a
+ * password manager's update channel: a package no signature ties to the pinned
+ * id must never reach a session.
+ *
+ * A Web Store package carries several key proofs — the publisher's key next to
+ * the developer's — and only one of them derives the pinned id. That is the
+ * proof whose signature has to verify and the key that becomes the install's
+ * `manifest.key`; trusting the first proof instead would let any key the
+ * package happens to carry vouch for it.
+ */
+export function verifyCrx(crx: Uint8Array, extensionId: string): VerifiedCrx {
+  if (crx.byteLength < CRX_PREFIX_BYTE_LENGTH) {
+    throw new Error(`CRX of ${crx.byteLength} bytes is too short to hold a header`);
+  }
+
+  const magic = new TextDecoder().decode(crx.subarray(0, CRX_MAGIC.length));
+
+  if (magic !== CRX_MAGIC) {
+    throw new Error(`CRX starts with "${magic}" instead of "${CRX_MAGIC}"`);
+  }
+
+  const formatVersion = readUint32Le(crx, 4);
+
+  if (formatVersion !== CRX_FORMAT_VERSION) {
+    throw new Error(`CRX format version ${formatVersion} is not supported`);
+  }
+
+  const headerByteLength = readUint32Le(crx, 8);
+
+  const archiveOffset = CRX_PREFIX_BYTE_LENGTH + headerByteLength;
+
+  if (archiveOffset > crx.byteLength) {
+    throw new Error(
+      `CRX header of ${headerByteLength} bytes does not fit in ${crx.byteLength} bytes`,
+    );
+  }
+
+  const headerFields = readLengthDelimitedFields(
+    crx.subarray(CRX_PREFIX_BYTE_LENGTH, archiveOffset),
+  );
+
+  const signedHeaderData = headerFields.find(
+    (field) => field.fieldNumber === SIGNED_HEADER_DATA_FIELD_NUMBER,
+  )?.bytes;
+
+  if (!signedHeaderData) {
+    throw new Error("CRX header carries no signed header data");
+  }
+
+  const crxId = readLengthDelimitedFields(signedHeaderData).find(
+    (field) => field.fieldNumber === CRX_ID_FIELD_NUMBER,
+  )?.bytes;
+
+  if (crxId?.byteLength !== EXTENSION_ID_BYTE_LENGTH) {
+    throw new Error(
+      `CRX signed header data carries a ${crxId?.byteLength ?? 0} byte id instead of ${EXTENSION_ID_BYTE_LENGTH}`,
+    );
+  }
+
+  const signedExtensionId = encodeExtensionId(crxId);
+
+  if (signedExtensionId !== extensionId) {
+    throw new Error(`CRX is signed for ${signedExtensionId} instead of ${extensionId}`);
+  }
+
+  const archive = crx.subarray(archiveOffset);
+
+  const signedContent = [
+    SIGNED_DATA_MAGIC,
+    encodeUint32Le(signedHeaderData.byteLength),
+    signedHeaderData,
+    archive,
+  ];
+
+  const proofs = headerFields
+    .map((field) => {
+      if (field.fieldNumber === SHA256_WITH_RSA_FIELD_NUMBER) {
+        return readProof(field.bytes, "rsa");
+      }
+
+      return field.fieldNumber === SHA256_WITH_ECDSA_FIELD_NUMBER
+        ? readProof(field.bytes, "ec")
+        : undefined;
+    })
+    .filter((proof) => proof !== undefined);
+
+  const pinnedProofs = proofs.filter(
+    (proof) => getExtensionIdFromPublicKey(proof.publicKey) === extensionId,
+  );
+
+  if (pinnedProofs.length === 0) {
+    throw new Error(`None of the ${proofs.length} keys in the CRX derives ${extensionId}`);
+  }
+
+  const verifiedProof = pinnedProofs.find((proof) => verifyProof(proof, signedContent));
+
+  if (!verifiedProof) {
+    throw new Error(`No signature by the key deriving ${extensionId} verifies the CRX`);
+  }
+
+  return { archive, publicKey: verifiedProof.publicKey, headerByteLength };
+}

--- a/packages/electron-extensions/crx/index.ts
+++ b/packages/electron-extensions/crx/index.ts
@@ -1,0 +1,3 @@
+export { verifyCrx } from "./crx";
+export type { VerifiedCrx } from "./crx";
+export { compareExtensionVersions } from "./version";

--- a/packages/electron-extensions/crx/protobuf.ts
+++ b/packages/electron-extensions/crx/protobuf.ts
@@ -1,0 +1,94 @@
+const WIRE_TYPE_VARINT = 0;
+
+const WIRE_TYPE_FIXED64 = 1;
+
+const WIRE_TYPE_LENGTH_DELIMITED = 2;
+
+const WIRE_TYPE_FIXED32 = 5;
+
+export type ProtobufField = {
+  fieldNumber: number;
+  bytes: Uint8Array;
+};
+
+function readVarint(message: Uint8Array, offset: number) {
+  let value = 0;
+
+  let shift = 0;
+
+  let cursor = offset;
+
+  while (cursor < message.byteLength) {
+    const byte = message[cursor] as number;
+
+    cursor += 1;
+
+    value += (byte & 0x7f) * 2 ** shift;
+
+    if ((byte & 0x80) === 0) {
+      return { value, nextOffset: cursor };
+    }
+
+    shift += 7;
+  }
+
+  throw new Error("Protobuf varint runs past the end of the message");
+}
+
+/**
+ * The length-delimited fields of a protobuf message, paired with their field
+ * numbers and in the order they were written. Fields of other wire types are
+ * skipped, since the CRX schema puts nothing this package needs in them.
+ *
+ * Everything the parse cannot account for throws instead of returning what it
+ * managed to read: a header that is not shaped like a header must never be
+ * mistaken for one carrying no proofs, which is a header nothing vouches for.
+ *
+ * Reading the few fields a CRX is made of by hand is what keeps this package
+ * free of a protobuf dependency.
+ */
+export function readLengthDelimitedFields(message: Uint8Array) {
+  const fields: ProtobufField[] = [];
+
+  let cursor = 0;
+
+  while (cursor < message.byteLength) {
+    const { value: fieldKey, nextOffset } = readVarint(message, cursor);
+
+    cursor = nextOffset;
+
+    const fieldNumber = fieldKey >>> 3;
+
+    const wireType = fieldKey & 0x7;
+
+    if (wireType === WIRE_TYPE_VARINT) {
+      cursor = readVarint(message, cursor).nextOffset;
+
+      continue;
+    }
+
+    if (wireType === WIRE_TYPE_FIXED64 || wireType === WIRE_TYPE_FIXED32) {
+      cursor += wireType === WIRE_TYPE_FIXED64 ? 8 : 4;
+
+      continue;
+    }
+
+    if (wireType !== WIRE_TYPE_LENGTH_DELIMITED) {
+      throw new Error(`Protobuf field ${fieldNumber} has unsupported wire type ${wireType}`);
+    }
+
+    const { value: fieldLength, nextOffset: afterLength } = readVarint(message, cursor);
+
+    const fieldEnd = afterLength + fieldLength;
+
+    if (fieldEnd > message.byteLength) {
+      throw new Error(`Protobuf field ${fieldNumber} runs past the end of the message`);
+    }
+
+    fields.push({ fieldNumber, bytes: message.subarray(afterLength, fieldEnd) });
+
+    cursor = fieldEnd;
+  }
+
+  return fields;
+}

--- a/packages/electron-extensions/crx/version.test.ts
+++ b/packages/electron-extensions/crx/version.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { compareExtensionVersions } from "./version";
+
+describe("compareExtensionVersions", () => {
+  test("compares component by component rather than as text", () => {
+    expect(compareExtensionVersions("2", "1.9")).toBeGreaterThan(0);
+    expect(compareExtensionVersions("1.9", "2")).toBeLessThan(0);
+    expect(compareExtensionVersions("8.12.32.33", "8.12.4.1")).toBeGreaterThan(0);
+  });
+
+  test("counts a missing component as zero", () => {
+    expect(compareExtensionVersions("1.2", "1.2.0.0")).toBe(0);
+    expect(compareExtensionVersions("1.2.0.1", "1.2")).toBeGreaterThan(0);
+  });
+
+  test("has the same version equal to itself", () => {
+    expect(compareExtensionVersions("8.12.32.33", "8.12.32.33")).toBe(0);
+  });
+
+  test("counts a component that is not a number as zero", () => {
+    expect(compareExtensionVersions("1.beta", "1.0")).toBe(0);
+    expect(compareExtensionVersions("1.beta", "1.1")).toBeLessThan(0);
+  });
+});

--- a/packages/electron-extensions/crx/version.ts
+++ b/packages/electron-extensions/crx/version.ts
@@ -1,0 +1,35 @@
+function readVersionComponent(component: string | undefined) {
+  const value = Number(component);
+
+  return Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * Chrome's order over extension versions: dot-separated numbers compared
+ * component by component, a missing component counting as zero, so `1.2` and
+ * `1.2.0` are the same version and `2` is newer than `1.9`. Negative when the
+ * first version is older, zero when they are the same, positive when it is
+ * newer.
+ *
+ * What an update check compares is a version an unpacked install carries
+ * against one the update endpoint offers, and neither is a semver range, so
+ * comparing them the way Chrome does is the whole job.
+ */
+export function compareExtensionVersions(version: string, otherVersion: string) {
+  const components = version.split(".");
+
+  const otherComponents = otherVersion.split(".");
+
+  const componentCount = Math.max(components.length, otherComponents.length);
+
+  for (let index = 0; index < componentCount; index += 1) {
+    const difference =
+      readVersionComponent(components[index]) - readVersionComponent(otherComponents[index]);
+
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+
+  return 0;
+}

--- a/packages/electron-extensions/derive/extension-id.ts
+++ b/packages/electron-extensions/derive/extension-id.ts
@@ -2,10 +2,34 @@ import { createHash } from "node:crypto";
 
 const ID_ALPHABET_OFFSET = "a".charCodeAt(0);
 
+/** An id is the first half of a sha256 digest, a character per nibble. */
+export const EXTENSION_ID_BYTE_LENGTH = 16;
+
 /**
- * The id Chromium gives an extension whose manifest carries a `key`: the first
- * 16 bytes of the key's sha256, written in the a-p alphabet extension ids use
- * instead of hexadecimal.
+ * The a-p alphabet Chromium writes extension ids in, a character per nibble of
+ * the 16 bytes an id is made of.
+ *
+ * A CRX names the extension it is signed for with those bytes rather than with
+ * the id, so the mapping is what ties a package to the id Meru pinned for it.
+ */
+export function encodeExtensionId(idBytes: Uint8Array) {
+  return Array.from(idBytes.subarray(0, EXTENSION_ID_BYTE_LENGTH), (byte) =>
+    String.fromCharCode(ID_ALPHABET_OFFSET + (byte >> 4), ID_ALPHABET_OFFSET + (byte & 0xf)),
+  ).join("");
+}
+
+/**
+ * The id Chromium gives an extension published under a key: the first 16 bytes
+ * of the key's sha256. The key is the DER SPKI public key, which is what a
+ * manifest carries base64-encoded in `key` and what a CRX carries in its
+ * signature proofs.
+ */
+export function getExtensionIdFromPublicKey(publicKey: Uint8Array) {
+  return encodeExtensionId(createHash("sha256").update(publicKey).digest());
+}
+
+/**
+ * The id Chromium gives an extension whose manifest carries a `key`.
  *
  * Knowing the id before the extension is loaded is what lets the loader address
  * the extension's own storage in a session. An extension without a `key` has no
@@ -17,9 +41,5 @@ export function getExtensionIdFromManifestKey(key: string | undefined) {
     return undefined;
   }
 
-  const digest = createHash("sha256").update(Buffer.from(key, "base64")).digest("hex").slice(0, 32);
-
-  return Array.from(digest, (digit) =>
-    String.fromCharCode(ID_ALPHABET_OFFSET + Number.parseInt(digit, 16)),
-  ).join("");
+  return getExtensionIdFromPublicKey(Buffer.from(key, "base64"));
 }

--- a/packages/electron-extensions/index.ts
+++ b/packages/electron-extensions/index.ts
@@ -1,4 +1,6 @@
 export type { ExtensionAction } from "./action";
+export { compareExtensionVersions, verifyCrx } from "./crx";
+export type { VerifiedCrx } from "./crx";
 export { Extensions } from "./extensions";
 export type { ActionsChangedListener, ExtensionsOptions } from "./extensions";
 export type { ExtensionsLogger } from "./logger";

--- a/packages/electron-extensions/package.json
+++ b/packages/electron-extensions/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "exports": {
-    ".": "./index.ts"
+    ".": "./index.ts",
+    "./crx": "./crx/index.ts"
   },
   "scripts": {
     "test": "bun test",

--- a/scripts/download-extensions.ts
+++ b/scripts/download-extensions.ts
@@ -2,16 +2,17 @@
  * Downloads the curated extensions into `extensions/` at the repository root,
  * which a development build loads into every account session.
  *
- * This is a development convenience that trusts the Chrome Web Store over TLS:
- * it does not verify the CRX signature, which is the job of the install
- * pipeline the app ships.
+ * Each package is verified against the id it is curated under before anything
+ * is unpacked, the way the install pipeline the app ships verifies it, and the
+ * CRX is kept next to the unpacked directory as a real-package test fixture.
  */
 
-import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parseArgs } from "node:util";
+// The crx entry, since the package's own entry reaches into Electron
+import { verifyCrx } from "@meru/electron-extensions/crx";
 import { unzipSync } from "fflate";
 
 type CuratedExtension = {
@@ -61,117 +62,7 @@ function buildUpdateUrl(id: string) {
   return `https://clients2.google.com/service/update2/crx?${searchParams}`;
 }
 
-function findZipOffset(crx: Buffer, headerSize: number) {
-  const zipMagic = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
-
-  const declaredOffset = 12 + headerSize;
-
-  if (crx.subarray(declaredOffset, declaredOffset + 4).equals(zipMagic)) {
-    return declaredOffset;
-  }
-
-  const scannedOffset = crx.indexOf(zipMagic, 12);
-
-  if (scannedOffset === -1) {
-    throw new Error("No zip payload found after the CRX header");
-  }
-
-  return scannedOffset;
-}
-
-function readVarint(message: Buffer, offset: number) {
-  let value = 0;
-
-  let shift = 0;
-
-  let cursor = offset;
-
-  while (cursor < message.byteLength) {
-    const byte = message[cursor] as number;
-
-    cursor += 1;
-
-    value += (byte & 0x7f) * 2 ** shift;
-
-    if ((byte & 0x80) === 0) {
-      break;
-    }
-
-    shift += 7;
-  }
-
-  return { value, nextOffset: cursor };
-}
-
-function readLengthDelimitedFields(message: Buffer) {
-  const fields: { fieldNumber: number; bytes: Buffer }[] = [];
-
-  let cursor = 0;
-
-  while (cursor < message.byteLength) {
-    const { value: fieldKey, nextOffset } = readVarint(message, cursor);
-
-    cursor = nextOffset;
-
-    const fieldNumber = fieldKey >>> 3;
-
-    const wireType = fieldKey & 0x7;
-
-    if (wireType !== 2) {
-      // Only varints appear alongside the proofs, so skipping them suffices here
-      cursor = readVarint(message, cursor).nextOffset;
-
-      continue;
-    }
-
-    const { value: fieldLength, nextOffset: afterLength } = readVarint(message, cursor);
-
-    fields.push({ fieldNumber, bytes: message.subarray(afterLength, afterLength + fieldLength) });
-
-    cursor = afterLength + fieldLength;
-  }
-
-  return fields;
-}
-
-function deriveExtensionId(publicKey: Buffer) {
-  const digest = createHash("sha256").update(publicKey).digest().subarray(0, 16);
-
-  let id = "";
-
-  for (const byte of digest) {
-    id += String.fromCharCode(97 + (byte >> 4));
-
-    id += String.fromCharCode(97 + (byte & 0xf));
-  }
-
-  return id;
-}
-
-/**
- * The publishing key of an extension, which a Web Store package carries next to
- * the developer's key. Only one of the proofs derives the id the extension is
- * known by, and the manifest needs that one: an unpacked extension without a
- * `key` loads under an id derived from its directory path, and everything keyed
- * to its real id — native messaging `allowed_origins` above all — stops
- * matching.
- */
-function findPublicKey(crxHeader: Buffer, id: string) {
-  const publicKeys = readLengthDelimitedFields(crxHeader)
-    .filter((field) => field.fieldNumber === 2 || field.fieldNumber === 3)
-    .map((proof) => readLengthDelimitedFields(proof.bytes)[0]?.bytes)
-    .filter((publicKey) => publicKey !== undefined);
-
-  const publicKey = publicKeys.find((candidateKey) => deriveExtensionId(candidateKey) === id);
-
-  if (!publicKey) {
-    throw new Error(`None of the ${publicKeys.length} keys in the CRX derives ${id}`);
-  }
-
-  return publicKey;
-}
-
-async function unpackZip(zip: Buffer, targetDir: string) {
+async function unpackZip(zip: Uint8Array, targetDir: string) {
   for (const [fileName, contents] of Object.entries(unzipSync(zip))) {
     if (fileName.endsWith("/")) {
       continue;
@@ -194,11 +85,12 @@ async function downloadExtension({ name, id }: CuratedExtension) {
 
   const crx = Buffer.from(await response.arrayBuffer());
 
-  if (crx.subarray(0, 4).toString("ascii") !== "Cr24") {
-    throw new Error(`${response.url} did not answer with a CRX`);
-  }
+  const { archive, publicKey } = verifyCrx(crx, id);
 
-  const headerSize = crx.readUInt32LE(8);
+  await mkdir(extensionsDir, { recursive: true });
+
+  // Kept as a fixture the verifier can be tested against a real package with
+  await writeFile(path.join(extensionsDir, `${name}.crx`), crx);
 
   const extensionDir = path.join(extensionsDir, name);
 
@@ -206,7 +98,7 @@ async function downloadExtension({ name, id }: CuratedExtension) {
 
   await rm(stagingDir, { recursive: true, force: true });
 
-  await unpackZip(crx.subarray(findZipOffset(crx, headerSize)), stagingDir);
+  await unpackZip(archive, stagingDir);
 
   const manifestPath = path.join(stagingDir, MANIFEST_FILE_NAME);
 
@@ -215,7 +107,10 @@ async function downloadExtension({ name, id }: CuratedExtension) {
     key: string;
   };
 
-  manifest.key = findPublicKey(crx.subarray(12, 12 + headerSize), id).toString("base64");
+  // An unpacked extension without a `key` loads under an id derived from its
+  // directory path, and everything keyed to its real id — native messaging
+  // `allowed_origins` above all — stops matching
+  manifest.key = Buffer.from(publicKey).toString("base64");
 
   await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 


### PR DESCRIPTION
- New `crx/` module in `@meru/electron-extensions`: fail-closed CRX3 verification (`verifyCrx`) — protobuf header parse, pinned-id anchoring via the signed `crx_id`, proof selection by derived id (never the first proof; the real 1Password package carries three keys and the pinned one is second), signature check over `"CRX3 SignedData\0" + header + archive`, plus a key-type cross-check so an RSA key in the ecdsa field can't vouch. Also `compareExtensionVersions` for the coming updater.
- `derive/extension-id.ts` refactored to share the id derivation (`encodeExtensionId`, `getExtensionIdFromPublicKey`).
- `scripts/download-extensions.ts` now verifies before unpacking (previously TLS-trust only), takes `manifest.key` from the verified proof, keeps the raw CRX at `extensions/<name>.crx` as a real-package test fixture, and drops its ~110 lines of private parsing.
- New Electron-free `./crx` subpath export so the Bun script can import without pulling in `electron`.

Synthetic-fixture tests cover tamper/wrong-id/truncation/stripped-signature/second-proof cases; a real-package test runs when `extensions/1password.crx` exists (skips in CI). Verified live: `bun run extensions:download --force` fetched and verified 1Password 8.12.32.33.

Test plan:
1. `bun run extensions:download --force` — prints the unpacked version, leaves `extensions/1password.crx` (~18 MB), and the unpacked extension still loads in `bun run dev`.
2. `bun test packages/electron-extensions` — the 1Password fixture test runs (not skipped) once the CRX exists.