### PR TITLE
install and update extensions from verified crx packages

### DIFF
--- a/packages/electron-extensions/crx/crx-fixture.ts
+++ b/packages/electron-extensions/crx/crx-fixture.ts
@@ -1,0 +1,141 @@
+/**
+ * Builds CRX3 packages the way the Web Store does, for tests that need a
+ * package no real signing key is around for. Shared by the verifier's tests and
+ * the installer's, since both need packages signed for a known id and only the
+ * signing key that produced them can make one.
+ */
+
+import { createHash, createSign, generateKeyPairSync, type KeyPairSyncResult } from "node:crypto";
+import { zipSync } from "fflate";
+import { EXTENSION_ID_BYTE_LENGTH, getExtensionIdFromPublicKey } from "../derive/extension-id";
+
+const SHA256_WITH_RSA_FIELD_NUMBER = 2;
+
+const SIGNED_HEADER_DATA_FIELD_NUMBER = 10000;
+
+const PUBLIC_KEY_FIELD_NUMBER = 1;
+
+const SIGNATURE_FIELD_NUMBER = 2;
+
+const CRX_ID_FIELD_NUMBER = 1;
+
+export const ARCHIVE_FILES = {
+  "manifest.json": new TextEncoder().encode('{"name":"Extension"}\n'),
+};
+
+type KeyPair = KeyPairSyncResult<Buffer, Buffer>;
+
+function createKeyPair(): KeyPair {
+  return generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: "spki", format: "der" },
+    privateKeyEncoding: { type: "pkcs8", format: "der" },
+  });
+}
+
+/** The key a package is signed with unless a test asks for another one. */
+export const signingKeyPair = createKeyPair();
+
+export const otherKeyPair = createKeyPair();
+
+/** The id the signing key derives, which packages are signed for by default. */
+export const extensionId = getExtensionIdFromPublicKey(signingKeyPair.publicKey);
+
+/** The form a key is compared in here, which is the form a manifest carries. */
+export function toBase64(key: Uint8Array) {
+  return Buffer.from(key).toString("base64");
+}
+
+function encodeVarint(value: number) {
+  const bytes: number[] = [];
+
+  let remaining = value;
+
+  do {
+    const byte = remaining % 0x80;
+
+    remaining = Math.floor(remaining / 0x80);
+
+    bytes.push(remaining > 0 ? byte | 0x80 : byte);
+  } while (remaining > 0);
+
+  return Buffer.from(bytes);
+}
+
+function encodeField(fieldNumber: number, bytes: Uint8Array) {
+  return Buffer.concat([
+    encodeVarint(fieldNumber * 8 + 2),
+    encodeVarint(bytes.byteLength),
+    Buffer.from(bytes),
+  ]);
+}
+
+function encodeUint32Le(value: number) {
+  const bytes = Buffer.alloc(4);
+
+  bytes.writeUInt32LE(value);
+
+  return bytes;
+}
+
+function sign(privateKey: Buffer, signedContent: Buffer) {
+  return createSign("sha256")
+    .update(signedContent)
+    .sign({ key: privateKey, format: "der", type: "pkcs8" });
+}
+
+export type CrxOptions = {
+  /** Every key the header carries a proof for, each signing with its own key. */
+  keyPairs?: KeyPair[];
+  /** The id the header is signed for, by default the signing key's. */
+  crxId?: Buffer;
+  archive?: Buffer;
+  formatVersion?: number;
+  omitSignature?: boolean;
+};
+
+export function createCrx({
+  keyPairs = [signingKeyPair],
+  crxId = createHash("sha256")
+    .update(signingKeyPair.publicKey)
+    .digest()
+    .subarray(0, EXTENSION_ID_BYTE_LENGTH),
+  archive = Buffer.from(zipSync(ARCHIVE_FILES)),
+  formatVersion = 3,
+  omitSignature = false,
+}: CrxOptions = {}) {
+  const signedHeaderData = encodeField(CRX_ID_FIELD_NUMBER, crxId);
+
+  const signedContent = Buffer.concat([
+    Buffer.from("CRX3 SignedData", "utf8"),
+    Buffer.from([0]),
+    encodeUint32Le(signedHeaderData.byteLength),
+    signedHeaderData,
+    archive,
+  ]);
+
+  const proofs = keyPairs.map((keyPair) =>
+    encodeField(
+      SHA256_WITH_RSA_FIELD_NUMBER,
+      Buffer.concat([
+        encodeField(PUBLIC_KEY_FIELD_NUMBER, keyPair.publicKey),
+        ...(omitSignature
+          ? []
+          : [encodeField(SIGNATURE_FIELD_NUMBER, sign(keyPair.privateKey, signedContent))]),
+      ]),
+    ),
+  );
+
+  const header = Buffer.concat([
+    ...proofs,
+    encodeField(SIGNED_HEADER_DATA_FIELD_NUMBER, signedHeaderData),
+  ]);
+
+  return Buffer.concat([
+    Buffer.from("Cr24", "ascii"),
+    encodeUint32Le(formatVersion),
+    encodeUint32Le(header.byteLength),
+    header,
+    archive,
+  ]);
+}

--- a/packages/electron-extensions/crx/crx.test.ts
+++ b/packages/electron-extensions/crx/crx.test.ts
@@ -1,137 +1,17 @@
 import { describe, expect, test } from "bun:test";
-import { createHash, createSign, generateKeyPairSync, type KeyPairSyncResult } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { unzipSync, zipSync } from "fflate";
-import { EXTENSION_ID_BYTE_LENGTH, getExtensionIdFromPublicKey } from "../derive/extension-id";
+import { getExtensionIdFromPublicKey } from "../derive/extension-id";
 import { verifyCrx } from "./crx";
-
-const SHA256_WITH_RSA_FIELD_NUMBER = 2;
-
-const SIGNED_HEADER_DATA_FIELD_NUMBER = 10000;
-
-const PUBLIC_KEY_FIELD_NUMBER = 1;
-
-const SIGNATURE_FIELD_NUMBER = 2;
-
-const CRX_ID_FIELD_NUMBER = 1;
-
-const ARCHIVE_FILES = { "manifest.json": new TextEncoder().encode('{"name":"Extension"}\n') };
-
-type KeyPair = KeyPairSyncResult<Buffer, Buffer>;
-
-function createKeyPair(): KeyPair {
-  return generateKeyPairSync("rsa", {
-    modulusLength: 2048,
-    publicKeyEncoding: { type: "spki", format: "der" },
-    privateKeyEncoding: { type: "pkcs8", format: "der" },
-  });
-}
-
-const signingKeyPair = createKeyPair();
-
-const otherKeyPair = createKeyPair();
-
-const extensionId = getExtensionIdFromPublicKey(signingKeyPair.publicKey);
-
-/** The form a key is compared in here, which is the form a manifest carries. */
-function toBase64(key: Uint8Array) {
-  return Buffer.from(key).toString("base64");
-}
-
-function encodeVarint(value: number) {
-  const bytes: number[] = [];
-
-  let remaining = value;
-
-  do {
-    const byte = remaining % 0x80;
-
-    remaining = Math.floor(remaining / 0x80);
-
-    bytes.push(remaining > 0 ? byte | 0x80 : byte);
-  } while (remaining > 0);
-
-  return Buffer.from(bytes);
-}
-
-function encodeField(fieldNumber: number, bytes: Uint8Array) {
-  return Buffer.concat([
-    encodeVarint(fieldNumber * 8 + 2),
-    encodeVarint(bytes.byteLength),
-    Buffer.from(bytes),
-  ]);
-}
-
-function encodeUint32Le(value: number) {
-  const bytes = Buffer.alloc(4);
-
-  bytes.writeUInt32LE(value);
-
-  return bytes;
-}
-
-function sign(privateKey: Buffer, signedContent: Buffer) {
-  return createSign("sha256")
-    .update(signedContent)
-    .sign({ key: privateKey, format: "der", type: "pkcs8" });
-}
-
-type CrxOptions = {
-  /** Every key the header carries a proof for, each signing with its own key. */
-  keyPairs?: KeyPair[];
-  /** The id the header is signed for, by default the signing key's. */
-  crxId?: Buffer;
-  archive?: Buffer;
-  formatVersion?: number;
-  omitSignature?: boolean;
-};
-
-function createCrx({
-  keyPairs = [signingKeyPair],
-  crxId = createHash("sha256")
-    .update(signingKeyPair.publicKey)
-    .digest()
-    .subarray(0, EXTENSION_ID_BYTE_LENGTH),
-  archive = Buffer.from(zipSync(ARCHIVE_FILES)),
-  formatVersion = 3,
-  omitSignature = false,
-}: CrxOptions = {}) {
-  const signedHeaderData = encodeField(CRX_ID_FIELD_NUMBER, crxId);
-
-  const signedContent = Buffer.concat([
-    Buffer.from("CRX3 SignedData", "utf8"),
-    Buffer.from([0]),
-    encodeUint32Le(signedHeaderData.byteLength),
-    signedHeaderData,
-    archive,
-  ]);
-
-  const proofs = keyPairs.map((keyPair) =>
-    encodeField(
-      SHA256_WITH_RSA_FIELD_NUMBER,
-      Buffer.concat([
-        encodeField(PUBLIC_KEY_FIELD_NUMBER, keyPair.publicKey),
-        ...(omitSignature
-          ? []
-          : [encodeField(SIGNATURE_FIELD_NUMBER, sign(keyPair.privateKey, signedContent))]),
-      ]),
-    ),
-  );
-
-  const header = Buffer.concat([
-    ...proofs,
-    encodeField(SIGNED_HEADER_DATA_FIELD_NUMBER, signedHeaderData),
-  ]);
-
-  return Buffer.concat([
-    Buffer.from("Cr24", "ascii"),
-    encodeUint32Le(formatVersion),
-    encodeUint32Le(header.byteLength),
-    header,
-    archive,
-  ]);
-}
+import {
+  ARCHIVE_FILES,
+  createCrx,
+  extensionId,
+  otherKeyPair,
+  signingKeyPair,
+  toBase64,
+} from "./crx-fixture";
 
 describe("verifyCrx", () => {
   test("returns the archive of a package signed for the pinned id", () => {

--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, readdir, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { deriveExtension } from "./index";
+import { deriveExtension, pruneDerivedExtensions } from "./index";
 
 let workDir: string;
 
@@ -259,5 +259,61 @@ describe("deriveExtension", () => {
     const page = await readFile(path.join(derivedDir, "popup.html"), "utf8");
 
     expect(page.split('<script src="/chrome-facade.js"></script>')).toHaveLength(2);
+  });
+});
+
+describe("pruneDerivedExtensions", () => {
+  async function deriveOtherExtension() {
+    const otherSourceDir = path.join(workDir, "other-source");
+
+    await mkdir(otherSourceDir, { recursive: true });
+
+    await writeFile(path.join(otherSourceDir, "manifest.json"), JSON.stringify(manifest));
+
+    const { derivedDir } = await deriveExtension({
+      sourceDir: otherSourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+    });
+
+    return { otherSourceDir, otherDerivedDir: derivedDir };
+  }
+
+  test("keeps the copies of the sources it was handed and drops the rest", async () => {
+    const derivedDir = await derive();
+
+    const { otherSourceDir, otherDerivedDir } = await deriveOtherExtension();
+
+    await pruneDerivedExtensions({ derivedExtensionsDir, keptSourceDirs: [otherSourceDir] });
+
+    expect((await readdir(derivedExtensionsDir)).sort()).toEqual([
+      path.basename(otherDerivedDir),
+      `${path.basename(otherDerivedDir)}.json`,
+    ]);
+
+    expect(await readFile(path.join(otherDerivedDir, "manifest.json"), "utf8")).toContain(
+      "chrome-facade-service-worker.js",
+    );
+
+    await deriveExtension({ sourceDir, derivedExtensionsDir, facadeScriptPath });
+
+    expect(await readdir(derivedDir)).toContain("manifest.json");
+  });
+
+  test("drops a copy no stamp accounts for", async () => {
+    const derivedDir = await derive();
+
+    await rm(`${derivedDir}.json`);
+
+    await pruneDerivedExtensions({ derivedExtensionsDir, keptSourceDirs: [sourceDir] });
+
+    expect(await readdir(derivedExtensionsDir)).toEqual([]);
+  });
+
+  test("does nothing when nothing was derived yet", async () => {
+    await pruneDerivedExtensions({
+      derivedExtensionsDir: path.join(workDir, "missing"),
+      keptSourceDirs: [],
+    });
   });
 });

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -11,6 +11,9 @@ import { deriveManifest, type ExtensionManifest } from "./manifest";
 
 const MANIFEST_FILE_NAME = "manifest.json";
 
+/** What the stamp next to a derived copy is called: `<derivedDir>.json`. */
+const STAMP_FILE_EXTENSION = ".json";
+
 const FACADE_FILE_NAME = "chrome-facade.js";
 
 const SERVICE_WORKER_FILE_NAME = "chrome-facade-service-worker.js";
@@ -111,7 +114,7 @@ export async function deriveExtension({
 
   const derivedDir = path.join(derivedExtensionsDir, hash(sourceDir).slice(0, 16));
 
-  const stampPath = `${derivedDir}.json`;
+  const stampPath = `${derivedDir}${STAMP_FILE_EXTENSION}`;
 
   // The source is copied again when any of its files changes, which is what an
   // installed extension moving to a new version does and what a developer
@@ -165,4 +168,75 @@ export async function deriveExtension({
     bridgeToken,
     extensionId: getExtensionIdFromManifestKey(sourceManifest.key),
   };
+}
+
+export type PruneDerivedExtensionsOptions = {
+  derivedExtensionsDir: string;
+  /**
+   * The source directories still being loaded. A copy derived from anything
+   * else is gone for good, since nothing but the source it names can recreate
+   * it.
+   */
+  keptSourceDirs: string[];
+};
+
+async function readStampSourceDir(stampPath: string) {
+  const stamp = await readStamp(stampPath);
+
+  if (!stamp) {
+    return undefined;
+  }
+
+  try {
+    return (JSON.parse(stamp) as { sourceDir?: string }).sourceDir;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Drops the derived copies of extensions the embedder no longer loads: the
+ * version directory an update replaced, an extension the user opted out of, a
+ * development extension whose folder is gone. Nothing points back from a copy
+ * to its source but its stamp, so a copy without one is unaccounted for and
+ * goes too.
+ *
+ * Meant to run once the embedder knows its load list, which is also why it is
+ * safe to delete: a copy still in use belongs to a source that is on the list.
+ */
+export async function pruneDerivedExtensions({
+  derivedExtensionsDir,
+  keptSourceDirs,
+}: PruneDerivedExtensionsOptions) {
+  let entryNames: string[];
+
+  try {
+    entryNames = await readdir(derivedExtensionsDir);
+  } catch {
+    return;
+  }
+
+  const derivedDirNames = new Set(
+    entryNames.map((entryName) =>
+      entryName.endsWith(STAMP_FILE_EXTENSION)
+        ? entryName.slice(0, -STAMP_FILE_EXTENSION.length)
+        : entryName,
+    ),
+  );
+
+  for (const derivedDirName of derivedDirNames) {
+    const derivedDir = path.join(derivedExtensionsDir, derivedDirName);
+
+    const stampPath = `${derivedDir}${STAMP_FILE_EXTENSION}`;
+
+    const sourceDir = await readStampSourceDir(stampPath);
+
+    if (sourceDir !== undefined && keptSourceDirs.includes(sourceDir)) {
+      continue;
+    }
+
+    await rm(derivedDir, { recursive: true, force: true });
+
+    await rm(stampPath, { force: true });
+  }
 }

--- a/packages/electron-extensions/index.ts
+++ b/packages/electron-extensions/index.ts
@@ -1,8 +1,28 @@
 export type { ExtensionAction } from "./action";
 export { compareExtensionVersions, verifyCrx } from "./crx";
 export type { VerifiedCrx } from "./crx";
+export { pruneDerivedExtensions } from "./derive";
+export type { PruneDerivedExtensionsOptions } from "./derive";
 export { Extensions } from "./extensions";
 export type { ActionsChangedListener, ExtensionsOptions } from "./extensions";
+export {
+  buildCrxDownloadUrl,
+  fetchCrx,
+  getInstalledExtension,
+  installExtension,
+  installLatestExtension,
+  uninstallExtension,
+} from "./install";
+export type {
+  CrxDownloadOptions,
+  FetchCrxOptions,
+  FetchImplementation,
+  InstalledExtension,
+  InstalledExtensionOptions,
+  InstallExtensionOptions,
+  InstallLatestExtensionOptions,
+  LatestExtensionInstall,
+} from "./install";
 export type { ExtensionsLogger } from "./logger";
 export type { NativeMessagingHostPolicy } from "./native-messaging/native-messaging";
 export { registerNativeMessagingScheme } from "./native-messaging/scheme";

--- a/packages/electron-extensions/install/index.ts
+++ b/packages/electron-extensions/install/index.ts
@@ -1,0 +1,15 @@
+export {
+  getInstalledExtension,
+  installExtension,
+  installLatestExtension,
+  uninstallExtension,
+} from "./installer";
+export type {
+  InstalledExtension,
+  InstalledExtensionOptions,
+  InstallExtensionOptions,
+  InstallLatestExtensionOptions,
+  LatestExtensionInstall,
+} from "./installer";
+export { buildCrxDownloadUrl, fetchCrx } from "./omaha";
+export type { CrxDownloadOptions, FetchCrxOptions, FetchImplementation } from "./omaha";

--- a/packages/electron-extensions/install/installer.test.ts
+++ b/packages/electron-extensions/install/installer.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { zipSync } from "fflate";
+import { createCrx, extensionId, signingKeyPair, toBase64 } from "../crx/crx-fixture";
+import { getExtensionIdFromManifestKey } from "../derive/extension-id";
+import {
+  getInstalledExtension,
+  installExtension,
+  installLatestExtension,
+  uninstallExtension,
+} from "./index";
+import type { FetchImplementation } from "./omaha";
+
+const chromeVersion = "146.0.0.0";
+
+let installDir: string;
+
+let extensionInstallDir: string;
+
+function encode(contents: string) {
+  return new TextEncoder().encode(contents);
+}
+
+/** A package the way the Web Store serves one, hashes and all. */
+function createExtensionCrx(version: string) {
+  return createCrx({
+    archive: Buffer.from(
+      zipSync({
+        "manifest.json": encode(JSON.stringify({ name: "Test Extension", version })),
+        "background/background.js": encode("// background\n"),
+        "_metadata/verified_contents.json": encode("[]"),
+      }),
+    ),
+  });
+}
+
+function createFetch(crx: Uint8Array): FetchImplementation {
+  return async () => new Response(crx);
+}
+
+async function readEntryNames(dirPath: string) {
+  try {
+    return (await readdir(dirPath, { recursive: true })).sort();
+  } catch {
+    return [];
+  }
+}
+
+beforeEach(async () => {
+  installDir = await mkdtemp(path.join(tmpdir(), "electron-extensions-"));
+
+  extensionInstallDir = path.join(installDir, extensionId);
+});
+
+afterEach(async () => {
+  await rm(installDir, { recursive: true, force: true });
+});
+
+describe("installExtension", () => {
+  test("unpacks a verified package under its version", async () => {
+    const { version, extensionDir } = await installExtension({
+      crx: createExtensionCrx("1.2.3"),
+      extensionId,
+      installDir,
+    });
+
+    expect(version).toBe("1.2.3");
+    expect(extensionDir).toBe(path.join(extensionInstallDir, "1.2.3"));
+
+    expect(await readEntryNames(extensionInstallDir)).toEqual([
+      "1.2.3",
+      path.join("1.2.3", "background"),
+      path.join("1.2.3", "background", "background.js"),
+      path.join("1.2.3", "manifest.json"),
+    ]);
+
+    expect(await readFile(path.join(extensionDir, "background", "background.js"), "utf8")).toBe(
+      "// background\n",
+    );
+  });
+
+  test("injects the key the package was signed with, so it loads under the pinned id", async () => {
+    const { extensionDir } = await installExtension({
+      crx: createExtensionCrx("1.2.3"),
+      extensionId,
+      installDir,
+    });
+
+    const manifest = JSON.parse(await readFile(path.join(extensionDir, "manifest.json"), "utf8"));
+
+    expect(manifest.key).toBe(toBase64(signingKeyPair.publicKey));
+    expect(getExtensionIdFromManifestKey(manifest.key)).toBe(extensionId);
+    expect(manifest.name).toBe("Test Extension");
+  });
+
+  test("leaves nothing behind when the package does not verify", async () => {
+    const crx = createExtensionCrx("1.2.3");
+
+    const tamperedByteOffset = crx.byteLength - 8;
+
+    crx[tamperedByteOffset] = (crx[tamperedByteOffset] as number) ^ 0xff;
+
+    await expect(installExtension({ crx, extensionId, installDir })).rejects.toThrow(
+      `No signature by the key deriving ${extensionId} verifies the CRX`,
+    );
+
+    expect(await readEntryNames(extensionInstallDir)).toEqual([]);
+  });
+});
+
+describe("getInstalledExtension", () => {
+  async function writeVersionDir(dirName: string) {
+    await mkdir(path.join(extensionInstallDir, dirName), { recursive: true });
+
+    await writeFile(path.join(extensionInstallDir, dirName, "manifest.json"), "{}");
+  }
+
+  test("reports nothing when the extension is not installed", async () => {
+    expect(await getInstalledExtension({ installDir, extensionId })).toBeUndefined();
+  });
+
+  test("reports the newest version, counting components as numbers", async () => {
+    await writeVersionDir("1.9.0");
+
+    await writeVersionDir("1.10.0");
+
+    await writeVersionDir("1.2.0");
+
+    expect(await getInstalledExtension({ installDir, extensionId })).toEqual({
+      version: "1.10.0",
+      extensionDir: path.join(extensionInstallDir, "1.10.0"),
+    });
+  });
+
+  test("passes over an interrupted install and a directory without a manifest", async () => {
+    await writeVersionDir("1.0.0");
+
+    await writeVersionDir("2.0.0.staging");
+
+    await mkdir(path.join(extensionInstallDir, "3.0.0"));
+
+    expect(await getInstalledExtension({ installDir, extensionId })).toEqual({
+      version: "1.0.0",
+      extensionDir: path.join(extensionInstallDir, "1.0.0"),
+    });
+  });
+});
+
+describe("installLatestExtension", () => {
+  test("installs when nothing is installed yet", async () => {
+    const latestExtension = await installLatestExtension({
+      extensionId,
+      installDir,
+      chromeVersion,
+      fetch: createFetch(createExtensionCrx("1.0.0")),
+    });
+
+    expect(latestExtension).toEqual({
+      updated: true,
+      version: "1.0.0",
+      extensionDir: path.join(extensionInstallDir, "1.0.0"),
+    });
+  });
+
+  test("writes nothing when the served version is already installed", async () => {
+    const crx = createExtensionCrx("1.0.0");
+
+    const { extensionDir } = await installExtension({ crx, extensionId, installDir });
+
+    await writeFile(path.join(extensionDir, "untouched"), "kept");
+
+    const latestExtension = await installLatestExtension({
+      extensionId,
+      installDir,
+      chromeVersion,
+      fetch: createFetch(crx),
+    });
+
+    expect(latestExtension).toEqual({ updated: false, version: "1.0.0", extensionDir });
+    expect(await readFile(path.join(extensionDir, "untouched"), "utf8")).toBe("kept");
+  });
+
+  test("installs a newer version and drops the one it replaces", async () => {
+    await installExtension({ crx: createExtensionCrx("1.0.0"), extensionId, installDir });
+
+    const latestExtension = await installLatestExtension({
+      extensionId,
+      installDir,
+      chromeVersion,
+      fetch: createFetch(createExtensionCrx("2.0.0")),
+    });
+
+    expect(latestExtension.updated).toBe(true);
+    expect(latestExtension.version).toBe("2.0.0");
+    expect(await readdir(extensionInstallDir)).toEqual(["2.0.0"]);
+  });
+});
+
+describe("uninstallExtension", () => {
+  test("drops every version of the extension", async () => {
+    await installExtension({ crx: createExtensionCrx("1.0.0"), extensionId, installDir });
+
+    await installExtension({ crx: createExtensionCrx("2.0.0"), extensionId, installDir });
+
+    await uninstallExtension({ installDir, extensionId });
+
+    expect(await readEntryNames(extensionInstallDir)).toEqual([]);
+    expect(await getInstalledExtension({ installDir, extensionId })).toBeUndefined();
+  });
+});

--- a/packages/electron-extensions/install/installer.ts
+++ b/packages/electron-extensions/install/installer.ts
@@ -1,0 +1,277 @@
+import { access, mkdir, readdir, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { unzipSync } from "fflate";
+import { verifyCrx } from "../crx/crx";
+import { compareExtensionVersions } from "../crx/version";
+import { type FetchImplementation, fetchCrx } from "./omaha";
+
+const MANIFEST_FILE_NAME = "manifest.json";
+
+/** Web Store content verification hashes, stale the moment a key is injected. */
+const METADATA_DIR_NAME = "_metadata";
+
+/**
+ * What a version directory is called until it is complete. A crashed install
+ * leaves one behind, and it must never be mistaken for an installed version.
+ */
+const STAGING_DIR_SUFFIX = ".staging";
+
+export type InstalledExtension = {
+  version: string;
+  /** The unpacked directory, what an embedder hands to the loader. */
+  extensionDir: string;
+};
+
+type ExtensionManifest = {
+  version: string;
+  key?: string;
+};
+
+type ExtensionPackage = {
+  /** Every file the install writes, the manifest already carrying its key. */
+  files: Record<string, Uint8Array>;
+  manifest: ExtensionManifest;
+};
+
+/**
+ * Turns CRX bytes into the files an install writes, refusing everything a
+ * verification failure refuses.
+ *
+ * The archive is unpacked in memory because the version an update check
+ * compares lives in the manifest inside it, and a package that turns out to be
+ * one an install already has must not have touched the disk.
+ */
+function readCrxPackage(crx: Uint8Array, extensionId: string): ExtensionPackage {
+  const { archive, publicKey } = verifyCrx(crx, extensionId);
+
+  const files = unzipSync(archive, {
+    filter: ({ name }) => !name.endsWith("/") && name.split("/")[0] !== METADATA_DIR_NAME,
+  });
+
+  const manifestSource = files[MANIFEST_FILE_NAME];
+
+  if (!manifestSource) {
+    throw new Error(`CRX for ${extensionId} carries no ${MANIFEST_FILE_NAME}`);
+  }
+
+  const manifest = JSON.parse(new TextDecoder().decode(manifestSource)) as ExtensionManifest;
+
+  if (typeof manifest.version !== "string") {
+    throw new Error(`CRX for ${extensionId} carries a manifest without a version`);
+  }
+
+  // An unpacked extension without a `key` loads under an id derived from its
+  // directory path, and everything keyed to its real id — native messaging
+  // `allowed_origins` above all — stops matching
+  manifest.key = Buffer.from(publicKey).toString("base64");
+
+  files[MANIFEST_FILE_NAME] = new TextEncoder().encode(`${JSON.stringify(manifest, null, 2)}\n`);
+
+  return { files, manifest };
+}
+
+async function writeExtensionPackage({ files }: ExtensionPackage, targetDir: string) {
+  for (const [fileName, contents] of Object.entries(files)) {
+    const filePath = path.join(targetDir, fileName);
+
+    if (!filePath.startsWith(`${targetDir}${path.sep}`)) {
+      throw new Error(`CRX carries "${fileName}", which unpacks outside the install directory`);
+    }
+
+    await mkdir(path.dirname(filePath), { recursive: true });
+
+    await writeFile(filePath, contents);
+  }
+}
+
+/**
+ * Unpacks into a staging directory and moves it into place in one step, so a
+ * failure or a crash halfway through leaves the version directory either
+ * complete or absent, never half written.
+ */
+async function installExtensionPackage(
+  extensionPackage: ExtensionPackage,
+  { extensionId, installDir }: { extensionId: string; installDir: string },
+): Promise<InstalledExtension> {
+  const { version } = extensionPackage.manifest;
+
+  const extensionDir = path.join(installDir, extensionId, version);
+
+  const stagingDir = `${extensionDir}${STAGING_DIR_SUFFIX}`;
+
+  await rm(stagingDir, { recursive: true, force: true });
+
+  try {
+    await writeExtensionPackage(extensionPackage, stagingDir);
+
+    await rm(extensionDir, { recursive: true, force: true });
+
+    await rename(stagingDir, extensionDir);
+  } catch (error) {
+    await rm(stagingDir, { recursive: true, force: true });
+
+    throw error;
+  }
+
+  return { version, extensionDir };
+}
+
+export type InstallExtensionOptions = {
+  crx: Uint8Array;
+  /** The id Meru pinned for the extension, which the package has to be signed for. */
+  extensionId: string;
+  /** The directory installs live under, `<installDir>/<extensionId>/<version>`. */
+  installDir: string;
+};
+
+/**
+ * Installs a package that is already in hand — the download script's path, and
+ * what `installLatestExtension` does once it has fetched.
+ *
+ * Versions are kept side by side under the id so an install never writes into
+ * the directory a running session loaded, and the manifest's own version names
+ * the directory so an update check can read what is installed off the disk.
+ */
+export async function installExtension({ crx, extensionId, installDir }: InstallExtensionOptions) {
+  return installExtensionPackage(readCrxPackage(crx, extensionId), { extensionId, installDir });
+}
+
+export type InstalledExtensionOptions = {
+  installDir: string;
+  extensionId: string;
+};
+
+async function isUnpackedExtensionDir(dirPath: string) {
+  try {
+    await access(path.join(dirPath, MANIFEST_FILE_NAME));
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readInstalledVersions(extensionInstallDir: string) {
+  let entryNames: string[];
+
+  try {
+    entryNames = await readdir(extensionInstallDir);
+  } catch {
+    return [];
+  }
+
+  const versions: string[] = [];
+
+  for (const entryName of entryNames) {
+    if (entryName.endsWith(STAGING_DIR_SUFFIX)) {
+      continue;
+    }
+
+    if (await isUnpackedExtensionDir(path.join(extensionInstallDir, entryName))) {
+      versions.push(entryName);
+    }
+  }
+
+  return versions;
+}
+
+/**
+ * The newest version installed for an extension, or nothing when it is not
+ * installed. This is what an embedder builds its load list from at startup: the
+ * disk is the record of what is installed, config only says what the user
+ * opted into.
+ *
+ * A directory counts as a version when it holds a manifest, so an install
+ * interrupted before its staging directory was moved into place is passed over
+ * rather than loaded.
+ */
+export async function getInstalledExtension({
+  installDir,
+  extensionId,
+}: InstalledExtensionOptions): Promise<InstalledExtension | undefined> {
+  const extensionInstallDir = path.join(installDir, extensionId);
+
+  const [version] = (await readInstalledVersions(extensionInstallDir)).sort(
+    (version, otherVersion) => compareExtensionVersions(otherVersion, version),
+  );
+
+  if (!version) {
+    return undefined;
+  }
+
+  return { version, extensionDir: path.join(extensionInstallDir, version) };
+}
+
+/**
+ * Everything under the id except the version just installed: older versions,
+ * and staging directories a crashed install left behind.
+ *
+ * Dropping an older version out from under a running session is safe because
+ * sessions load a derived copy of an extension, never the install itself.
+ */
+async function pruneOtherVersions(extensionInstallDir: string, keptVersion: string) {
+  const entryNames = await readdir(extensionInstallDir);
+
+  for (const entryName of entryNames) {
+    if (entryName !== keptVersion) {
+      await rm(path.join(extensionInstallDir, entryName), { recursive: true, force: true });
+    }
+  }
+}
+
+export type InstallLatestExtensionOptions = InstalledExtensionOptions & {
+  chromeVersion: string;
+  fetch?: FetchImplementation;
+};
+
+export type LatestExtensionInstall = InstalledExtension & {
+  /** False when the version already installed is the one the endpoint serves. */
+  updated: boolean;
+};
+
+/**
+ * Brings an extension to the version the update endpoint serves, which is both
+ * how it is installed the first time and how it is kept up to date — a first
+ * install is the case where nothing is installed yet.
+ *
+ * Nothing is written when the installed version is the served one or newer, so
+ * a periodic check costs a download and a signature check and leaves the disk
+ * alone.
+ */
+export async function installLatestExtension({
+  extensionId,
+  installDir,
+  chromeVersion,
+  fetch,
+}: InstallLatestExtensionOptions): Promise<LatestExtensionInstall> {
+  const crx = await fetchCrx({ extensionId, chromeVersion, fetch });
+
+  const extensionPackage = readCrxPackage(crx, extensionId);
+
+  const installedExtension = await getInstalledExtension({ installDir, extensionId });
+
+  if (
+    installedExtension &&
+    compareExtensionVersions(installedExtension.version, extensionPackage.manifest.version) >= 0
+  ) {
+    return { ...installedExtension, updated: false };
+  }
+
+  const latestExtension = await installExtensionPackage(extensionPackage, {
+    extensionId,
+    installDir,
+  });
+
+  await pruneOtherVersions(path.join(installDir, extensionId), latestExtension.version);
+
+  return { ...latestExtension, updated: true };
+}
+
+/**
+ * Drops every version of an extension, for when the user opts out of it. The
+ * copy the loader derived from it is the embedder's to prune, and the data the
+ * extension wrote lives in the session rather than here.
+ */
+export async function uninstallExtension({ installDir, extensionId }: InstalledExtensionOptions) {
+  await rm(path.join(installDir, extensionId), { recursive: true, force: true });
+}

--- a/packages/electron-extensions/install/omaha.test.ts
+++ b/packages/electron-extensions/install/omaha.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { buildCrxDownloadUrl, fetchCrx } from "./omaha";
+
+const extensionId = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
+
+const chromeVersion = "146.0.0.0";
+
+describe("buildCrxDownloadUrl", () => {
+  test("asks for the package of one id as the given Chrome", () => {
+    const { origin, pathname, searchParams } = new URL(
+      buildCrxDownloadUrl({ extensionId, chromeVersion }),
+    );
+
+    expect(origin + pathname).toBe("https://clients2.google.com/service/update2/crx");
+    expect(searchParams.get("prodversion")).toBe(chromeVersion);
+    expect(searchParams.get("acceptformat")).toBe("crx2,crx3");
+    expect(searchParams.get("response")).toBe("redirect");
+    expect(searchParams.get("x")).toBe(`id=${extensionId}&installsource=ondemand&uc`);
+  });
+});
+
+describe("fetchCrx", () => {
+  test("downloads the package the endpoint redirects to", async () => {
+    const requests: { url: string; redirect: string }[] = [];
+
+    const crx = await fetchCrx({
+      extensionId,
+      chromeVersion,
+      fetch: async (url, init) => {
+        requests.push({ url, redirect: init.redirect });
+
+        return new Response(Uint8Array.from([1, 2, 3]));
+      },
+    });
+
+    expect(crx).toEqual(Uint8Array.from([1, 2, 3]));
+    expect(requests).toEqual([
+      { url: buildCrxDownloadUrl({ extensionId, chromeVersion }), redirect: "follow" },
+    ]);
+  });
+
+  test("refuses an answer that is not a package", async () => {
+    await expect(
+      fetchCrx({
+        extensionId,
+        chromeVersion,
+        fetch: async () => new Response("", { status: 503, statusText: "Service Unavailable" }),
+      }),
+    ).rejects.toThrow(`Update endpoint answered 503 Service Unavailable for ${extensionId}`);
+  });
+});

--- a/packages/electron-extensions/install/omaha.ts
+++ b/packages/electron-extensions/install/omaha.ts
@@ -1,0 +1,79 @@
+const CRX_UPDATE_ENDPOINT = "https://clients2.google.com/service/update2/crx";
+
+export type CrxDownloadOptions = {
+  extensionId: string;
+  /**
+   * The Chrome version the request speaks for, `process.versions.chrome` in an
+   * Electron app. The endpoint answers 204 No Content without it, since it has
+   * no way to tell which package a browser it knows nothing about can run.
+   */
+  chromeVersion: string;
+};
+
+/**
+ * The Omaha URL serving the newest package for an extension id. The same
+ * request is the update check: there is no separate "what is the latest
+ * version" call, the answer is the package itself and its manifest carries the
+ * version.
+ *
+ * The platform parameters describe the browser asking rather than the machine,
+ * and every extension Meru curates ships one package for all of them, so they
+ * are constants.
+ */
+export function buildCrxDownloadUrl({ extensionId, chromeVersion }: CrxDownloadOptions) {
+  const searchParams = new URLSearchParams({
+    response: "redirect",
+    os: "linux",
+    arch: "x64",
+    os_arch: "x86_64",
+    nacl_arch: "x86-64",
+    prod: "chromiumcrx",
+    prodchannel: "unknown",
+    prodversion: chromeVersion,
+    acceptformat: "crx2,crx3",
+    x: `id=${extensionId}&installsource=ondemand&uc`,
+  });
+
+  return `${CRX_UPDATE_ENDPOINT}?${searchParams}`;
+}
+
+/**
+ * As much of `fetch` as a download needs. Structural rather than `typeof fetch`
+ * so a caller can hand over a plain function — a test's fake above all —
+ * without matching every property a runtime hangs off its global.
+ */
+export type FetchImplementation = (url: string, init: { redirect: "follow" }) => Promise<Response>;
+
+export type FetchCrxOptions = CrxDownloadOptions & {
+  /**
+   * Injectable so tests never reach the network, and so an embedder can send
+   * the request through a fetch of its own.
+   */
+  fetch?: FetchImplementation;
+};
+
+/**
+ * Downloads the newest package for an extension id. The endpoint answers with a
+ * redirect to Google's CDN, so redirects have to be followed.
+ *
+ * Nothing here decides whether the bytes are a package worth having: an answer
+ * that is not a CRX signed for this id fails in `verifyCrx`, which is the only
+ * place allowed to say a package is good.
+ */
+export async function fetchCrx({
+  extensionId,
+  chromeVersion,
+  fetch = globalThis.fetch,
+}: FetchCrxOptions) {
+  const response = await fetch(buildCrxDownloadUrl({ extensionId, chromeVersion }), {
+    redirect: "follow",
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Update endpoint answered ${response.status} ${response.statusText} for ${extensionId}`,
+    );
+  }
+
+  return new Uint8Array(await response.arrayBuffer());
+}

--- a/packages/electron-extensions/package.json
+++ b/packages/electron-extensions/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "exports": {
     ".": "./index.ts",
-    "./crx": "./crx/index.ts"
+    "./crx": "./crx/index.ts",
+    "./install": "./install/index.ts"
   },
   "scripts": {
     "test": "bun test",

--- a/scripts/download-extensions.ts
+++ b/scripts/download-extensions.ts
@@ -11,8 +11,9 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parseArgs } from "node:util";
-// The crx entry, since the package's own entry reaches into Electron
+// The crx and install entries, since the package's own entry reaches into Electron
 import { verifyCrx } from "@meru/electron-extensions/crx";
+import { fetchCrx } from "@meru/electron-extensions/install";
 import { unzipSync } from "fflate";
 
 type CuratedExtension = {
@@ -44,24 +45,6 @@ const args = parseArgs({
 
 const extensionsDir = path.join(import.meta.dirname, "..", "extensions");
 
-/** Omaha answers 204 No Content until it knows which Chrome is asking. */
-function buildUpdateUrl(id: string) {
-  const searchParams = new URLSearchParams({
-    response: "redirect",
-    os: "linux",
-    arch: "x64",
-    os_arch: "x86_64",
-    nacl_arch: "x86-64",
-    prod: "chromiumcrx",
-    prodchannel: "unknown",
-    prodversion: CHROME_VERSION,
-    acceptformat: "crx2,crx3",
-    x: `id=${id}&installsource=ondemand&uc`,
-  });
-
-  return `https://clients2.google.com/service/update2/crx?${searchParams}`;
-}
-
 async function unpackZip(zip: Uint8Array, targetDir: string) {
   for (const [fileName, contents] of Object.entries(unzipSync(zip))) {
     if (fileName.endsWith("/")) {
@@ -77,13 +60,7 @@ async function unpackZip(zip: Uint8Array, targetDir: string) {
 }
 
 async function downloadExtension({ name, id }: CuratedExtension) {
-  const response = await fetch(buildUpdateUrl(id), { redirect: "follow" });
-
-  if (!response.ok) {
-    throw new Error(`Update endpoint answered ${response.status} ${response.statusText}`);
-  }
-
-  const crx = Buffer.from(await response.arrayBuffer());
+  const crx = await fetchCrx({ extensionId: id, chromeVersion: CHROME_VERSION });
 
   const { archive, publicKey } = verifyCrx(crx, id);
 


### PR DESCRIPTION
Stacked on #829.

- New `install/` module in `@meru/electron-extensions` (Electron-free, also exported as the `./install` subpath): Omaha fetch (`buildCrxDownloadUrl`/`fetchCrx`, injectable fetch), `installExtension` (verify → in-memory unzip with zip-slip guard and `_metadata` filtered out → `manifest.key` injected from the verified proof → staged rename into `<installDir>/<id>/<version>`), `getInstalledExtension` (highest version on disk, staging dirs excluded), `installLatestExtension` (first install and update are the same call; prunes older versions after a successful install), `uninstallExtension`.
- `pruneDerivedExtensions` in `derive/`: drops derived copies whose source is no longer on the embedder's load list, and stampless dirs — the derived-copy GC left open since #822.
- The download script now shares `fetchCrx`; the synthetic CRX builder moved to `crx/crx-fixture.ts` for reuse by installer tests.

No app wiring yet (config keys, Pro gating, scheduling land in the next PR), and an update check downloads the full CRX rather than probing the version — acceptable at a multi-hour cadence, could move to Omaha's updatecheck response later. Real-package install exercised manually against 1Password 8.12.32.33; the genuine newer-version-from-Omaha path only ran with synthetic packages.

Test plan:
1. `bun test packages/electron-extensions` — installer/omaha/prune suites pass (153 tests).
2. `bun run extensions:download --force` — still fetches, verifies and unpacks 1Password through the shared fetch path.