### PR TITLE
install curated extensions from an extensions settings page

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -125,6 +125,7 @@ export const config = new Store<Config>({
     "verticalTabs.showWidthToggle": true,
     "verticalTabs.hideUnreadBadgeWhenActive": false,
     "verticalTabs.showAppLinksBadge": true,
+    "extensions.installed": [],
   },
   migrations: {
     ">=3.4.0": (store) => {

--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -3,31 +3,40 @@ import { is } from "@electron-toolkit/utils";
 import {
   Extensions,
   findExtensionDirs,
+  getInstalledExtension,
+  installLatestExtension,
+  pruneDerivedExtensions,
   registerNativeMessagingScheme,
+  uninstallExtension,
 } from "@meru/electron-extensions";
+import { curatedExtensions, isCuratedExtensionId } from "@meru/shared/extensions";
+import { ms } from "@meru/shared/ms";
+import type { InstalledExtensionState } from "@meru/shared/types";
 import { app } from "electron";
 import { serializeError } from "serialize-error";
+import { config } from "@/config";
 import { log } from "@/lib/log";
+import { licenseKey } from "@/license-key";
+
+/** Where the curated extensions are installed, `<installDir>/<id>/<version>`. */
+const INSTALL_DIR = path.join(app.getPath("userData"), "extensions");
+
+const DERIVED_EXTENSIONS_DIR = path.join(app.getPath("userData"), "derived-extensions");
 
 // 1Password overrides `navigator.credentials` in the page, which is what lets a
 // passkey sign-in go through in Electron and makes the passkey dialog moot
 export const ONEPASSWORD_EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
 
 /**
- * Unpacked extensions to load into every account session, one directory holding
- * a `manifest.json` per extension:
+ * Unpacked extensions to load on top of the installed ones, one directory
+ * holding a `manifest.json` per extension:
  *
  *   <repo root>/extensions/1password/manifest.json
  *
  * The folder is gitignored, and `app.getAppPath()` is the repo root in
  * development because `bun run dev` starts Electron as `electron .` there.
- *
- * Until extensions are installed from the curated list, this is the only source
- * of extensions, and it is read in development only — a packaged build has no
- * way to turn extensions on, so nothing is loaded and account sessions stay
- * exactly as they are today.
  */
-function getExtensionDirs() {
+function getDevExtensionDirs() {
   if (!is.dev) {
     return [];
   }
@@ -52,14 +61,51 @@ function getStrippedManifestKeys() {
     .filter(Boolean);
 }
 
+/** The curated extensions the user opted into, and Pro is what they run on. */
+function getOptedInExtensionIds() {
+  if (!licenseKey.isValid) {
+    return [];
+  }
+
+  return config
+    .get("extensions.installed")
+    .filter((extensionId) => isCuratedExtensionId(extensionId));
+}
+
+async function getInstalledExtensionDirs() {
+  const extensionDirs: string[] = [];
+
+  for (const extensionId of getOptedInExtensionIds()) {
+    const installedExtension = await getInstalledExtension({
+      installDir: INSTALL_DIR,
+      extensionId,
+    });
+
+    if (installedExtension) {
+      extensionDirs.push(installedExtension.extensionDir);
+    }
+  }
+
+  return extensionDirs;
+}
+
+/**
+ * Everything an account session loads: what the user opted into, plus the
+ * development folder. Asked again for every session, so an account created
+ * after an install gets that extension without anything being rebuilt.
+ */
+async function getExtensionDirs() {
+  return [...getDevExtensionDirs(), ...(await getInstalledExtensionDirs())];
+}
+
 // Extension contexts reach the native messaging bridge over a custom scheme,
 // and Electron only takes scheme privileges while modules are still loading
 registerNativeMessagingScheme();
 
 export const extensions = new Extensions({
-  extensionDirs: getExtensionDirs(),
+  extensionDirs: getExtensionDirs,
   facadeScriptPath: path.join(__dirname, "extensions-chrome-facade.js"),
-  derivedExtensionsDir: path.join(app.getPath("userData"), "derived-extensions"),
+  derivedExtensionsDir: DERIVED_EXTENSIONS_DIR,
   strippedManifestKeys: getStrippedManifestKeys(),
   logger: {
     info: (message, details) => {
@@ -70,3 +116,111 @@ export const extensions = new Extensions({
     },
   },
 });
+
+/**
+ * What is on disk, which config alone can't tell: an install carries a version,
+ * and an opt-in that never finished installing carries nothing.
+ */
+export async function getInstalledExtensions() {
+  const installedExtensions: InstalledExtensionState[] = [];
+
+  for (const curatedExtension of curatedExtensions) {
+    const installedExtension = await getInstalledExtension({
+      installDir: INSTALL_DIR,
+      extensionId: curatedExtension.id,
+    });
+
+    if (installedExtension) {
+      installedExtensions.push({ id: curatedExtension.id, version: installedExtension.version });
+    }
+  }
+
+  return installedExtensions;
+}
+
+/** Installs the latest version and records the opt-in, which is what loads it. */
+export async function installCuratedExtension(extensionId: string) {
+  const { version } = await installLatestExtension({
+    extensionId,
+    installDir: INSTALL_DIR,
+    chromeVersion: process.versions.chrome,
+  });
+
+  const installedExtensionIds = config.get("extensions.installed");
+
+  if (!installedExtensionIds.includes(extensionId)) {
+    config.set("extensions.installed", [...installedExtensionIds, extensionId]);
+  }
+
+  log.info("Installed extension", { extensionId, version });
+}
+
+export async function uninstallCuratedExtension(extensionId: string) {
+  config.set(
+    "extensions.installed",
+    config
+      .get("extensions.installed")
+      .filter((installedExtensionId) => installedExtensionId !== extensionId),
+  );
+
+  await uninstallExtension({ installDir: INSTALL_DIR, extensionId });
+
+  log.info("Uninstalled extension", { extensionId });
+}
+
+/**
+ * The copies the loader derived from extensions that are no longer loaded — an
+ * extension the user opted out of, a version an update replaced — are the
+ * embedder's to collect. Once per launch: every session derives from the same
+ * list.
+ */
+export async function pruneDerivedExtensionCopies() {
+  try {
+    await pruneDerivedExtensions({
+      derivedExtensionsDir: DERIVED_EXTENSIONS_DIR,
+      keptSourceDirs: await getExtensionDirs(),
+    });
+  } catch (error) {
+    log.error("Failed to prune derived extensions", { error: serializeError(error) });
+  }
+}
+
+/**
+ * Keeps the installed extensions at the version the update endpoint serves. A
+ * new version is loaded on the next launch, since sessions keep the copy they
+ * derived for as long as they live.
+ */
+class ExtensionUpdater {
+  init() {
+    if (!licenseKey.isValid || config.get("extensions.installed").length === 0) {
+      return;
+    }
+
+    this.checkForUpdates();
+
+    setInterval(() => {
+      this.checkForUpdates();
+    }, ms("3h"));
+  }
+
+  private async checkForUpdates() {
+    for (const extensionId of getOptedInExtensionIds()) {
+      try {
+        const { updated, version } = await installLatestExtension({
+          extensionId,
+          installDir: INSTALL_DIR,
+          chromeVersion: process.versions.chrome,
+        });
+
+        log.info(updated ? "Updated extension" : "Extension is up to date", {
+          extensionId,
+          version,
+        });
+      } catch (error) {
+        log.error("Failed to update extension", { extensionId, error: serializeError(error) });
+      }
+    }
+  }
+}
+
+export const extensionUpdater = new ExtensionUpdater();

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -7,7 +7,7 @@ import { bookmarks } from "@/bookmarks";
 import { config } from "@/config";
 import { downloads } from "@/downloads";
 import { extensionActions } from "@/extension-actions";
-import { extensions } from "@/extensions";
+import { extensions, extensionUpdater, pruneDerivedExtensionCopies } from "@/extensions";
 import { ipc } from "@/ipc";
 import { initLinuxWindowControls } from "@/lib/linux";
 import { licenseKey } from "@/license-key";
@@ -134,6 +134,10 @@ async function init() {
   appTray.init();
 
   appUpdater.init();
+
+  extensionUpdater.init();
+
+  pruneDerivedExtensionCopies();
 
   doNotDisturb.init();
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { IpcEmitter, IpcListener } from "@electron-toolkit/typed-ipc/main";
 import { platform } from "@electron-toolkit/utils";
 import { MAX_RECENT_DOWNLOAD_HISTORY_ITEMS } from "@meru/shared/constants";
+import { isCuratedExtensionId } from "@meru/shared/extensions";
 import { getWorkspaceAppUrl } from "@meru/shared/google";
 import { ms } from "@meru/shared/ms";
 import { GMAIL_TAB_ID } from "@meru/shared/tabs";
@@ -23,6 +24,7 @@ import {
   shell,
 } from "electron";
 import { machineId } from "node-machine-id";
+import { serializeError } from "serialize-error";
 import { accounts } from "@/accounts";
 import { bookmarks } from "@/bookmarks";
 import { config } from "@/config";
@@ -39,6 +41,11 @@ import { confirmAppLinksTabHandover } from "./dialogs";
 import { DoNotDisturb, doNotDisturb } from "./do-not-disturb";
 import { downloads } from "./downloads";
 import { extensionActions } from "./extension-actions";
+import {
+  getInstalledExtensions,
+  installCuratedExtension,
+  uninstallCuratedExtension,
+} from "./extensions";
 import { GMAIL_USER_STYLES_PATH } from "./gmail";
 import { log } from "./lib/log";
 import {
@@ -1009,6 +1016,48 @@ class Ipc {
 
     ipc.main.on("extensions.setActionPopupCloseOnBlurEnabled", (_event, enabled) => {
       extensionActions.popup.closeOnBlurEnabled = enabled;
+    });
+
+    ipc.main.handle("extensions.getInstalled", () => {
+      return getInstalledExtensions();
+    });
+
+    ipc.main.handle("extensions.install", async (_event, extensionId) => {
+      if (!licenseKey.isValid) {
+        return { error: "Meru Pro is required to install extensions" };
+      }
+
+      if (!isCuratedExtensionId(extensionId)) {
+        return { error: "This extension is not part of the extensions Meru offers" };
+      }
+
+      try {
+        await installCuratedExtension(extensionId);
+
+        return {};
+      } catch (error) {
+        log.error("Failed to install extension", { extensionId, error: serializeError(error) });
+
+        return {
+          error: `Failed to install extension: ${error instanceof Error ? error.message : String(error)}`,
+        };
+      }
+    });
+
+    // Opting out is never gated, so an extension can be taken off a device that
+    // has lost its license
+    ipc.main.handle("extensions.uninstall", async (_event, extensionId) => {
+      try {
+        await uninstallCuratedExtension(extensionId);
+
+        return {};
+      } catch (error) {
+        log.error("Failed to uninstall extension", { extensionId, error: serializeError(error) });
+
+        return {
+          error: `Failed to uninstall extension: ${error instanceof Error ? error.message : String(error)}`,
+        };
+      }
     });
 
     ipc.main.on("downloads.toggleRecentDownloadHistoryPopup", (event) => {

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -47,7 +47,7 @@ async function createExtensionDir(name: string, key?: string) {
 }
 
 function createExtensions(
-  extensionDirs: string[],
+  extensionDirs: ConstructorParameters<typeof Extensions>[0]["extensionDirs"],
   logger?: ConstructorParameters<typeof Extensions>[0]["logger"],
 ) {
   return new Extensions({
@@ -204,6 +204,30 @@ describe("Extensions", () => {
     await extensions.setupSession(createSession({ loadExtension }).session);
 
     expect(loadedExtensionDirs[0]).toBe(loadedExtensionDirs[1] as string);
+  });
+
+  test("asks for the directories of every session it sets up", async () => {
+    const loadedExtensionDirs: string[] = [];
+
+    const loadExtension = async (extensionDir: string) => {
+      loadedExtensionDirs.push(extensionDir);
+
+      return createExtension("aaa", extensionDir);
+    };
+
+    const extensionDirs = [await createExtensionDir("one")];
+
+    const extensions = createExtensions(async () => extensionDirs);
+
+    await extensions.setupSession(createSession({ loadExtension }).session);
+
+    // What an extension installed while the app is running looks like
+    extensionDirs.push(await createExtensionDir("two"));
+
+    await extensions.setupSession(createSession({ loadExtension }).session);
+
+    expect(loadedExtensionDirs).toHaveLength(3);
+    expect(new Set(loadedExtensionDirs).size).toBe(2);
   });
 
   test("drops the cached service worker before loading an extension", async () => {

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -32,12 +32,15 @@ const EXTENSION_INDEXED_DB_PREFIX = "chrome-extension_";
 
 export type ActionsChangedListener = (session: Session, actions: ExtensionAction[]) => void;
 
+export type ExtensionDirs = string[] | (() => Promise<string[]> | string[]);
+
 export type ExtensionsOptions = {
   /**
    * Unpacked extension directories, loaded into every session handed to
-   * `setupSession`.
+   * `setupSession`. A function is asked again for every session, so a session
+   * set up after an extension was installed loads that extension too.
    */
-  extensionDirs: string[];
+  extensionDirs: ExtensionDirs;
   /**
    * The bundled `chrome.*` facade script, copied into every extension so it
    * runs in the extension's own contexts.
@@ -71,7 +74,7 @@ export type ExtensionsOptions = {
  * between launches, which is why loading happens on every boot.
  */
 export class Extensions {
-  private extensionDirs: string[];
+  private extensionDirs: ExtensionDirs;
 
   private facadeScriptPath: string;
 
@@ -138,7 +141,10 @@ export class Extensions {
   }
 
   async setupSession(session: Session) {
-    if (this.extensionDirs.length === 0) {
+    const extensionDirs =
+      typeof this.extensionDirs === "function" ? await this.extensionDirs() : this.extensionDirs;
+
+    if (extensionDirs.length === 0) {
       return;
     }
 
@@ -156,7 +162,7 @@ export class Extensions {
       getExtensionId: (bridgeToken) => extensionIdsByBridgeToken.get(bridgeToken),
     });
 
-    for (const extensionDir of this.extensionDirs) {
+    for (const extensionDir of extensionDirs) {
       try {
         const { derivedDir, bridgeToken, extensionId } = await this.deriveExtension(extensionDir);
 

--- a/packages/electron-extensions/index.ts
+++ b/packages/electron-extensions/index.ts
@@ -4,7 +4,7 @@ export type { VerifiedCrx } from "./crx";
 export { pruneDerivedExtensions } from "./derive";
 export type { PruneDerivedExtensionsOptions } from "./derive";
 export { Extensions } from "./extensions";
-export type { ActionsChangedListener, ExtensionsOptions } from "./extensions";
+export type { ActionsChangedListener, ExtensionDirs, ExtensionsOptions } from "./extensions";
 export {
   buildCrxDownloadUrl,
   fetchCrx,

--- a/packages/renderer/components/app-sidebar.tsx
+++ b/packages/renderer/components/app-sidebar.tsx
@@ -10,6 +10,7 @@ import { AdvancedSettings } from "@/routes/settings/advanced";
 import { AppearanceSettings } from "@/routes/settings/appearance";
 import { BlockerSettings } from "@/routes/settings/blocker";
 import { DownloadsSettings } from "@/routes/settings/downloads";
+import { ExtensionsSettings } from "@/routes/settings/extensions";
 import { GeneralSettings } from "@/routes/settings/general";
 import { GmailSettings } from "@/routes/settings/gmail";
 import { LanguagesSettings } from "@/routes/settings/languages";
@@ -54,6 +55,11 @@ export const sidebarNavItems: SidebarNavItemProps[] = [
     label: "Workspace Apps",
     path: "/settings/workspace-apps",
     component: WorkspaceAppsSettings,
+  },
+  {
+    label: "Extensions",
+    path: "/settings/extensions",
+    component: ExtensionsSettings,
   },
   {
     label: "Languages",

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -1,0 +1,116 @@
+import { type CuratedExtension, curatedExtensions } from "@meru/shared/extensions";
+import { ipc } from "@meru/shared/renderer/ipc";
+import { FieldDescription } from "@meru/ui/components/field";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemTitle,
+} from "@meru/ui/components/item";
+import { Switch } from "@meru/ui/components/switch";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
+import { LicenseKeyRequiredFieldBadge } from "@/components/license-key-required-field-badge";
+import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
+import { useIsLicenseKeyValid } from "@/lib/hooks";
+import { queryClient, useConfig } from "@/lib/react-query";
+import { restartRequiredToast } from "@/lib/toast";
+
+const installedExtensionsQueryKey = ["installed-extensions"];
+
+function ExtensionItem({
+  extension,
+  installed,
+  installedVersion,
+}: {
+  extension: CuratedExtension;
+  installed: boolean;
+  installedVersion: string | undefined;
+}) {
+  const isLicenseKeyValid = useIsLicenseKeyValid();
+
+  const extensionMutation = useMutation({
+    mutationFn: (install: boolean) =>
+      install
+        ? ipc.main.invoke("extensions.install", extension.id)
+        : ipc.main.invoke("extensions.uninstall", extension.id),
+    onSuccess: ({ error }) => {
+      if (error) {
+        toast.error(error);
+
+        return;
+      }
+
+      queryClient.invalidateQueries({
+        queryKey: installedExtensionsQueryKey,
+      });
+
+      restartRequiredToast();
+    },
+  });
+
+  return (
+    <Item variant="muted">
+      <ItemContent>
+        <ItemTitle>
+          {extension.name}
+          <LicenseKeyRequiredFieldBadge />
+        </ItemTitle>
+        <ItemDescription>
+          {extension.description}
+          {installedVersion && ` Version ${installedVersion} is installed.`}
+        </ItemDescription>
+      </ItemContent>
+      <ItemActions>
+        <Switch
+          checked={isLicenseKeyValid && installed}
+          disabled={!isLicenseKeyValid || extensionMutation.isPending}
+          onCheckedChange={(checked) => {
+            extensionMutation.mutate(checked);
+          }}
+          aria-label={`Install ${extension.name}`}
+        />
+      </ItemActions>
+    </Item>
+  );
+}
+
+export function ExtensionsSettings() {
+  const { config } = useConfig();
+
+  const { data: installedExtensions } = useQuery({
+    queryKey: installedExtensionsQueryKey,
+    queryFn: () => ipc.main.invoke("extensions.getInstalled"),
+  });
+
+  if (!config) {
+    return;
+  }
+
+  return (
+    <Settings>
+      <SettingsHeader>
+        <SettingsTitle>Extensions</SettingsTitle>
+      </SettingsHeader>
+      <SettingsContent className="space-y-4">
+        <LicenseKeyRequiredBanner />
+        <FieldDescription>
+          Extensions are loaded into every account and take effect after a restart.
+        </FieldDescription>
+        <ItemGroup>
+          {curatedExtensions.map((extension) => (
+            <ExtensionItem
+              key={extension.id}
+              extension={extension}
+              installed={config["extensions.installed"].includes(extension.id)}
+              installedVersion={installedExtensions?.find(({ id }) => id === extension.id)?.version}
+            />
+          ))}
+        </ItemGroup>
+      </SettingsContent>
+    </Settings>
+  );
+}

--- a/packages/shared/extensions.ts
+++ b/packages/shared/extensions.ts
@@ -1,0 +1,24 @@
+export type CuratedExtension = {
+  /** The Chrome Web Store id, which every package has to be signed for. */
+  id: string;
+  name: string;
+  description: string;
+};
+
+/**
+ * The extensions Meru offers, the only ones it installs. An id outside this
+ * list is refused before anything is downloaded, and the settings page is a
+ * view of it.
+ */
+export const curatedExtensions: CuratedExtension[] = [
+  {
+    id: "aeblfdkhhhdcdjpifhhbdiojplfjncoa",
+    name: "1Password",
+    description:
+      "Password manager that fills logins and signs you in with passkeys stored in your vault.",
+  },
+];
+
+export function isCuratedExtensionId(extensionId: string) {
+  return curatedExtensions.some((curatedExtension) => curatedExtension.id === extensionId);
+}

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -60,6 +60,12 @@ export type ExtensionActionState = {
   iconDataUrl: string | null;
 };
 
+/** A curated extension as it is installed on disk, which config alone can't tell. */
+export type InstalledExtensionState = {
+  id: string;
+  version: string;
+};
+
 /** A titlebar button's rect, in its window's content coordinates. */
 export type ExtensionActionAnchorRect = { x: number; y: number; width: number; height: number };
 
@@ -177,6 +183,7 @@ export type Config = {
   "verticalTabs.showWidthToggle": boolean;
   "verticalTabs.hideUnreadBadgeWhenActive": boolean;
   "verticalTabs.showAppLinksBadge": boolean;
+  "extensions.installed": string[];
 };
 
 export type IpcMainEvents =
@@ -267,6 +274,9 @@ export type IpcMainEvents =
       "workspaceApp.getBookmarkState": (workspaceAppId: string) => WorkspaceAppBookmarkState;
       "bookmarks.getBookmarks": () => BookmarkState[];
       "extensions.getActions": () => ExtensionActionState[];
+      "extensions.getInstalled": () => InstalledExtensionState[];
+      "extensions.install": (extensionId: string) => { error?: string };
+      "extensions.uninstall": (extensionId: string) => { error?: string };
     };
 
 export type IpcRendererEvent = {

--- a/scripts/download-extensions.ts
+++ b/scripts/download-extensions.ts
@@ -14,18 +14,8 @@ import { parseArgs } from "node:util";
 // The crx and install entries, since the package's own entry reaches into Electron
 import { verifyCrx } from "@meru/electron-extensions/crx";
 import { fetchCrx } from "@meru/electron-extensions/install";
+import { type CuratedExtension, curatedExtensions } from "@meru/shared/extensions";
 import { unzipSync } from "fflate";
-
-type CuratedExtension = {
-  /** The directory the extension is unpacked into. */
-  name: string;
-  /** The Chrome Web Store id, which the injected key has to derive. */
-  id: string;
-};
-
-const CURATED_EXTENSIONS: CuratedExtension[] = [
-  { name: "1password", id: "aeblfdkhhhdcdjpifhhbdiojplfjncoa" },
-];
 
 // Keep in sync with Electron
 const CHROME_VERSION = "146.0.0.0";
@@ -59,7 +49,16 @@ async function unpackZip(zip: Uint8Array, targetDir: string) {
   }
 }
 
-async function downloadExtension({ name, id }: CuratedExtension) {
+/** The directory an extension is unpacked into, `extensions/1password`. */
+function getDirectoryName({ name }: CuratedExtension) {
+  return name.toLowerCase();
+}
+
+async function downloadExtension(extension: CuratedExtension) {
+  const { name, id } = extension;
+
+  const directoryName = getDirectoryName(extension);
+
   const crx = await fetchCrx({ extensionId: id, chromeVersion: CHROME_VERSION });
 
   const { archive, publicKey } = verifyCrx(crx, id);
@@ -67,9 +66,9 @@ async function downloadExtension({ name, id }: CuratedExtension) {
   await mkdir(extensionsDir, { recursive: true });
 
   // Kept as a fixture the verifier can be tested against a real package with
-  await writeFile(path.join(extensionsDir, `${name}.crx`), crx);
+  await writeFile(path.join(extensionsDir, `${directoryName}.crx`), crx);
 
-  const extensionDir = path.join(extensionsDir, name);
+  const extensionDir = path.join(extensionsDir, directoryName);
 
   const stagingDir = `${extensionDir}.staging`;
 
@@ -101,10 +100,10 @@ async function downloadExtension({ name, id }: CuratedExtension) {
   console.log(`${name}: unpacked version ${manifest.version} as ${id}`);
 }
 
-for (const extension of CURATED_EXTENSIONS) {
+for (const extension of curatedExtensions) {
   if (
     !args.values.force &&
-    existsSync(path.join(extensionsDir, extension.name, MANIFEST_FILE_NAME))
+    existsSync(path.join(extensionsDir, getDirectoryName(extension), MANIFEST_FILE_NAME))
   ) {
     console.log(`${extension.name}: already downloaded, --force downloads it again`);
 


### PR DESCRIPTION
Stacked on #830. Completes slice 7 of the chrome-extensions feature.

- Curated catalog in `packages/shared/extensions.ts` (v1: 1Password); the settings page renders it, the main process refuses ids outside it, and the download script's own list is gone.
- `"extensions.installed": string[]` config key (default `[]`), written main-side only after a successful install.
- IPC: `extensions.install` (Pro-gated with `licenseKey.isValid` first, then catalog check), `extensions.uninstall` (deliberately ungated so opting out survives a lapsed license), `extensions.getInstalled` (versions read off disk).
- The loader's `extensionDirs` option now also takes a provider function, evaluated per `setupSession` (unit-tested) — the app passes dev dirs + the opted-in installs from `userData/extensions`, gated on a valid license, which is settled before the first account session (validated in `init()` before `accounts.init()`).
- `ExtensionUpdater`: immediate check + every 3h per opted-in id, updates load next launch; derived-copy prune runs once per launch after license validation.
- Extensions settings page after Workspace Apps: banner + one row per catalog entry with install switch, installed version, restart-required toast on change.

Not verified at runtime — no app launch or real install round trip; unit tests and checks only. Dev-only quirk: an installed extension plus the same one in the repo `extensions/` folder hands the session the same id twice; the second load fails and is logged, nothing else breaks.

Test plan:
1. With a valid license: Settings → Extensions, toggle 1Password on — restart toast fires, `userData/extensions/aebl…/8.x.y/` appears, and after a restart the titlebar shows the 1Password button in every account.
2. Toggle it off — config and the install dir are cleared, extension gone after restart.
3. Without a license (and no trial): the switch is disabled with the Pro badge, and the page shows the banner.