### PR TITLE
fix crash at launch from popup import cycle

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -29,10 +29,10 @@ import { createStore } from "zustand/vanilla";
 import { accounts } from "@/accounts";
 import { config } from "@/config";
 import { ipc } from "@/ipc";
+import { loadUrl } from "@/lib/load-url";
 import { log } from "@/lib/log";
 import {
   createChildWebContentsView,
-  loadUrl,
   logLoadFailures,
   openViewDevToolsOnLaunch,
   removeWebContentsListeners,

--- a/packages/app/lib/load-url.ts
+++ b/packages/app/lib/load-url.ts
@@ -1,0 +1,24 @@
+import type { WebContents } from "electron";
+import { serializeError } from "serialize-error";
+import { log } from "./log";
+
+/**
+ * `loadURL` rejects when the load never commits — a renderer that went away
+ * mid-navigation, a network stack that gave up — and nothing waits on the
+ * promise, which turns every such load into an unhandled rejection. Says what
+ * happened and answers whether the page arrived.
+ *
+ * Lives apart from `web-contents.ts`, which reaches into app modules that in
+ * turn import `popup.ts`: importing it from `popup.ts` or `window.ts` closes an
+ * import cycle that leaves `Popup` undefined at app launch.
+ */
+export function loadUrl(webContents: WebContents, url: string) {
+  return webContents
+    .loadURL(url)
+    .then(() => true)
+    .catch((error: unknown) => {
+      log.error("Failed to load URL", { url, error: serializeError(error) });
+
+      return false;
+    });
+}

--- a/packages/app/lib/popup.ts
+++ b/packages/app/lib/popup.ts
@@ -3,7 +3,7 @@ import { APP_TITLEBAR_HEIGHT, BASE_SPACING } from "@meru/shared/constants";
 import { clamp } from "@meru/shared/utils";
 import type { BrowserWindow, Event, Input, Session, Size } from "electron";
 import { WebContentsView } from "electron";
-import { loadUrl } from "./web-contents";
+import { loadUrl } from "./load-url";
 import { getPreloadPath, loadRenderer, type RendererPage } from "./window";
 
 /** What a popup shows: a renderer page, or any URL loaded in a given session. */

--- a/packages/app/lib/web-contents.ts
+++ b/packages/app/lib/web-contents.ts
@@ -4,28 +4,10 @@ import {
   WebContentsView,
   type WebContentsViewConstructorOptions,
 } from "electron";
-import { serializeError } from "serialize-error";
 import { setupWindowContextMenu } from "@/context-menu";
 import { ipc } from "@/ipc";
 import { shouldOpenDevToolsOnLaunch } from "./dev-tools";
 import { log } from "./log";
-
-/**
- * `loadURL` rejects when the load never commits — a renderer that went away
- * mid-navigation, a network stack that gave up — and nothing waits on the
- * promise, which turns every such load into an unhandled rejection. Says what
- * happened and answers whether the page arrived.
- */
-export function loadUrl(webContents: WebContents, url: string) {
-  return webContents
-    .loadURL(url)
-    .then(() => true)
-    .catch((error: unknown) => {
-      log.error("Failed to load URL", { url, error: serializeError(error) });
-
-      return false;
-    });
-}
 
 /**
  * Says why a view is empty. A load that never arrives leaves nothing behind on

--- a/packages/app/lib/window.ts
+++ b/packages/app/lib/window.ts
@@ -11,7 +11,7 @@ import {
 } from "electron";
 import { shouldOpenDevToolsOnLaunch } from "./dev-tools";
 import { isLinuxWindowControlsEnabled } from "./linux";
-import { loadUrl } from "./web-contents";
+import { loadUrl } from "./load-url";
 
 const CASCADE_OFFSET = 30;
 

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -28,9 +28,9 @@ import { bookmarks } from "./bookmarks";
 import { config } from "./config";
 import { extensions, ONEPASSWORD_EXTENSION_ID } from "./extensions";
 import { ipc } from "./ipc";
+import { loadUrl } from "./lib/load-url";
 import {
   createChildWebContentsView,
-  loadUrl,
   openViewDevToolsOnLaunch,
   removeWebContentsListeners,
 } from "./lib/web-contents";


### PR DESCRIPTION
- `dcf0ff4` had `lib/popup.ts` and `lib/window.ts` import `loadUrl` from `lib/web-contents.ts`, which imports `@/ipc` → `downloads.ts` → `lib/popup.ts`. `Downloads` builds a `Popup` at module scope, so the bundle ran that initializer before the class existed: `TypeError: Popup is not a constructor` at launch.
- `loadUrl` moves to `lib/load-url.ts`, which imports nothing app-level, so `popup.ts`/`window.ts` no longer reach back into `@/ipc`.

`lib/web-contents.ts` still imports `@/context-menu` and `@/ipc` (pre-existing), so anything in `lib/` importing it can close a cycle again. Verified only by bundle order plus types/lint/fmt/tests — Electron can't run in this sandbox, so the app was not launched.

Test plan:

1. `bun run build:js`, then grep `build-js/app.js` for `var Popup = class` and `new Downloads()` — `Popup` is defined before `new Downloads()` runs.
2. Launch the app — it starts instead of throwing during load, and the downloads popup still opens from the titlebar.
