### PR TITLE
sign macos pr builds on demand behind a label

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,20 @@ on:
     paths-ignore:
       - "**.md"
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
     paths-ignore:
       - "**.md"
 
 jobs:
   build:
+    # Signing and notarizing macOS adds ~4 minutes to a run, so pull request builds are
+    # unsigned by default: label a pull request `sign-macos` to sign that build and every
+    # build after it. Only that label starts a run; any other label is ignored.
+    if: github.event.action != 'labeled' || github.event.label.name == 'sign-macos'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -20,11 +29,15 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
+    env:
+      SIGN_MACOS: ${{ contains(github.event.pull_request.labels.*.name, 'sign-macos') }}
     steps:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
-      - if: startsWith(matrix.os, 'macos')
+      - if: startsWith(matrix.os, 'macos') && env.SIGN_MACOS != 'true'
+        run: bun run build:mac -- --publish never
+      - if: startsWith(matrix.os, 'macos') && env.SIGN_MACOS == 'true'
         run: bun run build:mac -- --publish never
         env:
           # electron-builder skips signing on PR builds unless this is true; fork PRs never


### PR DESCRIPTION
- PR and main-push macOS builds are unsigned again — signing and notarizing was adding ~4 min to every run (`build:mac` step: ~2m unsigned vs 5m45s signed), making macOS the long pole of every PR.
- Adding the `sign-macos` label to a PR builds a signed and notarized DMG, for that build and every build after it while the label stays on. The label already exists in the repo.
- `pull_request` now also listens for `labeled`, with a job-level `if` so no other label starts a build.
- Signing on releases is untouched — `release.yml` still signs and notarizes.

Fork PRs still can't sign even with the label: they never receive the secrets, so they fall back to unsigned as before. `paths-ignore` still applies to the label event, so labelling a markdown-only PR won't build anything. The label path itself hasn't been exercised yet — only this PR's unsigned run will have.

## Test plan
1. Open this PR — the macOS build job finishes in ~2:30 with no signing/notarization step in the log.
2. Add the `sign-macos` label — a new build run starts, and the macOS job's `build:mac` step logs signing and notarization and takes ~6 min.
3. Add any other label (e.g. `macos`) — no new build run is started.