### PR TITLE
add per-architecture macos build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "build:js": "bun run scripts/build.ts",
     "build:linux": "bun run build:js && bun run build:clean-dist && electron-builder --linux",
     "build:mac": "bun run build:js && bun run build:clean-dist && electron-builder --mac",
+    "build:mac:arm64": "bun run build:mac -- --arm64",
+    "build:mac:x64": "bun run build:mac -- --x64",
     "build:win": "bun run build:js && bun run build:clean-dist && electron-builder --win",
     "dev": "bun run scripts/build.ts --dev",
     "extensions:download": "bun run scripts/download-extensions.ts",


### PR DESCRIPTION
- `build:mac:arm64` and `build:mac:x64` build a single macOS architecture, so a local build on an Apple silicon machine no longer wastes time on x64.
- Both delegate to `build:mac`, appending electron-builder's arch flag; extra args still pass through (`bun run build:mac:arm64 -- --publish never`).
- `build:mac` is unchanged and still builds both architectures, as does CI.

Not verified on macOS — only the arg forwarding and electron-builder's arch handling were checked locally on Linux.

## Test plan
1. `bun run build:mac:arm64` on the M2 — `dist/` gets only the `-arm64` dmg/zip, no x64 artifacts.
2. `bun run build:mac` — both architectures, as before.