### PR TITLE
kill the native messaging host when the extension cancels its stream

### DIFF
--- a/packages/electron-extensions/native-messaging/native-messaging.test.ts
+++ b/packages/electron-extensions/native-messaging/native-messaging.test.ts
@@ -122,6 +122,21 @@ function createNativeMessaging(options: ConstructorParameters<typeof NativeMessa
   return nativeMessaging;
 }
 
+/** Kill with signal 0 probes for existence, and ESRCH says the process is gone. */
+async function waitForProcessExit(pid: number) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+
+  throw new Error(`Process ${pid} is still running`);
+}
+
 /** Reads frames off a connect response until one has arrived. */
 async function readFrame(response: Response) {
   const reader = (response.body as ReadableStream<Uint8Array>).getReader();
@@ -214,6 +229,37 @@ describe("NativeMessaging", () => {
       type: "disconnect",
       error: "Access to the specified native messaging host is forbidden.",
     });
+  });
+
+  test("kills the host when the extension side cancels the stream", async () => {
+    await writeHostManifest();
+
+    const logs: { message: string; details: Record<string, unknown> }[] = [];
+
+    const nativeMessaging = createNativeMessaging({
+      logger: {
+        info: (message, details) => {
+          logs.push({ message, details });
+        },
+        error: () => undefined,
+      },
+    });
+
+    const response = await connect();
+
+    const hostPid = logs.find(({ message }) => message === "Connected native messaging host")
+      ?.details.pid as number;
+
+    expect(hostPid).toBeGreaterThan(0);
+
+    // The extension context went away: a closed page, a restarted service worker
+    await (response.body as ReadableStream<Uint8Array>).cancel();
+
+    expect(logs.some(({ message }) => message === "Disconnected native messaging host")).toBe(true);
+
+    await waitForProcessExit(hostPid);
+
+    nativeMessaging.teardownSession(session);
   });
 
   test("takes the session's ports down with the session", async () => {

--- a/packages/electron-extensions/native-messaging/native-messaging.ts
+++ b/packages/electron-extensions/native-messaging/native-messaging.ts
@@ -296,7 +296,14 @@ export class NativeMessaging {
       return;
     }
 
-    port.controller.enqueue(encodeNativeMessage(frame));
+    try {
+      port.controller.enqueue(encodeNativeMessage(frame));
+    } catch {
+      // The stream no longer accepts frames when the extension cancelled it —
+      // a closed page, a restarted service worker — and a throw out of here
+      // would keep `closePort` from killing the port's host process
+      return;
+    }
 
     // Stop reading the host until the extension has taken what it was sent
     if ((port.controller.desiredSize ?? 1) <= 0) {


### PR DESCRIPTION
- \`closePort\` sent the disconnect frame before doing its cleanup, and \`controller.enqueue\` throws once the extension side cancelled the connect stream (closed page, restarted service worker) — the throw skipped the cleanup, so the port stayed registered and the host process was never killed, leaking one \`1Password-BrowserSupport\` per cancelled port.
- \`sendFrame\` now treats a stream that no longer accepts frames as best-effort and returns, letting \`closePort\` finish.
- New test covers the cancel path end to end (fails on the unfixed code): host pid from the connect log, cancel the response body, assert the disconnect log and that the process is gone.

Test plan:
1. \`bun test packages/electron-extensions/native-messaging\` — 8 tests pass, including the new cancel-path test.
2. Revert \`native-messaging.ts\` and re-run — the new test fails with the enqueue TypeError.