### PR TITLE
keep the extension updater running for mid-session installs

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -192,11 +192,16 @@ export async function pruneDerivedExtensionCopies() {
  */
 class ExtensionUpdater {
   init() {
-    if (!licenseKey.isValid || config.get("extensions.installed").length === 0) {
+    if (!licenseKey.isValid) {
       return;
     }
 
-    this.checkForUpdates();
+    // The interval stands even when nothing is installed yet, and every check
+    // re-reads the opt-ins, so an extension installed mid-session is kept up to
+    // date without a restart
+    if (config.get("extensions.installed").length > 0) {
+      this.checkForUpdates();
+    }
 
     setInterval(() => {
       this.checkForUpdates();


### PR DESCRIPTION
- `ExtensionUpdater.init` returned early when no extension was installed at boot, so an extension installed from the settings page mid-session got no update checks until the next launch.
- The 3h interval now always stands once the license is valid; every tick re-reads the opt-ins, and the immediate boot check still only runs when something is installed (a fresh install is already at the latest version).

Test plan:
1. Start with no extensions installed, install 1Password from the settings page, and wait for (or shorten) the interval — the log shows "Extension is up to date" checks without a restart.