### PR TITLE
expand environment variables in windows registry host manifest paths

### DIFF
--- a/packages/electron-extensions/native-messaging/windows-registry.test.ts
+++ b/packages/electron-extensions/native-messaging/windows-registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { WINDOWS_HOST_REGISTRY_KEYS } from "./host-manifest";
-import { parseRegistryQueryOutput } from "./windows-registry";
+import { expandEnvironmentVariables, parseRegistryQueryOutput } from "./windows-registry";
 
 describe("parseRegistryQueryOutput", () => {
   test("reads the manifest path out of a default string value", () => {
@@ -16,9 +16,19 @@ describe("parseRegistryQueryOutput", () => {
     ).toBe("C:\\Users\\Tim\\AppData\\Local\\1Password\\com.1password.1password.json");
   });
 
-  test("reads an expandable string value too", () => {
+  test("expands an expandable string value the way Windows reads it", () => {
     expect(
-      parseRegistryQueryOutput("    (Default)    REG_EXPAND_SZ    %LOCALAPPDATA%\\host.json\r\n"),
+      parseRegistryQueryOutput("    (Default)    REG_EXPAND_SZ    %LOCALAPPDATA%\\host.json\r\n", {
+        LOCALAPPDATA: "C:\\Users\\Tim\\AppData\\Local",
+      }),
+    ).toBe("C:\\Users\\Tim\\AppData\\Local\\host.json");
+  });
+
+  test("expands nothing in an ordinary string value", () => {
+    expect(
+      parseRegistryQueryOutput("    (Default)    REG_SZ    %LOCALAPPDATA%\\host.json", {
+        LOCALAPPDATA: "C:\\Users\\Tim\\AppData\\Local",
+      }),
     ).toBe("%LOCALAPPDATA%\\host.json");
   });
 
@@ -38,6 +48,29 @@ describe("parseRegistryQueryOutput", () => {
         "\r\nHKEY_CURRENT_USER\\Software\\Google\\Chrome\\NativeMessagingHosts\r\n",
       ),
     ).toBeUndefined();
+  });
+});
+
+describe("expandEnvironmentVariables", () => {
+  test("matches variable names without regard to case", () => {
+    expect(
+      expandEnvironmentVariables("%localappdata%\\host.json", {
+        LOCALAPPDATA: "C:\\Users\\Tim\\AppData\\Local",
+      }),
+    ).toBe("C:\\Users\\Tim\\AppData\\Local\\host.json");
+  });
+
+  test("leaves a reference nothing is set for as written", () => {
+    expect(expandEnvironmentVariables("%NOT_SET%\\host.json", {})).toBe("%NOT_SET%\\host.json");
+  });
+
+  test("expands several references in one value", () => {
+    expect(
+      expandEnvironmentVariables("%SystemDrive%%HOMEPATH%\\host.json", {
+        SystemDrive: "C:",
+        HOMEPATH: "\\Users\\Tim",
+      }),
+    ).toBe("C:\\Users\\Tim\\host.json");
   });
 });
 

--- a/packages/electron-extensions/native-messaging/windows-registry.ts
+++ b/packages/electron-extensions/native-messaging/windows-registry.ts
@@ -4,6 +4,27 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 /**
+ * What Windows does to a `REG_EXPAND_SZ` value when it is read: every
+ * `%NAME%` becomes the environment variable's value, matched without regard to
+ * case the way Windows matches them, and a name nothing is set for stays as
+ * written. `reg query` prints the value unexpanded, so a host registered under
+ * `%LocalAppData%` needs this to come out as a readable path.
+ */
+export function expandEnvironmentVariables(
+  value: string,
+  environment: Record<string, string | undefined> = process.env,
+) {
+  const valuesByLowerCaseName = new Map(
+    Object.entries(environment).map(([name, variableValue]) => [name.toLowerCase(), variableValue]),
+  );
+
+  return value.replace(
+    /%([^%]+)%/g,
+    (reference, name: string) => valuesByLowerCaseName.get(name.toLowerCase()) ?? reference,
+  );
+}
+
+/**
  * The manifest path out of `reg query <key> /ve`, which prints the key it read
  * and then the default value as name, type and data separated by runs of
  * spaces. Only a string value is a path; anything else is a registration this
@@ -12,12 +33,17 @@ const execFileAsync = promisify(execFile);
  *     HKEY_CURRENT_USER\Software\Google\Chrome\NativeMessagingHosts\com.1password.1password
  *         (Default)    REG_SZ    C:\Users\me\AppData\Local\1Password\com.1password.1password.json
  */
-export function parseRegistryQueryOutput(output: string) {
+export function parseRegistryQueryOutput(
+  output: string,
+  environment?: Record<string, string | undefined>,
+) {
   for (const line of output.split(/\r?\n/)) {
-    const value = /^\s+\(Default\)\s+REG_(?:SZ|EXPAND_SZ)\s+(.+?)\s*$/.exec(line);
+    const value = /^\s+\(Default\)\s+(REG_SZ|REG_EXPAND_SZ)\s+(.+?)\s*$/.exec(line);
 
-    if (value?.[1]) {
-      return value[1];
+    if (value?.[2]) {
+      return value[1] === "REG_EXPAND_SZ"
+        ? expandEnvironmentVariables(value[2], environment)
+        : value[2];
     }
   }
 


### PR DESCRIPTION
- `parseRegistryQueryOutput` accepted `REG_EXPAND_SZ` values but returned them unexpanded, so a host registered with `%LocalAppData%\...` produced a literal path the manifest read then failed on — the host reported as not found.
- Expansion now happens for `REG_EXPAND_SZ` only, matching names case-insensitively the way Windows does and leaving unknown references as written; `REG_SZ` values stay untouched.

Not verified against a real Windows registry — covered by unit tests on `reg query` output shapes only.

Test plan:
1. `bun test packages/electron-extensions/native-messaging` — the expansion tests pass.
2. On Windows with 1Password installed, connecting to the desktop app still finds the host (its registration is `REG_SZ`, so this path is unchanged for it).