### PR TITLE
derive an extension again after a failed derive

### DIFF
--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -329,6 +329,32 @@ describe("Extensions", () => {
     );
   });
 
+  test("derives again for the next session after a failed derive", async () => {
+    const extensionDir = path.join(workDir, "healed");
+
+    await mkdir(extensionDir);
+
+    const extensions = createExtensions([extensionDir], {
+      info: () => {},
+      error: () => {},
+    });
+
+    const firstSession = createSession();
+
+    await extensions.setupSession(firstSession.session);
+
+    expect(extensions.getSessionActions(firstSession.session)).toHaveLength(0);
+
+    // The directory is whole now — a finished install, a corrected dev folder
+    await createExtensionDir("healed");
+
+    const secondSession = createSession();
+
+    await extensions.setupSession(secondSession.session);
+
+    expect(extensions.getSessionActions(secondSession.session)).toHaveLength(1);
+  });
+
   test("matches URLs of extensions loaded into that session only", async () => {
     const { session: sessionWithExtension } = createSession();
     const { session: sessionWithoutExtension } = createSession();

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -135,6 +135,17 @@ export class Extensions {
       });
 
       this.derivedExtensions.set(sourceDir, derivedExtension);
+
+      // A failure must not be the answer for every later session: dropped from
+      // the memo, the next setup derives again and can succeed once whatever
+      // failed — an unfinished install, a half-written dev directory — is gone
+      const failedDerivedExtension = derivedExtension;
+
+      derivedExtension.catch(() => {
+        if (this.derivedExtensions.get(sourceDir) === failedDerivedExtension) {
+          this.derivedExtensions.delete(sourceDir);
+        }
+      });
     }
 
     return derivedExtension;


### PR DESCRIPTION
- `Extensions.deriveExtension` memoized the derive promise per source directory, rejection included: one transient failure (an fs race with an update swap, a half-written dev directory) failed every later `setupSession` for that extension until restart.
- A rejected derive now evicts itself from the memo — guarded by identity so it never drops a newer attempt — and the next session derives fresh; successful derives stay memoized as before.

Test plan:
1. `bun test packages/electron-extensions/extensions.test.ts` — the new "derives again for the next session" test passes (it fails on the unfixed code).