### PR TITLE
name the update endpoint's no-package answer for what it is

### DIFF
--- a/packages/electron-extensions/install/omaha.test.ts
+++ b/packages/electron-extensions/install/omaha.test.ts
@@ -39,6 +39,16 @@ describe("fetchCrx", () => {
     ]);
   });
 
+  test("names the endpoint's no-package answer for what it is", async () => {
+    await expect(
+      fetchCrx({
+        extensionId,
+        chromeVersion,
+        fetch: async () => new Response(null, { status: 204 }),
+      }),
+    ).rejects.toThrow(`Update endpoint has no package for ${extensionId}`);
+  });
+
   test("refuses an answer that is not a package", async () => {
     await expect(
       fetchCrx({

--- a/packages/electron-extensions/install/omaha.ts
+++ b/packages/electron-extensions/install/omaha.ts
@@ -69,6 +69,13 @@ export async function fetchCrx({
     redirect: "follow",
   });
 
+  // No Content is the endpoint's no: an id it does not serve, or a request it
+  // could not place — and it counts as `ok`, so left alone it would surface as
+  // a verification error about an empty package
+  if (response.status === 204) {
+    throw new Error(`Update endpoint has no package for ${extensionId}`);
+  }
+
   if (!response.ok) {
     throw new Error(
       `Update endpoint answered ${response.status} ${response.statusText} for ${extensionId}`,


### PR DESCRIPTION
- The Omaha endpoint answers 204 No Content for an id it does not serve (or a malformed request), which passes `response.ok` — the empty body then failed later in `verifyCrx` as "CRX of 0 bytes is too short to hold a header", pointing away from the real cause.
- `fetchCrx` now refuses a 204 with an error naming the endpoint's answer; everything else is unchanged.

Test plan:
1. `bun test packages/electron-extensions/install` — the new 204 test passes.