### PR TITLE
inject the facade into every page name chromium serves

### DIFF
--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -98,6 +98,20 @@ describe("deriveExtension", () => {
     );
   });
 
+  test("injects the facade into pages of every name Chromium serves", async () => {
+    await writeSourceFile("options.htm", "<html><head></head></html>");
+
+    await writeSourceFile("Onboarding.HTML", "<html><head></head></html>");
+
+    const derivedDir = await derive();
+
+    for (const pageFileName of ["options.htm", "Onboarding.HTML"]) {
+      expect(await readFile(path.join(derivedDir, pageFileName), "utf8")).toContain(
+        '<script src="/chrome-facade.js"></script>',
+      );
+    }
+  });
+
   test("never writes to the directory it was handed", async () => {
     await derive();
 

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -71,11 +71,14 @@ async function readStamp(stampPath: string) {
   }
 }
 
+/** Chromium serves `Popup.HTM` as a page just as well, so the net is this wide. */
+const PAGE_FILE_EXTENSIONS = new Set([".html", ".htm"]);
+
 async function injectFacadeIntoPages(derivedDir: string) {
   const fileNames = await readdir(derivedDir, { recursive: true });
 
   for (const fileName of fileNames) {
-    if (!fileName.endsWith(".html")) {
+    if (!PAGE_FILE_EXTENSIONS.has(path.extname(fileName).toLowerCase())) {
       continue;
     }
 


### PR DESCRIPTION
- `injectFacadeIntoPages` matched `.html` exactly, so a page named `options.htm` or `Onboarding.HTML` — both of which Chromium serves as extension pages — ran without the facade and hit the same incomplete `chrome` the derive exists to complete.
- The match is now on the lowercased extension, `.html` and `.htm`.

Test plan:
1. `bun test packages/electron-extensions/derive` — the new page-name test passes.