### PR TITLE
generate the macos entitlements with the signing team id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ dist
 .DS_Store
 
 # Meru
+build/entitlements.mac.plist
 build-js
 docs/
 /extensions/

--- a/build/entitlements.mac.template.plist
+++ b/build/entitlements.mac.template.plist
@@ -12,9 +12,5 @@
     <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
-    <key>keychain-access-groups</key>
-    <array>
-      <string>$(AppIdentifierPrefix)sh.zoid.meru.webauthn</string>
-    </array>
   </dict>
 </plist>

--- a/build/hooks/beforePack.js
+++ b/build/hooks/beforePack.js
@@ -1,0 +1,42 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+// `codesign` never expands Xcode's `$(AppIdentifierPrefix)`, and macOS refuses to launch an app
+// whose `keychain-access-groups` entitlement doesn't match the team it was signed with, so the
+// group Touch ID WebAuthn credentials live under is written out here with the team id that only
+// signed builds carry. Keep the group in sync with `configureWebAuthn` in `packages/app/index.ts`.
+export default async (context) => {
+  if (context.packager.platform.name !== "mac") {
+    return;
+  }
+
+  const buildPath = path.join(process.cwd(), "build");
+
+  const template = await fs.readFile(
+    path.join(buildPath, "entitlements.mac.template.plist"),
+    "utf8",
+  );
+
+  const teamId = process.env.APPLE_TEAM_ID;
+
+  const entitlements = teamId
+    ? template.replace(
+        "  </dict>",
+        [
+          "    <key>keychain-access-groups</key>",
+          "    <array>",
+          `      <string>${teamId}.${context.packager.appInfo.id}.webauthn</string>`,
+          "    </array>",
+          "  </dict>",
+        ].join("\n"),
+      )
+    : template;
+
+  await fs.writeFile(path.join(buildPath, "entitlements.mac.plist"), entitlements);
+
+  console.log(
+    teamId
+      ? "Generated macOS entitlements with the Touch ID keychain access group"
+      : "Generated macOS entitlements without the Touch ID keychain access group, `APPLE_TEAM_ID` is unset",
+  );
+};

--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
       "provider": "github",
       "releaseType": "release"
     },
+    "beforePack": "./build/hooks/beforePack.js",
     "afterPack": "./build/hooks/afterPack.js"
   },
   "patchedDependencies": {


### PR DESCRIPTION
- `codesign` never expands Xcode's `$(AppIdentifierPrefix)`, so signed builds since #810 carried a literal `$(AppIdentifierPrefix)sh.zoid.meru.webauthn` keychain access group. A signed app whose `keychain-access-groups` entitlement doesn't match its signing team is killed at launch — "The application "Meru.app" can't be opened."
- `build/entitlements.mac.plist` is now generated by a `beforePack` hook from `build/entitlements.mac.template.plist`, adding the group as `$APPLE_TEAM_ID.sh.zoid.meru.webauthn` only when `APPLE_TEAM_ID` is set, so unsigned builds carry no group at all. The generated file is gitignored.
- The bundle id comes from `context.packager.appInfo.id`; the team id matches what `configureWebAuthn` already builds at runtime in `packages/app/index.ts`, which means Touch ID enrollment has never worked in a shipped build.

Only verified by running the hook standalone and validating the generated plist — no signed build was produced from this branch, and Touch ID enrollment itself is still unverified end to end.

## Test plan

1. Label this PR `sign-macos`, download the arm64 dmg from the run, and launch the app — it should open instead of showing "can't be opened".
2. `codesign -d --entitlements - --xml /Applications/Meru.app | plutil -convert xml1 -o - -` → `keychain-access-groups` holds `<TEAM_ID>.sh.zoid.meru.webauthn`, no `$(AppIdentifierPrefix)`.
3. In Gmail's security settings, enroll a passkey → the Touch ID prompt appears and the credential is created.