### PR TITLE
add release channels with a channel setting

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: release
 description: Cut a Meru release. Use when asked to release, cut a release, ship a version, or bump the version.
-argument-hint: [major|minor|patch]
+argument-hint: [major|minor|patch|beta]
 ---
 
 # Release
@@ -16,7 +16,7 @@ Check all of these first. If one fails, report it and stop — never work around
 - The last `main` workflow run is for the current `HEAD` and passed: `gh run list --workflow=main.yml --branch=main -L 1 --json headSha,status,conclusion,url`.
   - `headSha` must equal `git rev-parse HEAD`. A `HEAD` with no run yet, or a run still `in_progress`, means waiting — say which and ask whether to wait for it.
   - Any `conclusion` other than `success` means `main` is broken. Report the run URL and stop.
-- There is something to release: the range from the last release's tag (`gh release list -L 1`) to `HEAD` is non-empty.
+- There is something to release: the range from the last release's tag to `HEAD` is non-empty. For a stable release that's the last stable tag (`gh release list --exclude-pre-releases -L 1`); for a beta it's the last release of any kind (`gh release list -L 1`).
 
 ## Choosing the bump
 
@@ -27,6 +27,14 @@ Read `git log --oneline <lastTag>..HEAD` — a release usually runs to a few doz
 - **major** — never propose one unprompted. It is for breaking changes (a config migration that drops data, dropping an OS). If the range looks like it contains one, say so and let the user decide.
 
 Arguments naming a level or an explicit version override this triage — take them, and still confirm.
+
+## Beta releases
+
+A `beta` argument (or an explicit `-beta.N` version) cuts a pre-release for the beta update channel instead of a stable release. Only cut one when asked — never propose a beta unprompted.
+
+- The version is the next stable version per the triage above with `-beta.N` appended: the first beta of a cycle is `X.Y.Z-beta.1`, each further beta before that stable ships increments `N`.
+- Everything else follows the stable flow, with two differences: `gh release create` gets `--prerelease`, and the triage range runs from the last release of any kind, not the last stable.
+- Promoting a beta to stable is just the normal stable flow with the suffix dropped (`3.60.0-beta.2` → `3.60.0`); beta users are moved onto the stable build automatically.
 
 ## Confirming
 
@@ -46,6 +54,7 @@ Always confirm before editing `package.json`, even when the bump is obvious.
 
 - `gh release create v<version> --target "$(git rev-parse HEAD)" --notes ""`.
   - `--target` pins the tag to the version commit rather than wherever `main` has drifted to.
+  - For a beta, add `--prerelease` — it keeps the release off `/releases/latest` (so stable users never see it) and makes `release.yml` publish `beta*.yml` update metadata instead of `latest*.yml`.
   - No `--title`: every prior release leaves the title empty so GitHub shows the tag.
   - Empty notes are deliberate — the next step writes them. Don't pass `--generate-notes`.
 - Never create it as a draft. `release.yml` triggers on `released`/`prereleased` only, so a draft never builds.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
       - if: startsWith(matrix.os, 'macos')
-        run: bun run build:mac -- --publish always
+        run: bun run build:mac -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=beta' || '' }}
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
@@ -35,10 +35,10 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: startsWith(matrix.os, 'ubuntu')
-        run: bun run build:linux -- --publish always
+        run: bun run build:linux -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=beta' || '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: startsWith(matrix.os, 'windows')
-        run: bun run build:win -- --publish always
+        run: bun run build:win -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=beta' || '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -68,6 +68,7 @@ export const config = new Store<Config>({
     "notifications.times": [],
     "updates.autoCheck": true,
     "updates.showNotifications": true,
+    "updates.channel": "stable",
     "blocker.enabled": true,
     "blocker.ads": true,
     "blocker.tracking": true,

--- a/packages/app/updater.ts
+++ b/packages/app/updater.ts
@@ -6,8 +6,26 @@ import { log } from "./lib/log";
 import { main } from "./main";
 
 class AppUpdater {
+  private applyChannel() {
+    const channel = config.get("updates.channel");
+
+    // The channel setter force-enables allowDowngrade, so it must be assigned last.
+    autoUpdater.channel = channel === "stable" ? null : channel;
+    autoUpdater.allowPrerelease = channel !== "stable";
+    autoUpdater.allowDowngrade =
+      channel === "stable" && autoUpdater.currentVersion.prerelease.length > 0;
+  }
+
   init() {
     autoUpdater.logger = log;
+
+    this.applyChannel();
+
+    config.onDidChange("updates.channel", () => {
+      this.applyChannel();
+
+      this.checkForUpdates();
+    });
 
     if (config.get("updates.showNotifications")) {
       autoUpdater.on("update-downloaded", (updateInfo) => {

--- a/packages/renderer/routes/settings/updates.tsx
+++ b/packages/renderer/routes/settings/updates.tsx
@@ -1,6 +1,12 @@
 import { FieldGroup } from "@meru/ui/components/field";
+import { ConfigSelectField } from "@/components/config-select-field";
 import { ConfigSwitchField } from "@/components/config-switch-field";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
+
+const releaseChannelItems = [
+  { value: "stable", label: "Stable" },
+  { value: "beta", label: "Beta" },
+];
 
 export function UpdatesSettings() {
   return (
@@ -20,6 +26,20 @@ export function UpdatesSettings() {
             label="Notify When Updates Are Available"
             description="Receive notifications when updates are available."
             configKey="updates.showNotifications"
+          />
+          <ConfigSelectField
+            label="Release Channel"
+            description="Choose which releases to receive. The beta channel gets upcoming features early."
+            configKey="updates.channel"
+            items={releaseChannelItems}
+            placeholder="Select channel"
+            confirmation={{
+              when: (value) => value === "beta",
+              title: "Switch to the beta channel?",
+              description:
+                "Beta releases are pre-release builds of upcoming versions. They may contain bugs or unfinished features. You can switch back to the stable channel at any time.",
+              confirmLabel: "Switch to Beta",
+            }}
           />
         </FieldGroup>
       </SettingsContent>

--- a/packages/renderer/routes/settings/version-history.tsx
+++ b/packages/renderer/routes/settings/version-history.tsx
@@ -11,8 +11,11 @@ import rehypeRaw from "rehype-raw";
 import z from "zod";
 import { SettingsDescription, SettingsHeader, SettingsTitle } from "@/components/settings";
 import { dayjs } from "@/lib/date";
+import { useConfig } from "@/lib/react-query";
 
 export function VersionHistorySettings() {
+  const { config } = useConfig();
+
   const { data: info } = useQuery({
     queryKey: ["about", "info"],
     queryFn: () => ipc.main.invoke("about.getInfo"),
@@ -33,6 +36,7 @@ export function VersionHistorySettings() {
             published_at: z.string(),
             body: z.string().nullable(),
             tag_name: z.string(),
+            prerelease: z.boolean(),
             id: z.number(),
           }),
         )
@@ -70,7 +74,12 @@ export function VersionHistorySettings() {
       );
     }
 
-    return data.map((release) => (
+    const releases =
+      config?.["updates.channel"] === "beta"
+        ? data
+        : data.filter((release) => !release.prerelease || release.tag_name === currentTagName);
+
+    return releases.map((release) => (
       <Item key={release.id} variant="muted">
         <ItemContent>
           <div className="flex items-center justify-between gap-2">

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -121,6 +121,7 @@ export type Config = {
   "notifications.times": NotificationTime[];
   "updates.autoCheck": boolean;
   "updates.showNotifications": boolean;
+  "updates.channel": "stable" | "beta";
   "blocker.enabled": boolean;
   "blocker.ads": boolean;
   "blocker.tracking": boolean;


### PR DESCRIPTION
- New `updates.channel` config key (`stable` | `beta`, default `stable`) with a Release Channel select on the Updates settings page; switching to Beta asks for confirmation.
- `AppUpdater` applies the channel to `autoUpdater` (`channel`, `allowPrerelease`, and `allowDowngrade` when leaving beta on a prerelease build) and re-applies live on config change, triggering one check.
- `release.yml` passes `--config.publish.channel=beta` on prerelease events — with the GitHub provider, electron-builder does not derive the channel file from the version suffix, so without this a beta would publish `latest*.yml`.
- What's New hides prerelease entries from stable-channel users (except the running version).
- Release skill gains the beta flow: `X.Y.Z-beta.N`, `gh release create --prerelease`, stable triage ranges use `--exclude-pre-releases`.

Not verified: the publish path and an actual cross-channel update — that needs the first real `-beta.1` release. UI untested in a live app (sandbox can't launch Electron); the select mirrors the existing `tray.iconColor` field. The `release-notes` skill doesn't yet handle interleaved beta tags — tracked in the docs feature doc.

Test plan:
1. Open Settings → Updates: Release Channel shows Stable by default; picking Beta opens the confirmation dialog, Cancel leaves Stable selected, confirm persists Beta.
2. After the next stable ships, cut a `-beta.1` prerelease and confirm the release assets contain `beta*.yml` (not `latest*.yml`).
3. On a beta-channel install, confirm the beta is offered; switch back to Stable and confirm it downgrades to the newest stable.