### PR TITLE
extract a general extension bridge from the native messaging transport

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -6,7 +6,7 @@ import {
   getInstalledExtension,
   installLatestExtension,
   pruneDerivedExtensions,
-  registerNativeMessagingScheme,
+  registerExtensionBridgeScheme,
   uninstallExtension,
 } from "@meru/electron-extensions";
 import { curatedExtensions, isCuratedExtensionId } from "@meru/shared/extensions";
@@ -98,9 +98,9 @@ async function getExtensionDirs() {
   return [...getDevExtensionDirs(), ...(await getInstalledExtensionDirs())];
 }
 
-// Extension contexts reach the native messaging bridge over a custom scheme,
+// Extension contexts reach the main process over the bridge's custom scheme,
 // and Electron only takes scheme privileges while modules are still loading
-registerNativeMessagingScheme();
+registerExtensionBridgeScheme();
 
 export const extensions = new Extensions({
   extensionDirs: getExtensionDirs,

--- a/packages/electron-extensions/bridge/bridge.test.ts
+++ b/packages/electron-extensions/bridge/bridge.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import type { Session } from "electron";
+import { ExtensionBridge } from "./bridge";
+import { EXTENSION_BRIDGE_ORIGIN, EXTENSION_BRIDGE_SCHEME } from "./protocol";
+
+const EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
+
+const BRIDGE_TOKEN = "bridge-token";
+
+function createSession() {
+  const handledSchemes: string[] = [];
+
+  let requestHandler: ((request: GlobalRequest) => Promise<Response>) | undefined;
+
+  const session = {
+    protocol: {
+      handle: (scheme: string, handler: (request: GlobalRequest) => Promise<Response>) => {
+        handledSchemes.push(scheme);
+
+        requestHandler = handler;
+      },
+      unhandle: (scheme: string) => {
+        handledSchemes.splice(handledSchemes.indexOf(scheme), 1);
+
+        requestHandler = undefined;
+      },
+    },
+  } as unknown as Session;
+
+  return {
+    session,
+    handledSchemes,
+    request: (pathName: string, body: Record<string, unknown>, origin?: string) =>
+      requestHandler?.({
+        url: `${EXTENSION_BRIDGE_ORIGIN}${pathName}`,
+        headers: new Headers(origin === undefined ? {} : { origin }),
+        json: async () => body,
+      } as unknown as GlobalRequest) as Promise<Response>,
+  };
+}
+
+function createBridge(session: Session) {
+  const bridge = new ExtensionBridge();
+
+  bridge.setupSession(session, {
+    getExtensionId: (bridgeToken) => (bridgeToken === BRIDGE_TOKEN ? EXTENSION_ID : undefined),
+  });
+
+  return bridge;
+}
+
+describe("ExtensionBridge", () => {
+  test("routes an authenticated request to its handler", async () => {
+    const { session, request } = createSession();
+
+    const bridge = createBridge(session);
+
+    bridge.handle("/echo", ({ extensionId, body, headers }) =>
+      Response.json({ extensionId, echoed: body.value }, { headers }),
+    );
+
+    const response = await request(
+      "/echo",
+      { token: BRIDGE_TOKEN, value: 42 },
+      "chrome-extension://aaa",
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ extensionId: EXTENSION_ID, echoed: 42 });
+    expect(response.headers.get("access-control-allow-origin")).toBe("chrome-extension://aaa");
+  });
+
+  test("refuses a request without the token of a loaded extension", async () => {
+    const { session, request } = createSession();
+
+    const bridge = createBridge(session);
+
+    bridge.handle("/echo", ({ headers }) => new Response(null, { status: 204, headers }));
+
+    expect((await request("/echo", { token: "guessed" })).status).toBe(403);
+    expect((await request("/echo", {})).status).toBe(403);
+  });
+
+  test("answers 404 for a path nothing registered", async () => {
+    const { session, request } = createSession();
+
+    createBridge(session);
+
+    expect((await request("/unregistered", { token: BRIDGE_TOKEN })).status).toBe(404);
+  });
+
+  test("answers 400 when the handler throws", async () => {
+    const { session, request } = createSession();
+
+    const bridge = createBridge(session);
+
+    bridge.handle("/broken", () => {
+      throw new Error("boom");
+    });
+
+    expect((await request("/broken", { token: BRIDGE_TOKEN })).status).toBe(400);
+  });
+
+  test("handles the scheme for the session's lifetime", () => {
+    const { session, handledSchemes } = createSession();
+
+    const bridge = createBridge(session);
+
+    expect(handledSchemes).toEqual([EXTENSION_BRIDGE_SCHEME]);
+
+    bridge.teardownSession(session);
+
+    expect(handledSchemes).toEqual([]);
+
+    // A session that was never set up has nothing to unhandle
+    bridge.teardownSession(session);
+
+    expect(handledSchemes).toEqual([]);
+  });
+});

--- a/packages/electron-extensions/bridge/bridge.ts
+++ b/packages/electron-extensions/bridge/bridge.ts
@@ -1,0 +1,91 @@
+import type { Session } from "electron";
+import type { ExtensionsLogger } from "../logger";
+import { EXTENSION_BRIDGE_SCHEME, type ExtensionBridgeRequest } from "./protocol";
+
+export type ExtensionBridgeHandler = (request: {
+  session: Session;
+  /** The extension whose facade copy carried the request's token. */
+  extensionId: string;
+  body: Record<string, unknown>;
+  /** For the handler's `Response`, so every answer carries the CORS headers. */
+  headers: Record<string, string>;
+}) => Promise<Response> | Response;
+
+type ExtensionBridgeSession = {
+  /** The extension whose copy of the facade carries this token, if any. */
+  getExtensionId: (bridgeToken: string) => string | undefined;
+};
+
+/**
+ * The main-process end of the facade's transport: one privileged custom scheme
+ * per session, answered here and routed by path to whichever `chrome.*`
+ * implementation registered it. The bridge owns what every route needs alike —
+ * telling which extension is calling from the request's token, and turning
+ * anything else away — so a route handler only ever sees an authenticated
+ * caller.
+ */
+export class ExtensionBridge {
+  private logger: ExtensionsLogger | undefined;
+
+  private sessions = new Map<Session, ExtensionBridgeSession>();
+
+  private routes = new Map<string, ExtensionBridgeHandler>();
+
+  constructor({ logger }: { logger?: ExtensionsLogger } = {}) {
+    this.logger = logger;
+  }
+
+  handle(pathname: string, handler: ExtensionBridgeHandler) {
+    this.routes.set(pathname, handler);
+  }
+
+  setupSession(session: Session, sessionOptions: ExtensionBridgeSession) {
+    this.sessions.set(session, sessionOptions);
+
+    session.protocol.handle(EXTENSION_BRIDGE_SCHEME, (request) =>
+      this.handleRequest(session, request),
+    );
+  }
+
+  teardownSession(session: Session) {
+    if (!this.sessions.delete(session)) {
+      return;
+    }
+
+    session.protocol.unhandle(EXTENSION_BRIDGE_SCHEME);
+  }
+
+  private async handleRequest(session: Session, request: GlobalRequest) {
+    const headers = {
+      "access-control-allow-origin": request.headers.get("origin") ?? "*",
+      "cache-control": "no-store",
+    };
+
+    const { pathname } = new URL(request.url);
+
+    try {
+      const body = (await request.json()) as ExtensionBridgeRequest & Record<string, unknown>;
+
+      // Everything else in the session — Gmail, workspace apps, any page a user
+      // navigated to — can reach this scheme just as well, and only the loaded
+      // extensions know a token
+      const extensionId = this.sessions.get(session)?.getExtensionId(body.token);
+
+      if (!extensionId) {
+        return new Response(null, { status: 403, headers });
+      }
+
+      const handler = this.routes.get(pathname);
+
+      if (!handler) {
+        return new Response(null, { status: 404, headers });
+      }
+
+      return await handler({ session, extensionId, body, headers });
+    } catch (error) {
+      this.logger?.error("Extension bridge request failed", { pathname, error });
+
+      return new Response(null, { status: 400, headers });
+    }
+  }
+}

--- a/packages/electron-extensions/bridge/protocol.ts
+++ b/packages/electron-extensions/bridge/protocol.ts
@@ -1,0 +1,33 @@
+/**
+ * The transport between the facade running inside an extension and the main
+ * process, shared by both sides.
+ *
+ * Extension contexts have no IPC of their own — service worker preload scripts
+ * never run for extension service workers on Electron 43 (see the injection
+ * notes in the feature docs) — but they do have `fetch`, and a custom scheme
+ * handled per session is something only the main process can answer. That is
+ * the whole transport: one POST per call, routed by path to whichever `chrome.*`
+ * implementation registered it.
+ */
+
+export const EXTENSION_BRIDGE_SCHEME = "extension-bridge";
+
+/** Every request goes to the one bridge, so only the path varies. */
+export const EXTENSION_BRIDGE_ORIGIN = `${EXTENSION_BRIDGE_SCHEME}://bridge`;
+
+/**
+ * Where the derived copy of an extension leaves the secret that says a request
+ * came from that extension.
+ *
+ * Something has to, because nothing else in the request does: Electron hands
+ * the handler no `Origin` header and no sender, and the scheme is reachable
+ * from any document in the session whose own policy allows it — a workspace app
+ * or any page a user navigates to. The secret is written into the extension's
+ * copy of the facade, which only the extension can read, and is new on every
+ * launch.
+ */
+export const EXTENSION_BRIDGE_TOKEN_GLOBAL = "__electronExtensionsBridgeToken";
+
+export type ExtensionBridgeRequest = {
+  token: string;
+};

--- a/packages/electron-extensions/bridge/scheme.ts
+++ b/packages/electron-extensions/bridge/scheme.ts
@@ -1,10 +1,10 @@
 import { protocol } from "electron";
-import { NATIVE_MESSAGING_SCHEME } from "./bridge-protocol";
+import { EXTENSION_BRIDGE_SCHEME } from "./protocol";
 
 /**
- * Registers the scheme the native messaging bridge answers on. Electron only
- * takes scheme privileges before the app is ready, so an embedder has to call
- * this while its modules are still loading.
+ * Registers the scheme the extension bridge answers on. Electron only takes
+ * scheme privileges before the app is ready, so an embedder has to call this
+ * while its modules are still loading.
  *
  * `supportFetchAPI` and `corsEnabled` are what let an extension context fetch
  * the scheme at all, and `allowServiceWorkers` is what extends that to service
@@ -13,10 +13,10 @@ import { NATIVE_MESSAGING_SCHEME } from "./bridge-protocol";
  * asked (measured on Electron 43.2.0). Nothing can navigate to the scheme, so
  * the workers it allows to be registered on it are hypothetical.
  */
-export function registerNativeMessagingScheme() {
+export function registerExtensionBridgeScheme() {
   protocol.registerSchemesAsPrivileged([
     {
-      scheme: NATIVE_MESSAGING_SCHEME,
+      scheme: EXTENSION_BRIDGE_SCHEME,
       privileges: {
         standard: true,
         secure: true,

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -1,10 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { cp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
-import {
-  NATIVE_MESSAGING_SCHEME,
-  NATIVE_MESSAGING_TOKEN_GLOBAL,
-} from "../native-messaging/bridge-protocol";
+import { EXTENSION_BRIDGE_SCHEME, EXTENSION_BRIDGE_TOKEN_GLOBAL } from "../bridge/protocol";
 import { getExtensionIdFromManifestKey } from "./extension-id";
 import { injectFacadeScript } from "./html";
 import { deriveManifest, type ExtensionManifest } from "./manifest";
@@ -19,7 +16,7 @@ const FACADE_FILE_NAME = "chrome-facade.js";
 const SERVICE_WORKER_FILE_NAME = "chrome-facade-service-worker.js";
 
 /** Bump whenever what is written into a derived copy changes. */
-const DERIVE_VERSION = 3;
+const DERIVE_VERSION = 4;
 
 export type DeriveExtensionOptions = {
   /** The unpacked extension the embedder handed over, never written to. */
@@ -140,7 +137,7 @@ export async function deriveExtension({
     const { manifest, serviceWorkerWrapper } = deriveManifest(sourceManifest, {
       facadeFileName: FACADE_FILE_NAME,
       serviceWorkerFileName: SERVICE_WORKER_FILE_NAME,
-      bridgeConnectSource: `${NATIVE_MESSAGING_SCHEME}:`,
+      bridgeConnectSource: `${EXTENSION_BRIDGE_SCHEME}:`,
       strippedManifestKeys,
     });
 
@@ -160,7 +157,7 @@ export async function deriveExtension({
 
   await writeFile(
     path.join(derivedDir, FACADE_FILE_NAME),
-    `globalThis.${NATIVE_MESSAGING_TOKEN_GLOBAL} = ${JSON.stringify(bridgeToken)};\n${await readFile(
+    `globalThis.${EXTENSION_BRIDGE_TOKEN_GLOBAL} = ${JSON.stringify(bridgeToken)};\n${await readFile(
       facadeScriptPath,
       "utf8",
     )}`,

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -3,11 +3,9 @@ import fs, { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os, { tmpdir } from "node:os";
 import path from "node:path";
 import type { ClearStorageDataOptions, Extension, Session } from "electron";
+import { EXTENSION_BRIDGE_ORIGIN } from "./bridge/protocol";
 import { Extensions } from "./extensions";
-import {
-  NATIVE_MESSAGING_ORIGIN,
-  NATIVE_MESSAGING_PATHS,
-} from "./native-messaging/bridge-protocol";
+import { NATIVE_MESSAGING_PATHS } from "./native-messaging/bridge-protocol";
 
 let workDir: string;
 
@@ -129,7 +127,7 @@ function createSession({
     sessionEvents,
     request: (body: Record<string, unknown>) =>
       requestHandler?.({
-        url: `${NATIVE_MESSAGING_ORIGIN}${NATIVE_MESSAGING_PATHS.connect}`,
+        url: `${EXTENSION_BRIDGE_ORIGIN}${NATIVE_MESSAGING_PATHS.connect}`,
         headers: new Headers(),
         json: async () => body,
       } as unknown as GlobalRequest) as Promise<Response>,

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -7,6 +7,7 @@ import {
   type ExtensionAction,
   readExtensionActionIcon,
 } from "./action";
+import { ExtensionBridge } from "./bridge/bridge";
 import { deriveExtension } from "./derive";
 import type { ExtensionsLogger } from "./logger";
 import {
@@ -92,6 +93,8 @@ export class Extensions {
 
   private derivedExtensions = new Map<string, ReturnType<typeof deriveExtension>>();
 
+  private bridge: ExtensionBridge;
+
   private nativeMessaging: NativeMessaging;
 
   constructor({
@@ -112,10 +115,14 @@ export class Extensions {
 
     this.logger = logger;
 
+    this.bridge = new ExtensionBridge({ logger });
+
     this.nativeMessaging = new NativeMessaging({
       isHostAllowed: isNativeMessagingHostAllowed,
       logger,
     });
+
+    this.nativeMessaging.registerRoutes(this.bridge);
   }
 
   /**
@@ -169,7 +176,7 @@ export class Extensions {
 
     const extensionIdsByBridgeToken = new Map<string, string>();
 
-    this.nativeMessaging.setupSession(session, {
+    this.bridge.setupSession(session, {
       getExtensionId: (bridgeToken) => extensionIdsByBridgeToken.get(bridgeToken),
     });
 
@@ -256,6 +263,8 @@ export class Extensions {
     this.loadedExtensionIdsBySession.delete(session);
 
     this.actionsBySession.delete(session);
+
+    this.bridge.teardownSession(session);
 
     this.nativeMessaging.teardownSession(session);
 

--- a/packages/electron-extensions/facade/api/native-messaging.ts
+++ b/packages/electron-extensions/facade/api/native-messaging.ts
@@ -1,10 +1,9 @@
 import {
-  NATIVE_MESSAGING_ORIGIN,
   NATIVE_MESSAGING_PATHS,
-  NATIVE_MESSAGING_TOKEN_GLOBAL,
   type NativeMessagingFrame,
 } from "../../native-messaging/bridge-protocol";
 import { NativeMessageDecoder } from "../../native-messaging/framing";
+import { postBridge } from "../lib/bridge";
 import type { ChromeNamespace } from "../lib/chrome";
 import { createEvent } from "../lib/event";
 
@@ -19,19 +18,6 @@ type NativeMessagingPort = {
   onMessage: ReturnType<typeof createEvent>;
   onDisconnect: ReturnType<typeof createEvent>;
 };
-
-function post(pathName: string, body: Record<string, unknown>) {
-  const token = (globalThis as unknown as Record<string, string | undefined>)[
-    NATIVE_MESSAGING_TOKEN_GLOBAL
-  ];
-
-  return fetch(`${NATIVE_MESSAGING_ORIGIN}${pathName}`, {
-    method: "POST",
-    // A safelisted content type keeps this a simple request, so no preflight
-    headers: { "content-type": "text/plain;charset=UTF-8" },
-    body: JSON.stringify({ ...body, token }),
-  });
-}
 
 /**
  * `chrome.runtime.lastError` the way Chrome exposes it: set for the duration of
@@ -90,7 +76,7 @@ function createPort(runtime: ChromeNamespace, hostName: string): NativeMessaging
       }
 
       sendChain = sendChain
-        .then(() => post(NATIVE_MESSAGING_PATHS.post, { portId, message }))
+        .then(() => postBridge(NATIVE_MESSAGING_PATHS.post, { portId, message }))
         .catch(() => undefined);
     },
     disconnect() {
@@ -102,7 +88,7 @@ function createPort(runtime: ChromeNamespace, hostName: string): NativeMessaging
 
       markOpened();
 
-      void post(NATIVE_MESSAGING_PATHS.disconnect, { portId });
+      void postBridge(NATIVE_MESSAGING_PATHS.disconnect, { portId });
     },
   };
 
@@ -122,7 +108,7 @@ function createPort(runtime: ChromeNamespace, hostName: string): NativeMessaging
   };
 
   const readFrames = async () => {
-    const response = await post(NATIVE_MESSAGING_PATHS.connect, { portId, hostName });
+    const response = await postBridge(NATIVE_MESSAGING_PATHS.connect, { portId, hostName });
 
     if (!response.ok || !response.body) {
       throw new Error(`The native messaging bridge answered ${response.status}`);

--- a/packages/electron-extensions/facade/lib/bridge.ts
+++ b/packages/electron-extensions/facade/lib/bridge.ts
@@ -1,0 +1,19 @@
+import { EXTENSION_BRIDGE_ORIGIN, EXTENSION_BRIDGE_TOKEN_GLOBAL } from "../../bridge/protocol";
+
+/**
+ * A call to the main-process end of the bridge, carrying the token the derived
+ * copy of the facade wrote next to this script — what tells the bridge which
+ * extension is calling, since the request itself carries no sender.
+ */
+export function postBridge(pathName: string, body: Record<string, unknown>) {
+  const token = (globalThis as unknown as Record<string, string | undefined>)[
+    EXTENSION_BRIDGE_TOKEN_GLOBAL
+  ];
+
+  return fetch(`${EXTENSION_BRIDGE_ORIGIN}${pathName}`, {
+    method: "POST",
+    // A safelisted content type keeps this a simple request, so no preflight
+    headers: { "content-type": "text/plain;charset=UTF-8" },
+    body: JSON.stringify({ ...body, token }),
+  });
+}

--- a/packages/electron-extensions/index.ts
+++ b/packages/electron-extensions/index.ts
@@ -1,4 +1,5 @@
 export type { ExtensionAction } from "./action";
+export { registerExtensionBridgeScheme } from "./bridge/scheme";
 export { compareExtensionVersions, verifyCrx } from "./crx";
 export type { VerifiedCrx } from "./crx";
 export { pruneDerivedExtensions } from "./derive";
@@ -25,5 +26,4 @@ export type {
 } from "./install";
 export type { ExtensionsLogger } from "./logger";
 export type { NativeMessagingHostPolicy } from "./native-messaging/native-messaging";
-export { registerNativeMessagingScheme } from "./native-messaging/scheme";
 export { findExtensionDirs } from "./scan";

--- a/packages/electron-extensions/native-messaging/bridge-protocol.ts
+++ b/packages/electron-extensions/native-messaging/bridge-protocol.ts
@@ -1,42 +1,15 @@
 /**
- * The contract between the facade running inside an extension and the bridge
- * running in the main process, shared by both sides.
- *
- * Extension contexts have no IPC of their own — service worker preload scripts
- * never run for extension service workers on Electron 43 (see the injection
- * notes in the feature docs) — but they do have `fetch`, and a custom scheme
- * handled per session is something only the main process can answer. That is
- * the whole transport: one request per call, and the connect request's response
- * body left open to carry everything the host says back.
+ * What native messaging says over the extension bridge (`bridge/protocol.ts`),
+ * shared by the facade and the main process: one request per call, and the
+ * connect request's response body left open to carry everything the host says
+ * back.
  */
-
-export const NATIVE_MESSAGING_SCHEME = "extension-native-messaging";
-
-/** Every request goes to the one bridge, so only the path varies. */
-export const NATIVE_MESSAGING_ORIGIN = `${NATIVE_MESSAGING_SCHEME}://port`;
 
 export const NATIVE_MESSAGING_PATHS = {
-  connect: "/connect",
-  post: "/post",
-  disconnect: "/disconnect",
+  connect: "/native-messaging/connect",
+  post: "/native-messaging/post",
+  disconnect: "/native-messaging/disconnect",
 } as const;
-
-/**
- * Where the derived copy of an extension leaves the secret that says a request
- * came from that extension.
- *
- * Something has to, because nothing else in the request does: Electron hands
- * the handler no `Origin` header and no sender, and the scheme is reachable
- * from any document in the session whose own policy allows it — a workspace app
- * or any page a user navigates to. The secret is written into the extension's
- * copy of the facade, which only the extension can read, and is new on every
- * launch.
- */
-export const NATIVE_MESSAGING_TOKEN_GLOBAL = "__electronExtensionsNativeMessagingToken";
-
-export type NativeMessagingRequest = {
-  token: string;
-};
 
 /**
  * The port id is the extension's to choose so that it can post to a port the
@@ -44,17 +17,17 @@ export type NativeMessagingRequest = {
  * what the id may reach: a port answers only to the session and extension that
  * opened it.
  */
-export type NativeMessagingConnectRequest = NativeMessagingRequest & {
+export type NativeMessagingConnectRequest = {
   portId: string;
   hostName: string;
 };
 
-export type NativeMessagingPostRequest = NativeMessagingRequest & {
+export type NativeMessagingPostRequest = {
   portId: string;
   message: unknown;
 };
 
-export type NativeMessagingDisconnectRequest = NativeMessagingRequest & {
+export type NativeMessagingDisconnectRequest = {
   portId: string;
 };
 

--- a/packages/electron-extensions/native-messaging/native-messaging.test.ts
+++ b/packages/electron-extensions/native-messaging/native-messaging.test.ts
@@ -3,12 +3,9 @@ import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Session } from "electron";
-import {
-  NATIVE_MESSAGING_ORIGIN,
-  NATIVE_MESSAGING_PATHS,
-  NATIVE_MESSAGING_SCHEME,
-  type NativeMessagingFrame,
-} from "./bridge-protocol";
+import { ExtensionBridge } from "../bridge/bridge";
+import { EXTENSION_BRIDGE_ORIGIN } from "../bridge/protocol";
+import { NATIVE_MESSAGING_PATHS, type NativeMessagingFrame } from "./bridge-protocol";
 import { NativeMessageDecoder } from "./framing";
 import { getHostManifestSearchPaths } from "./host-manifest";
 import { NativeMessaging } from "./native-messaging";
@@ -93,7 +90,7 @@ async function writeHostManifest(allowedExtensionId = EXTENSION_ID) {
 
 function createRequest(pathName: string, body: Record<string, unknown>) {
   return {
-    url: `${NATIVE_MESSAGING_ORIGIN}${pathName}`,
+    url: `${EXTENSION_BRIDGE_ORIGIN}${pathName}`,
     headers: new Headers(),
     json: async () => body,
   } as unknown as GlobalRequest;
@@ -115,11 +112,22 @@ function createNativeMessaging(options: ConstructorParameters<typeof NativeMessa
     hostManifestSearch: { homeDir: workDir },
   });
 
-  nativeMessaging.setupSession(session, {
+  const bridge = new ExtensionBridge();
+
+  nativeMessaging.registerRoutes(bridge);
+
+  bridge.setupSession(session, {
     getExtensionId: (bridgeToken) => (bridgeToken === BRIDGE_TOKEN ? EXTENSION_ID : undefined),
   });
 
-  return nativeMessaging;
+  return {
+    nativeMessaging,
+    teardown: () => {
+      bridge.teardownSession(session);
+
+      nativeMessaging.teardownSession(session);
+    },
+  };
 }
 
 /** Kill with signal 0 probes for existence, and ESRCH says the process is gone. */
@@ -162,7 +170,7 @@ describe("NativeMessaging", () => {
   test("carries messages both ways and tells the host who is calling", async () => {
     await writeHostManifest();
 
-    const nativeMessaging = createNativeMessaging();
+    const { teardown } = createNativeMessaging();
 
     const response = await connect();
 
@@ -181,23 +189,7 @@ describe("NativeMessaging", () => {
       message: { echo: { hello: "host" }, origin: `chrome-extension://${EXTENSION_ID}/` },
     });
 
-    nativeMessaging.teardownSession(session);
-  });
-
-  test("refuses a request without the token of a loaded extension", async () => {
-    await writeHostManifest();
-
-    createNativeMessaging();
-
-    const response = await requestHandler?.(
-      createRequest(NATIVE_MESSAGING_PATHS.connect, {
-        token: "guessed",
-        portId: "port-1",
-        hostName: HOST_NAME,
-      }),
-    );
-
-    expect(response?.status).toBe(403);
+    teardown();
   });
 
   test("disconnects when the host does not list the extension", async () => {
@@ -236,7 +228,7 @@ describe("NativeMessaging", () => {
 
     const logs: { message: string; details: Record<string, unknown> }[] = [];
 
-    const nativeMessaging = createNativeMessaging({
+    const { teardown } = createNativeMessaging({
       logger: {
         info: (message, details) => {
           logs.push({ message, details });
@@ -259,37 +251,19 @@ describe("NativeMessaging", () => {
 
     await waitForProcessExit(hostPid);
 
-    nativeMessaging.teardownSession(session);
+    teardown();
   });
 
   test("takes the session's ports down with the session", async () => {
     await writeHostManifest();
 
-    const nativeMessaging = createNativeMessaging();
+    const { teardown } = createNativeMessaging();
 
     const response = await connect();
 
-    nativeMessaging.teardownSession(session);
+    teardown();
 
     expect(requestHandler).toBeUndefined();
     expect(await readFrame(response)).toEqual({ type: "disconnect", error: undefined });
-  });
-
-  test("handles the scheme on the session it is set up for", () => {
-    const handledSchemes: string[] = [];
-
-    new NativeMessaging().setupSession(
-      {
-        protocol: {
-          handle: (scheme: string) => {
-            handledSchemes.push(scheme);
-          },
-          unhandle: () => undefined,
-        },
-      } as unknown as Session,
-      { getExtensionId: () => undefined },
-    );
-
-    expect(handledSchemes).toEqual([NATIVE_MESSAGING_SCHEME]);
   });
 });

--- a/packages/electron-extensions/native-messaging/native-messaging.ts
+++ b/packages/electron-extensions/native-messaging/native-messaging.ts
@@ -1,13 +1,12 @@
 import type { Session } from "electron";
+import type { ExtensionBridge } from "../bridge/bridge";
 import type { ExtensionsLogger } from "../logger";
 import {
   NATIVE_MESSAGING_PATHS,
-  NATIVE_MESSAGING_SCHEME,
   type NativeMessagingConnectRequest,
   type NativeMessagingDisconnectRequest,
   type NativeMessagingFrame,
   type NativeMessagingPostRequest,
-  type NativeMessagingRequest,
 } from "./bridge-protocol";
 import { encodeNativeMessage } from "./framing";
 import { NativeMessagingHost } from "./host";
@@ -46,11 +45,6 @@ export type NativeMessagingOptions = {
   logger?: ExtensionsLogger;
 };
 
-type NativeMessagingSession = {
-  /** The extension whose copy of the facade carries this token, if any. */
-  getExtensionId: (bridgeToken: string) => string | undefined;
-};
-
 type NativeMessagingPort = {
   id: string;
   session: Session;
@@ -70,14 +64,12 @@ type NativeMessagingPort = {
  * `DISALLOW` and `CreateReceiverForNativeApp` returns nullptr, so the built-in
  * `connectNative` disconnects every port with "Access to the native messaging
  * host was disabled by the system administrator" no matter where a host
- * manifest sits. The facade therefore replaces both methods and they land here,
- * which finds the host manifest the way Chromium would, honours its
- * `allowed_origins`, and runs one host process per port.
+ * manifest sits. The facade therefore replaces both methods and they land here
+ * over the extension bridge, which finds the host manifest the way Chromium
+ * would, honours its `allowed_origins`, and runs one host process per port.
  */
 export class NativeMessaging {
   private options: NativeMessagingOptions;
-
-  private sessions = new Map<Session, NativeMessagingSession>();
 
   private ports = new Map<string, NativeMessagingPort>();
 
@@ -93,83 +85,43 @@ export class NativeMessaging {
     });
   }
 
-  setupSession(session: Session, sessionOptions: NativeMessagingSession) {
-    this.sessions.set(session, sessionOptions);
-
-    session.protocol.handle(NATIVE_MESSAGING_SCHEME, (request) =>
-      this.handleRequest(session, request),
+  registerRoutes(bridge: ExtensionBridge) {
+    bridge.handle(NATIVE_MESSAGING_PATHS.connect, ({ session, extensionId, body, headers }) =>
+      this.handleConnect(
+        session,
+        extensionId,
+        body as unknown as NativeMessagingConnectRequest,
+        headers,
+      ),
     );
+
+    bridge.handle(NATIVE_MESSAGING_PATHS.post, ({ session, extensionId, body, headers }) => {
+      this.handlePost(session, extensionId, body as unknown as NativeMessagingPostRequest);
+
+      return new Response(null, { status: 204, headers });
+    });
+
+    bridge.handle(NATIVE_MESSAGING_PATHS.disconnect, ({ session, extensionId, body, headers }) => {
+      const port = this.getPort(
+        session,
+        extensionId,
+        (body as unknown as NativeMessagingDisconnectRequest).portId,
+      );
+
+      if (port) {
+        this.closePort(port);
+      }
+
+      return new Response(null, { status: 204, headers });
+    });
   }
 
   teardownSession(session: Session) {
-    if (!this.sessions.delete(session)) {
-      return;
-    }
-
-    session.protocol.unhandle(NATIVE_MESSAGING_SCHEME);
-
     for (const port of this.ports.values()) {
       if (port.session === session) {
         this.closePort(port);
       }
     }
-  }
-
-  private async handleRequest(session: Session, request: GlobalRequest) {
-    const headers = {
-      "access-control-allow-origin": request.headers.get("origin") ?? "*",
-      "cache-control": "no-store",
-    };
-
-    const { pathname } = new URL(request.url);
-
-    try {
-      const body = (await request.json()) as NativeMessagingRequest;
-
-      // Everything else in the session — Gmail, workspace apps, any page a user
-      // navigated to — can reach this scheme just as well, and only the loaded
-      // extensions know a token
-      const extensionId = this.sessions.get(session)?.getExtensionId(body.token);
-
-      if (!extensionId) {
-        return new Response(null, { status: 403, headers });
-      }
-
-      if (pathname === NATIVE_MESSAGING_PATHS.connect) {
-        return this.handleConnect(
-          session,
-          extensionId,
-          body as NativeMessagingConnectRequest,
-          headers,
-        );
-      }
-
-      if (pathname === NATIVE_MESSAGING_PATHS.post) {
-        this.handlePost(session, extensionId, body as NativeMessagingPostRequest);
-
-        return new Response(null, { status: 204, headers });
-      }
-
-      if (pathname === NATIVE_MESSAGING_PATHS.disconnect) {
-        const port = this.getPort(
-          session,
-          extensionId,
-          (body as NativeMessagingDisconnectRequest).portId,
-        );
-
-        if (port) {
-          this.closePort(port);
-        }
-
-        return new Response(null, { status: 204, headers });
-      }
-    } catch (error) {
-      this.options.logger?.error("Native messaging request failed", { pathname, error });
-
-      return new Response(null, { status: 400, headers });
-    }
-
-    return new Response(null, { status: 404, headers });
   }
 
   /**


### PR DESCRIPTION
- Moves the privileged scheme, bearer-token auth and path routing out of `NativeMessaging` into a general `ExtensionBridge` any `chrome.*` implementation can register routes on; native messaging is now just its first consumer.
- Scheme renamed to `extension-bridge`, native messaging paths namespaced under `/native-messaging/*`, token global renamed; `DERIVE_VERSION` bumped so existing derived copies regenerate with the new CSP source.
- No behavior change intended. Verified by unit tests only on its own — the live 1Password pass happens on #845 at the stack tip, which exercises this transport for every call.

Test plan (covered by testing #845):
1. With the stack build, unlock 1Password via its popup — native messaging still reaching the desktop app proves the renamed transport end to end.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>