### PR TITLE
answer webNavigation frame queries and surface extension worker consoles

### DIFF
--- a/packages/electron-extensions/bridge/bridge.test.ts
+++ b/packages/electron-extensions/bridge/bridge.test.ts
@@ -87,6 +87,10 @@ describe("ExtensionBridge", () => {
     createBridge(session);
 
     expect((await request("/unregistered", { token: BRIDGE_TOKEN })).status).toBe(404);
+
+    // The token is checked first, so an unauthenticated caller learns nothing
+    // about which paths exist
+    expect((await request("/unregistered", { token: "guessed" })).status).toBe(403);
   });
 
   test("answers 400 when the handler throws", async () => {

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -93,6 +93,10 @@ function createSession({
 
   let requestHandler: ((request: GlobalRequest) => Promise<Response>) | undefined;
 
+  const serviceWorkerConsoleListeners = new Set<
+    (event: unknown, messageDetails: Record<string, unknown>) => void
+  >();
+
   const session = {
     extensions: {
       loadExtension: async (extensionDir: string) => {
@@ -118,6 +122,20 @@ function createSession({
       sessionEvents.push(`clearStorageData ${origin} ${storages?.join()}`);
     },
     getStoragePath: () => storagePath,
+    serviceWorkers: {
+      on: (
+        _eventName: string,
+        listener: (event: unknown, messageDetails: Record<string, unknown>) => void,
+      ) => {
+        serviceWorkerConsoleListeners.add(listener);
+      },
+      removeListener: (
+        _eventName: string,
+        listener: (event: unknown, messageDetails: Record<string, unknown>) => void,
+      ) => {
+        serviceWorkerConsoleListeners.delete(listener);
+      },
+    },
   } as unknown as Session;
 
   return {
@@ -125,6 +143,12 @@ function createSession({
     removedExtensionIds,
     handledSchemes,
     sessionEvents,
+    serviceWorkerConsoleListeners,
+    emitServiceWorkerConsole: (messageDetails: Record<string, unknown>) => {
+      for (const listener of serviceWorkerConsoleListeners) {
+        listener(undefined, messageDetails);
+      }
+    },
     request: (body: Record<string, unknown>) =>
       requestHandler?.({
         url: `${EXTENSION_BRIDGE_ORIGIN}${NATIVE_MESSAGING_PATHS.connect}`,
@@ -277,6 +301,69 @@ describe("Extensions", () => {
     expect((await connect(first.request, bridgeToken, "first")).status).not.toBe(403);
     expect((await connect(second.request, bridgeToken, "second")).status).not.toBe(403);
     expect((await connect(first.request, "not-a-token", "third")).status).toBe(403);
+  });
+
+  test("forwards extension service worker console output to the logger", async () => {
+    const logs: { level: string; message: string; details: Record<string, unknown> }[] = [];
+
+    const { session, emitServiceWorkerConsole, serviceWorkerConsoleListeners } = createSession();
+
+    const extensions = createExtensions([await createExtensionDir("one")], {
+      info: (message, details) => {
+        logs.push({ level: "info", message, details });
+      },
+      error: (message, details) => {
+        logs.push({ level: "error", message, details });
+      },
+    });
+
+    await extensions.setupSession(session);
+
+    emitServiceWorkerConsole({
+      message: "Failed to relay message to parent frame",
+      level: 2,
+      sourceUrl: "chrome-extension://aaa/background.js",
+    });
+
+    emitServiceWorkerConsole({
+      message: "unlock failed",
+      level: 3,
+      sourceUrl: "chrome-extension://aaa/background.js",
+    });
+
+    // The session's own pages can run workers too, and they are not extensions
+    emitServiceWorkerConsole({
+      message: "mail worker chatter",
+      level: 3,
+      sourceUrl: "https://mail.google.com/worker.js",
+    });
+
+    const consoleLogs = logs.filter(({ message }) =>
+      message.startsWith("Extension service worker"),
+    );
+
+    expect(consoleLogs).toEqual([
+      {
+        level: "info",
+        message: "Extension service worker log",
+        details: {
+          sourceUrl: "chrome-extension://aaa/background.js",
+          message: "Failed to relay message to parent frame",
+        },
+      },
+      {
+        level: "error",
+        message: "Extension service worker error",
+        details: {
+          sourceUrl: "chrome-extension://aaa/background.js",
+          message: "unlock failed",
+        },
+      },
+    ]);
+
+    extensions.teardownSession(session);
+
+    expect(serviceWorkerConsoleListeners.size).toBe(0);
   });
 
   test("does nothing without extension directories", async () => {

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { Session } from "electron";
+import type { Event as ElectronEvent, MessageDetails, Session } from "electron";
 import {
   type ActionExtension,
   createExtensionAction,
@@ -14,6 +14,7 @@ import {
   NativeMessaging,
   type NativeMessagingHostPolicy,
 } from "./native-messaging/native-messaging";
+import { WebNavigation } from "./web-navigation/web-navigation";
 
 /**
  * Chromium keeps every `chrome.storage` area of every extension in its own
@@ -30,6 +31,9 @@ const EXTENSION_STORAGE_DIR_NAMES = [
 
 /** `IndexedDB/chrome-extension_<extensionId>_0.indexeddb.leveldb` and friends. */
 const EXTENSION_INDEXED_DB_PREFIX = "chrome-extension_";
+
+/** Chromium's console levels run verbose, info, warning, error — 0 to 3. */
+const CONSOLE_ERROR_LEVEL = 3;
 
 export type ActionsChangedListener = (session: Session, actions: ExtensionAction[]) => void;
 
@@ -97,6 +101,13 @@ export class Extensions {
 
   private nativeMessaging: NativeMessaging;
 
+  private webNavigation: WebNavigation;
+
+  private serviceWorkerConsoleListeners = new Map<
+    Session,
+    (event: ElectronEvent, messageDetails: MessageDetails) => void
+  >();
+
   constructor({
     extensionDirs,
     facadeScriptPath,
@@ -123,6 +134,10 @@ export class Extensions {
     });
 
     this.nativeMessaging.registerRoutes(this.bridge);
+
+    this.webNavigation = new WebNavigation();
+
+    this.webNavigation.registerRoutes(this.bridge);
   }
 
   /**
@@ -179,6 +194,8 @@ export class Extensions {
     this.bridge.setupSession(session, {
       getExtensionId: (bridgeToken) => extensionIdsByBridgeToken.get(bridgeToken),
     });
+
+    this.pipeServiceWorkerConsole(session);
 
     for (const extensionDir of extensionDirs) {
       try {
@@ -240,6 +257,31 @@ export class Extensions {
     });
   }
 
+  /**
+   * An extension's service worker has no page and no devtools anywhere in the
+   * embedding app, so what it writes to its console — 1Password saying why it
+   * declined to fill, say — surfaces nowhere unless it is forwarded to the
+   * logger. Every worker on a `chrome-extension://` origin is one this loader
+   * put there, since nothing else loads extensions into the session.
+   */
+  private pipeServiceWorkerConsole(session: Session) {
+    const listener = (_event: ElectronEvent, { message, level, sourceUrl }: MessageDetails) => {
+      if (!sourceUrl.startsWith("chrome-extension://")) {
+        return;
+      }
+
+      if (level >= CONSOLE_ERROR_LEVEL) {
+        this.logger?.error("Extension service worker error", { sourceUrl, message });
+      } else {
+        this.logger?.info("Extension service worker log", { sourceUrl, message });
+      }
+    };
+
+    this.serviceWorkerConsoleListeners.set(session, listener);
+
+    session.serviceWorkers.on("console-message", listener);
+  }
+
   /** A broken icon costs the button its icon, not the extension its button. */
   private async createAction(extension: ActionExtension) {
     const action = createExtensionAction(extension);
@@ -267,6 +309,14 @@ export class Extensions {
     this.bridge.teardownSession(session);
 
     this.nativeMessaging.teardownSession(session);
+
+    const consoleListener = this.serviceWorkerConsoleListeners.get(session);
+
+    if (consoleListener) {
+      this.serviceWorkerConsoleListeners.delete(session);
+
+      session.serviceWorkers.removeListener("console-message", consoleListener);
+    }
 
     for (const extensionId of loadedExtensionIds) {
       session.extensions.removeExtension(extensionId);

--- a/packages/electron-extensions/facade/api/web-navigation.test.ts
+++ b/packages/electron-extensions/facade/api/web-navigation.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { EXTENSION_BRIDGE_ORIGIN } from "../../bridge/protocol";
+import { WEB_NAVIGATION_PATHS } from "../../web-navigation/bridge-protocol";
+import { createWebNavigation } from "./web-navigation";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+type FrameQueryMethod = (details: Record<string, unknown>) => Promise<unknown>;
+
+describe("facade webNavigation", () => {
+  test("asks the bridge and answers what it said", async () => {
+    const requests: { url: string; body: unknown }[] = [];
+
+    globalThis.fetch = (async (url: string, init: RequestInit) => {
+      requests.push({ url, body: JSON.parse(init.body as string) });
+
+      return Response.json({ frameId: 42, parentFrameId: 0 });
+    }) as typeof fetch;
+
+    const getFrame = createWebNavigation().getFrame as FrameQueryMethod;
+
+    expect(await getFrame({ tabId: 12, frameId: 42 })).toEqual({ frameId: 42, parentFrameId: 0 });
+
+    expect(requests).toEqual([
+      {
+        url: `${EXTENSION_BRIDGE_ORIGIN}${WEB_NAVIGATION_PATHS.getFrame}`,
+        body: { details: { tabId: 12, frameId: 42 } },
+      },
+    ]);
+  });
+
+  test("answers null when the bridge is unreachable or refuses", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("Failed to fetch");
+    }) as unknown as typeof fetch;
+
+    const webNavigation = createWebNavigation();
+
+    expect(
+      await (webNavigation.getFrame as FrameQueryMethod)({ tabId: 12, frameId: 0 }),
+    ).toBeNull();
+
+    globalThis.fetch = (async () => new Response(null, { status: 403 })) as unknown as typeof fetch;
+
+    expect(await (webNavigation.getAllFrames as FrameQueryMethod)({ tabId: 12 })).toBeNull();
+  });
+});

--- a/packages/electron-extensions/facade/api/web-navigation.ts
+++ b/packages/electron-extensions/facade/api/web-navigation.ts
@@ -1,12 +1,40 @@
+import { WEB_NAVIGATION_PATHS } from "../../web-navigation/bridge-protocol";
+import { postBridge } from "../lib/bridge";
 import type { ChromeNamespace } from "../lib/chrome";
 import { createNoopEvent } from "../lib/event";
-import { createNoopMethod } from "../lib/method";
+import { createBridgedMethod } from "../lib/method";
 
+/**
+ * A frame query answered by the main process, since only it sees the session's
+ * frame tree. `null` is Chrome's own answer for a frame or tab it cannot find,
+ * and extensions handle it — so it also stands in when the bridge cannot be
+ * reached.
+ */
+function createFrameQuery(pathName: string) {
+  return createBridgedMethod(async (callArguments) => {
+    try {
+      const response = await postBridge(pathName, { details: callArguments[0] });
+
+      if (!response.ok) {
+        return null;
+      }
+
+      return await response.json();
+    } catch {
+      return null;
+    }
+  });
+}
+
+/**
+ * The frame queries are real (`web-navigation/web-navigation.ts`); the events
+ * still never fire. 1Password registers four of them at boot but its fill flow
+ * asks `getFrame` live, which is the part autofill hangs on.
+ */
 export function createWebNavigation(): ChromeNamespace {
   return {
-    // Chrome answers `null` for a frame it cannot find, and extensions handle it
-    getFrame: createNoopMethod(() => null),
-    getAllFrames: createNoopMethod(() => []),
+    getFrame: createFrameQuery(WEB_NAVIGATION_PATHS.getFrame),
+    getAllFrames: createFrameQuery(WEB_NAVIGATION_PATHS.getAllFrames),
 
     onBeforeNavigate: createNoopEvent(),
     onCommitted: createNoopEvent(),

--- a/packages/electron-extensions/facade/lib/method.test.ts
+++ b/packages/electron-extensions/facade/lib/method.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { createBridgedMethod } from "./method";
+
+describe("createBridgedMethod", () => {
+  test("answers a promise-style call with the produced result", async () => {
+    const method = createBridgedMethod(async (callArguments) => ({ callArguments }));
+
+    expect(await method("a", 1)).toEqual({ callArguments: ["a", 1] });
+  });
+
+  test("answers a callback-style call without handing it the callback", async () => {
+    const method = createBridgedMethod(async (callArguments) => ({ callArguments }));
+
+    const { promise: answered, resolve } = Promise.withResolvers<unknown>();
+
+    expect(method("a", 1, resolve)).toBeUndefined();
+
+    expect(await answered).toEqual({ callArguments: ["a", 1] });
+  });
+
+  test("rejects a promise-style call the way the producer did", async () => {
+    const method = createBridgedMethod(async () => {
+      throw new Error("bridge gone");
+    });
+
+    expect(method("a")).rejects.toThrow("bridge gone");
+  });
+
+  test("answers a callback-style call with undefined when the producer rejects", async () => {
+    const method = createBridgedMethod(async () => {
+      throw new Error("bridge gone");
+    });
+
+    const { promise: answered, resolve } = Promise.withResolvers<unknown>();
+
+    method("a", resolve);
+
+    expect(await answered).toBeUndefined();
+  });
+});

--- a/packages/electron-extensions/facade/lib/method.ts
+++ b/packages/electron-extensions/facade/lib/method.ts
@@ -22,3 +22,25 @@ export function createNoopMethod(createResult: (callArguments: unknown[]) => unk
     return Promise.resolve(result);
   };
 }
+
+/**
+ * A method answered elsewhere — over the bridge, typically — with the same
+ * callback-or-promise duality as a noop. `produceResult` sees the call's
+ * arguments without any trailing callback, and must resolve rather than throw:
+ * a rejection would surface differently to the two calling styles.
+ */
+export function createBridgedMethod(produceResult: (callArguments: unknown[]) => Promise<unknown>) {
+  return (...callArguments: unknown[]) => {
+    const callback = callArguments.at(-1);
+
+    if (typeof callback === "function") {
+      void produceResult(callArguments.slice(0, -1)).then((result) => {
+        (callback as (callbackResult: unknown) => void)(result);
+      });
+
+      return undefined;
+    }
+
+    return produceResult(callArguments);
+  };
+}

--- a/packages/electron-extensions/facade/lib/method.ts
+++ b/packages/electron-extensions/facade/lib/method.ts
@@ -26,17 +26,23 @@ export function createNoopMethod(createResult: (callArguments: unknown[]) => unk
 /**
  * A method answered elsewhere — over the bridge, typically — with the same
  * callback-or-promise duality as a noop. `produceResult` sees the call's
- * arguments without any trailing callback, and must resolve rather than throw:
- * a rejection would surface differently to the two calling styles.
+ * arguments without any trailing callback. A rejection reaches a promise-style
+ * caller as its own, the way Chrome's APIs reject; a callback-style caller is
+ * answered `undefined`, never left waiting on a callback that no longer fires.
  */
 export function createBridgedMethod(produceResult: (callArguments: unknown[]) => Promise<unknown>) {
   return (...callArguments: unknown[]) => {
     const callback = callArguments.at(-1);
 
     if (typeof callback === "function") {
-      void produceResult(callArguments.slice(0, -1)).then((result) => {
-        (callback as (callbackResult: unknown) => void)(result);
-      });
+      produceResult(callArguments.slice(0, -1)).then(
+        (result) => {
+          (callback as (callbackResult: unknown) => void)(result);
+        },
+        () => {
+          (callback as (callbackResult: unknown) => void)(undefined);
+        },
+      );
 
       return undefined;
     }

--- a/packages/electron-extensions/web-navigation/bridge-protocol.ts
+++ b/packages/electron-extensions/web-navigation/bridge-protocol.ts
@@ -1,0 +1,31 @@
+/**
+ * What `chrome.webNavigation` frame queries say over the extension bridge
+ * (`bridge/protocol.ts`), shared by the facade and the main process.
+ */
+
+export const WEB_NAVIGATION_PATHS = {
+  getFrame: "/web-navigation/get-frame",
+  getAllFrames: "/web-navigation/get-all-frames",
+} as const;
+
+/** What the extension handed to `getFrame`/`getAllFrames`, taken as untrusted. */
+export type WebNavigationFrameQuery = {
+  tabId?: unknown;
+  frameId?: unknown;
+};
+
+/**
+ * Chrome's frame details, minus `documentId`: Chromium mints those per document
+ * inside its extensions layer and Electron exposes nothing equivalent, and a
+ * made-up value would defeat exactly the caching and dedup extensions use the
+ * id for.
+ */
+export type WebNavigationFrameDetails = {
+  frameId: number;
+  parentFrameId: number;
+  processId: number;
+  url: string;
+  errorOccurred: boolean;
+  frameType: "outermost_frame" | "sub_frame";
+  documentLifecycle: "active";
+};

--- a/packages/electron-extensions/web-navigation/web-navigation.test.ts
+++ b/packages/electron-extensions/web-navigation/web-navigation.test.ts
@@ -138,6 +138,40 @@ describe("WebNavigation", () => {
     ).toBeNull();
   });
 
+  test("answers a live frame while another frame in the tree is disposed", () => {
+    const { contents, mainFrame } = createTab();
+
+    // A disposed WebFrameMain throws from every accessor but isDestroyed
+    const disposedFrame: FakeFrame = {
+      isDestroyed: () => true,
+      get frameTreeNodeId(): number {
+        throw new Error("Render frame was disposed before WebFrameMain could be accessed");
+      },
+      get url(): string {
+        throw new Error("Render frame was disposed before WebFrameMain could be accessed");
+      },
+      get parent(): FakeFrame | null {
+        throw new Error("Render frame was disposed before WebFrameMain could be accessed");
+      },
+      get processId(): number {
+        throw new Error("Render frame was disposed before WebFrameMain could be accessed");
+      },
+      framesInSubtree: [],
+    };
+
+    mainFrame.framesInSubtree.splice(1, 0, disposedFrame);
+
+    const webNavigation = createWebNavigation(contents);
+
+    expect(webNavigation.getFrame(SESSION, { tabId: TAB_ID, frameId: 42 })).toMatchObject({
+      frameId: 42,
+    });
+
+    expect(
+      webNavigation.getAllFrames(SESSION, { tabId: TAB_ID })?.map(({ frameId }) => frameId),
+    ).toEqual([0, 42, 77]);
+  });
+
   test("lists every live frame of a tab", () => {
     const { contents, nestedFrame } = createTab();
 

--- a/packages/electron-extensions/web-navigation/web-navigation.test.ts
+++ b/packages/electron-extensions/web-navigation/web-navigation.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "bun:test";
+import type { Session, WebContents } from "electron";
+import { ExtensionBridge } from "../bridge/bridge";
+import { EXTENSION_BRIDGE_ORIGIN } from "../bridge/protocol";
+import { WEB_NAVIGATION_PATHS } from "./bridge-protocol";
+import { WebNavigation } from "./web-navigation";
+
+const SESSION = { partition: "persist:one" } as unknown as Session;
+
+const OTHER_SESSION = { partition: "persist:two" } as unknown as Session;
+
+const TAB_ID = 12;
+
+type FakeFrame = {
+  frameTreeNodeId: number;
+  url: string;
+  parent: FakeFrame | null;
+  processId: number;
+  isDestroyed: () => boolean;
+  framesInSubtree: FakeFrame[];
+};
+
+function createFrame(
+  frameTreeNodeId: number,
+  url: string,
+  parent: FakeFrame | null,
+  { isDestroyed = false } = {},
+): FakeFrame {
+  return {
+    frameTreeNodeId,
+    url,
+    parent,
+    processId: 7,
+    isDestroyed: () => isDestroyed,
+    framesInSubtree: [],
+  };
+}
+
+/**
+ * The shape of 1Password's fill flow: a page's main frame, the inline-menu
+ * iframe the content script injected into it, and a frame nested one deeper.
+ */
+function createTab({ session = SESSION, isDestroyed = false } = {}) {
+  const mainFrame = createFrame(1, "https://accounts.google.com/signin", null);
+
+  const menuFrame = createFrame(42, "chrome-extension://aaa/menu.html", mainFrame);
+
+  const nestedFrame = createFrame(77, "https://accounts.google.com/challenge", menuFrame);
+
+  mainFrame.framesInSubtree = [mainFrame, menuFrame, nestedFrame];
+
+  const contents = {
+    id: TAB_ID,
+    session,
+    isDestroyed: () => isDestroyed,
+    mainFrame,
+  } as unknown as WebContents;
+
+  return { contents, mainFrame, menuFrame, nestedFrame };
+}
+
+function createWebNavigation(contents: WebContents) {
+  return new WebNavigation({
+    getWebContentsById: (tabId) => (tabId === TAB_ID ? contents : undefined),
+  });
+}
+
+describe("WebNavigation", () => {
+  test("answers the main frame as frame 0", () => {
+    const { contents } = createTab();
+
+    expect(createWebNavigation(contents).getFrame(SESSION, { tabId: TAB_ID, frameId: 0 })).toEqual({
+      frameId: 0,
+      parentFrameId: -1,
+      processId: 7,
+      url: "https://accounts.google.com/signin",
+      errorOccurred: false,
+      frameType: "outermost_frame",
+      documentLifecycle: "active",
+    });
+  });
+
+  test("answers a subframe by its frame tree node id, with its parent's id", () => {
+    const { contents } = createTab();
+
+    const webNavigation = createWebNavigation(contents);
+
+    expect(webNavigation.getFrame(SESSION, { tabId: TAB_ID, frameId: 42 })).toMatchObject({
+      frameId: 42,
+      parentFrameId: 0,
+      url: "chrome-extension://aaa/menu.html",
+      frameType: "sub_frame",
+    });
+
+    expect(webNavigation.getFrame(SESSION, { tabId: TAB_ID, frameId: 77 })).toMatchObject({
+      frameId: 77,
+      parentFrameId: 42,
+    });
+  });
+
+  test("never answers the main frame to its own node id, the way Chrome doesn't", () => {
+    const { contents, mainFrame } = createTab();
+
+    expect(
+      createWebNavigation(contents).getFrame(SESSION, {
+        tabId: TAB_ID,
+        frameId: mainFrame.frameTreeNodeId,
+      }),
+    ).toBeNull();
+  });
+
+  test("answers null for what it cannot find", () => {
+    const { contents } = createTab();
+
+    const webNavigation = createWebNavigation(contents);
+
+    expect(webNavigation.getFrame(SESSION, { tabId: TAB_ID, frameId: 999 })).toBeNull();
+    expect(webNavigation.getFrame(SESSION, { tabId: 999, frameId: 0 })).toBeNull();
+    expect(webNavigation.getFrame(SESSION, { tabId: TAB_ID, frameId: "0" })).toBeNull();
+    expect(webNavigation.getFrame(SESSION, undefined)).toBeNull();
+    expect(webNavigation.getAllFrames(SESSION, { tabId: 999 })).toBeNull();
+  });
+
+  test("answers only the session the tab belongs to", () => {
+    const { contents } = createTab();
+
+    const webNavigation = createWebNavigation(contents);
+
+    expect(webNavigation.getFrame(OTHER_SESSION, { tabId: TAB_ID, frameId: 0 })).toBeNull();
+    expect(webNavigation.getAllFrames(OTHER_SESSION, { tabId: TAB_ID })).toBeNull();
+  });
+
+  test("answers nothing for a destroyed tab", () => {
+    const { contents } = createTab({ isDestroyed: true });
+
+    expect(
+      createWebNavigation(contents).getFrame(SESSION, { tabId: TAB_ID, frameId: 0 }),
+    ).toBeNull();
+  });
+
+  test("lists every live frame of a tab", () => {
+    const { contents, nestedFrame } = createTab();
+
+    nestedFrame.isDestroyed = () => true;
+
+    const frames = createWebNavigation(contents).getAllFrames(SESSION, { tabId: TAB_ID });
+
+    expect(frames?.map(({ frameId }) => frameId)).toEqual([0, 42]);
+  });
+
+  test("answers frame queries over the bridge", async () => {
+    let requestHandler: ((request: GlobalRequest) => Promise<Response>) | undefined;
+
+    const bridgeSession = {
+      protocol: {
+        handle: (_scheme: string, handler: (request: GlobalRequest) => Promise<Response>) => {
+          requestHandler = handler;
+        },
+        unhandle: () => undefined,
+      },
+    } as unknown as Session;
+
+    const { contents } = createTab({ session: bridgeSession });
+
+    const bridge = new ExtensionBridge();
+
+    createWebNavigation(contents).registerRoutes(bridge);
+
+    bridge.setupSession(bridgeSession, {
+      getExtensionId: (bridgeToken) => (bridgeToken === "token" ? "aaa" : undefined),
+    });
+
+    const response = await requestHandler?.({
+      url: `${EXTENSION_BRIDGE_ORIGIN}${WEB_NAVIGATION_PATHS.getFrame}`,
+      headers: new Headers(),
+      json: async () => ({ token: "token", details: { tabId: TAB_ID, frameId: 42 } }),
+    } as unknown as GlobalRequest);
+
+    expect(await response?.json()).toMatchObject({ frameId: 42, parentFrameId: 0 });
+  });
+});

--- a/packages/electron-extensions/web-navigation/web-navigation.ts
+++ b/packages/electron-extensions/web-navigation/web-navigation.ts
@@ -1,0 +1,137 @@
+import type { Session, WebContents, WebFrameMain } from "electron";
+import type { ExtensionBridge } from "../bridge/bridge";
+import {
+  WEB_NAVIGATION_PATHS,
+  type WebNavigationFrameDetails,
+  type WebNavigationFrameQuery,
+} from "./bridge-protocol";
+
+/** Chromium addresses a tab's main frame as frame 0 in every extension API. */
+const MAIN_FRAME_ID = 0;
+
+/**
+ * The id an extension knows a frame by: Chromium's frame-tree-node id, with the
+ * main frame pinned to 0 — which is why the main frame never answers to its own
+ * node id.
+ */
+function getExtensionFrameId(frame: WebFrameMain) {
+  return frame.parent ? frame.frameTreeNodeId : MAIN_FRAME_ID;
+}
+
+function createFrameDetails(frame: WebFrameMain): WebNavigationFrameDetails {
+  return {
+    frameId: getExtensionFrameId(frame),
+    parentFrameId: frame.parent ? getExtensionFrameId(frame.parent) : -1,
+    processId: frame.processId,
+    url: frame.url,
+    errorOccurred: false,
+    frameType: frame.parent ? "sub_frame" : "outermost_frame",
+    documentLifecycle: "active",
+  };
+}
+
+export type WebNavigationOptions = {
+  /** How a tab id resolves to the WebContents behind it, Electron's mapping by default. */
+  getWebContentsById?: (tabId: number) => WebContents | undefined;
+};
+
+/**
+ * Resolved at call time: a value import of "electron" cannot even be loaded
+ * outside Electron, which is where this module's tests run.
+ */
+function getElectronWebContentsById(tabId: number) {
+  const { webContents } = require("electron") as typeof import("electron");
+
+  return webContents.fromId(tabId);
+}
+
+/**
+ * `chrome.webNavigation.getFrame` and `getAllFrames` for extensions loaded into
+ * Electron sessions, answered over the extension bridge — Electron implements
+ * no webNavigation at all. The frame queries are what a fill-style flow hangs
+ * on: 1Password's worker relays a command from its inline-menu iframe to the
+ * frame owning the form only after `getFrame` has named that frame's parent,
+ * and the facade's former noop `null` dropped the relay silently.
+ *
+ * Extension frame ids are frame-tree-node ids with the main frame pinned to 0,
+ * which is exactly what `WebFrameMain` exposes; tab ids are `WebContents` ids,
+ * Electron's own tabs mapping. The namespace's events stay noops in the facade.
+ */
+export class WebNavigation {
+  private getWebContentsById: (tabId: number) => WebContents | undefined;
+
+  constructor({ getWebContentsById }: WebNavigationOptions = {}) {
+    this.getWebContentsById = getWebContentsById ?? getElectronWebContentsById;
+  }
+
+  registerRoutes(bridge: ExtensionBridge) {
+    bridge.handle(WEB_NAVIGATION_PATHS.getFrame, ({ session, body, headers }) =>
+      Response.json(this.getFrame(session, body.details as WebNavigationFrameQuery), { headers }),
+    );
+
+    bridge.handle(WEB_NAVIGATION_PATHS.getAllFrames, ({ session, body, headers }) =>
+      Response.json(this.getAllFrames(session, body.details as WebNavigationFrameQuery), {
+        headers,
+      }),
+    );
+  }
+
+  /** Chrome answers `null` for a frame it cannot find, never an error. */
+  getFrame(
+    session: Session,
+    query: WebNavigationFrameQuery | undefined,
+  ): WebNavigationFrameDetails | null {
+    const contents = this.getTabContents(session, query?.tabId);
+
+    if (!contents || typeof query?.frameId !== "number") {
+      return null;
+    }
+
+    const frame =
+      query.frameId === MAIN_FRAME_ID
+        ? contents.mainFrame
+        : contents.mainFrame.framesInSubtree.find(
+            (candidate) => candidate.parent !== null && candidate.frameTreeNodeId === query.frameId,
+          );
+
+    if (!frame || frame.isDestroyed()) {
+      return null;
+    }
+
+    return createFrameDetails(frame);
+  }
+
+  getAllFrames(
+    session: Session,
+    query: WebNavigationFrameQuery | undefined,
+  ): WebNavigationFrameDetails[] | null {
+    const contents = this.getTabContents(session, query?.tabId);
+
+    if (!contents) {
+      return null;
+    }
+
+    return contents.mainFrame.framesInSubtree
+      .filter((frame) => !frame.isDestroyed())
+      .map((frame) => createFrameDetails(frame));
+  }
+
+  /**
+   * A tab id resolves only within the session that asked: every session runs
+   * its own extension instances, and an id from any other session is another
+   * account's page.
+   */
+  private getTabContents(session: Session, tabId: unknown) {
+    if (typeof tabId !== "number") {
+      return undefined;
+    }
+
+    const contents = this.getWebContentsById(tabId);
+
+    if (!contents || contents.isDestroyed() || contents.session !== session) {
+      return undefined;
+    }
+
+    return contents;
+  }
+}

--- a/packages/electron-extensions/web-navigation/web-navigation.ts
+++ b/packages/electron-extensions/web-navigation/web-navigation.ts
@@ -87,11 +87,16 @@ export class WebNavigation {
       return null;
     }
 
+    // Destroyed first: a disposed frame's other accessors throw, and one dead
+    // frame in the subtree must not fail a query for a live one
     const frame =
       query.frameId === MAIN_FRAME_ID
         ? contents.mainFrame
         : contents.mainFrame.framesInSubtree.find(
-            (candidate) => candidate.parent !== null && candidate.frameTreeNodeId === query.frameId,
+            (candidate) =>
+              !candidate.isDestroyed() &&
+              candidate.parent !== null &&
+              candidate.frameTreeNodeId === query.frameId,
           );
 
     if (!frame || frame.isDestroyed()) {


### PR DESCRIPTION
- Promotes `chrome.webNavigation.getFrame`/`getAllFrames` from noops to real answers over the extension bridge: frame-tree lookups on `WebFrameMain` (extension frame ids are frame-tree-node ids with the main frame pinned to 0, tab ids are `WebContents` ids), answered only within the session that asked so account isolation holds.
- This is the autofill fix: 1Password's worker relays an inline-menu click to the frame owning the form only after `getFrame` names that frame's parent — the noop `null` dropped the relay silently (`frame-manager.ts` in its SW bundle).
- Extension service worker console output is now forwarded to Meru's log (level 3 as error, the rest as info) — the worker has no page and no devtools anywhere in the app, and 1Password logs there exactly why it declines to fill.
- webNavigation's events stay noops, and frame details carry no `documentId` (Electron exposes no equivalent); if the fill flow needs either, the new logs will say so.
- Not verified at runtime — needs the real fill flow on a machine with 1Password. If the relay now resolves but filling still fails, the next suspect is Electron's `tabs.sendMessage` honoring the `frameId` option.

Test plan:
1. Signed build with 1Password installed, Google sign-in page: click an account in the inline dropdown — fields should fill.
2. If they don't, grep the app log for `Extension service worker` — the forwarded messages carry 1Password's own reason and name the next gap.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>