### PR TITLE
refuse to derive an extension whose web accessible resources cover the facade

### DIFF
--- a/packages/electron-extensions/derive/manifest.test.ts
+++ b/packages/electron-extensions/derive/manifest.test.ts
@@ -165,6 +165,58 @@ describe("deriveManifest", () => {
     expect(manifest.content_scripts).toEqual(contentScripts);
   });
 
+  test("refuses a manifest whose web accessible resources cover the facade", () => {
+    expect(() =>
+      deriveManifest(
+        {
+          web_accessible_resources: [{ resources: ["*.js"], matches: ["<all_urls>"] }],
+        },
+        fileNames,
+      ),
+    ).toThrow('web_accessible_resources pattern "*.js" makes "chrome-facade.js" fetchable');
+  });
+
+  test("refuses a pattern covering the service worker wrapper", () => {
+    expect(() =>
+      deriveManifest(
+        {
+          web_accessible_resources: [{ resources: ["chrome-facade-service-worker.js"] }],
+        },
+        fileNames,
+      ),
+    ).toThrow("chrome-facade-service-worker.js");
+  });
+
+  test("derives a manifest whose web accessible resources stay clear of the facade", () => {
+    const { manifest } = deriveManifest(
+      {
+        web_accessible_resources: [
+          {
+            resources: ["fonts/*.woff2", "images/*.png", "inline/injected.js", "*.js.map"],
+            matches: ["<all_urls>"],
+          },
+        ],
+      },
+      fileNames,
+    );
+
+    expect(manifest.web_accessible_resources).toEqual([
+      {
+        resources: ["fonts/*.woff2", "images/*.png", "inline/injected.js", "*.js.map"],
+        matches: ["<all_urls>"],
+      },
+    ]);
+  });
+
+  test("derives a manifest whose web accessible resources were stripped away", () => {
+    const { manifest } = deriveManifest(
+      { web_accessible_resources: [{ resources: ["*.js"] }] },
+      { ...fileNames, strippedManifestKeys: ["web_accessible_resources"] },
+    );
+
+    expect(manifest.web_accessible_resources).toBeUndefined();
+  });
+
   test("strips nothing an extension does not have", () => {
     const { manifest } = deriveManifest(
       { name: "1Password" },

--- a/packages/electron-extensions/derive/manifest.ts
+++ b/packages/electron-extensions/derive/manifest.ts
@@ -1,3 +1,5 @@
+import { findWebAccessiblePattern, type WebAccessibleResources } from "./web-accessible";
+
 /** Only what the derive reads or rewrites is spelled out; the rest is carried. */
 export type ExtensionManifest = {
   [manifestKey: string]: unknown;
@@ -14,6 +16,7 @@ export type ExtensionManifest = {
     sandbox?: string;
   };
   content_scripts?: ({ matches?: string[] } & { [contentScriptKey: string]: unknown })[];
+  web_accessible_resources?: WebAccessibleResources;
 };
 
 export type DerivedManifest = {
@@ -189,6 +192,24 @@ export function deriveManifest(
 
   for (const strippedManifestKey of strippedManifestKeys) {
     delete derivedManifest[strippedManifestKey];
+  }
+
+  // The facade copy carries the bridge token, which only holds as a secret
+  // while nothing outside the extension can fetch it. Today no curated
+  // extension's `web_accessible_resources` comes near the facade, but an update
+  // widening a pattern to `*.js` would hand the token to every page in the
+  // session — refusing to derive is what keeps that an outage instead of a leak
+  for (const derivedFileName of [facadeFileName, serviceWorkerFileName]) {
+    const exposingPattern = findWebAccessiblePattern(
+      derivedManifest.web_accessible_resources,
+      derivedFileName,
+    );
+
+    if (exposingPattern) {
+      throw new Error(
+        `web_accessible_resources pattern "${exposingPattern}" makes "${derivedFileName}" fetchable by web pages`,
+      );
+    }
   }
 
   const backgroundFileName = manifest.background?.service_worker?.replace(/^\//, "");

--- a/packages/electron-extensions/derive/web-accessible.test.ts
+++ b/packages/electron-extensions/derive/web-accessible.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { findWebAccessiblePattern } from "./web-accessible";
+
+describe("findWebAccessiblePattern", () => {
+  test("matches an exact path", () => {
+    expect(
+      findWebAccessiblePattern([{ resources: ["chrome-facade.js"] }], "chrome-facade.js"),
+    ).toBe("chrome-facade.js");
+  });
+
+  test("matches a wildcard across separators the way Chrome does", () => {
+    expect(findWebAccessiblePattern([{ resources: ["*.js"] }], "chrome-facade.js")).toBe("*.js");
+
+    expect(findWebAccessiblePattern([{ resources: ["*"] }], "chrome-facade.js")).toBe("*");
+
+    expect(findWebAccessiblePattern([{ resources: ["inline/*"] }], "inline/menu/menu.html")).toBe(
+      "inline/*",
+    );
+  });
+
+  test("matches a root-relative pattern spelled with a leading slash", () => {
+    expect(
+      findWebAccessiblePattern([{ resources: ["/chrome-facade.js"] }], "chrome-facade.js"),
+    ).toBe("/chrome-facade.js");
+  });
+
+  test("matches manifest v2 entries, which are plain patterns", () => {
+    expect(findWebAccessiblePattern(["*.js"], "chrome-facade.js")).toBe("*.js");
+  });
+
+  test("passes over patterns that only share a suffix or a prefix", () => {
+    expect(
+      findWebAccessiblePattern(
+        [
+          {
+            resources: [
+              "fonts/*.woff2",
+              "images/*.svg",
+              "inline/injected.js",
+              "*.js.map",
+              "facade.js",
+            ],
+          },
+        ],
+        "chrome-facade.js",
+      ),
+    ).toBeUndefined();
+  });
+
+  test("treats a wildcard as the only special character", () => {
+    expect(
+      findWebAccessiblePattern([{ resources: ["chrome.facade|js"] }], "chromeXfacade|js"),
+    ).toBeUndefined();
+  });
+
+  test("answers nothing for a manifest without the key or with a malformed one", () => {
+    expect(findWebAccessiblePattern(undefined, "chrome-facade.js")).toBeUndefined();
+
+    expect(
+      findWebAccessiblePattern(
+        [{ resources: undefined }, {} as { resources?: string[] }],
+        "chrome-facade.js",
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/packages/electron-extensions/derive/web-accessible.ts
+++ b/packages/electron-extensions/derive/web-accessible.ts
@@ -1,0 +1,61 @@
+/**
+ * `web_accessible_resources` entries: plain path patterns in manifest v2, and
+ * objects carrying them in v3. Who a v3 entry exposes its resources to does not
+ * matter here — see `findWebAccessiblePattern`.
+ */
+export type WebAccessibleResources = (
+  | string
+  | { [entryKey: string]: unknown; resources?: string[] }
+)[];
+
+function escapeRegExp(literal: string) {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Chrome matches a resource pattern against the resource's path from the
+ * extension root, with `*` standing for any run of characters, separators
+ * included. A leading slash spells the same root-relative path.
+ */
+function matchesResourcePattern(pattern: string, fileName: string) {
+  const normalizedPattern = pattern.replace(/^\//, "");
+
+  const patternRegExp = new RegExp(
+    `^${normalizedPattern.split("*").map(escapeRegExp).join(".*")}$`,
+  );
+
+  return patternRegExp.test(fileName);
+}
+
+/**
+ * The first pattern that lets a resource the derive wrote be fetched from
+ * outside the extension, or nothing.
+ *
+ * The facade copy carries the bridge token, and `web_accessible_resources` is
+ * the one manifest key that would hand it out: a pattern covering the facade —
+ * `*.js`, say — makes it fetchable by every page in the session, and the token
+ * with it. An entry that names `extension_ids` instead of `matches`, or asks
+ * for a dynamic URL, still counts: what those narrow it to is Chromium's to
+ * enforce and Electron's support for them is unmeasured, and a token must not
+ * ride on either.
+ */
+export function findWebAccessiblePattern(
+  webAccessibleResources: WebAccessibleResources | undefined,
+  fileName: string,
+) {
+  if (!Array.isArray(webAccessibleResources)) {
+    return undefined;
+  }
+
+  for (const entry of webAccessibleResources) {
+    const patterns = typeof entry === "string" ? [entry] : (entry.resources ?? []);
+
+    for (const pattern of patterns) {
+      if (typeof pattern === "string" && matchesResourcePattern(pattern, fileName)) {
+        return pattern;
+      }
+    }
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
- The derived facade carries the per-launch bridge token, which is only a secret while no `web_accessible_resources` pattern makes it fetchable from web pages. Nothing enforced that: a curated extension update widening a pattern to `*.js` would have silently handed the token — and with it native messaging as the extension — to every page in the session.
- `deriveManifest` now throws when any pattern (v2 or v3 entries, `*` matching across separators the way Chrome does) covers the facade or the service worker wrapper, so the load fails and is logged instead of the token leaking. Verified against 1Password 8.12.32.33's real manifest: its patterns (`*.js.map`, `inline/injected.js`, fonts/images) stay clear.
- Entries scoped by `extension_ids` or `use_dynamic_url` count as exposing too — fail closed rather than trusting Electron to enforce narrowing that was never measured.

Test plan:
1. `bun test packages/electron-extensions` — new pattern-matching and refusal tests pass.
2. `bun run dev` with 1Password in `extensions/` — it derives and loads as before.
3. Add `"*.js"` to a dev extension's `web_accessible_resources` resources — the load fails with the new error in the log instead of loading.