### PR TITLE
cap what the extension bridge reads out of a request body

### DIFF
--- a/packages/electron-extensions/bridge/bridge.test.ts
+++ b/packages/electron-extensions/bridge/bridge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { Session } from "electron";
-import { ExtensionBridge } from "./bridge";
+import { ExtensionBridge, MAX_BRIDGE_REQUEST_BYTES } from "./bridge";
 import { EXTENSION_BRIDGE_ORIGIN, EXTENSION_BRIDGE_SCHEME } from "./protocol";
 
 const EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
@@ -27,15 +27,21 @@ function createSession() {
     },
   } as unknown as Session;
 
+  const sendRequest = (pathName: string, bodySource: string, origin?: string) =>
+    requestHandler?.(
+      new Request(`${EXTENSION_BRIDGE_ORIGIN}${pathName}`, {
+        method: "POST",
+        headers: origin === undefined ? {} : { origin },
+        body: bodySource,
+      }) as GlobalRequest,
+    ) as Promise<Response>;
+
   return {
     session,
     handledSchemes,
+    sendRequest,
     request: (pathName: string, body: Record<string, unknown>, origin?: string) =>
-      requestHandler?.({
-        url: `${EXTENSION_BRIDGE_ORIGIN}${pathName}`,
-        headers: new Headers(origin === undefined ? {} : { origin }),
-        json: async () => body,
-      } as unknown as GlobalRequest) as Promise<Response>,
+      sendRequest(pathName, JSON.stringify(body), origin),
   };
 }
 
@@ -91,6 +97,28 @@ describe("ExtensionBridge", () => {
     // The token is checked first, so an unauthenticated caller learns nothing
     // about which paths exist
     expect((await request("/unregistered", { token: "guessed" })).status).toBe(403);
+  });
+
+  test("refuses a body past the cap without handling it, token or no token", async () => {
+    const { session, sendRequest } = createSession();
+
+    const bridge = createBridge(session);
+
+    let handled = false;
+
+    bridge.handle("/echo", ({ headers }) => {
+      handled = true;
+
+      return new Response(null, { status: 204, headers });
+    });
+
+    const response = await sendRequest(
+      "/echo",
+      `{"token":"${BRIDGE_TOKEN}","padding":"${"x".repeat(MAX_BRIDGE_REQUEST_BYTES)}"}`,
+    );
+
+    expect(response.status).toBe(413);
+    expect(handled).toBe(false);
   });
 
   test("answers 400 when the handler throws", async () => {

--- a/packages/electron-extensions/bridge/bridge.ts
+++ b/packages/electron-extensions/bridge/bridge.ts
@@ -2,6 +2,14 @@ import type { Session } from "electron";
 import type { ExtensionsLogger } from "../logger";
 import { EXTENSION_BRIDGE_SCHEME, type ExtensionBridgeRequest } from "./protocol";
 
+/**
+ * Far past what any bridge call has business sending, but a bound all the same:
+ * the scheme is reachable from every document in the session, and without one a
+ * page that never learns the token could still make the main process buffer an
+ * arbitrarily large body on the way to its 403.
+ */
+export const MAX_BRIDGE_REQUEST_BYTES = 64 * 1024 * 1024;
+
 export type ExtensionBridgeHandler = (request: {
   session: Session;
   /** The extension whose facade copy carried the request's token. */
@@ -64,7 +72,13 @@ export class ExtensionBridge {
     const { pathname } = new URL(request.url);
 
     try {
-      const body = (await request.json()) as ExtensionBridgeRequest & Record<string, unknown>;
+      const bodySource = await this.readBody(request);
+
+      if (bodySource === null) {
+        return new Response(null, { status: 413, headers });
+      }
+
+      const body = JSON.parse(bodySource) as ExtensionBridgeRequest & Record<string, unknown>;
 
       // Everything else in the session — Gmail, workspace apps, any page a user
       // navigated to — can reach this scheme just as well, and only the loaded
@@ -86,6 +100,40 @@ export class ExtensionBridge {
       this.logger?.error("Extension bridge request failed", { pathname, error });
 
       return new Response(null, { status: 400, headers });
+    }
+  }
+
+  /**
+   * The request body, or `null` the moment it runs past the cap — nothing more
+   * is read then, so an oversized body costs the cap and not its whole length.
+   */
+  private async readBody(request: GlobalRequest) {
+    if (!request.body) {
+      return "";
+    }
+
+    const reader = request.body.getReader();
+
+    const chunks: Uint8Array[] = [];
+
+    let byteLength = 0;
+
+    for (;;) {
+      const { value, done } = await reader.read();
+
+      if (done) {
+        return Buffer.concat(chunks).toString("utf8");
+      }
+
+      byteLength += value.byteLength;
+
+      if (byteLength > MAX_BRIDGE_REQUEST_BYTES) {
+        await reader.cancel();
+
+        return null;
+      }
+
+      chunks.push(value);
     }
   }
 }

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -150,11 +150,12 @@ function createSession({
       }
     },
     request: (body: Record<string, unknown>) =>
-      requestHandler?.({
-        url: `${EXTENSION_BRIDGE_ORIGIN}${NATIVE_MESSAGING_PATHS.connect}`,
-        headers: new Headers(),
-        json: async () => body,
-      } as unknown as GlobalRequest) as Promise<Response>,
+      requestHandler?.(
+        new Request(`${EXTENSION_BRIDGE_ORIGIN}${NATIVE_MESSAGING_PATHS.connect}`, {
+          method: "POST",
+          body: JSON.stringify(body),
+        }) as GlobalRequest,
+      ) as Promise<Response>,
   };
 }
 

--- a/packages/electron-extensions/native-messaging/native-messaging.test.ts
+++ b/packages/electron-extensions/native-messaging/native-messaging.test.ts
@@ -89,11 +89,10 @@ async function writeHostManifest(allowedExtensionId = EXTENSION_ID) {
 }
 
 function createRequest(pathName: string, body: Record<string, unknown>) {
-  return {
-    url: `${EXTENSION_BRIDGE_ORIGIN}${pathName}`,
-    headers: new Headers(),
-    json: async () => body,
-  } as unknown as GlobalRequest;
+  return new Request(`${EXTENSION_BRIDGE_ORIGIN}${pathName}`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  }) as GlobalRequest;
 }
 
 function connect(portId = "port-1") {

--- a/packages/electron-extensions/web-navigation/web-navigation.test.ts
+++ b/packages/electron-extensions/web-navigation/web-navigation.test.ts
@@ -204,11 +204,12 @@ describe("WebNavigation", () => {
       getExtensionId: (bridgeToken) => (bridgeToken === "token" ? "aaa" : undefined),
     });
 
-    const response = await requestHandler?.({
-      url: `${EXTENSION_BRIDGE_ORIGIN}${WEB_NAVIGATION_PATHS.getFrame}`,
-      headers: new Headers(),
-      json: async () => ({ token: "token", details: { tabId: TAB_ID, frameId: 42 } }),
-    } as unknown as GlobalRequest);
+    const response = await requestHandler?.(
+      new Request(`${EXTENSION_BRIDGE_ORIGIN}${WEB_NAVIGATION_PATHS.getFrame}`, {
+        method: "POST",
+        body: JSON.stringify({ token: "token", details: { tabId: TAB_ID, frameId: 42 } }),
+      }) as GlobalRequest,
+    );
 
     expect(await response?.json()).toMatchObject({ frameId: 42, parentFrameId: 0 });
   });


### PR DESCRIPTION
- The bridge scheme is fetchable by every document in a session, and the token check required parsing the whole body first — so a page that never learns the token could still make the main process buffer and `JSON.parse` an arbitrarily large body on the way to its 403.
- `handleRequest` now streams the body and answers 413 the moment it runs past 64 MB, reading no further; the cap is far above any real bridge call (Chrome itself allows multi-gigabyte native messages, 1Password's are kilobytes).
- The test fakes now build real `Request` objects instead of `{ json: async () => body }`, since the bridge reads the body stream itself.

Test plan:
1. `bun test packages/electron-extensions` — new 413 test and existing bridge/native-messaging tests pass.
2. `bun run dev` with 1Password loaded and the desktop app connected — unlock still works over the bridge.