### PR TITLE
grant extension pages only the permissions curated extensions need

### DIFF
--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -17,6 +17,12 @@ import { areWorkspaceAppNotificationsAllowed } from "./notifications";
 import { Tabs } from "./tabs";
 import { WorkspaceApp } from "./workspace-app";
 
+const EXTENSION_PAGE_PERMISSIONS = new Set([
+  "clipboard-read",
+  "clipboard-sanitized-write",
+  "notifications",
+]);
+
 export class Account {
   accountId: AccountConfig["id"];
 
@@ -106,10 +112,14 @@ export class Account {
 
   private registerSessionPermissionsRequestsHandler() {
     this.session.setPermissionRequestHandler((_webContents, permission, callback, details) => {
-      // Extensions are loaded deliberately and Chromium checks their requests
-      // against the permissions they declare, unlike web content
+      // Extensions are loaded deliberately, but their pages still only get what
+      // a curated extension has business asking for — copying a password, a
+      // notification. Anything else, the microphone and camera above all, meets
+      // the same refusal as anywhere: manifest permissions don't gate these
+      // requests, and 1Password's own pages are framable by any page in the
+      // session
       if (extensions.isLoadedExtensionUrl(this.session, details.requestingUrl)) {
-        callback(true);
+        callback(EXTENSION_PAGE_PERMISSIONS.has(permission));
 
         return;
       }


### PR DESCRIPTION
- The permission carve-out for loaded extension URLs answered `callback(true)` for every permission — broader than Chrome, which prompts even extension pages for mic, camera and geolocation; manifest permissions don't gate these requests, and 1Password's inline pages are framable by any page in the session (`frame-ancestors http: https:`).
- Extension pages now get an allowlist instead: `clipboard-read`, `clipboard-sanitized-write`, `notifications` — what a password manager has business asking for. Everything else falls to the same refusal as unlisted web-content permissions.
- The list is the place to extend when a future curated extension (Bitwarden, Proton Pass) needs more.

Test plan:
1. `bun run dev` with 1Password loaded: copy a password from the popup — it lands on the clipboard.
2. Trigger a 1Password notification (e.g. save prompt) — it still shows.