### PR TITLE
open links from the extension popup in the default browser

### DIFF
--- a/packages/app/extension-actions.ts
+++ b/packages/app/extension-actions.ts
@@ -6,6 +6,7 @@ import { extensions } from "./extensions";
 import { ipc } from "./ipc";
 import { Popup } from "./lib/popup";
 import { main } from "./main";
+import { openExternalUrl } from "./url";
 import { WorkspaceApp } from "./workspace-app";
 
 /** The size a menu item's icon is drawn at. */
@@ -98,7 +99,7 @@ class ExtensionActions {
       return;
     }
 
-    this.popup.toggle(parentWindow, {
+    const opened = this.popup.toggle(parentWindow, {
       content: { url: action.popupUrl, session },
       width: "preferred",
       height: "preferred",
@@ -112,6 +113,18 @@ class ExtensionActions {
     // nothing holds the blur off the way hovering a button that toggles a popup
     // does — a click anywhere else closes it
     this.popup.closeOnBlurEnabled = true;
+
+    // A link out of the popup — "open 1password.com", a vault item's website —
+    // opens a browser tab in Chrome. The default browser is Meru's equivalent;
+    // the window Electron would otherwise create belongs to no titlebar and
+    // none of the app's navigation policing
+    if (opened) {
+      this.popup.webContents?.setWindowOpenHandler(({ url }) => {
+        openExternalUrl(url);
+
+        return { action: "deny" };
+      });
+    }
   }
 
   showMenu(webContents: WebContents, anchorRect: ExtensionActionAnchorRect) {


### PR DESCRIPTION
- The extension action popup had no window-open handler — Gmail views, workspace apps and the main window all police `window.open`, but a link out of the popup ("open 1password.com", a vault item's website) created a bare default `BrowserWindow` in the account session with no titlebar and none of the app's navigation policing.
- The popup's webContents now routes opens through `openExternalUrl` (the user's external-link confirm/trusted-hosts settings apply) and denies the window, matching Chrome where a popup link opens a browser tab.
- Lives in `ExtensionActions` rather than `Popup`, keeping the generic popup free of app-module imports (the import cycle #833 fixed) and the renderer-page popups untouched.

Test plan:
1. `bun run dev` with 1Password loaded: open the popup, click an external link (e.g. the "open 1password.com" footer) — it opens in the default browser, no new Electron window appears.
2. Downloads/bookmarks popups still open and close as before.