### PR TITLE
clamp curated content scripts to catalog match patterns

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -98,6 +98,16 @@ async function getExtensionDirs() {
   return [...getDevExtensionDirs(), ...(await getInstalledExtensionDirs())];
 }
 
+/**
+ * Where a curated extension's content scripts may run, from the catalog entry it
+ * is offered under. An extension the catalog says nothing about — a development
+ * folder — runs its content scripts as its author declared them.
+ */
+function getContentScriptMatches(extensionId: string) {
+  return curatedExtensions.find((curatedExtension) => curatedExtension.id === extensionId)
+    ?.contentScriptMatches;
+}
+
 // Extension contexts reach the main process over the bridge's custom scheme,
 // and Electron only takes scheme privileges while modules are still loading
 registerExtensionBridgeScheme();
@@ -107,6 +117,7 @@ export const extensions = new Extensions({
   facadeScriptPath: path.join(__dirname, "extensions-chrome-facade.js"),
   derivedExtensionsDir: DERIVED_EXTENSIONS_DIR,
   strippedManifestKeys: getStrippedManifestKeys(),
+  getContentScriptMatches,
   logger: {
     info: (message, details) => {
       log.info(message, details);

--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -253,6 +253,83 @@ describe("deriveExtension", () => {
     ).not.toHaveProperty("content_scripts");
   });
 
+  // Nothing in the source changes between the two derives, so the copy is
+  // written again only because the matches did
+  test("clamps the content scripts of the copy and derives again when the matches change", async () => {
+    await writeManifest({
+      ...manifest,
+      content_scripts: [{ matches: ["<all_urls>"], js: ["content.js"], all_frames: true }],
+    });
+
+    const derivedDir = await derive();
+
+    expect(
+      JSON.parse(await readFile(path.join(derivedDir, "manifest.json"), "utf8")).content_scripts,
+    ).toEqual([{ matches: ["<all_urls>"], js: ["content.js"], all_frames: true }]);
+
+    await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      getContentScriptMatches: () => ["https://accounts.google.com/*"],
+    });
+
+    expect(
+      JSON.parse(await readFile(path.join(derivedDir, "manifest.json"), "utf8")).content_scripts,
+    ).toEqual([
+      { matches: ["https://accounts.google.com/*"], js: ["content.js"], all_frames: true },
+    ]);
+  });
+
+  test("asks for the matches by the id the extension will be loaded as", async () => {
+    const askedExtensionIds: string[] = [];
+
+    await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      getContentScriptMatches: (extensionId) => {
+        askedExtensionIds.push(extensionId);
+
+        return undefined;
+      },
+    });
+
+    expect(askedExtensionIds).toEqual(["gkodpobagfoadfbnehppbpmagfgmimpa"]);
+  });
+
+  test("clamps nothing for an extension without a key", async () => {
+    const contentScripts = [{ matches: ["<all_urls>"], js: ["content.js"] }];
+
+    await writeManifest({ ...manifest, key: undefined, content_scripts: contentScripts });
+
+    let asked = false;
+
+    const { derivedDir } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      getContentScriptMatches: () => {
+        asked = true;
+
+        return ["https://accounts.google.com/*"];
+      },
+    });
+
+    expect(asked).toBe(false);
+    expect(
+      JSON.parse(await readFile(path.join(derivedDir, "manifest.json"), "utf8")).content_scripts,
+    ).toEqual(contentScripts);
+  });
+
+  test("stamps a copy without matches as it did before they existed", async () => {
+    const derivedDir = await derive();
+
+    expect(JSON.parse(await readFile(`${derivedDir}.json`, "utf8"))).not.toHaveProperty(
+      "contentScriptMatches",
+    );
+  });
+
   test("reports no id for an extension without a key", async () => {
     await writeManifest({ ...manifest, key: undefined });
 

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -29,6 +29,12 @@ export type DeriveExtensionOptions = {
    * see what changes.
    */
   strippedManifestKeys?: string[];
+  /**
+   * Match patterns the extension's content scripts are clamped to, asked for by
+   * the id the copy will be loaded as. An extension without a `manifest.key`
+   * has no id to be recognised by and keeps the patterns its author declared.
+   */
+  getContentScriptMatches?: (extensionId: string) => string[] | undefined;
 };
 
 function hash(value: string) {
@@ -107,10 +113,15 @@ export async function deriveExtension({
   derivedExtensionsDir,
   facadeScriptPath,
   strippedManifestKeys = [],
+  getContentScriptMatches,
 }: DeriveExtensionOptions) {
   const manifestSource = await readFile(path.join(sourceDir, MANIFEST_FILE_NAME), "utf8");
 
   const sourceManifest = JSON.parse(manifestSource) as ExtensionManifest;
+
+  const extensionId = getExtensionIdFromManifestKey(sourceManifest.key);
+
+  const contentScriptMatches = extensionId ? getContentScriptMatches?.(extensionId) : undefined;
 
   const derivedDir = path.join(derivedExtensionsDir, hash(sourceDir).slice(0, 16));
 
@@ -125,6 +136,7 @@ export async function deriveExtension({
     sourceDir,
     sourceTree: await hashSourceTree(sourceDir),
     strippedManifestKeys,
+    contentScriptMatches,
   });
 
   if ((await readStamp(stampPath)) !== stamp) {
@@ -139,6 +151,7 @@ export async function deriveExtension({
       serviceWorkerFileName: SERVICE_WORKER_FILE_NAME,
       bridgeConnectSource: `${EXTENSION_BRIDGE_SCHEME}:`,
       strippedManifestKeys,
+      contentScriptMatches,
     });
 
     await writeFile(path.join(derivedDir, MANIFEST_FILE_NAME), JSON.stringify(manifest, null, 2));
@@ -163,11 +176,7 @@ export async function deriveExtension({
     )}`,
   );
 
-  return {
-    derivedDir,
-    bridgeToken,
-    extensionId: getExtensionIdFromManifestKey(sourceManifest.key),
-  };
+  return { derivedDir, bridgeToken, extensionId };
 }
 
 export type PruneDerivedExtensionsOptions = {

--- a/packages/electron-extensions/derive/manifest.test.ts
+++ b/packages/electron-extensions/derive/manifest.test.ts
@@ -117,6 +117,54 @@ describe("deriveManifest", () => {
     expect(manifest).toEqual({ name: "1Password" });
   });
 
+  test("clamps every content script to the matches it was handed", () => {
+    const { manifest } = deriveManifest(
+      {
+        name: "1Password",
+        content_scripts: [
+          {
+            matches: ["<all_urls>"],
+            js: ["inline/inject-content-scripts.js"],
+            all_frames: true,
+            run_at: "document_start",
+          },
+          { matches: ["https://*/*"], js: ["content.js"] },
+        ],
+      },
+      { ...fileNames, contentScriptMatches: ["https://accounts.google.com/*"] },
+    );
+
+    expect(manifest.content_scripts).toEqual([
+      {
+        matches: ["https://accounts.google.com/*"],
+        js: ["inline/inject-content-scripts.js"],
+        all_frames: true,
+        run_at: "document_start",
+      },
+      { matches: ["https://accounts.google.com/*"], js: ["content.js"] },
+    ]);
+  });
+
+  test("clamps nothing in a manifest without content scripts", () => {
+    const { manifest } = deriveManifest(
+      { name: "No content scripts" },
+      { ...fileNames, contentScriptMatches: ["https://accounts.google.com/*"] },
+    );
+
+    expect(manifest.content_scripts).toBeUndefined();
+  });
+
+  test("leaves the content scripts alone without matches to clamp them to", () => {
+    const contentScripts = [{ matches: ["<all_urls>"], js: ["content.js"] }];
+
+    const { manifest } = deriveManifest(
+      { name: "1Password", content_scripts: contentScripts },
+      fileNames,
+    );
+
+    expect(manifest.content_scripts).toEqual(contentScripts);
+  });
+
   test("strips nothing an extension does not have", () => {
     const { manifest } = deriveManifest(
       { name: "1Password" },

--- a/packages/electron-extensions/derive/manifest.ts
+++ b/packages/electron-extensions/derive/manifest.ts
@@ -13,6 +13,7 @@ export type ExtensionManifest = {
     extension_pages?: string;
     sandbox?: string;
   };
+  content_scripts?: ({ matches?: string[] } & { [contentScriptKey: string]: unknown })[];
 };
 
 export type DerivedManifest = {
@@ -131,9 +132,29 @@ function deriveContentSecurityPolicy(
 }
 
 /**
+ * Narrows where the extension's content scripts run. Electron has no per-site
+ * extension controls, so the manifest is the only lever: an extension declaring
+ * `<all_urls>` injects into every frame of every view otherwise.
+ *
+ * Every entry keeps the rest of what its author wrote — which scripts run, when
+ * they run, which frames they reach — and only the sites they run on change.
+ */
+function deriveContentScripts(
+  contentScripts: ExtensionManifest["content_scripts"],
+  matches: string[] | undefined,
+) {
+  if (!contentScripts || !matches) {
+    return contentScripts;
+  }
+
+  return contentScripts.map((contentScript) => ({ ...contentScript, matches }));
+}
+
+/**
  * Points the manifest's service worker at a generated wrapper, lets its content
- * security policy reach the native messaging bridge and drops the permissions
- * Electron cannot serve. Everything else is carried over untouched — `key`
+ * security policy reach the native messaging bridge, clamps its content scripts
+ * to the sites they may run on and drops the permissions Electron cannot serve.
+ * Everything else is carried over untouched — `key`
  * above all, since without it Chromium derives the extension id from the
  * directory it was loaded from and the derived copy would answer to a different
  * id than the extension it came from.
@@ -145,18 +166,25 @@ export function deriveManifest(
     serviceWorkerFileName,
     bridgeConnectSource,
     strippedManifestKeys = [],
+    contentScriptMatches,
   }: {
     facadeFileName: string;
     serviceWorkerFileName: string;
     bridgeConnectSource: string;
     /** Manifest keys to leave out of the copy, e.g. `content_scripts`. */
     strippedManifestKeys?: string[];
+    /**
+     * Match patterns to write over every content script's own. Without them the
+     * extension's content scripts run wherever its author declared.
+     */
+    contentScriptMatches?: string[];
   },
 ): DerivedManifest {
   const derivedManifest: ExtensionManifest = {
     ...manifest,
     permissions: derivePermissions(manifest.permissions),
     content_security_policy: deriveContentSecurityPolicy(manifest, bridgeConnectSource),
+    content_scripts: deriveContentScripts(manifest.content_scripts, contentScriptMatches),
   };
 
   for (const strippedManifestKey of strippedManifestKeys) {

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -60,6 +60,12 @@ export type ExtensionsOptions = {
    */
   strippedManifestKeys?: string[];
   /**
+   * Narrows where an extension's content scripts run, asked for by the id the
+   * extension is loaded as. Without it every extension injects wherever its own
+   * manifest says, which for a password manager is every frame of every view.
+   */
+  getContentScriptMatches?: (extensionId: string) => string[] | undefined;
+  /**
    * Narrows which native messaging hosts an extension may drive. Without it any
    * host that lists the extension in its own `allowed_origins` is reachable.
    */
@@ -87,6 +93,8 @@ export class Extensions {
 
   private strippedManifestKeys: string[] | undefined;
 
+  private getContentScriptMatches: ExtensionsOptions["getContentScriptMatches"];
+
   private logger: ExtensionsLogger | undefined;
 
   private loadedExtensionIdsBySession = new Map<Session, Set<string>>();
@@ -113,6 +121,7 @@ export class Extensions {
     facadeScriptPath,
     derivedExtensionsDir,
     strippedManifestKeys,
+    getContentScriptMatches,
     isNativeMessagingHostAllowed,
     logger,
   }: ExtensionsOptions) {
@@ -123,6 +132,8 @@ export class Extensions {
     this.derivedExtensionsDir = derivedExtensionsDir;
 
     this.strippedManifestKeys = strippedManifestKeys;
+
+    this.getContentScriptMatches = getContentScriptMatches;
 
     this.logger = logger;
 
@@ -154,6 +165,7 @@ export class Extensions {
         derivedExtensionsDir: this.derivedExtensionsDir,
         facadeScriptPath: this.facadeScriptPath,
         strippedManifestKeys: this.strippedManifestKeys,
+        getContentScriptMatches: this.getContentScriptMatches,
       });
 
       this.derivedExtensions.set(sourceDir, derivedExtension);

--- a/packages/shared/extensions.ts
+++ b/packages/shared/extensions.ts
@@ -3,6 +3,12 @@ export type CuratedExtension = {
   id: string;
   name: string;
   description: string;
+  /**
+   * Match patterns the derive writes over every `content_scripts[].matches` of
+   * the extension, so its content scripts only reach the sites it is offered
+   * for. Absent leaves the manifest's own patterns in place.
+   */
+  contentScriptMatches?: string[];
 };
 
 /**
@@ -16,6 +22,7 @@ export const curatedExtensions: CuratedExtension[] = [
     name: "1Password",
     description:
       "Password manager that fills logins and signs you in with passkeys stored in your vault.",
+    contentScriptMatches: ["https://accounts.google.com/*"],
   },
 ];
 


### PR DESCRIPTION
- `CuratedExtension` gains `contentScriptMatches`; 1Password is clamped to `https://accounts.google.com/*`.
- The derive step writes the list over every `content_scripts[].matches` of the derived copy, so 1Password's three all-frames/document_start content scripts only inject on Google sign-in pages instead of every frame of every view.
- The resolved list is part of the derive stamp: a changed list re-derives on the next launch, an absent one leaves existing stamps valid.
- Keyless extensions and dirs the catalog doesn't know stay unclamped.

Not verified in a running app (headless sandbox): fill/passkeys on accounts.google.com are untouched by design but unexercised, and the memory win is expected, not measured.

Test plan:
1. With 1Password installed, open Gmail and focus a compose/search field — no 1Password inline UI appears on mail pages anymore.
2. Reach accounts.google.com (add account / re-sign-in) — inline dropdown and fill still work there.
3. Optionally compare the app's memory with the previous build after browsing a few Workspace tabs.