### PR TITLE
let users add sites to an extension's content script clamp

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -127,6 +127,7 @@ export const config = new Store<Config>({
     "verticalTabs.hideUnreadBadgeWhenActive": false,
     "verticalTabs.showAppLinksBadge": true,
     "extensions.installed": [],
+    "extensions.additionalSites": {},
   },
   migrations: {
     ">=3.4.0": (store) => {

--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -9,7 +9,11 @@ import {
   registerExtensionBridgeScheme,
   uninstallExtension,
 } from "@meru/electron-extensions";
-import { curatedExtensions, isCuratedExtensionId } from "@meru/shared/extensions";
+import {
+  curatedExtensions,
+  hostnameToMatchPattern,
+  isCuratedExtensionId,
+} from "@meru/shared/extensions";
 import { ms } from "@meru/shared/ms";
 import type { InstalledExtensionState } from "@meru/shared/types";
 import { app } from "electron";
@@ -99,13 +103,23 @@ async function getExtensionDirs() {
 }
 
 /**
- * Where a curated extension's content scripts may run, from the catalog entry it
- * is offered under. An extension the catalog says nothing about — a development
- * folder — runs its content scripts as its author declared them.
+ * Where a curated extension's content scripts may run: the catalog entry it is
+ * offered under, plus the sites the user added for it. An extension the catalog
+ * says nothing about — a development folder — runs its content scripts as its
+ * author declared them, and additional sites don't start clamping one.
  */
 function getContentScriptMatches(extensionId: string) {
-  return curatedExtensions.find((curatedExtension) => curatedExtension.id === extensionId)
-    ?.contentScriptMatches;
+  const contentScriptMatches = curatedExtensions.find(
+    (curatedExtension) => curatedExtension.id === extensionId,
+  )?.contentScriptMatches;
+
+  if (!contentScriptMatches) {
+    return;
+  }
+
+  const additionalSites = config.get("extensions.additionalSites")[extensionId] ?? [];
+
+  return [...contentScriptMatches, ...additionalSites.map(hostnameToMatchPattern)];
 }
 
 // Extension contexts reach the main process over the bridge's custom scheme,

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -1,34 +1,133 @@
-import { type CuratedExtension, curatedExtensions } from "@meru/shared/extensions";
+import {
+  type CuratedExtension,
+  curatedExtensions,
+  normalizeExtensionSiteHostname,
+} from "@meru/shared/extensions";
 import { ipc } from "@meru/shared/renderer/ipc";
-import { FieldDescription } from "@meru/ui/components/field";
+import type { Config } from "@meru/shared/types";
+import { Button } from "@meru/ui/components/button";
+import { Field, FieldDescription, FieldLabel } from "@meru/ui/components/field";
+import { Input } from "@meru/ui/components/input";
 import {
   Item,
   ItemActions,
   ItemContent,
   ItemDescription,
+  ItemFooter,
   ItemGroup,
   ItemTitle,
 } from "@meru/ui/components/item";
 import { Switch } from "@meru/ui/components/switch";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { PlusIcon, XIcon } from "lucide-react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { LicenseKeyRequiredFieldBadge } from "@/components/license-key-required-field-badge";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
-import { queryClient, useConfig } from "@/lib/react-query";
+import { queryClient, useConfig, useConfigMutation } from "@/lib/react-query";
 import { restartRequiredToast } from "@/lib/toast";
 
 const installedExtensionsQueryKey = ["installed-extensions"];
+
+/**
+ * The sites the user added on top of the ones the extension is offered for, which
+ * only exist for an extension the catalog clamps to begin with.
+ */
+function ExtensionAdditionalSites({
+  extension,
+  additionalSites,
+}: {
+  extension: CuratedExtension;
+  additionalSites: Config["extensions.additionalSites"];
+}) {
+  const [siteInput, setSiteInput] = useState("");
+
+  const configMutation = useConfigMutation({ onSuccess: restartRequiredToast });
+
+  const sites = additionalSites[extension.id] ?? [];
+
+  const saveSites = (updatedSites: string[]) => {
+    configMutation.mutate({
+      "extensions.additionalSites": { ...additionalSites, [extension.id]: updatedSites },
+    });
+  };
+
+  const addSite = () => {
+    const hostname = normalizeExtensionSiteHostname(siteInput);
+
+    if (!hostname) {
+      toast.error("Enter a site as a hostname, like sso.example.com.");
+
+      return;
+    }
+
+    setSiteInput("");
+
+    if (sites.includes(hostname)) {
+      return;
+    }
+
+    saveSites([...sites, hostname]);
+  };
+
+  return (
+    <Field>
+      <FieldLabel>Additional Sites</FieldLabel>
+      <FieldDescription>
+        {extension.name} only runs on the sign-in pages Meru offers it for. Sites added here run it
+        too, such as your company's single sign-on provider.
+      </FieldDescription>
+      {sites.map((site) => (
+        <div className="flex items-center gap-2 text-sm" key={site}>
+          <div className="flex-1">{site}</div>
+          <Button
+            variant="outline"
+            size="icon-sm"
+            onClick={() => {
+              saveSites(sites.filter((keptSite) => keptSite !== site));
+            }}
+            aria-label={`Remove ${site} from ${extension.name}`}
+          >
+            <XIcon />
+          </Button>
+        </div>
+      ))}
+      <form
+        className="flex gap-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+
+          addSite();
+        }}
+      >
+        <Input
+          value={siteInput}
+          onChange={(event) => {
+            setSiteInput(event.target.value);
+          }}
+          placeholder="sso.example.com"
+          aria-label={`Site to add to ${extension.name}`}
+        />
+        <Button type="submit" variant="outline">
+          <PlusIcon /> Add
+        </Button>
+      </form>
+    </Field>
+  );
+}
 
 function ExtensionItem({
   extension,
   installed,
   installedVersion,
+  additionalSites,
 }: {
   extension: CuratedExtension;
   installed: boolean;
   installedVersion: string | undefined;
+  additionalSites: Config["extensions.additionalSites"];
 }) {
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
@@ -74,6 +173,11 @@ function ExtensionItem({
           aria-label={`Install ${extension.name}`}
         />
       </ItemActions>
+      {isLicenseKeyValid && installed && extension.contentScriptMatches && (
+        <ItemFooter>
+          <ExtensionAdditionalSites extension={extension} additionalSites={additionalSites} />
+        </ItemFooter>
+      )}
     </Item>
   );
 }
@@ -107,6 +211,7 @@ export function ExtensionsSettings() {
               extension={extension}
               installed={config["extensions.installed"].includes(extension.id)}
               installedVersion={installedExtensions?.find(({ id }) => id === extension.id)?.version}
+              additionalSites={config["extensions.additionalSites"]}
             />
           ))}
         </ItemGroup>

--- a/packages/shared/extensions.test.ts
+++ b/packages/shared/extensions.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { hostnameToMatchPattern, normalizeExtensionSiteHostname } from "./extensions";
+
+describe("hostnameToMatchPattern", () => {
+  test("covers every path of the site over HTTPS", () => {
+    expect(hostnameToMatchPattern("sso.okta.com")).toBe("https://sso.okta.com/*");
+  });
+});
+
+describe("normalizeExtensionSiteHostname", () => {
+  test("takes a bare hostname", () => {
+    expect(normalizeExtensionSiteHostname("sso.okta.com")).toBe("sso.okta.com");
+    expect(normalizeExtensionSiteHostname("login.microsoftonline.com")).toBe(
+      "login.microsoftonline.com",
+    );
+    expect(normalizeExtensionSiteHostname("my-company.onelogin.com")).toBe(
+      "my-company.onelogin.com",
+    );
+  });
+
+  test("lowercases and trims what it takes", () => {
+    expect(normalizeExtensionSiteHostname("  SSO.Okta.com ")).toBe("sso.okta.com");
+  });
+
+  test("refuses an empty entry", () => {
+    expect(normalizeExtensionSiteHostname("")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname("   ")).toBeUndefined();
+  });
+
+  test("refuses a hostname without a dot", () => {
+    expect(normalizeExtensionSiteHostname("localhost")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname("okta")).toBeUndefined();
+  });
+
+  test("refuses anything more than a hostname", () => {
+    expect(normalizeExtensionSiteHostname("https://sso.okta.com")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname("sso.okta.com/app/login")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname("sso.okta.com:8443")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname("user@sso.okta.com")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname("sso okta.com")).toBeUndefined();
+  });
+
+  test("refuses a match pattern of its own", () => {
+    expect(normalizeExtensionSiteHostname("*.okta.com")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname("https://*.okta.com/*")).toBeUndefined();
+  });
+
+  test("refuses empty labels", () => {
+    expect(normalizeExtensionSiteHostname("sso..okta.com")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname(".okta.com")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname("okta.com.")).toBeUndefined();
+  });
+});

--- a/packages/shared/extensions.ts
+++ b/packages/shared/extensions.ts
@@ -29,3 +29,31 @@ export const curatedExtensions: CuratedExtension[] = [
 export function isCuratedExtensionId(extensionId: string) {
   return curatedExtensions.some((curatedExtension) => curatedExtension.id === extensionId);
 }
+
+/** The pattern a site the user added stands for, every path of it over HTTPS. */
+export function hostnameToMatchPattern(hostname: string) {
+  return `https://${hostname}/*`;
+}
+
+const HOSTNAME_LABEL = /^[a-z0-9-]+$/;
+
+/**
+ * The hostname a site the user typed holds, lowercased, or `undefined` when it is
+ * anything else — a URL, a host carrying a port, a path or a wildcard. It ends up
+ * in a match pattern verbatim, so only what `URL` reads back unchanged passes.
+ */
+export function normalizeExtensionSiteHostname(site: string) {
+  const hostname = site.trim().toLowerCase();
+
+  const labels = hostname.split(".");
+
+  if (labels.length < 2 || !labels.every((label) => HOSTNAME_LABEL.test(label))) {
+    return;
+  }
+
+  try {
+    return new URL(`https://${hostname}`).hostname === hostname ? hostname : undefined;
+  } catch {
+    return;
+  }
+}

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -185,6 +185,7 @@ export type Config = {
   "verticalTabs.hideUnreadBadgeWhenActive": boolean;
   "verticalTabs.showAppLinksBadge": boolean;
   "extensions.installed": string[];
+  "extensions.additionalSites": Record<string, string[]>;
 };
 
 export type IpcMainEvents =


### PR DESCRIPTION
- New `extensions.additionalSites` config key (extension id → hostnames, default `{}`).
- Shared `normalizeExtensionSiteHostname` (strict: bare lowercase hostname, no ports/paths/wildcards; unit-tested) and `hostnameToMatchPattern` (`https://<host>/*`).
- Main appends the user's sites to the catalog clamp; an unclamped extension never becomes clamped by additional sites.
- Settings: an "Additional Sites" list under each installed, licensed, clamped extension — add via input (Enter submits), remove per row, restart-required toast on change. Covers sign-in through a third-party SSO provider.

Not verified: the footer's rendering in the running app (no display in the sandbox). IDN hostnames must be entered as punycode.

Test plan:
1. Install 1Password → "Additional Sites" appears under it; adding `sso.example.com` lists it and shows the restart toast; a URL, port, or wildcard input shows an error toast instead.
2. After restart, a login page on the added host gets 1Password's inline UI; accounts.google.com still works.
3. Remove the site and restart — the host no longer gets content scripts.