### PR TITLE
authorize the touch id keychain group with a provisioning profile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,13 @@ jobs:
       - if: startsWith(matrix.os, 'macos') && env.SIGN_MACOS != 'true'
         run: bun run build:mac -- --publish never
       - if: startsWith(matrix.os, 'macos') && env.SIGN_MACOS == 'true'
-        run: bun run build:mac -- --publish never
+        # The provisioning profile authorizes the Touch ID keychain access group entitlement;
+        # without it macOS refuses to launch the signed app.
+        run: |
+          echo "$APPLE_PROVISIONING_PROFILE" | base64 --decode > build/embedded.provisionprofile
+          bun run build:mac -- --publish never
         env:
+          APPLE_PROVISIONING_PROFILE: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
           # electron-builder skips signing on PR builds unless this is true; fork PRs never
           # receive the secrets, so they still fall back to an unsigned build.
           CSC_FOR_PULL_REQUEST: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,13 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
       - if: startsWith(matrix.os, 'macos')
-        run: bun run build:mac -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=beta' || '' }}
+        # The provisioning profile authorizes the Touch ID keychain access group entitlement;
+        # without it macOS refuses to launch the signed app.
+        run: |
+          echo "$APPLE_PROVISIONING_PROFILE" | base64 --decode > build/embedded.provisionprofile
+          bun run build:mac -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=beta' || '' }}
         env:
+          APPLE_PROVISIONING_PROFILE: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ dist
 .DS_Store
 
 # Meru
+build/embedded.provisionprofile
 build/entitlements.mac.plist
 build-js
 docs/

--- a/build/hooks/beforePack.js
+++ b/build/hooks/beforePack.js
@@ -5,6 +5,11 @@ import path from "node:path";
 // whose `keychain-access-groups` entitlement doesn't match the team it was signed with, so the
 // group Touch ID WebAuthn credentials live under is written out here with the team id that only
 // signed builds carry. Keep the group in sync with `configureWebAuthn` in `packages/app/index.ts`.
+//
+// `keychain-access-groups` is a restricted entitlement: Gatekeeper only honours it when the
+// provisioning profile embedded in the app authorizes it, and the profile only binds to the app
+// through the application and team identifiers below. `@electron/osx-sign` adds those two itself,
+// but only for sandboxed apps, so they are written out here too.
 export default async (context) => {
   if (context.packager.platform.name !== "mac") {
     return;
@@ -23,6 +28,10 @@ export default async (context) => {
     ? template.replace(
         "  </dict>",
         [
+          "    <key>com.apple.application-identifier</key>",
+          `    <string>${teamId}.${context.packager.appInfo.id}</string>`,
+          "    <key>com.apple.developer.team-identifier</key>",
+          `    <string>${teamId}</string>`,
           "    <key>keychain-access-groups</key>",
           "    <array>",
           `      <string>${teamId}.${context.packager.appInfo.id}.webauthn</string>`,

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
       "category": "public.app-category.productivity",
       "icon": "build/icon.icns",
       "darkModeSupport": true,
+      "provisioningProfile": "build/embedded.provisionprofile",
       "target": {
         "target": "default",
         "arch": [


### PR DESCRIPTION
`keychain-access-groups` is a restricted entitlement, so Gatekeeper refuses to launch a signed build unless an embedded provisioning profile authorizes it — which is why every signed build since #810 dies with "The application "Meru.app" can't be opened", including after #842 fixed the team id.

- Sign with `build/embedded.provisionprofile`, which `@electron/osx-sign` copies to `Contents/embedded.provisionprofile`
- Add `com.apple.application-identifier` and `com.apple.developer.team-identifier` to the generated entitlements, without which the profile doesn't bind to the app. `@electron/osx-sign` adds them itself, but only for sandboxed apps
- Keep the profile out of the repo: gitignored, and CI decodes it from the `APPLE_PROVISIONING_PROFILE` secret before the signed macOS build

Verified with a local signed build: the app launches and Touch ID passkey enrollment works. The `APPLE_PROVISIONING_PROFILE` secret is set, holding a Developer ID profile for the explicit App ID `sh.zoid.meru` that expires 2044-08-12. What hasn't been exercised is the CI path — the decode step in the workflows has never run.

## Test plan

1. Label this PR `sign-macos` and download the arm64 DMG artifact.
2. Open the app — it launches rather than showing "can't be opened", which is what proves CI embedded the profile.
