### PR TITLE
collapse extension actions behind an extensions menu button

### DIFF
--- a/packages/app/extension-actions.ts
+++ b/packages/app/extension-actions.ts
@@ -1,6 +1,6 @@
 import { APP_TITLEBAR_HEIGHT } from "@meru/shared/constants";
 import type { ExtensionActionAnchorRect } from "@meru/shared/types";
-import { BrowserWindow, type WebContents } from "electron";
+import { BrowserWindow, Menu, nativeImage, type WebContents } from "electron";
 import { accounts } from "./accounts";
 import { extensions } from "./extensions";
 import { ipc } from "./ipc";
@@ -8,12 +8,30 @@ import { Popup } from "./lib/popup";
 import { main } from "./main";
 import { WorkspaceApp } from "./workspace-app";
 
+/** The size a menu item's icon is drawn at. */
+const MENU_ICON_SIZE = 16;
+
 /**
- * The titlebar buttons of the extensions loaded into an account's session, and
- * the popup a click on one opens.
+ * Action icons are read at twice the size a menu draws them at, and a data URL
+ * carries no scale factor for Electron to work that out from.
+ */
+function createMenuIcon(iconDataUrl: string) {
+  const icon = nativeImage.createFromDataURL(iconDataUrl);
+
+  // An icon `nativeImage` cannot decode — an SVG one — comes back empty
+  if (icon.isEmpty()) {
+    return undefined;
+  }
+
+  return icon.resize({ width: MENU_ICON_SIZE, height: MENU_ICON_SIZE });
+}
+
+/**
+ * The titlebar button listing the extensions loaded into an account's session,
+ * and the popup picking one from that list opens.
  *
- * Extensions load into every account, so every titlebar shows the same buttons
- * — the session a window belongs to only decides which of an extension's
+ * Extensions load into every account, so every titlebar shows the same list —
+ * the session a window belongs to only decides which of an extension's
  * per-account instances the popup runs against.
  */
 class ExtensionActions {
@@ -54,14 +72,13 @@ class ExtensionActions {
     }
   }
 
-  togglePopup(
+  private openPopup(
+    parentWindow: BrowserWindow,
     webContents: WebContents,
     extensionId: string,
     anchorRect: ExtensionActionAnchorRect,
   ) {
-    const parentWindow = BrowserWindow.fromWebContents(webContents);
-
-    if (!parentWindow) {
+    if (parentWindow.isDestroyed()) {
       return;
     }
 
@@ -90,6 +107,35 @@ class ExtensionActions {
       // short of it
       anchor: { x: anchorRect.x + anchorRect.width, y: APP_TITLEBAR_HEIGHT, align: "end" },
     });
+
+    // The menu the popup was picked from is gone by the time it opens, so
+    // nothing holds the blur off the way hovering a button that toggles a popup
+    // does — a click anywhere else closes it
+    this.popup.closeOnBlurEnabled = true;
+  }
+
+  showMenu(webContents: WebContents, anchorRect: ExtensionActionAnchorRect) {
+    const parentWindow = BrowserWindow.fromWebContents(webContents);
+
+    if (!parentWindow) {
+      return;
+    }
+
+    // A click on the button lands here through the blur that closes an open
+    // popup, so the menu takes over rather than opening on top of one
+    this.popup.close();
+
+    const menu = Menu.buildFromTemplate(
+      this.serialize(webContents).map(({ extensionId, title, iconDataUrl }) => ({
+        label: title,
+        icon: iconDataUrl ? createMenuIcon(iconDataUrl) : undefined,
+        click: () => {
+          this.openPopup(parentWindow, webContents, extensionId, anchorRect);
+        },
+      })),
+    );
+
+    menu.popup({ window: parentWindow, x: anchorRect.x, y: anchorRect.y + anchorRect.height });
   }
 }
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -1010,12 +1010,8 @@ class Ipc {
       return extensionActions.serialize(event.sender);
     });
 
-    ipc.main.on("extensions.toggleActionPopup", (event, extensionId, anchorRect) => {
-      extensionActions.togglePopup(event.sender, extensionId, anchorRect);
-    });
-
-    ipc.main.on("extensions.setActionPopupCloseOnBlurEnabled", (_event, enabled) => {
-      extensionActions.popup.closeOnBlurEnabled = enabled;
+    ipc.main.on("extensions.showActionsMenu", (event, anchorRect) => {
+      extensionActions.showMenu(event.sender, anchorRect);
     });
 
     ipc.main.handle("extensions.getInstalled", () => {

--- a/packages/renderer/components/extension-actions.tsx
+++ b/packages/renderer/components/extension-actions.tsx
@@ -1,43 +1,15 @@
 import { ipc } from "@meru/shared/renderer/ipc";
-import type { ExtensionActionState } from "@meru/shared/types";
 import { PuzzleIcon } from "lucide-react";
-import { TitlebarButtonGroup, TitlebarIconButton } from "@/components/titlebar";
+import { TitlebarIconButton } from "@/components/titlebar";
 import { useExtensionActionsStore } from "@/lib/extension-actions";
 
-function ExtensionActionButton({ action }: { action: ExtensionActionState }) {
-  return (
-    <TitlebarIconButton
-      onClick={(event) => {
-        const { x, y, width, height } = event.currentTarget.getBoundingClientRect();
-
-        ipc.main.send("extensions.toggleActionPopup", action.extensionId, {
-          x: Math.round(x),
-          y: Math.round(y),
-          width: Math.round(width),
-          height: Math.round(height),
-        });
-      }}
-      onMouseEnter={() => {
-        ipc.main.send("extensions.setActionPopupCloseOnBlurEnabled", false);
-      }}
-      onMouseLeave={() => {
-        ipc.main.send("extensions.setActionPopupCloseOnBlurEnabled", true);
-      }}
-      title={action.title}
-    >
-      {action.iconDataUrl ? (
-        <img src={action.iconDataUrl} alt="" className="size-4" />
-      ) : (
-        <PuzzleIcon />
-      )}
-    </TitlebarIconButton>
-  );
-}
-
 /**
- * One button per extension loaded into the account this window shows, drawing
- * nothing at all while no extension is loaded — which is every window until
- * extensions can be installed.
+ * The titlebar button listing the extensions loaded into the account this window
+ * shows, drawing nothing at all while no extension is loaded — which is every
+ * window until extensions can be installed.
+ *
+ * The list itself is a native menu the main process pops up: a renderer-drawn
+ * one would be covered wherever a workspace app view sits.
  */
 export function ExtensionActions() {
   const actions = useExtensionActionsStore((state) => state.actions);
@@ -47,10 +19,20 @@ export function ExtensionActions() {
   }
 
   return (
-    <TitlebarButtonGroup>
-      {actions.map((action) => (
-        <ExtensionActionButton key={action.extensionId} action={action} />
-      ))}
-    </TitlebarButtonGroup>
+    <TitlebarIconButton
+      title="Extensions"
+      onClick={(event) => {
+        const { x, y, width, height } = event.currentTarget.getBoundingClientRect();
+
+        ipc.main.send("extensions.showActionsMenu", {
+          x: Math.round(x),
+          y: Math.round(y),
+          width: Math.round(width),
+          height: Math.round(height),
+        });
+      }}
+    >
+      <PuzzleIcon />
+    </TitlebarIconButton>
   );
 }

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -49,10 +49,10 @@ export type NotificationTime = {
 export type BookmarksPopupPlacement = "titlebar" | "verticalTabs";
 
 /**
- * One loaded extension's titlebar button. Everything here comes from the
- * extension's manifest and never changes while it runs — Electron implements no
- * part of `chrome.action`, so an extension setting an icon, a badge or a title
- * at runtime changes nothing and leaves no state to read.
+ * One loaded extension's entry in the extensions menu. Everything here comes
+ * from the extension's manifest and never changes while it runs — Electron
+ * implements no part of `chrome.action`, so an extension setting an icon, a
+ * badge or a title at runtime changes nothing and leaves no state to read.
  */
 export type ExtensionActionState = {
   extensionId: string;
@@ -66,7 +66,7 @@ export type InstalledExtensionState = {
   version: string;
 };
 
-/** A titlebar button's rect, in its window's content coordinates. */
+/** The extensions titlebar button's rect, in its window's content coordinates. */
 export type ExtensionActionAnchorRect = { x: number; y: number; width: number; height: number };
 
 export type WorkspaceAppNotification = {
@@ -243,8 +243,7 @@ export type IpcMainEvents =
         bookmarkId: Bookmark["id"],
         targetIndex: number,
       ];
-      "extensions.toggleActionPopup": [extensionId: string, anchorRect: ExtensionActionAnchorRect];
-      "extensions.setActionPopupCloseOnBlurEnabled": [enabled: boolean];
+      "extensions.showActionsMenu": [anchorRect: ExtensionActionAnchorRect];
       "doNotDisturb.toggle": [];
       "doNotDisturb.showOptions": [];
       "downloads.toggleRecentDownloadHistoryPopup": [];


### PR DESCRIPTION
- Replaces the per-extension titlebar buttons with a single puzzle-icon extensions button (both titlebars, unchanged component API).
- Clicking it opens a native `Menu.popup` listing the window's loaded extensions with icon + name; picking one opens that extension's action popup at the same titlebar anchor as before.
- `extensions.toggleActionPopup` and `extensions.setActionPopupCloseOnBlurEnabled` IPC replaced by one `extensions.showActionsMenu` message; the hover-based blur dance is gone — `showMenu` closes any open popup before the menu, and opening from the menu re-enables close-on-blur (which `Popup.close()` resets).
- Menu icons come from `nativeImage.createFromDataURL` resized to 16px; undecodable (SVG) icons fall back to no icon.

Interactive behavior is unverified (headless sandbox): menu position under the button per platform, icon rendering, and the popup-open → button-click → menu takeover sequence.

Test plan:
1. With 1Password installed, both the main and a workspace-app titlebar show one puzzle button; clicking it opens a menu under it listing 1Password with its icon.
2. Picking 1Password opens its popup in the usual spot; clicking anywhere outside closes it on the first click.
3. With the popup open, click the puzzle button: the popup closes and the menu opens (no stacking, no flicker-reopen).
4. Escape closes the popup as before.