### PR TITLE
show a spinner while an extension installs or uninstalls

### DIFF
--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -9,6 +9,7 @@ import {
   ItemGroup,
   ItemTitle,
 } from "@meru/ui/components/item";
+import { Spinner } from "@meru/ui/components/spinner";
 import { Switch } from "@meru/ui/components/switch";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -65,6 +66,7 @@ function ExtensionItem({
         </ItemDescription>
       </ItemContent>
       <ItemActions>
+        {extensionMutation.isPending && <Spinner />}
         <Switch
           checked={isLicenseKeyValid && installed}
           disabled={!isLicenseKeyValid || extensionMutation.isPending}


### PR DESCRIPTION
- Shows a spinner beside the switch while the install/uninstall mutation runs — the multi-second ~18 MB download previously only disabled the switch. No percentage, no new IPC.

Test plan:
1. Toggle 1Password on: a spinner sits next to the switch until the install finishes, then the restart toast shows.
2. Toggle it off: same spinner during uninstall.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>