### PR TITLE
mark extensions as beta and state where each extension comes from

### DIFF
--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -13,6 +13,7 @@ import {
 import { Spinner } from "@meru/ui/components/spinner";
 import { Switch } from "@meru/ui/components/switch";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { ExternalLinkIcon } from "lucide-react";
 import { toast } from "sonner";
 import { BetaFieldBadge } from "@/components/beta-field-badge";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
@@ -63,9 +64,10 @@ function ExtensionItem({
             href={`https://chromewebstore.google.com/detail/${extension.id}`}
             target="_blank"
             rel="noreferrer"
-            className="hover:underline"
+            className="flex items-center gap-1 hover:underline"
           >
             {extension.name}
+            <ExternalLinkIcon className="size-3 text-muted-foreground" />
           </a>
           {installedVersion && <Badge variant="outline">Version {installedVersion}</Badge>}
           <LicenseKeyRequiredFieldBadge />
@@ -111,8 +113,7 @@ export function ExtensionsSettings() {
         <LicenseKeyRequiredBanner />
         <FieldDescription>
           Extensions are loaded into every account and take effect after a restart. Meru installs
-          the official packages from the Chrome Web Store, and each extension's name links to its
-          listing.
+          the official extensions from the Chrome Web Store.
         </FieldDescription>
         <ItemGroup>
           {curatedExtensions.map((extension) => (

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -59,22 +59,18 @@ function ExtensionItem({
     <Item variant="muted">
       <ItemContent>
         <ItemTitle>
-          {extension.name}
-          {installedVersion && <Badge variant="outline">Version {installedVersion}</Badge>}
-          <LicenseKeyRequiredFieldBadge />
-        </ItemTitle>
-        <ItemDescription>{extension.description}</ItemDescription>
-        <ItemDescription>
-          Installs the official extension from the{" "}
           <a
             href={`https://chromewebstore.google.com/detail/${extension.id}`}
             target="_blank"
             rel="noreferrer"
+            className="hover:underline"
           >
-            Chrome Web Store
+            {extension.name}
           </a>
-          .
-        </ItemDescription>
+          {installedVersion && <Badge variant="outline">Version {installedVersion}</Badge>}
+          <LicenseKeyRequiredFieldBadge />
+        </ItemTitle>
+        <ItemDescription>{extension.description}</ItemDescription>
       </ItemContent>
       <ItemActions>
         {extensionMutation.isPending && <Spinner />}
@@ -114,7 +110,9 @@ export function ExtensionsSettings() {
       <SettingsContent className="space-y-4">
         <LicenseKeyRequiredBanner />
         <FieldDescription>
-          Extensions are loaded into every account and take effect after a restart.
+          Extensions are loaded into every account and take effect after a restart. Meru installs
+          the official packages from the Chrome Web Store, and each extension's name links to its
+          listing.
         </FieldDescription>
         <ItemGroup>
           {curatedExtensions.map((extension) => (

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -1,5 +1,6 @@
 import { type CuratedExtension, curatedExtensions } from "@meru/shared/extensions";
 import { ipc } from "@meru/shared/renderer/ipc";
+import { Badge } from "@meru/ui/components/badge";
 import { FieldDescription } from "@meru/ui/components/field";
 import {
   Item,
@@ -13,6 +14,7 @@ import { Spinner } from "@meru/ui/components/spinner";
 import { Switch } from "@meru/ui/components/switch";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { BetaFieldBadge } from "@/components/beta-field-badge";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { LicenseKeyRequiredFieldBadge } from "@/components/license-key-required-field-badge";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
@@ -58,11 +60,20 @@ function ExtensionItem({
       <ItemContent>
         <ItemTitle>
           {extension.name}
+          {installedVersion && <Badge variant="outline">Version {installedVersion}</Badge>}
           <LicenseKeyRequiredFieldBadge />
         </ItemTitle>
+        <ItemDescription>{extension.description}</ItemDescription>
         <ItemDescription>
-          {extension.description}
-          {installedVersion && ` Version ${installedVersion} is installed.`}
+          Installs the official extension from the{" "}
+          <a
+            href={`https://chromewebstore.google.com/detail/${extension.id}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Chrome Web Store
+          </a>
+          .
         </ItemDescription>
       </ItemContent>
       <ItemActions>
@@ -95,7 +106,10 @@ export function ExtensionsSettings() {
   return (
     <Settings>
       <SettingsHeader>
-        <SettingsTitle>Extensions</SettingsTitle>
+        <SettingsTitle className="flex items-center gap-2">
+          Extensions
+          <BetaFieldBadge />
+        </SettingsTitle>
       </SettingsHeader>
       <SettingsContent className="space-y-4">
         <LicenseKeyRequiredBanner />


### PR DESCRIPTION
- Beta badge next to the "Extensions" page title — the whole `chrome.*` layer is Meru's own implementation.
- Provenance stated once in the page description ("Meru installs the official extensions from the Chrome Web Store"); each extension's name links to its own store listing with a small external-link icon after it, so nothing repeats as the catalog grows.
- The installed version moves out of the description prose into an outline badge in the item title.

Test plan:
1. With 1Password installed, its title shows a "Version X" badge and clicking the name (external-link icon after it) opens the 1Password listing in the browser.
2. Uninstalled, no version badge shows and the rest of the item is unchanged.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
