### PR TITLE
check for extension updates on demand

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -11,7 +11,7 @@ import {
 } from "@meru/electron-extensions";
 import { curatedExtensions, isCuratedExtensionId } from "@meru/shared/extensions";
 import { ms } from "@meru/shared/ms";
-import type { InstalledExtensionState } from "@meru/shared/types";
+import type { ExtensionUpdateResult, InstalledExtensionState } from "@meru/shared/types";
 import { app } from "electron";
 import { serializeError } from "serialize-error";
 import { config } from "@/config";
@@ -202,6 +202,9 @@ export async function pruneDerivedExtensionCopies() {
  * derived for as long as they live.
  */
 class ExtensionUpdater {
+  /** The check in flight, which a second trigger joins instead of downloading again. */
+  private runningCheck: Promise<ExtensionUpdateResult[]> | undefined;
+
   init() {
     if (!licenseKey.isValid) {
       return;
@@ -219,7 +222,19 @@ class ExtensionUpdater {
     }, ms("3h"));
   }
 
-  private async checkForUpdates() {
+  checkForUpdates() {
+    if (!this.runningCheck) {
+      this.runningCheck = this.updateOptedInExtensions().finally(() => {
+        this.runningCheck = undefined;
+      });
+    }
+
+    return this.runningCheck;
+  }
+
+  private async updateOptedInExtensions() {
+    const results: ExtensionUpdateResult[] = [];
+
     for (const extensionId of getOptedInExtensionIds()) {
       try {
         const { updated, version } = await installLatestExtension({
@@ -232,10 +247,24 @@ class ExtensionUpdater {
           extensionId,
           version,
         });
+
+        results.push(
+          updated
+            ? { id: extensionId, status: "updated", version }
+            : { id: extensionId, status: "upToDate" },
+        );
       } catch (error) {
         log.error("Failed to update extension", { extensionId, error: serializeError(error) });
+
+        results.push({
+          id: extensionId,
+          status: "failed",
+          error: error instanceof Error ? error.message : String(error),
+        });
       }
     }
+
+    return results;
   }
 }
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -42,6 +42,7 @@ import { DoNotDisturb, doNotDisturb } from "./do-not-disturb";
 import { downloads } from "./downloads";
 import { extensionActions } from "./extension-actions";
 import {
+  extensionUpdater,
   getInstalledExtensions,
   installCuratedExtension,
   uninstallCuratedExtension,
@@ -1054,6 +1055,14 @@ class Ipc {
           error: `Failed to uninstall extension: ${error instanceof Error ? error.message : String(error)}`,
         };
       }
+    });
+
+    ipc.main.handle("extensions.update", async () => {
+      if (!licenseKey.isValid) {
+        return { error: "Meru Pro is required to update extensions" };
+      }
+
+      return { results: await extensionUpdater.checkForUpdates() };
     });
 
     ipc.main.on("downloads.toggleRecentDownloadHistoryPopup", (event) => {

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -1,6 +1,7 @@
 import { type CuratedExtension, curatedExtensions } from "@meru/shared/extensions";
 import { ipc } from "@meru/shared/renderer/ipc";
 import { Badge } from "@meru/ui/components/badge";
+import { Button } from "@meru/ui/components/button";
 import { FieldDescription } from "@meru/ui/components/field";
 import {
   Item,
@@ -89,6 +90,66 @@ function ExtensionItem({
   );
 }
 
+function UpdateExtensionsButton() {
+  const updateExtensionsMutation = useMutation({
+    mutationFn: () => ipc.main.invoke("extensions.update"),
+    onSuccess: ({ error, results }) => {
+      if (error) {
+        toast.error(error);
+
+        return;
+      }
+
+      let updatedAny = false;
+
+      for (const result of results ?? []) {
+        const name = curatedExtensions.find(({ id }) => id === result.id)?.name ?? result.id;
+
+        switch (result.status) {
+          case "updated": {
+            updatedAny = true;
+
+            toast.success(`${name} updated to ${result.version}`);
+
+            break;
+          }
+          case "upToDate": {
+            toast.success(`${name} is up to date`);
+
+            break;
+          }
+          case "failed": {
+            toast.error(`Failed to update ${name}: ${result.error}`);
+
+            break;
+          }
+        }
+      }
+
+      if (updatedAny) {
+        queryClient.invalidateQueries({
+          queryKey: installedExtensionsQueryKey,
+        });
+
+        restartRequiredToast();
+      }
+    },
+  });
+
+  return (
+    <Button
+      variant="outline"
+      disabled={updateExtensionsMutation.isPending}
+      onClick={() => {
+        updateExtensionsMutation.mutate();
+      }}
+    >
+      {updateExtensionsMutation.isPending && <Spinner />}
+      Update Extensions
+    </Button>
+  );
+}
+
 export function ExtensionsSettings() {
   const { config } = useConfig();
 
@@ -108,6 +169,7 @@ export function ExtensionsSettings() {
           Extensions
           <BetaFieldBadge />
         </SettingsTitle>
+        {config["extensions.installed"].length > 0 && <UpdateExtensionsButton />}
       </SettingsHeader>
       <SettingsContent className="space-y-4">
         <LicenseKeyRequiredBanner />

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -66,6 +66,12 @@ export type InstalledExtensionState = {
   version: string;
 };
 
+/** What an update check did to one extension, which is what the page reports. */
+export type ExtensionUpdateResult =
+  | { id: string; status: "updated"; version: string }
+  | { id: string; status: "upToDate" }
+  | { id: string; status: "failed"; error: string };
+
 /** The extensions titlebar button's rect, in its window's content coordinates. */
 export type ExtensionActionAnchorRect = { x: number; y: number; width: number; height: number };
 
@@ -277,6 +283,7 @@ export type IpcMainEvents =
       "extensions.getInstalled": () => InstalledExtensionState[];
       "extensions.install": (extensionId: string) => { error?: string };
       "extensions.uninstall": (extensionId: string) => { error?: string };
+      "extensions.update": () => { error?: string; results?: ExtensionUpdateResult[] };
     };
 
 export type IpcRendererEvent = {


### PR DESCRIPTION
- "Update Extensions" button in the settings header, shown once anything is installed, running the update check on demand over a new Pro-gated `extensions.update` invoke.
- `ExtensionUpdater.checkForUpdates` holds a single in-flight promise, so scheduled (launch + 3h) and manual runs join instead of overlapping downloads.
- Per-extension result toasts (updated to X / up to date / failed with the error message), plus query invalidation and the restart toast when anything actually updated.

Not exercised against a real Omaha update. Each check still downloads the full ~18 MB CRX — the `updatecheck` probe noted in the feature doc got more worthwhile now that checks are user-triggered.

Test plan:
1. With 1Password installed and current, click Update Extensions: the button disables with a spinner, then "1Password is up to date".
2. With an older version on disk, the check installs the newer one: "1Password updated to X" and the restart toast; after restart the new version loads.
3. Click while a scheduled check happens to be running: one download, one set of toasts.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>