### PR TITLE
categorize curated extensions and explain passkeys per platform

### DIFF
--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -1,5 +1,6 @@
 import { type CuratedExtension, curatedExtensions } from "@meru/shared/extensions";
 import { ipc } from "@meru/shared/renderer/ipc";
+import { Alert, AlertDescription, AlertTitle } from "@meru/ui/components/alert";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import { FieldDescription } from "@meru/ui/components/field";
@@ -14,7 +15,7 @@ import {
 import { Spinner } from "@meru/ui/components/spinner";
 import { Switch } from "@meru/ui/components/switch";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { ExternalLinkIcon } from "lucide-react";
+import { ExternalLinkIcon, KeyRoundIcon } from "lucide-react";
 import { toast } from "sonner";
 import { BetaFieldBadge } from "@/components/beta-field-badge";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
@@ -23,6 +24,7 @@ import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/comp
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { queryClient, useConfig } from "@/lib/react-query";
 import { restartRequiredToast } from "@/lib/toast";
+import { platform } from "@/lib/utils";
 
 const installedExtensionsQueryKey = ["installed-extensions"];
 
@@ -87,6 +89,49 @@ function ExtensionItem({
         />
       </ItemActions>
     </Item>
+  );
+}
+
+function PasskeysAlert() {
+  if (platform.isMacOS) {
+    return (
+      <Alert>
+        <KeyRoundIcon />
+        <AlertTitle>Your Mac can sign you in with a passkey</AlertTitle>
+        <AlertDescription>
+          Instead of installing a password manager, you can add a Touch ID passkey to your Google
+          account — open myaccount.google.com inside Meru and enroll one under Security. Nothing to
+          install, and no per-account memory cost. It has to be a new passkey — existing iCloud
+          passkeys can't be used here — and it only signs you in to Google, it doesn't fill
+          passwords on other sites.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (platform.isWindows) {
+    return (
+      <Alert>
+        <KeyRoundIcon />
+        <AlertTitle>Passkeys already work without an extension</AlertTitle>
+        <AlertDescription>
+          Meru signs you in to Google through Windows' own passkey dialog, so Windows Hello and
+          synced passkey providers work with nothing installed. A password manager is still what
+          fills regular passwords.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <Alert>
+      <KeyRoundIcon />
+      <AlertTitle>Passkeys need a password manager on Linux</AlertTitle>
+      <AlertDescription>
+        Linux has no system passkey support, so a password manager extension is the only way to sign
+        in to Google with a passkey in Meru.
+      </AlertDescription>
+    </Alert>
   );
 }
 
@@ -177,6 +222,9 @@ export function ExtensionsSettings() {
           Extensions are loaded into every account and take effect after a restart. Meru installs
           the official extensions from the Chrome Web Store.
         </FieldDescription>
+        {curatedExtensions.some(({ category }) => category === "passwordManager") && (
+          <PasskeysAlert />
+        )}
         <ItemGroup>
           {curatedExtensions.map((extension) => (
             <ExtensionItem

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -100,8 +100,7 @@ function PasskeysAlert() {
         <AlertTitle>Meru can sign you in with a Touch ID passkey</AlertTitle>
         <AlertDescription>
           Add a passkey to your Google account from its security settings inside Meru and sign in
-          with Touch ID — lighter than running an extension. Existing iCloud passkeys can't be used,
-          and it won't fill passwords on other sites.
+          with Touch ID — lighter than running an extension. Existing iCloud passkeys can't be used.
         </AlertDescription>
       </Alert>
     );

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -100,7 +100,8 @@ function PasskeysAlert() {
         <AlertTitle>Meru can sign you in with a Touch ID passkey</AlertTitle>
         <AlertDescription>
           Add a passkey to your Google account from its security settings inside Meru and sign in
-          with Touch ID — lighter than running an extension. Existing iCloud passkeys can't be used.
+          with Touch ID — lighter than running an extension. Existing iCloud passkeys can't be used,
+          and filling passwords still needs a password manager.
         </AlertDescription>
       </Alert>
     );

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -3,7 +3,7 @@ import { ipc } from "@meru/shared/renderer/ipc";
 import { Alert, AlertDescription, AlertTitle } from "@meru/ui/components/alert";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
-import { FieldDescription } from "@meru/ui/components/field";
+import { FieldDescription, FieldLegend, FieldSet } from "@meru/ui/components/field";
 import {
   Item,
   ItemActions,
@@ -97,13 +97,11 @@ function PasskeysAlert() {
     return (
       <Alert>
         <KeyRoundIcon />
-        <AlertTitle>Your Mac can sign you in with a passkey</AlertTitle>
+        <AlertTitle>Meru can sign you in with a Touch ID passkey</AlertTitle>
         <AlertDescription>
-          Instead of installing a password manager, you can add a Touch ID passkey to your Google
-          account — open myaccount.google.com inside Meru and enroll one under Security. Nothing to
-          install, and no per-account memory cost. It has to be a new passkey — existing iCloud
-          passkeys can't be used here — and it only signs you in to Google, it doesn't fill
-          passwords on other sites.
+          Add a passkey to your Google account from its security settings inside Meru and sign in
+          with Touch ID — lighter than running an extension. Existing iCloud passkeys can't be used,
+          and it won't fill passwords on other sites.
         </AlertDescription>
       </Alert>
     );
@@ -113,11 +111,10 @@ function PasskeysAlert() {
     return (
       <Alert>
         <KeyRoundIcon />
-        <AlertTitle>Passkeys already work without an extension</AlertTitle>
+        <AlertTitle>Meru can sign you in with your Windows passkeys</AlertTitle>
         <AlertDescription>
-          Meru signs you in to Google through Windows' own passkey dialog, so Windows Hello and
-          synced passkey providers work with nothing installed. A password manager is still what
-          fills regular passwords.
+          Google sign-in uses Windows' own passkey dialog, so Windows Hello and synced passkeys work
+          with no extension. Filling passwords still needs a password manager.
         </AlertDescription>
       </Alert>
     );
@@ -222,19 +219,24 @@ export function ExtensionsSettings() {
           Extensions are loaded into every account and take effect after a restart. Meru installs
           the official extensions from the Chrome Web Store.
         </FieldDescription>
-        {curatedExtensions.some(({ category }) => category === "passwordManager") && (
+        <FieldSet>
+          <FieldLegend>Password Managers</FieldLegend>
           <PasskeysAlert />
-        )}
-        <ItemGroup>
-          {curatedExtensions.map((extension) => (
-            <ExtensionItem
-              key={extension.id}
-              extension={extension}
-              installed={config["extensions.installed"].includes(extension.id)}
-              installedVersion={installedExtensions?.find(({ id }) => id === extension.id)?.version}
-            />
-          ))}
-        </ItemGroup>
+          <ItemGroup>
+            {curatedExtensions
+              .filter(({ category }) => category === "passwordManager")
+              .map((extension) => (
+                <ExtensionItem
+                  key={extension.id}
+                  extension={extension}
+                  installed={config["extensions.installed"].includes(extension.id)}
+                  installedVersion={
+                    installedExtensions?.find(({ id }) => id === extension.id)?.version
+                  }
+                />
+              ))}
+          </ItemGroup>
+        </FieldSet>
       </SettingsContent>
     </Settings>
   );

--- a/packages/shared/extensions.ts
+++ b/packages/shared/extensions.ts
@@ -1,8 +1,12 @@
+/** The class an extension belongs to, which is what the page can speak about. */
+export type CuratedExtensionCategory = "passwordManager";
+
 export type CuratedExtension = {
   /** The Chrome Web Store id, which every package has to be signed for. */
   id: string;
   name: string;
   description: string;
+  category: CuratedExtensionCategory;
   /**
    * Match patterns the derive writes over every `content_scripts[].matches` of
    * the extension, so its content scripts only reach the sites it is offered
@@ -22,6 +26,7 @@ export const curatedExtensions: CuratedExtension[] = [
     name: "1Password",
     description:
       "Password manager that fills logins and signs you in with passkeys stored in your vault.",
+    category: "passwordManager",
     contentScriptMatches: ["https://accounts.google.com/*"],
   },
 ];


### PR DESCRIPTION
- `CuratedExtension` gains a `category` (`"passwordManager"`); 1Password carries it.
- The list sits under a "Password Managers" section legend (`FieldSet` + `FieldLegend`, filtered by category) with an info alert between legend and items.
- Alert copy branched on platform: macOS "Meru can sign you in with a Touch ID passkey" (add one from Google security settings, lighter than running an extension; new passkeys only, filling passwords still needs a manager); Windows "Meru can sign you in with your Windows passkeys" (native OS dialog, no extension, same filling note); Linux states a password-manager extension is the only passkey route.

The Windows copy ships ahead of live verification against a passkey-only account — same call as the PR #809 platform gate. The three variants were only reasoned about, not rendered.

Test plan:
1. Each platform shows its own alert variant under the "Password Managers" legend, above the 1Password item.
2. The alert shows regardless of license state and doesn't affect installing.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
