### PR TITLE
probe the update endpoint before downloading an extension

### DIFF
--- a/packages/electron-extensions/index.ts
+++ b/packages/electron-extensions/index.ts
@@ -8,7 +8,9 @@ export { Extensions } from "./extensions";
 export type { ActionsChangedListener, ExtensionDirs, ExtensionsOptions } from "./extensions";
 export {
   buildCrxDownloadUrl,
+  buildUpdateCheckUrl,
   fetchCrx,
+  fetchCrxUpdate,
   getInstalledExtension,
   installExtension,
   installLatestExtension,
@@ -16,13 +18,16 @@ export {
 } from "./install";
 export type {
   CrxDownloadOptions,
+  CrxUpdate,
   FetchCrxOptions,
+  FetchCrxUpdateOptions,
   FetchImplementation,
   InstalledExtension,
   InstalledExtensionOptions,
   InstallExtensionOptions,
   InstallLatestExtensionOptions,
   LatestExtensionInstall,
+  UpdateCheckOptions,
 } from "./install";
 export type { ExtensionsLogger } from "./logger";
 export type { NativeMessagingHostPolicy } from "./native-messaging/native-messaging";

--- a/packages/electron-extensions/install/index.ts
+++ b/packages/electron-extensions/install/index.ts
@@ -11,5 +11,12 @@ export type {
   InstallLatestExtensionOptions,
   LatestExtensionInstall,
 } from "./installer";
-export { buildCrxDownloadUrl, fetchCrx } from "./omaha";
-export type { CrxDownloadOptions, FetchCrxOptions, FetchImplementation } from "./omaha";
+export { buildCrxDownloadUrl, buildUpdateCheckUrl, fetchCrx, fetchCrxUpdate } from "./omaha";
+export type {
+  CrxDownloadOptions,
+  CrxUpdate,
+  FetchCrxOptions,
+  FetchCrxUpdateOptions,
+  FetchImplementation,
+  UpdateCheckOptions,
+} from "./omaha";

--- a/packages/electron-extensions/install/installer.test.ts
+++ b/packages/electron-extensions/install/installer.test.ts
@@ -36,8 +36,40 @@ function createExtensionCrx(version: string) {
   });
 }
 
-function createFetch(crx: Uint8Array): FetchImplementation {
-  return async () => new Response(crx);
+function createUpdateCheckResponse(servedVersion: string | undefined) {
+  const updateCheckElement = servedVersion
+    ? `<updatecheck codebase="https://packages.test/extension.crx" status="ok" version="${servedVersion}"/>`
+    : '<updatecheck status="noupdate"/>';
+
+  return new Response(
+    `<?xml version="1.0" encoding="UTF-8"?><gupdate protocol="2.0"><app appid="${extensionId}" status="ok">${updateCheckElement}</app></gupdate>`,
+  );
+}
+
+/**
+ * The endpoint as an install meets it: the update check naming the version it
+ * serves, and the package behind the download redirect. A fake without a
+ * package fails the download, so a check that should have stopped at the update
+ * check is caught rather than quietly downloading.
+ */
+function createFetch({ crx, servedVersion }: { crx?: Uint8Array; servedVersion?: string }) {
+  const downloadedUrls: string[] = [];
+
+  const fetch: FetchImplementation = async (url) => {
+    if (new URL(url).searchParams.get("response") !== "redirect") {
+      return createUpdateCheckResponse(servedVersion);
+    }
+
+    downloadedUrls.push(url);
+
+    if (!crx) {
+      throw new Error("Downloaded the package for an extension that is up to date");
+    }
+
+    return new Response(crx);
+  };
+
+  return { fetch, downloadedUrls };
 }
 
 async function readEntryNames(dirPath: string) {
@@ -150,11 +182,13 @@ describe("getInstalledExtension", () => {
 
 describe("installLatestExtension", () => {
   test("installs when nothing is installed yet", async () => {
+    const { fetch, downloadedUrls } = createFetch({ crx: createExtensionCrx("1.0.0") });
+
     const latestExtension = await installLatestExtension({
       extensionId,
       installDir,
       chromeVersion,
-      fetch: createFetch(createExtensionCrx("1.0.0")),
+      fetch,
     });
 
     expect(latestExtension).toEqual({
@@ -162,39 +196,97 @@ describe("installLatestExtension", () => {
       version: "1.0.0",
       extensionDir: path.join(extensionInstallDir, "1.0.0"),
     });
+    expect(downloadedUrls).toHaveLength(1);
   });
 
-  test("writes nothing when the served version is already installed", async () => {
+  test("downloads nothing when the endpoint serves the version already installed", async () => {
+    const { extensionDir } = await installExtension({
+      crx: createExtensionCrx("1.0.0"),
+      extensionId,
+      installDir,
+    });
+
+    await writeFile(path.join(extensionDir, "untouched"), "kept");
+
+    const { fetch, downloadedUrls } = createFetch({ servedVersion: "1.0.0" });
+
+    const latestExtension = await installLatestExtension({
+      extensionId,
+      installDir,
+      chromeVersion,
+      fetch,
+    });
+
+    expect(latestExtension).toEqual({ updated: false, version: "1.0.0", extensionDir });
+    expect(downloadedUrls).toEqual([]);
+    expect(await readFile(path.join(extensionDir, "untouched"), "utf8")).toBe("kept");
+  });
+
+  test("downloads nothing when the endpoint answers that nothing is newer", async () => {
+    await installExtension({ crx: createExtensionCrx("1.0.0"), extensionId, installDir });
+
+    const { fetch, downloadedUrls } = createFetch({});
+
+    const latestExtension = await installLatestExtension({
+      extensionId,
+      installDir,
+      chromeVersion,
+      fetch,
+    });
+
+    expect(latestExtension.updated).toBe(false);
+    expect(latestExtension.version).toBe("1.0.0");
+    expect(downloadedUrls).toEqual([]);
+  });
+
+  test("installs a newer version and drops the one it replaces", async () => {
+    await installExtension({ crx: createExtensionCrx("1.0.0"), extensionId, installDir });
+
+    const { fetch } = createFetch({ crx: createExtensionCrx("2.0.0"), servedVersion: "2.0.0" });
+
+    const latestExtension = await installLatestExtension({
+      extensionId,
+      installDir,
+      chromeVersion,
+      fetch,
+    });
+
+    expect(latestExtension.updated).toBe(true);
+    expect(latestExtension.version).toBe("2.0.0");
+    expect(await readdir(extensionInstallDir)).toEqual(["2.0.0"]);
+  });
+
+  test("writes nothing when the package turns out to carry the installed version", async () => {
     const crx = createExtensionCrx("1.0.0");
 
     const { extensionDir } = await installExtension({ crx, extensionId, installDir });
 
     await writeFile(path.join(extensionDir, "untouched"), "kept");
 
+    const { fetch } = createFetch({ crx, servedVersion: "2.0.0" });
+
     const latestExtension = await installLatestExtension({
       extensionId,
       installDir,
       chromeVersion,
-      fetch: createFetch(crx),
+      fetch,
     });
 
     expect(latestExtension).toEqual({ updated: false, version: "1.0.0", extensionDir });
     expect(await readFile(path.join(extensionDir, "untouched"), "utf8")).toBe("kept");
   });
 
-  test("installs a newer version and drops the one it replaces", async () => {
+  test("fails the check rather than reporting up to date when the answer cannot be read", async () => {
     await installExtension({ crx: createExtensionCrx("1.0.0"), extensionId, installDir });
 
-    const latestExtension = await installLatestExtension({
-      extensionId,
-      installDir,
-      chromeVersion,
-      fetch: createFetch(createExtensionCrx("2.0.0")),
-    });
-
-    expect(latestExtension.updated).toBe(true);
-    expect(latestExtension.version).toBe("2.0.0");
-    expect(await readdir(extensionInstallDir)).toEqual(["2.0.0"]);
+    await expect(
+      installLatestExtension({
+        extensionId,
+        installDir,
+        chromeVersion,
+        fetch: async () => new Response("<html><body>Try again later</body></html>"),
+      }),
+    ).rejects.toThrow(`Update endpoint answered an unreadable update check for ${extensionId}`);
   });
 });
 

--- a/packages/electron-extensions/install/installer.ts
+++ b/packages/electron-extensions/install/installer.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { unzipSync } from "fflate";
 import { verifyCrx } from "../crx/crx";
 import { compareExtensionVersions } from "../crx/version";
-import { type FetchImplementation, fetchCrx } from "./omaha";
+import { type FetchImplementation, fetchCrx, fetchCrxUpdate } from "./omaha";
 
 const MANIFEST_FILE_NAME = "manifest.json";
 
@@ -234,9 +234,11 @@ export type LatestExtensionInstall = InstalledExtension & {
  * how it is installed the first time and how it is kept up to date — a first
  * install is the case where nothing is installed yet.
  *
- * Nothing is written when the installed version is the served one or newer, so
- * a periodic check costs a download and a signature check and leaves the disk
- * alone.
+ * An install that already has a version asks the endpoint what it serves before
+ * asking for it, so a check that finds nothing new costs one small answer
+ * rather than a download and an unzip of tens of megabytes. The package is
+ * still the last word on the version, so a download that turns out to carry
+ * what is installed is written no further.
  */
 export async function installLatestExtension({
   extensionId,
@@ -244,11 +246,27 @@ export async function installLatestExtension({
   chromeVersion,
   fetch,
 }: InstallLatestExtensionOptions): Promise<LatestExtensionInstall> {
+  const installedExtension = await getInstalledExtension({ installDir, extensionId });
+
+  if (installedExtension) {
+    const crxUpdate = await fetchCrxUpdate({
+      extensionId,
+      chromeVersion,
+      installedVersion: installedExtension.version,
+      fetch,
+    });
+
+    if (
+      crxUpdate.status === "noupdate" ||
+      compareExtensionVersions(installedExtension.version, crxUpdate.version) >= 0
+    ) {
+      return { ...installedExtension, updated: false };
+    }
+  }
+
   const crx = await fetchCrx({ extensionId, chromeVersion, fetch });
 
   const extensionPackage = readCrxPackage(crx, extensionId);
-
-  const installedExtension = await getInstalledExtension({ installDir, extensionId });
 
   if (
     installedExtension &&

--- a/packages/electron-extensions/install/omaha.test.ts
+++ b/packages/electron-extensions/install/omaha.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import { buildCrxDownloadUrl, fetchCrx } from "./omaha";
+import { buildCrxDownloadUrl, buildUpdateCheckUrl, fetchCrx, fetchCrxUpdate } from "./omaha";
 
 const extensionId = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
 
 const chromeVersion = "146.0.0.0";
+
+const codebaseUrl = "https://clients2.googleusercontent.com/crx/blobs/abc/EXT_8_12_32_33.crx";
+
+/** An answer the way the endpoint sends one, around the update check under test. */
+function createUpdateCheckResponse(updateCheckElement: string) {
+  return new Response(
+    `<?xml version="1.0" encoding="UTF-8"?><gupdate xmlns="http://www.google.com/update2/response" protocol="2.0" server="prod"><daystart elapsed_days="7169" elapsed_seconds="44109"/><app appid="${extensionId}" cohort="1::" cohortname="" status="ok">${updateCheckElement}</app></gupdate>`,
+  );
+}
 
 describe("buildCrxDownloadUrl", () => {
   test("asks for the package of one id as the given Chrome", () => {
@@ -16,6 +25,21 @@ describe("buildCrxDownloadUrl", () => {
     expect(searchParams.get("acceptformat")).toBe("crx2,crx3");
     expect(searchParams.get("response")).toBe("redirect");
     expect(searchParams.get("x")).toBe(`id=${extensionId}&installsource=ondemand&uc`);
+  });
+});
+
+describe("buildUpdateCheckUrl", () => {
+  test("asks what the endpoint serves for an id, naming the installed version", () => {
+    const { origin, pathname, searchParams } = new URL(
+      buildUpdateCheckUrl({ extensionId, chromeVersion, installedVersion: "8.11.0.0" }),
+    );
+
+    expect(origin + pathname).toBe("https://clients2.google.com/service/update2/crx");
+    expect(searchParams.get("prodversion")).toBe(chromeVersion);
+    expect(searchParams.get("x")).toBe(`id=${extensionId}&v=8.11.0.0&uc`);
+    // The redirect is what turns the answer into the package itself, which is
+    // the download this call exists to avoid
+    expect(searchParams.get("response")).toBeNull();
   });
 });
 
@@ -54,6 +78,90 @@ describe("fetchCrx", () => {
       fetchCrx({
         extensionId,
         chromeVersion,
+        fetch: async () => new Response("", { status: 503, statusText: "Service Unavailable" }),
+      }),
+    ).rejects.toThrow(`Update endpoint answered 503 Service Unavailable for ${extensionId}`);
+  });
+});
+
+describe("fetchCrxUpdate", () => {
+  test("reads the version and the package URL the endpoint offers", async () => {
+    const requests: string[] = [];
+
+    const crxUpdate = await fetchCrxUpdate({
+      extensionId,
+      chromeVersion,
+      installedVersion: "8.11.0.0",
+      fetch: async (url) => {
+        requests.push(url);
+
+        return createUpdateCheckResponse(
+          `<updatecheck _esbAllowlist="true" codebase="${codebaseUrl}" fp="1.3bd6" hash_sha256="3bd6" protected="0" size="17863744" status="ok" version="8.12.32.33"/>`,
+        );
+      },
+    });
+
+    expect(crxUpdate).toEqual({ status: "update", version: "8.12.32.33", codebaseUrl });
+    expect(requests).toEqual([
+      buildUpdateCheckUrl({ extensionId, chromeVersion, installedVersion: "8.11.0.0" }),
+    ]);
+  });
+
+  test("reads the answer that nothing newer is served", async () => {
+    expect(
+      await fetchCrxUpdate({
+        extensionId,
+        chromeVersion,
+        installedVersion: "8.12.32.33",
+        fetch: async () =>
+          createUpdateCheckResponse('<updatecheck _esbAllowlist="true" status="noupdate"/>'),
+      }),
+    ).toEqual({ status: "noupdate" });
+  });
+
+  test("refuses an answer that is not an update check", async () => {
+    await expect(
+      fetchCrxUpdate({
+        extensionId,
+        chromeVersion,
+        installedVersion: "8.12.32.33",
+        fetch: async () => new Response("<html><body>Try again later</body></html>"),
+      }),
+    ).rejects.toThrow(`Update endpoint answered an unreadable update check for ${extensionId}`);
+  });
+
+  test("names the no-package answer for an id the endpoint does not serve", async () => {
+    await expect(
+      fetchCrxUpdate({
+        extensionId,
+        chromeVersion,
+        installedVersion: "8.12.32.33",
+        fetch: async () =>
+          new Response(
+            `<?xml version="1.0" encoding="UTF-8"?><gupdate protocol="2.0"><app appid="${extensionId}" status="error-unknownApplication"/></gupdate>`,
+          ),
+      }),
+    ).rejects.toThrow(`Update endpoint has no package for ${extensionId}`);
+  });
+
+  test("refuses an update that names no version", async () => {
+    await expect(
+      fetchCrxUpdate({
+        extensionId,
+        chromeVersion,
+        installedVersion: "8.12.32.33",
+        fetch: async () =>
+          createUpdateCheckResponse(`<updatecheck codebase="${codebaseUrl}" status="ok"/>`),
+      }),
+    ).rejects.toThrow(`Update endpoint offered ${extensionId} without a version or a package URL`);
+  });
+
+  test("refuses an answer that is not an answer at all", async () => {
+    await expect(
+      fetchCrxUpdate({
+        extensionId,
+        chromeVersion,
+        installedVersion: "8.12.32.33",
         fetch: async () => new Response("", { status: 503, statusText: "Service Unavailable" }),
       }),
     ).rejects.toThrow(`Update endpoint answered 503 Service Unavailable for ${extensionId}`);

--- a/packages/electron-extensions/install/omaha.ts
+++ b/packages/electron-extensions/install/omaha.ts
@@ -11,18 +11,13 @@ export type CrxDownloadOptions = {
 };
 
 /**
- * The Omaha URL serving the newest package for an extension id. The same
- * request is the update check: there is no separate "what is the latest
- * version" call, the answer is the package itself and its manifest carries the
- * version.
- *
- * The platform parameters describe the browser asking rather than the machine,
- * and every extension Meru curates ships one package for all of them, so they
- * are constants.
+ * What every request to the endpoint carries besides the extension. The
+ * platform parameters describe the browser asking rather than the machine, and
+ * every extension Meru curates ships one package for all of them, so they are
+ * constants.
  */
-export function buildCrxDownloadUrl({ extensionId, chromeVersion }: CrxDownloadOptions) {
-  const searchParams = new URLSearchParams({
-    response: "redirect",
+function buildEndpointParams(chromeVersion: string) {
+  return {
     os: "linux",
     arch: "x64",
     os_arch: "x86_64",
@@ -31,7 +26,42 @@ export function buildCrxDownloadUrl({ extensionId, chromeVersion }: CrxDownloadO
     prodchannel: "unknown",
     prodversion: chromeVersion,
     acceptformat: "crx2,crx3",
+  };
+}
+
+/**
+ * The Omaha URL serving the newest package for an extension id. The request
+ * names no installed version, so the endpoint always answers with the package
+ * rather than with "nothing newer".
+ */
+export function buildCrxDownloadUrl({ extensionId, chromeVersion }: CrxDownloadOptions) {
+  const searchParams = new URLSearchParams({
+    ...buildEndpointParams(chromeVersion),
+    response: "redirect",
     x: `id=${extensionId}&installsource=ondemand&uc`,
+  });
+
+  return `${CRX_UPDATE_ENDPOINT}?${searchParams}`;
+}
+
+export type UpdateCheckOptions = CrxDownloadOptions & {
+  /** The version on disk, which the endpoint answers `noupdate` to when it serves nothing newer. */
+  installedVersion: string;
+};
+
+/**
+ * The same endpoint asked what it serves rather than asked for it. Without
+ * `response=redirect` the answer is the update check document instead of a
+ * redirect to the package, which is what makes a check cost a few hundred bytes.
+ */
+export function buildUpdateCheckUrl({
+  extensionId,
+  chromeVersion,
+  installedVersion,
+}: UpdateCheckOptions) {
+  const searchParams = new URLSearchParams({
+    ...buildEndpointParams(chromeVersion),
+    x: `id=${extensionId}&v=${installedVersion}&uc`,
   });
 
   return `${CRX_UPDATE_ENDPOINT}?${searchParams}`;
@@ -83,4 +113,99 @@ export async function fetchCrx({
   }
 
   return new Uint8Array(await response.arrayBuffer());
+}
+
+export type CrxUpdate =
+  /** The version the endpoint serves, newer than the one the check named. */
+  | { status: "update"; version: string; codebaseUrl: string }
+  /** The endpoint serves nothing newer than the installed version. */
+  | { status: "noupdate" };
+
+function readElementAttributes(element: string) {
+  const attributes: Record<string, string> = {};
+
+  for (const [, name = "", value = ""] of element.matchAll(/([\w-]+)="([^"]*)"/g)) {
+    attributes[name] = value;
+  }
+
+  return attributes;
+}
+
+/**
+ * Reads the update check out of the endpoint's answer, the `gupdate` document
+ * the update protocol replies to a version query with:
+ *
+ *   <gupdate protocol="2.0"><app appid="…" status="ok">
+ *     <updatecheck codebase="https://…crx" version="8.12.32.33" status="ok"/>
+ *   </app></gupdate>
+ *
+ * Everything that is neither an update nor a `noupdate` throws, so an answer
+ * that could not be read never passes for up to date and never installs.
+ */
+function parseUpdateCheck(responseBody: string, extensionId: string): CrxUpdate {
+  if (!responseBody.includes("<gupdate")) {
+    throw new Error(`Update endpoint answered an unreadable update check for ${extensionId}`);
+  }
+
+  const updateCheckElement = responseBody.match(/<updatecheck\b[^>]*>/)?.[0];
+
+  // An id the endpoint does not serve comes back as an app element carrying an
+  // error status and no update check at all
+  if (!updateCheckElement) {
+    throw new Error(`Update endpoint has no package for ${extensionId}`);
+  }
+
+  const { status, version, codebase } = readElementAttributes(updateCheckElement);
+
+  if (status === "noupdate") {
+    return { status: "noupdate" };
+  }
+
+  if (status !== "ok") {
+    throw new Error(`Update endpoint has no package for ${extensionId}`);
+  }
+
+  if (!version || !codebase) {
+    throw new Error(`Update endpoint offered ${extensionId} without a version or a package URL`);
+  }
+
+  return { status: "update", version, codebaseUrl: codebase };
+}
+
+export type FetchCrxUpdateOptions = UpdateCheckOptions & {
+  /** Injectable the way `fetchCrx` takes one, and for the same reasons. */
+  fetch?: FetchImplementation;
+};
+
+/**
+ * Asks the endpoint which version it serves for an extension, an answer of a
+ * few hundred bytes where the package is tens of megabytes. This is what keeps
+ * a check cheap enough to run on a schedule and on a button.
+ *
+ * The version it answers with is the endpoint's word rather than a verified
+ * one, and nothing installs off it: it only decides whether `fetchCrx` runs,
+ * and the package that brings back still has to pass `verifyCrx`.
+ */
+export async function fetchCrxUpdate({
+  extensionId,
+  chromeVersion,
+  installedVersion,
+  fetch = globalThis.fetch,
+}: FetchCrxUpdateOptions) {
+  const response = await fetch(
+    buildUpdateCheckUrl({ extensionId, chromeVersion, installedVersion }),
+    { redirect: "follow" },
+  );
+
+  if (response.status === 204) {
+    throw new Error(`Update endpoint has no package for ${extensionId}`);
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Update endpoint answered ${response.status} ${response.statusText} for ${extensionId}`,
+    );
+  }
+
+  return parseUpdateCheck(await response.text(), extensionId);
 }


### PR DESCRIPTION
- `fetchCrxUpdate` asks the update endpoint which version it serves — the same URL without `response=redirect`, carrying the installed version as `v` — and parses the `updatecheck` answer into an update with its version and codebase URL, or a `noupdate`.
- `installLatestExtension` now probes first whenever a version is already installed and downloads only when the endpoint offers something newer, so a check that finds nothing costs a few hundred bytes instead of an 18 MB CRX and a synchronous unzip. A first install still goes straight to the download.
- Every answer that is neither an update nor a `noupdate` throws: an id the endpoint does not serve reuses the existing "has no package" wording, a body that is not an update check gets its own message. A failed probe surfaces as the manual flow's `failed` result, never as "up to date".
- The download half is untouched: `fetchCrx`, `verifyCrx` and the staged install are as they were, and the post-download version guard stays, so a package that turns out to carry the installed version is still written no further. `ExtensionUpdater` and the toasts need no change.
- Tests cover the parse (update, noupdate, unknown id, unreadable body, update without a version) and the skipped download; the three that assert nothing is downloaded fail against the old installer.

The probe is a regex read of the `gupdate` document rather than an XML parse — the endpoint answers protocol 2.0 here, not the JSON of Omaha 3, and the parse is deliberately strict so an unexpected shape throws. Verified against the live endpoint for 1Password (update, noupdate, unknown id); not verified inside the running app, so the scheduled and manual checks against a real install are untested. The `docs/features/chrome-extensions.md` slices that record this debt are not updated here, since `docs/` is a separate repo.

Test plan

1. Install 1Password from Settings › Extensions, then click **Update Extensions** with a network log or proxy open: only the small update-check request goes out, no CRX download, and the toast says the extension is up to date.
2. Rename the installed version directory under `userData/extensions/<id>/` to an older version, say `1.0.0`, and click **Update Extensions**: the probe offers the current version, the CRX downloads, verification passes, the toast names the new version and the renamed directory is gone.
3. Click **Update Extensions** with the machine offline: the toast reports a failure with the fetch error, and the extension keeps loading from the version already installed.
