### PR TITLE
walk through 1Password's add browser step after installing

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -23,10 +23,6 @@ const INSTALL_DIR = path.join(app.getPath("userData"), "extensions");
 
 const DERIVED_EXTENSIONS_DIR = path.join(app.getPath("userData"), "derived-extensions");
 
-// 1Password overrides `navigator.credentials` in the page, which is what lets a
-// passkey sign-in go through in Electron and makes the passkey dialog moot
-export const ONEPASSWORD_EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
-
 /**
  * Unpacked extensions to load on top of the installed ones, one directory
  * holding a `manifest.json` per extension:

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { platform } from "@electron-toolkit/utils";
 import { APP_TITLEBAR_HEIGHT, GOOGLE_ACCOUNTS_URL } from "@meru/shared/constants";
+import { ONEPASSWORD_EXTENSION_ID } from "@meru/shared/extensions";
 import { getWorkspaceAppFromUrl, getWorkspaceAppUrl } from "@meru/shared/google";
 import type { AccountConfig } from "@meru/shared/schemas";
 import { clamp } from "@meru/shared/utils";
@@ -26,7 +27,7 @@ import {
 import { accounts } from "./accounts";
 import { bookmarks } from "./bookmarks";
 import { config } from "./config";
-import { extensions, ONEPASSWORD_EXTENSION_ID } from "./extensions";
+import { extensions } from "./extensions";
 import { ipc } from "./ipc";
 import { loadUrl } from "./lib/load-url";
 import {
@@ -171,6 +172,8 @@ export class WorkspaceApp {
       return;
     }
 
+    // 1Password overrides `navigator.credentials` in the page, which is what lets
+    // a passkey sign-in go through in Electron and makes the passkey dialog moot.
     if (extensions.isExtensionLoaded(session, ONEPASSWORD_EXTENSION_ID)) {
       return;
     }

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -189,12 +189,11 @@ function ExtensionItem({
             <LicenseKeyRequiredFieldBadge />
           </ItemTitle>
           <ItemDescription>{extension.description}</ItemDescription>
-        </ItemContent>
-        <ItemActions>
           {isOnePassword && (
             <Button
               variant="outline"
               size="sm"
+              className="mt-1 self-start"
               onClick={() => {
                 setIsSetupDialogOpen(true);
               }}
@@ -202,6 +201,8 @@ function ExtensionItem({
               Set up desktop app
             </Button>
           )}
+        </ItemContent>
+        <ItemActions>
           {extensionMutation.isPending && <Spinner />}
           <Switch
             checked={isLicenseKeyValid && installed}

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -1,8 +1,21 @@
-import { type CuratedExtension, curatedExtensions } from "@meru/shared/extensions";
+import {
+  type CuratedExtension,
+  curatedExtensions,
+  ONEPASSWORD_EXTENSION_ID,
+} from "@meru/shared/extensions";
 import { ipc } from "@meru/shared/renderer/ipc";
 import { Alert, AlertDescription, AlertTitle } from "@meru/ui/components/alert";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@meru/ui/components/dialog";
 import { FieldDescription, FieldLegend, FieldSet } from "@meru/ui/components/field";
 import {
   Item,
@@ -14,10 +27,13 @@ import {
 } from "@meru/ui/components/item";
 import { Spinner } from "@meru/ui/components/spinner";
 import { Switch } from "@meru/ui/components/switch";
+import { cn } from "@meru/ui/lib/utils";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { ExternalLinkIcon, KeyRoundIcon } from "lucide-react";
+import { type ComponentProps, useState } from "react";
 import { toast } from "sonner";
 import { BetaFieldBadge } from "@/components/beta-field-badge";
+import { CopyButton } from "@/components/copy-button";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { LicenseKeyRequiredFieldBadge } from "@/components/license-key-required-field-badge";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
@@ -27,6 +43,90 @@ import { restartRequiredToast } from "@/lib/toast";
 import { platform } from "@/lib/utils";
 
 const installedExtensionsQueryKey = ["installed-extensions"];
+
+const ONEPASSWORD_ALLOWED_BROWSERS_COMMAND = "sudo nano /etc/1password/custom_allowed_browsers";
+
+function Code({ className, ...props }: ComponentProps<"code">) {
+  return (
+    <code
+      className={cn("rounded-sm bg-muted px-1 py-0.5 font-mono text-xs", className)}
+      {...props}
+    />
+  );
+}
+
+function OnePasswordSetupSteps() {
+  if (platform.isLinux) {
+    return (
+      <>
+        <li>Quit 1Password.</li>
+        <li>
+          Open the browser allowlist in an editor with root permissions.
+          <div className="mt-2 flex items-center gap-2">
+            <Code className="min-w-0 flex-1 truncate rounded-md px-2 py-1.5">
+              {ONEPASSWORD_ALLOWED_BROWSERS_COMMAND}
+            </Code>
+            <CopyButton value={ONEPASSWORD_ALLOWED_BROWSERS_COMMAND} size="icon-sm" />
+          </div>
+        </li>
+        <li>
+          Add <Code>meru</Code> on its own line, then save.
+        </li>
+        <li>Open and unlock 1Password again.</li>
+        <li>Restart Meru.</li>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <li>Open and unlock 1Password.</li>
+      <li>Select your account at the top of the sidebar, then select Settings.</li>
+      <li>Select Browser, then select Add Browser.</li>
+      <li>
+        {platform.isMacOS
+          ? "Choose Meru in the Applications folder."
+          : "Choose Meru in the C:\\Program Files folder."}
+      </li>
+      <li>Restart Meru.</li>
+    </>
+  );
+}
+
+function OnePasswordSetupDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Connect 1Password</DialogTitle>
+        </DialogHeader>
+        <DialogDescription>
+          Filling passwords and passkeys needs the 1Password desktop app — Meru stores no vault data
+          of its own. Trust Meru in 1Password's settings to connect them.
+        </DialogDescription>
+        <ol className="ml-4 list-decimal space-y-2 marker:text-muted-foreground">
+          <OnePasswordSetupSteps />
+        </ol>
+        <DialogFooter>
+          <DialogClose render={<Button variant="outline">Later</Button>} />
+          <Button
+            onClick={() => {
+              ipc.main.send("app.relaunch");
+            }}
+          >
+            Restart Now
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 function ExtensionItem({
   extension,
@@ -39,12 +139,16 @@ function ExtensionItem({
 }) {
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
+  const isOnePassword = extension.id === ONEPASSWORD_EXTENSION_ID;
+
+  const [isSetupDialogOpen, setIsSetupDialogOpen] = useState(false);
+
   const extensionMutation = useMutation({
     mutationFn: (install: boolean) =>
       install
         ? ipc.main.invoke("extensions.install", extension.id)
         : ipc.main.invoke("extensions.uninstall", extension.id),
-    onSuccess: ({ error }) => {
+    onSuccess: ({ error }, install) => {
       if (error) {
         toast.error(error);
 
@@ -55,40 +159,64 @@ function ExtensionItem({
         queryKey: installedExtensionsQueryKey,
       });
 
+      // The setup dialog ends on restarting Meru and carries its own restart
+      // button, so the toast would only repeat it.
+      if (isOnePassword && install) {
+        setIsSetupDialogOpen(true);
+
+        return;
+      }
+
       restartRequiredToast();
     },
   });
 
   return (
-    <Item variant="muted">
-      <ItemContent>
-        <ItemTitle>
-          <a
-            href={`https://chromewebstore.google.com/detail/${extension.id}`}
-            target="_blank"
-            rel="noreferrer"
-            className="flex items-center gap-1 hover:underline"
-          >
-            {extension.name}
-            <ExternalLinkIcon className="size-3 text-muted-foreground" />
-          </a>
-          {installedVersion && <Badge variant="outline">Version {installedVersion}</Badge>}
-          <LicenseKeyRequiredFieldBadge />
-        </ItemTitle>
-        <ItemDescription>{extension.description}</ItemDescription>
-      </ItemContent>
-      <ItemActions>
-        {extensionMutation.isPending && <Spinner />}
-        <Switch
-          checked={isLicenseKeyValid && installed}
-          disabled={!isLicenseKeyValid || extensionMutation.isPending}
-          onCheckedChange={(checked) => {
-            extensionMutation.mutate(checked);
-          }}
-          aria-label={`Install ${extension.name}`}
-        />
-      </ItemActions>
-    </Item>
+    <>
+      <Item variant="muted">
+        <ItemContent>
+          <ItemTitle>
+            <a
+              href={`https://chromewebstore.google.com/detail/${extension.id}`}
+              target="_blank"
+              rel="noreferrer"
+              className="flex items-center gap-1 hover:underline"
+            >
+              {extension.name}
+              <ExternalLinkIcon className="size-3 text-muted-foreground" />
+            </a>
+            {installedVersion && <Badge variant="outline">Version {installedVersion}</Badge>}
+            <LicenseKeyRequiredFieldBadge />
+          </ItemTitle>
+          <ItemDescription>{extension.description}</ItemDescription>
+        </ItemContent>
+        <ItemActions>
+          {isOnePassword && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setIsSetupDialogOpen(true);
+              }}
+            >
+              Set up desktop app
+            </Button>
+          )}
+          {extensionMutation.isPending && <Spinner />}
+          <Switch
+            checked={isLicenseKeyValid && installed}
+            disabled={!isLicenseKeyValid || extensionMutation.isPending}
+            onCheckedChange={(checked) => {
+              extensionMutation.mutate(checked);
+            }}
+            aria-label={`Install ${extension.name}`}
+          />
+        </ItemActions>
+      </Item>
+      {isOnePassword && (
+        <OnePasswordSetupDialog open={isSetupDialogOpen} onOpenChange={setIsSetupDialogOpen} />
+      )}
+    </>
   );
 }
 

--- a/packages/shared/extensions.ts
+++ b/packages/shared/extensions.ts
@@ -15,6 +15,9 @@ export type CuratedExtension = {
   contentScriptMatches?: string[];
 };
 
+/** The 1Password Chrome Web Store id, which app and settings both single out. */
+export const ONEPASSWORD_EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
+
 /**
  * The extensions Meru offers, the only ones it installs. An id outside this
  * list is refused before anything is downloaded, and the settings page is a
@@ -22,7 +25,7 @@ export type CuratedExtension = {
  */
 export const curatedExtensions: CuratedExtension[] = [
   {
-    id: "aeblfdkhhhdcdjpifhhbdiojplfjncoa",
+    id: ONEPASSWORD_EXTENSION_ID,
     name: "1Password",
     description:
       "Password manager that fills logins and signs you in with passkeys stored in your vault.",


### PR DESCRIPTION
- Adds a **Connect 1Password** dialog to the Extensions settings page with static Add Browser steps branched for macOS, Windows, and Linux. On Linux the root command sits in a copyable code block, following 1Password's own documented editor route.
- The dialog opens by itself when a 1Password install succeeds, and a persistent outline **Set up desktop app** action in the 1Password item reopens it whether or not the extension is installed.
- The restart toast is suppressed on that one path only, because the dialog's last step and its **Restart Now** button already cover it. Uninstalls, other extensions, and the update button keep the toast.
- `ONEPASSWORD_EXTENSION_ID` moves from `packages/app/extensions.ts` to `packages/shared/extensions.ts` so the renderer can reference the same handle; `workspace-app.ts` now imports it from there.

Nothing here has been exercised in a running app on any platform, and the Linux steps in particular are untested — the allowlist path, the `meru` binary name, and the editor route come from 1Password's docs and from electron-builder resolving the executable name from the root `package.json` `name`. The renderer has no component test harness at all (no DOM environment, no testing-library, no renderer test files), so the install-vs-uninstall branch is covered by type checks only.

Test plan

1. Toggle 1Password on. Expect the dialog to open on success with the steps for the current platform, and no restart toast behind it.
2. Toggle 1Password off. Expect no dialog and the usual restart toast.
3. On Linux, open the dialog from **Set up desktop app** and press copy on the command. Expect `sudo nano /etc/1password/custom_allowed_browsers` on the clipboard and the icon to flip to a check.
4. Press **Restart Now** in the dialog. Expect Meru to relaunch, the same as the toast's action.
