### PR TITLE
Restore a hibernated tab's navigation history when it wakes

### DIFF
--- a/packages/app/lib/load-url.test.ts
+++ b/packages/app/lib/load-url.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import type { NavigationEntry, RestoreOptions, WebContents } from "electron";
+import { restoreNavigationHistory } from "./load-url";
+
+function makeWebContents(restore: (options: RestoreOptions) => Promise<void>) {
+  return {
+    navigationHistory: { restore },
+  } as unknown as WebContents;
+}
+
+const entries: NavigationEntry[] = [
+  { url: "https://mail.google.com/", title: "Inbox", pageState: "state-0" },
+  { url: "https://calendar.google.com/", title: "Calendar", pageState: "state-1" },
+];
+
+describe("restoreNavigationHistory", () => {
+  test("hands the entries and the active index to the view", async () => {
+    let restoredOptions: RestoreOptions | undefined;
+
+    const restored = await restoreNavigationHistory(
+      makeWebContents(async (options) => {
+        restoredOptions = options;
+      }),
+      { entries, index: 1 },
+    );
+
+    expect(restored).toBe(true);
+    expect(restoredOptions).toEqual({ entries, index: 1 });
+  });
+
+  test("answers false instead of rejecting when the page fails to load", async () => {
+    const restored = await restoreNavigationHistory(
+      makeWebContents(() => Promise.reject(new Error("ERR_NAME_NOT_RESOLVED"))),
+      { entries, index: 1 },
+    );
+
+    expect(restored).toBe(false);
+  });
+});

--- a/packages/app/lib/load-url.ts
+++ b/packages/app/lib/load-url.ts
@@ -1,4 +1,4 @@
-import type { WebContents } from "electron";
+import type { RestoreOptions, WebContents } from "electron";
 import { serializeError } from "serialize-error";
 import { log } from "./log";
 
@@ -18,6 +18,26 @@ export function loadUrl(webContents: WebContents, url: string) {
     .then(() => true)
     .catch((error: unknown) => {
       log.error("Failed to load URL", { url, error: serializeError(error) });
+
+      return false;
+    });
+}
+
+/**
+ * Brings a view back on the history the tab it belongs to went away with, so
+ * back and forward keep working and each page returns to the scroll position
+ * and form values it was left at. Restoring loads the entry it lands on, so it
+ * answers whether the page arrived just as `loadUrl` does.
+ */
+export function restoreNavigationHistory(webContents: WebContents, options: RestoreOptions) {
+  return webContents.navigationHistory
+    .restore(options)
+    .then(() => true)
+    .catch((error: unknown) => {
+      log.error("Failed to restore navigation history", {
+        url: options.entries.at(options.index ?? -1)?.url,
+        error: serializeError(error),
+      });
 
       return false;
     });

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -4,7 +4,7 @@ import { ms } from "@meru/shared/ms";
 import type { SavedTab } from "@meru/shared/schemas";
 import { getTabSection, GMAIL_TAB_ID, type TabState, tabSections } from "@meru/shared/tabs";
 import type { SupportedWorkspaceApp } from "@meru/shared/workspace-apps";
-import type { WebContentsView } from "electron";
+import type { RestoreOptions, WebContentsView } from "electron";
 import { accounts } from "./accounts";
 import { bookmarks } from "./bookmarks";
 import { config } from "./config";
@@ -68,6 +68,17 @@ export type Tab = {
 };
 
 /**
+ * What the view a tab left behind was holding, carried so that waking the tab
+ * lands where it was rather than at the top of a freshly loaded page. Only a
+ * tab hibernated in this session has any of it — a tab restored from disk at
+ * launch starts from its URL alone.
+ */
+type UnloadedViewState = {
+  zoomFactor?: number;
+  restorableNavigationHistory?: RestoreOptions;
+};
+
+/**
  * A saved tab that has not been opened yet. Only pinned tabs are saved, so a
  * dormant tab is always a pinned one waiting to be materialized.
  */
@@ -98,7 +109,9 @@ export class DormantTab {
 
   zoomFactor: number | undefined;
 
-  constructor(savedTab: SavedTab, zoomFactor?: number) {
+  restorableNavigationHistory: RestoreOptions | undefined;
+
+  constructor(savedTab: SavedTab, unloadedViewState?: UnloadedViewState) {
     this.app = savedTab.app;
     this.url = savedTab.url;
     this.title = savedTab.title;
@@ -106,7 +119,8 @@ export class DormantTab {
     this.hibernatesWhenIdle = Boolean(savedTab.hibernatesWhenIdle);
     this.opensLinksForApp = savedTab.opensLinksForApp ?? null;
     this.windowed = Boolean(savedTab.windowed);
-    this.zoomFactor = zoomFactor;
+    this.zoomFactor = unloadedViewState?.zoomFactor;
+    this.restorableNavigationHistory = unloadedViewState?.restorableNavigationHistory;
   }
 }
 
@@ -290,6 +304,9 @@ export class Tabs {
       savedAsWindow: dormantTab.windowed,
       app: dormantTab.app,
       zoomFactor: dormantTab.zoomFactor,
+      // A URL passed in wins: the tab is being woken to take that link, which
+      // the history it hibernated with knows nothing about.
+      navigationHistory: url ? undefined : dormantTab.restorableNavigationHistory,
     });
 
     if (workspaceApp.isWindowed) {
@@ -399,7 +416,10 @@ export class Tabs {
           opensLinksForApp: savedWorkspaceApp.opensLinksForApp,
           windowed: savedWorkspaceApp.opensAsWindow,
         },
-        savedWorkspaceApp.zoomFactor,
+        {
+          zoomFactor: savedWorkspaceApp.zoomFactor,
+          restorableNavigationHistory: savedWorkspaceApp.restorableNavigationHistory,
+        },
       ),
     );
 

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -18,6 +18,7 @@ import {
   dialog,
   globalShortcut,
   powerSaveBlocker,
+  type RestoreOptions,
   type Session,
   type WebContents,
   type WebContentsView,
@@ -28,7 +29,7 @@ import { bookmarks } from "./bookmarks";
 import { config } from "./config";
 import { extensions, ONEPASSWORD_EXTENSION_ID } from "./extensions";
 import { ipc } from "./ipc";
-import { loadUrl } from "./lib/load-url";
+import { loadUrl, restoreNavigationHistory } from "./lib/load-url";
 import {
   createChildWebContentsView,
   openViewDevToolsOnLaunch,
@@ -94,6 +95,7 @@ type WorkspaceAppOptions = {
   opensLinksForApp?: SupportedWorkspaceApp | null;
   app?: SupportedWorkspaceApp;
   zoomFactor?: number;
+  navigationHistory?: RestoreOptions;
 };
 
 export class WorkspaceApp {
@@ -503,6 +505,7 @@ export class WorkspaceApp {
     opensLinksForApp,
     app,
     zoomFactor,
+    navigationHistory,
   }: WorkspaceAppOptions) {
     this.accountId = accountId;
     this.app = app ?? getWorkspaceAppFromUrl(url);
@@ -517,7 +520,7 @@ export class WorkspaceApp {
       this._window = this.createBrowserWindow(window);
     }
 
-    this.view = this.createView({ url, options: view });
+    this.view = this.createView({ url, options: view, navigationHistory });
 
     this.updateViewBounds();
     this.registerViewListeners();
@@ -584,9 +587,11 @@ export class WorkspaceApp {
   private createView({
     url,
     options,
+    navigationHistory,
   }: {
     url: string;
     options?: WebContentsViewConstructorOptions;
+    navigationHistory?: RestoreOptions;
   }) {
     const view = createChildWebContentsView({
       session: this.account.instance.session,
@@ -613,7 +618,11 @@ export class WorkspaceApp {
       },
     });
 
-    loadUrl(view.webContents, url);
+    if (navigationHistory) {
+      restoreNavigationHistory(view.webContents, navigationHistory);
+    } else {
+      loadUrl(view.webContents, url);
+    }
 
     openViewDevToolsOnLaunch(view);
 
@@ -859,6 +868,18 @@ export class WorkspaceApp {
     return {
       canGoBack: this.view.webContents.navigationHistory.canGoBack(),
       canGoForward: this.view.webContents.navigationHistory.canGoForward(),
+    };
+  }
+
+  /**
+   * The back-forward stack as Chromium hands it over, entry page state and all,
+   * for a fresh view to be restored onto. It is what a tab takes with it into
+   * hibernation, so waking it lands on the page it left, scrolled where it was.
+   */
+  get restorableNavigationHistory(): RestoreOptions {
+    return {
+      entries: this.view.webContents.navigationHistory.getAllEntries(),
+      index: this.view.webContents.navigationHistory.getActiveIndex(),
     };
   }
 


### PR DESCRIPTION
Waking a hibernated tab constructed a fresh `WorkspaceApp` and loaded the tab's URL, so the back-forward stack was gone and the page came back at the top. This carries the stack across hibernation.

`WorkspaceApp` gains a `restorableNavigationHistory` getter that hands over Chromium's entries and the active index. `dormantizeSavedTab` captures it onto the `DormantTab`, and `materializeDormantTab` passes it back so the new view restores it instead of loading the URL. The entries carry each page's `pageState`, so scroll position and form values come back with them — the reason the pinned tab you left mid-thread returns where you left it.

A tab woken to take a link is the exception: `openInAppLinksTab` passes a URL the captured history knows nothing about, so that path loads the URL as before.

The history lives in memory only. A pinned tab restored from disk at launch has none, since `SavedTab` still persists nothing but the URL.

This lands ahead of the rest of hibernation phase 2, which extends `DormantTab` to unpinned tabs. Both pinned and unpinned tabs use this path.

## Test plan

1. Mark a pinned tab **Hibernate When Idle**, browse two or three pages deep in it, scroll down, then switch away and wait out **Hibernate After** (set it to 30 minutes, or close the tab by hand to hibernate it immediately). The tab dims in the strip.
2. Click the tab. It returns on the page you left, scrolled where you left it, and Back walks the pages you visited before hibernating.
3. Designate the tab **Open Gmail Links in This Tab**, hibernate it again, then open a Gmail link from another app. The tab wakes on the link, with no back stack — the link wins over the captured history.
4. Restart the app and open a pinned tab that was hibernated. It loads its saved URL with an empty back stack, as before.

Not verified in the running app: this sandbox has no display server, so every step of the test plan is reasoned from the code. `restoreNavigationHistory` itself is covered by unit tests.
