### PR TITLE
Let a tab be dormant without being pinned

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -366,10 +366,7 @@ class Ipc {
 
       const hasOtherClosableTabs = account.instance.tabs.tabs.some(
         (accountTab) =>
-          accountTab.id !== tabId &&
-          accountTab.id !== GMAIL_TAB_ID &&
-          !accountTab.pinned &&
-          !accountTab.dormant,
+          accountTab.id !== tabId && accountTab.id !== GMAIL_TAB_ID && !accountTab.pinned,
       );
 
       const contextTabIndex = account.instance.tabs.tabs.findIndex(
@@ -378,7 +375,7 @@ class Ipc {
 
       const hasClosableTabsBelow = account.instance.tabs.tabs
         .slice(contextTabIndex + 1)
-        .some((accountTab) => !accountTab.pinned && !accountTab.dormant);
+        .some((accountTab) => !accountTab.pinned);
 
       const isWindowsMode = config.get("workspaceApps.mode") === "windows";
 
@@ -568,27 +565,36 @@ class Ipc {
         {
           type: "separator",
         },
-        tab instanceof DormantTab
-          ? {
-              label: "Open",
-              click: () => {
-                account.instance.tabs.activateTab(tabId);
+        ...(tab instanceof DormantTab
+          ? [
+              {
+                label: "Open",
+                click: () => {
+                  account.instance.tabs.activateTab(tabId);
 
-                if (account.config.selected) {
-                  accounts.refreshSelectedAccountView();
-                }
+                  if (account.config.selected) {
+                    accounts.refreshSelectedAccountView();
+                  }
+                },
               },
-            }
-          : {
-              label: "Close",
-              click: () => {
-                account.instance.tabs.closeTab(tabId);
+            ]
+          : []),
+        // An unloaded pinned tab is the one thing with nothing left to close:
+        // it is already saved, and closing it again would drop what was pinned.
+        ...(tab instanceof DormantTab && tab.pinned
+          ? []
+          : [
+              {
+                label: "Close",
+                click: () => {
+                  account.instance.tabs.closeTab(tabId);
 
-                if (account.config.selected) {
-                  accounts.refreshSelectedAccountView();
-                }
+                  if (account.config.selected) {
+                    accounts.refreshSelectedAccountView();
+                  }
+                },
               },
-            },
+            ]),
         {
           label: "Close Other Tabs",
           enabled: hasOtherClosableTabs,

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -212,10 +212,9 @@ export class AppMenu {
     const selectedAccountActiveTab = selectedAccount.instance.tabs.activeTab;
 
     // Exactly what the strip's close button offers: the pinned section — Gmail
-    // included — and dormant entries carry no close button, so the shortcut has
-    // nothing to close there either.
-    const isActiveTabCloseable =
-      getTabSection(selectedAccountActiveTab) !== "pinned" && !selectedAccountActiveTab.dormant;
+    // included — carries no close button, so the shortcut has nothing to close
+    // there either.
+    const isActiveTabCloseable = getTabSection(selectedAccountActiveTab) !== "pinned";
 
     const isGmailVisible =
       focusedWindow === main.window &&

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -78,18 +78,24 @@ type UnloadedViewState = {
   restorableNavigationHistory?: RestoreOptions;
 };
 
+type DormantTabOptions = Omit<SavedTab, "app"> & {
+  app: SupportedWorkspaceApp | undefined;
+  pinned: boolean;
+};
+
 /**
- * A saved tab that has not been opened yet. Only pinned tabs are saved, so a
- * dormant tab is always a pinned one waiting to be materialized.
+ * A tab with no view behind it. It is either a pinned tab restored from disk
+ * that has not been opened yet, or a tab that was unloaded after sitting idle.
+ * Either way it holds its place in the strip until something materializes it.
  */
 export class DormantTab {
   id = randomUUID();
 
-  app: SupportedWorkspaceApp;
+  app: SupportedWorkspaceApp | undefined;
 
   url: string;
 
-  pinned = true;
+  pinned: boolean;
 
   dormant = true;
 
@@ -111,14 +117,15 @@ export class DormantTab {
 
   restorableNavigationHistory: RestoreOptions | undefined;
 
-  constructor(savedTab: SavedTab, unloadedViewState?: UnloadedViewState) {
-    this.app = savedTab.app;
-    this.url = savedTab.url;
-    this.title = savedTab.title;
-    this.loadOnLaunch = Boolean(savedTab.loadOnLaunch);
-    this.hibernatesWhenIdle = Boolean(savedTab.hibernatesWhenIdle);
-    this.opensLinksForApp = savedTab.opensLinksForApp ?? null;
-    this.windowed = Boolean(savedTab.windowed);
+  constructor(dormantTab: DormantTabOptions, unloadedViewState?: UnloadedViewState) {
+    this.app = dormantTab.app;
+    this.url = dormantTab.url;
+    this.title = dormantTab.title;
+    this.pinned = dormantTab.pinned;
+    this.loadOnLaunch = Boolean(dormantTab.loadOnLaunch);
+    this.hibernatesWhenIdle = Boolean(dormantTab.hibernatesWhenIdle);
+    this.opensLinksForApp = dormantTab.opensLinksForApp ?? null;
+    this.windowed = Boolean(dormantTab.windowed);
     this.zoomFactor = unloadedViewState?.zoomFactor;
     this.restorableNavigationHistory = unloadedViewState?.restorableNavigationHistory;
   }
@@ -332,7 +339,7 @@ export class Tabs {
 
   restoreSavedTabs(savedTabs: SavedTab[]) {
     for (const savedTab of savedTabs) {
-      this.tabs.push(new DormantTab(savedTab));
+      this.tabs.push(new DormantTab({ ...savedTab, pinned: true }));
     }
   }
 
@@ -348,7 +355,7 @@ export class Tabs {
     const isWindowsMode = config.get("workspaceApps.mode") === "windows";
 
     const cyclableTabs = this.tabs.filter(
-      (tab) => !isWindowedTab(tab) && !(isWindowsMode && tab.dormant),
+      (tab) => !isWindowedTab(tab) && !(isWindowsMode && tab.dormant && tab.pinned),
     );
 
     const activeTabIndex = cyclableTabs.findIndex((tab) => tab.id === this.activeTabId);
@@ -372,6 +379,21 @@ export class Tabs {
 
   closeTab(tabId: string) {
     const closableTab = this.getTab(tabId);
+
+    // An unloaded tab has no view to close, so closing it is closing the entry
+    // itself. A pinned one is saved, and closing it again would throw away what
+    // the user pinned.
+    if (closableTab instanceof DormantTab) {
+      if (closableTab.pinned) {
+        return;
+      }
+
+      this.recordRecentlyClosedTab(closableTab.url);
+
+      this.removeTab(tabId);
+
+      return;
+    }
 
     if (!(closableTab instanceof WorkspaceApp)) {
       return;
@@ -411,6 +433,7 @@ export class Tabs {
           app: savedWorkspaceApp.app,
           url: savedWorkspaceApp.url,
           title: savedWorkspaceApp.title,
+          pinned: savedWorkspaceApp.pinned,
           loadOnLaunch: savedWorkspaceApp.loadOnLaunch,
           hibernatesWhenIdle: savedWorkspaceApp.hibernatesWhenIdle,
           opensLinksForApp: savedWorkspaceApp.opensLinksForApp,
@@ -550,14 +573,7 @@ export class Tabs {
   setTabPinned(tabId: string, pinned: boolean) {
     const pinnableTab = this.getTab(tabId);
 
-    // Unpinning a tab that was never opened leaves nothing behind to keep.
-    if (!pinned && pinnableTab instanceof DormantTab) {
-      this.removeTab(tabId);
-
-      return;
-    }
-
-    if (!(pinnableTab instanceof WorkspaceApp)) {
+    if (!(pinnableTab instanceof WorkspaceApp) && !(pinnableTab instanceof DormantTab)) {
       return;
     }
 
@@ -707,7 +723,7 @@ export class Tabs {
           opensLinksForApp: tab.opensLinksForApp,
           windowed: tab.opensAsWindow,
         });
-      } else if (tab instanceof DormantTab) {
+      } else if (tab instanceof DormantTab && tab.pinned && tab.app) {
         savedTabs.push({
           app: tab.app,
           url: tab.url,

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -133,7 +133,10 @@ function VerticalTab({
 
   const isPinnedSectionTab = getTabSection(tab) === "pinned";
 
-  const isCloseable = !isPinnedSectionTab && !tab.dormant;
+  // An unloaded tab closes as readily as a loaded one — it is the entry that
+  // goes, rather than a view. Pinned tabs are the ones with no close button,
+  // since closing one only unloads it.
+  const isCloseable = !isPinnedSectionTab;
 
   const isWideRow = presentation === "wideRow";
 

--- a/packages/shared/tabs.test.ts
+++ b/packages/shared/tabs.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { getVisibleVerticalTabs } from "./tabs";
+
+type VerticalTab = { id: string; dormant: boolean; pinned: boolean; windowed: boolean };
+
+const gmailTab: VerticalTab = { id: "gmail", dormant: false, pinned: false, windowed: false };
+
+const openTab: VerticalTab = { id: "open", dormant: false, pinned: false, windowed: false };
+
+const unloadedTab: VerticalTab = { id: "unloaded", dormant: true, pinned: false, windowed: false };
+
+const unopenedPinnedTab: VerticalTab = {
+  id: "unopened-pinned",
+  dormant: true,
+  pinned: true,
+  windowed: false,
+};
+
+const windowedTab: VerticalTab = { id: "windowed", dormant: false, pinned: false, windowed: true };
+
+const tabs = [gmailTab, unopenedPinnedTab, openTab, unloadedTab, windowedTab];
+
+describe("getVisibleVerticalTabs", () => {
+  test("lists an unloaded unpinned tab in windows mode", () => {
+    const visibleTabs = getVisibleVerticalTabs(tabs, {
+      workspaceAppsMode: "windows",
+      showWindows: true,
+    });
+
+    expect(visibleTabs.map((tab) => tab.id)).toEqual(["gmail", "open", "unloaded"]);
+  });
+
+  test("lists every unwindowed tab in tabs mode", () => {
+    const visibleTabs = getVisibleVerticalTabs(tabs, {
+      workspaceAppsMode: "tabs",
+      showWindows: false,
+    });
+
+    expect(visibleTabs.map((tab) => tab.id)).toEqual([
+      "gmail",
+      "unopened-pinned",
+      "open",
+      "unloaded",
+    ]);
+  });
+
+  test("lists windowed tabs in tabs mode when they are shown", () => {
+    const visibleTabs = getVisibleVerticalTabs(tabs, {
+      workspaceAppsMode: "tabs",
+      showWindows: true,
+    });
+
+    expect(visibleTabs).toEqual(tabs);
+  });
+});

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -62,11 +62,15 @@ export function getTabSection(tab: Pick<TabState, "id" | "pinned">): TabSection 
 
 /**
  * `windows` mode leaves the strip with only what lives in the main window:
- * windowed apps have a window of their own, and dormant entries would open as
- * one. In `tabs` mode windowed apps are listed alongside the tabs unless the
- * user turns that off. Everything filtered out here stays saved either way.
+ * windowed apps have a window of their own, and a pinned entry that has never
+ * been opened would open as one. An unloaded unpinned tab stays listed, because
+ * it is a tab the user opened and dropping it from the strip would read as
+ * closing it. In `tabs` mode windowed apps are listed alongside the tabs unless
+ * the user turns that off. Everything filtered out here stays saved either way.
  */
-export function getVisibleVerticalTabs<VerticalTab extends Pick<TabState, "dormant" | "windowed">>(
+export function getVisibleVerticalTabs<
+  VerticalTab extends Pick<TabState, "dormant" | "pinned" | "windowed">,
+>(
   tabs: VerticalTab[],
   {
     workspaceAppsMode,
@@ -74,7 +78,7 @@ export function getVisibleVerticalTabs<VerticalTab extends Pick<TabState, "dorma
   }: { workspaceAppsMode: WorkspaceAppsMode; showWindows: boolean },
 ) {
   if (workspaceAppsMode === "windows") {
-    return tabs.filter((tab) => !tab.dormant && !tab.windowed);
+    return tabs.filter((tab) => !(tab.dormant && tab.pinned) && !tab.windowed);
   }
 
   return showWindows ? tabs : tabs.filter((tab) => !tab.windowed);


### PR DESCRIPTION
Second of three PRs for hibernation phase 2, which extends the idle sweep from #811 to unpinned tabs. This one changes the model the sweep needs; the sweep itself follows in the PR on top.

`DormantTab` assumed a dormant tab was always a pinned one restored from disk: `pinned` was hardcoded `true` and `app` was required, because only a saved tab could be dormant. It now takes both from its options, so an unpinned tab — including one that browsed off Google and has no app — can sit in the strip with no view behind it.

What that ripples into:

- **Unpinning keeps the tab.** Unpinning a dormant tab removed it, on the reasoning that a tab you never opened has nothing to keep. It now becomes an unpinned dormant tab, which you can open or close like any other.
- **A dormant tab that isn't pinned can be closed.** The strip shows its close button, the context menu offers Close alongside Open, Close Other Tabs and Close Tabs Below sweep it, and its URL goes to the reopen list. A pinned dormant tab still has no close button, because closing a pinned tab only unloads it.
- **Windows mode lists it.** `getVisibleVerticalTabs` dropped every dormant entry in `windows` mode, since a pinned entry that has never been opened would open as a window rather than a tab. An unpinned dormant tab is one the user opened, so dropping it from the strip would read as closing it. Tab cycling follows the same rule.
- **Only pinned dormant tabs are saved.** `serializeSavedTabs` skips the rest, so an unpinned tab still doesn't survive a quit, hibernated or not.

## Test plan

1. Right-click a pinned tab you have never opened and choose Unpin. The tab stays in the strip, dimmed, below the pinned section, with a close button — previously it disappeared.
2. Click it. It loads, then quit and reopen the app: it doesn't come back, because unpinned tabs aren't saved.
3. Set Workspace Apps to New Windows, then repeat step 1. The unpinned dormant tab stays listed in the strip, while pinned tabs you have never opened stay hidden.

Not verified in the running app: this sandbox has no display server, so every step of the test plan is reasoned from the code. `getVisibleVerticalTabs` is covered by unit tests, one of which fails on the old filter.
