### PR TITLE
Hibernate idle unpinned tabs too

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -511,9 +511,9 @@ class Ipc {
                     },
                   ]
                 : []),
-              // Only saved tabs hibernate, and only the tabs picked here do
-              // while the setting is on Selected Tabs.
-              ...(config.get("workspaceApps.hibernation") === "selected" && tab.pinned
+              // While the setting is on Selected Tabs, only the tabs marked
+              // here hibernate.
+              ...(config.get("workspaceApps.hibernation") === "selected"
                 ? [
                     {
                       label: "Hibernate When Idle",
@@ -522,7 +522,11 @@ class Ipc {
                       click: () => {
                         tab.hibernatesWhenIdle = !tab.hibernatesWhenIdle;
 
-                        accounts.saveTabs();
+                        // An unpinned tab is not saved, so the mark lasts as
+                        // long as the tab itself does.
+                        if (tab.pinned) {
+                          accounts.saveTabs();
+                        }
                       },
                     },
                   ]

--- a/packages/app/lib/hibernation.test.ts
+++ b/packages/app/lib/hibernation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { ms } from "@meru/shared/ms";
+import { canHibernateTab } from "./hibernation";
+
+const now = new Date("2026-08-18T12:00:00Z").getTime();
+
+const idleTimeout = ms("1h");
+
+const idleTab = {
+  isWindowed: false,
+  isAudible: false,
+  url: "https://calendar.google.com/",
+  hibernatesWhenIdle: false,
+  lastActiveAt: now - ms("2h"),
+};
+
+const sweepEveryTab = { hibernatesEveryTab: true, idleTimeout, now };
+
+const sweepSelectedTabs = { hibernatesEveryTab: false, idleTimeout, now };
+
+describe("canHibernateTab", () => {
+  test("unloads a tab idle past the timeout", () => {
+    expect(canHibernateTab(idleTab, sweepEveryTab)).toBe(true);
+  });
+
+  test("keeps a tab used within the timeout", () => {
+    expect(canHibernateTab({ ...idleTab, lastActiveAt: now - ms("30m") }, sweepEveryTab)).toBe(
+      false,
+    );
+  });
+
+  test("unloads a tab at the timeout itself", () => {
+    expect(canHibernateTab({ ...idleTab, lastActiveAt: now - idleTimeout }, sweepEveryTab)).toBe(
+      true,
+    );
+  });
+
+  test("keeps a tab in its own window", () => {
+    expect(canHibernateTab({ ...idleTab, isWindowed: true }, sweepEveryTab)).toBe(false);
+  });
+
+  test("keeps a tab playing audio", () => {
+    expect(canHibernateTab({ ...idleTab, isAudible: true }, sweepEveryTab)).toBe(false);
+  });
+
+  test("keeps a tab that never arrived anywhere", () => {
+    expect(canHibernateTab({ ...idleTab, url: "" }, sweepEveryTab)).toBe(false);
+  });
+
+  test("unloads only marked tabs while the sweep is on selected tabs", () => {
+    expect(canHibernateTab(idleTab, sweepSelectedTabs)).toBe(false);
+    expect(canHibernateTab({ ...idleTab, hibernatesWhenIdle: true }, sweepSelectedTabs)).toBe(true);
+  });
+});

--- a/packages/app/lib/hibernation.ts
+++ b/packages/app/lib/hibernation.ts
@@ -1,0 +1,43 @@
+/**
+ * What the idle sweep reads off a tab to decide whether it may unload it. A
+ * `WorkspaceApp` satisfies it; nothing else is needed to make the call.
+ */
+type HibernatableTab = {
+  isWindowed: boolean;
+  isAudible: boolean;
+  url: string;
+  hibernatesWhenIdle: boolean;
+  lastActiveAt: number;
+};
+
+/**
+ * Whether a tab has gone idle long enough to be unloaded. The caller has
+ * already ruled out the active tab, which is the one exclusion that depends on
+ * the account rather than on the tab.
+ */
+export function canHibernateTab(
+  tab: HibernatableTab,
+  {
+    hibernatesEveryTab,
+    idleTimeout,
+    now,
+  }: { hibernatesEveryTab: boolean; idleTimeout: number; now: number },
+) {
+  // A tab in its own window is a window the user left open, and one playing
+  // audio stops mid-track if its renderer goes away.
+  if (tab.isWindowed || tab.isAudible) {
+    return false;
+  }
+
+  if (!hibernatesEveryTab && !tab.hibernatesWhenIdle) {
+    return false;
+  }
+
+  // A tab that never arrived anywhere has no URL to come back to, so unloading
+  // it would strand an entry that cannot be opened.
+  if (!tab.url) {
+    return false;
+  }
+
+  return now - tab.lastActiveAt >= idleTimeout;
+}

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -9,6 +9,7 @@ import { accounts } from "./accounts";
 import { bookmarks } from "./bookmarks";
 import { config } from "./config";
 import type { Gmail } from "./gmail";
+import { canHibernateTab } from "./lib/hibernation";
 import { main } from "./main";
 import { appMenu } from "./menu";
 import { openExternalUrl } from "./url";
@@ -400,7 +401,7 @@ export class Tabs {
     }
 
     if (isSavedWorkspaceApp(closableTab)) {
-      this.dormantizeSavedTab(closableTab);
+      this.dormantizeTab(closableTab);
     } else {
       this.recordRecentlyClosedTab(closableTab.url);
     }
@@ -414,7 +415,7 @@ export class Tabs {
     }
 
     if (isSavedWorkspaceApp(windowedTab)) {
-      this.dormantizeSavedTab(windowedTab);
+      this.dormantizeTab(windowedTab);
 
       return;
     }
@@ -424,29 +425,34 @@ export class Tabs {
     this.removeTab(windowedTab.id);
   }
 
-  private dormantizeSavedTab(savedWorkspaceApp: SavedWorkspaceApp) {
+  /**
+   * Swaps a tab's view for the entry it leaves behind, keeping its place in the
+   * strip. Only a pinned tab is written back to disk — an unpinned one lives
+   * for as long as the app runs either way.
+   */
+  private dormantizeTab(workspaceApp: WorkspaceApp) {
     this.tabs.splice(
-      this.tabs.indexOf(savedWorkspaceApp),
+      this.tabs.indexOf(workspaceApp),
       1,
       new DormantTab(
         {
-          app: savedWorkspaceApp.app,
-          url: savedWorkspaceApp.url,
-          title: savedWorkspaceApp.title,
-          pinned: savedWorkspaceApp.pinned,
-          loadOnLaunch: savedWorkspaceApp.loadOnLaunch,
-          hibernatesWhenIdle: savedWorkspaceApp.hibernatesWhenIdle,
-          opensLinksForApp: savedWorkspaceApp.opensLinksForApp,
-          windowed: savedWorkspaceApp.opensAsWindow,
+          app: workspaceApp.app,
+          url: workspaceApp.url,
+          title: workspaceApp.title,
+          pinned: workspaceApp.pinned,
+          loadOnLaunch: workspaceApp.loadOnLaunch,
+          hibernatesWhenIdle: workspaceApp.hibernatesWhenIdle,
+          opensLinksForApp: workspaceApp.opensLinksForApp,
+          windowed: workspaceApp.opensAsWindow,
         },
         {
-          zoomFactor: savedWorkspaceApp.zoomFactor,
-          restorableNavigationHistory: savedWorkspaceApp.restorableNavigationHistory,
+          zoomFactor: workspaceApp.zoomFactor,
+          restorableNavigationHistory: workspaceApp.restorableNavigationHistory,
         },
       ),
     );
 
-    if (this.activeTabId === savedWorkspaceApp.id) {
+    if (this.activeTabId === workspaceApp.id) {
       this.activeTabId = GMAIL_TAB_ID;
     }
 
@@ -454,13 +460,15 @@ export class Tabs {
 
     this.broadcastTabsChanged();
 
-    accounts.saveTabs();
+    if (workspaceApp.pinned) {
+      accounts.saveTabs();
+    }
   }
 
   /**
-   * Unloads saved tabs the user has left alone for the configured timeout,
-   * giving back the renderer process each one holds. A hibernated tab keeps its
-   * place in the strip and loads again when it is opened.
+   * Unloads tabs the user has left alone for the configured timeout, giving
+   * back the renderer process each one holds. A hibernated tab keeps its place
+   * in the strip and loads again when it is opened.
    */
   hibernateIdleTabs() {
     const now = Date.now();
@@ -476,20 +484,20 @@ export class Tabs {
     const idleTimeout = ms(config.get("workspaceApps.hibernationTimeout"));
 
     for (const tab of this.tabs.slice()) {
-      if (!isSavedWorkspaceApp(tab) || tab.id === this.activeTabId || tab.isWindowed) {
+      if (!(tab instanceof WorkspaceApp) || tab.id === this.activeTabId) {
         continue;
       }
 
-      if (!hibernatesEveryTab && !tab.hibernatesWhenIdle) {
-        continue;
+      if (canHibernateTab(tab, { hibernatesEveryTab, idleTimeout, now })) {
+        this.hibernateTab(tab);
       }
-
-      if (tab.isAudible || now - tab.lastActiveAt < idleTimeout) {
-        continue;
-      }
-
-      this.closeTab(tab.id);
     }
+  }
+
+  private hibernateTab(workspaceApp: WorkspaceApp) {
+    this.dormantizeTab(workspaceApp);
+
+    workspaceApp.close();
   }
 
   private recordRecentlyClosedTab(closedTabUrl: string) {

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -295,7 +295,7 @@ export function WorkspaceAppsSettings() {
           <FieldSeparator />
           <ConfigSelectField
             label="Hibernate Idle Tabs"
-            description="Unload pinned tabs that have been sitting unused, giving back the memory they hold. A hibernated tab keeps its place in the sidebar and loads again when you click it. Selected Tabs only hibernates the tabs you mark with Hibernate When Idle in the tab's context menu."
+            description="Unload tabs that have been sitting unused, giving back the memory they hold. A hibernated tab keeps its place in the sidebar and loads again when you click it, on the page you left. Selected Tabs only hibernates the tabs you mark with Hibernate When Idle in the tab's context menu."
             configKey="workspaceApps.hibernation"
             placeholder="Select tabs"
             licenseKeyRequired
@@ -306,7 +306,7 @@ export function WorkspaceAppsSettings() {
           />
           <ConfigSelectField
             label="Hibernate After"
-            description="How long a pinned tab has to go unused before it hibernates. The active tab, tabs in their own window and tabs playing audio are left alone."
+            description="How long a tab has to go unused before it hibernates. The active tab, tabs in their own window and tabs playing audio are left alone."
             configKey="workspaceApps.hibernationTimeout"
             placeholder="Select timeout"
             licenseKeyRequired


### PR DESCRIPTION
Last of three PRs for hibernation phase 2. #864 taught `DormantTab` to hold an unpinned tab; this points the idle sweep at those tabs.

The sweep from #811 only considered pinned saved tabs, and it hibernated them by calling `closeTab`, which dormantizes a pinned tab as a side effect. That path removes an unpinned tab instead of unloading it, so the sweep now calls `dormantizeTab` directly and closes the view afterwards. `dormantizeTab` writes to disk only for a pinned tab, since an unpinned one isn't saved either way.

The per-tab decision moves into `canHibernateTab` in `lib/hibernation.ts`, which is what the tests cover. The rules are unchanged apart from one addition: a tab that never arrived at a URL is left alone, because unloading it would leave an entry in the strip with nothing to open.

**Hibernate When Idle** now appears in the context menu of unpinned tabs too. On a pinned tab the mark is saved as before; on an unpinned tab it lasts as long as the tab does.

One gap: the checkbox sits in the menu group that only tabs with a Workspace app have, so a tab that browsed off Google can't be marked individually. Such a tab still hibernates under All Tabs.

## Test plan

1. Set **Hibernate Idle Tabs** to All Tabs and **Hibernate After** to 30 minutes. Open a few Workspace app tabs without pinning them, switch to Gmail, and leave the app alone. Within a minute of the timeout each unpinned tab dims in place, and Activity Monitor shows one fewer Meru Helper (Renderer) process per tab.
2. Click a hibernated unpinned tab. It loads the page you left, and Back walks the pages you visited before it hibernated.
3. Play a video in an unpinned tab, switch away, and leave it past the timeout. It keeps playing and stays loaded.
4. Set **Hibernate Idle Tabs** to Selected Tabs, mark one unpinned tab **Hibernate When Idle**, and leave both it and an unmarked tab idle. Only the marked one hibernates.

Not verified in the running app: this sandbox has no display server, so every step of the test plan is reasoned from the code, including the process count in step 1 and the audio exclusion in step 3. `canHibernateTab` is covered by unit tests.
