### PR TITLE
hide the promotional banner above the Gmail message list

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -79,6 +79,7 @@ export const config = new Store<Config>({
     "gmail.hideGmailLogo": true,
     "gmail.hideInboxFooter": true,
     "gmail.hideOutOfOfficeBanner": false,
+    "gmail.hidePromoBanner": true,
     "gmail.hideUpgradeButton": true,
     "gmail.reverseConversation": false,
     "gmail.savedSearches": [],

--- a/packages/app/gmail/gmail.css
+++ b/packages/app/gmail/gmail.css
@@ -39,6 +39,12 @@ html.meru-hide-out-of-office-banner #\:7 {
   display: none !important;
 }
 
+/* Gmail Promotional Banner */
+html.meru-hide-promo-banner
+  [data-elevated-container-view-type="timely_bump"]:has([data-rp-onramp-container]) {
+  display: none !important;
+}
+
 html.meru-hide-gmail-upgrade div[data-pep-id="global-pep-gmail"],
 html.meru-hide-gmail-upgrade
   span:has(> div > div > div > div > div[data-action-behavior*="one.google.com/dynamic-plans"]) {

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -346,6 +346,10 @@ export class Gmail {
         additionalArguments.push(GMAIL_PRELOAD_ARGUMENTS.hideOutOfOfficeBanner);
       }
 
+      if (config.get("gmail.hidePromoBanner")) {
+        additionalArguments.push(GMAIL_PRELOAD_ARGUMENTS.hidePromoBanner);
+      }
+
       if (config.get("gmail.hideUpgradeButton")) {
         additionalArguments.push(GMAIL_PRELOAD_ARGUMENTS.hideUpgradeButton);
       }

--- a/packages/preload-gmail/css.ts
+++ b/packages/preload-gmail/css.ts
@@ -17,6 +17,10 @@ export function initCss() {
     document.documentElement.classList.add("meru-hide-out-of-office-banner");
   }
 
+  if (process.argv.includes(GMAIL_PRELOAD_ARGUMENTS.hidePromoBanner)) {
+    document.documentElement.classList.add("meru-hide-promo-banner");
+  }
+
   if (process.argv.includes(GMAIL_PRELOAD_ARGUMENTS.hideUpgradeButton)) {
     document.documentElement.classList.add("meru-hide-gmail-upgrade");
   }

--- a/packages/renderer/routes/settings/gmail/index.tsx
+++ b/packages/renderer/routes/settings/gmail/index.tsx
@@ -62,6 +62,13 @@ export function GmailSettings() {
               licenseKeyRequired
             />
             <ConfigSwitchField
+              label="Hide Promotional Banner"
+              description="Hides promotional banners at the top of the message list, such as the Google Workspace upgrade offer."
+              configKey="gmail.hidePromoBanner"
+              restartRequired
+              licenseKeyRequired
+            />
+            <ConfigSwitchField
               label="Hide Upgrade Button"
               description="Hides the Upgrade button in Gmail."
               configKey="gmail.hideUpgradeButton"

--- a/packages/shared/gmail.ts
+++ b/packages/shared/gmail.ts
@@ -21,6 +21,7 @@ export const GMAIL_PRELOAD_ARGUMENTS = {
   openComposeInNewWindow: "--meru-open-compose-in-new-window",
   showSenderIcons: "--meru-show-sender-icons",
   hideOutOfOfficeBanner: "--meru-hide-out-of-office-banner",
+  hidePromoBanner: "--meru-hide-promo-banner",
   hideUpgradeButton: "--meru-hide-gmail-upgrade",
   moveAttachmentsToTop: "--meru-move-attachments-to-top",
   closeComposeWindowAfterSend: "--meru-close-compose-after-send",

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -140,6 +140,7 @@ export type Config = {
   "gmail.hideGmailLogo": boolean;
   "gmail.hideInboxFooter": boolean;
   "gmail.hideOutOfOfficeBanner": boolean;
+  "gmail.hidePromoBanner": boolean;
   "gmail.hideUpgradeButton": boolean;
   "gmail.reverseConversation": boolean;
   "gmail.savedSearches": GmailSavedSearches;


### PR DESCRIPTION
Gmail injects a recommendation banner above the message list, such as a Google Workspace upgrade offer, and the banner returns after you dismiss it. This change adds the `gmail.hidePromoBanner` configuration key, on by default and license-gated, which hides it.

The change follows the path the other Gmail appearance settings take: the configuration key becomes a preload argument, the preload adds the `meru-hide-promo-banner` class to the `html` element, and a rule in the `gmail.css` file hides the banner. No JavaScript runs on the page, so this adds nothing to the preload's mutation observer.

## The selector

```css
[data-elevated-container-view-type="timely_bump"]:has([data-rp-onramp-container])
```

Two independent semantic attributes, no obfuscated class names, and no positional `> div > div` chain. The `:has()` selector scopes the rule to an elevated container that holds a promotional banner, so an unrelated `timely_bump` container stays visible. If Google renames either attribute, the selector matches nothing and the banner reappears, rather than the rule hiding something else.

The rule targets the outer container rather than the inner `[data-rp-onramp-container]` element, so the wrapper's padding doesn't stay behind as a gap.

The selector anchors on the recommendation container itself rather than on the `data-promo-type="1001"` attribute of the Workspace offer, so it also covers a different promotional banner rendered through the same machinery.

## Verification

I checked the selector against the banner's real markup in a throwaway DOM: it matches the promotional banner, leaves a non-promotional `timely_bump` container alone, and drops to zero matches when the anchor attribute is renamed. That check used happy-dom rather than Chromium, and it isn't checked in, because the repository has no DOM test environment and neither Hide Gmail Logo nor Hide Upgrade Button has a test. Everything else is manual, and I haven't confirmed the layout above the message list in the running app.

The missing Gmail selector tests are a gap across the whole feature area, not something this change introduces, so they're tracked as a separate todo entry.

## Test plan

1. Turn **Hide Promotional Banner** off and restart the app. The Workspace banner appears above the message list.
2. Turn it on and restart the app. The banner is gone, and the message list starts where it does when no banner is present, with no gap left behind.
3. With the setting on, edit the rule in DevTools to drop `[data-rp-onramp-container]` from the `:has()` selector. The banner returns, which confirms that a stale selector degrades to showing it.
4. Without a license key, the switch is disabled and shows the Pro badge, and the banner appears.
