### PR TITLE
apply the writing style guide to the READMEs and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <div align="center">
 	<img src="media/logo-round.svg" width="200" height="200" alt="Meru logo">
 	<h1>Meru (formerly Gmail Desktop)</h1>
-  <h3>Gmail as a desktop app</h3>
+  <h3>The Gmail experience you deserve</h3>
   <p>
-		Meru gives Gmail its own window, with several accounts, native notifications, and the Google Workspace apps alongside it.
+		Tired of losing your inbox in browser tabs? Meru brings Gmail to your fingertips as a desktop app.
 	</p>
   <p><a href="https://meru.so">Website</a></p>
   <p><a href="https://meru.so/download">Download for macOS, Windows, and Linux</a></p>

--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
 <div align="center">
-	<img src="media/logo-round.svg" width="200" height="200">
+	<img src="media/logo-round.svg" width="200" height="200" alt="Meru logo">
 	<h1>Meru (formerly Gmail Desktop)</h1>
-  <h3>The Gmail experience you deserve</h3>
+  <h3>Gmail as a desktop app</h3>
   <p>
-		Tired of losing your inbox in browser tabs? Meru brings Gmail to your fingertips as a desktop app.
+		Meru gives Gmail its own window, with several accounts, native notifications, and the Google Workspace apps alongside it.
 	</p>
   <p><a href="https://meru.so">Website</a></p>
-  <p><a href="https://meru.so/download">Download for macOS, Windows & Linux</a></p>
+  <p><a href="https://meru.so/download">Download for macOS, Windows, and Linux</a></p>
   <p><a href="https://meru.so/discord">Discord</a></p>
-  <img src="media/screenshot.png">
+  <img src="media/screenshot.png" alt="Two Meru windows, one light and one dark, each showing a Gmail inbox with tabs for a Personal and a Work account">
 </div>
 
 ## Maintainers
 
 - [Tim Cheung](https://github.com/timche)
 
-### Former
+### Former maintainers
 
 - [Mark Skelton](https://github.com/mskelton)
 
 ## Contributors
 
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+These people have contributed to Meru ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
@@ -48,8 +48,8 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome.
 
 ## Disclaimer
 
-Meru is a third-party app and not affiliated with Google.
+Meru is a third-party app and isn't affiliated with Google.

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@
 
 - [Tim Cheung](https://github.com/timche)
 
-### Former maintainers
+### Former
 
 - [Mark Skelton](https://github.com/mskelton)
 
 ## Contributors
 
-These people have contributed to Meru ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
@@ -48,8 +48,8 @@ These people have contributed to Meru ([emoji key](https://allcontributors.org/d
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
-This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome.
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
 
 ## Disclaimer
 
-Meru is a third-party app and isn't affiliated with Google.
+Meru is a third-party app and not affiliated with Google.

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,7 +1,7 @@
 !macro customInstall
   # Capabilities
   WriteRegStr HKCU "Software\Meru\Capabilities" "ApplicationName" "Meru"
-  WriteRegStr HKCU "Software\Meru\Capabilities" "ApplicationDescription" "Gmail as a desktop app"
+  WriteRegStr HKCU "Software\Meru\Capabilities" "ApplicationDescription" "The Gmail experience you deserve"
   
   # URL Associations
   WriteRegStr HKCU "Software\Meru\Capabilities\URLAssociations" "mailto" "Meru.mailto"

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,7 +1,7 @@
 !macro customInstall
   # Capabilities
   WriteRegStr HKCU "Software\Meru\Capabilities" "ApplicationName" "Meru"
-  WriteRegStr HKCU "Software\Meru\Capabilities" "ApplicationDescription" "Meru"
+  WriteRegStr HKCU "Software\Meru\Capabilities" "ApplicationDescription" "Gmail as a desktop app"
   
   # URL Associations
   WriteRegStr HKCU "Software\Meru\Capabilities\URLAssociations" "mailto" "Meru.mailto"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "meru",
   "version": "3.59.0",
   "private": true,
-  "description": "Gmail as a desktop app, with several accounts, native notifications, and the Google Workspace apps alongside it",
+  "description": "Tired of losing your inbox in browser tabs? Meru brings Gmail to your fingertips as a desktop app",
   "author": "Tim Cheung <tim@meru.so>",
   "repository": "zoidsh/meru",
   "workspaces": [
@@ -152,8 +152,8 @@
           ]
         }
       ],
-      "synopsis": "Gmail as a desktop app",
-      "description": "Gmail as a desktop app, with several accounts, native notifications, and the Google Workspace apps alongside it",
+      "synopsis": "The Gmail experience you deserve",
+      "description": "Tired of losing your inbox in browser tabs? Meru brings Gmail to your fingertips as a desktop app",
       "category": "Network;Office"
     },
     "win": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "meru",
   "version": "3.59.0",
   "private": true,
-  "description": "Tired of losing your inbox in browser tabs? Meru brings Gmail to your fingertips as a desktop app",
+  "description": "Gmail as a desktop app, with several accounts, native notifications, and the Google Workspace apps alongside it",
   "author": "Tim Cheung <tim@meru.so>",
   "repository": "zoidsh/meru",
   "workspaces": [
@@ -123,8 +123,8 @@
           "meru",
           "mailto"
         ],
-        "NSCameraUsageDescription": "Meru needs access to your camera for Google apps like Meet and Chat.",
-        "NSMicrophoneUsageDescription": "Meru needs access to your camera for Google apps like Meet and Chat."
+        "NSCameraUsageDescription": "Meru uses your camera for video calls in Google apps such as Meet and Chat.",
+        "NSMicrophoneUsageDescription": "Meru uses your microphone for calls and voice input in Google apps such as Meet and Chat."
       }
     },
     "linux": {
@@ -152,8 +152,8 @@
           ]
         }
       ],
-      "synopsis": "The Gmail experience you deserve",
-      "description": "Tired of losing your inbox in browser tabs? Meru brings Gmail to your fingertips as a desktop app",
+      "synopsis": "Gmail as a desktop app",
+      "description": "Gmail as a desktop app, with several accounts, native notifications, and the Google Workspace apps alongside it",
       "category": "Network;Office"
     },
     "win": {

--- a/packages/dark-theme/README.md
+++ b/packages/dark-theme/README.md
@@ -1,7 +1,7 @@
 # @meru/dark-theme
 
-Apply a dark theme to any DOM element and its subtree — colors, gradients, and
-images — with good contrast, without touching the rest of the document.
+Applies a dark theme to any DOM element and its subtree — colors, gradients, and
+images — with good contrast, and without touching the rest of the document.
 
 ## Usage
 
@@ -10,86 +10,97 @@ import { applyDarkTheme } from "@meru/dark-theme";
 
 const controller = applyDarkTheme(element);
 
-// when the subtree is discarded (e.g. removed from the DOM):
+// When the subtree is discarded, for example by removing it from the DOM:
 controller.destroy();
 
-// or, to undo theming on a still-live subtree:
+// Or, to undo theming on a still-live subtree:
 controller.revert();
 ```
 
-Runs in a DOM context (it uses `getComputedStyle`, `<canvas>`, and `Image`), so
-use it in a renderer or content script, not the Electron main process.
+The engine needs a DOM context, because it uses `getComputedStyle`, `<canvas>`,
+and `Image`. Use it in a renderer or a content script rather than in the Electron
+main process.
 
 ## Options
 
-`applyDarkTheme(root, options?)` — `options` is a partial `Theme` plus a couple of
-engine flags:
+The `options` argument of `applyDarkTheme(root, options?)` is a partial `Theme`
+plus the following engine options:
 
-- `backgroundColor` / `textColor` — the HSL poles that light colors are remapped
+- `backgroundColor` / `textColor`: the HSL poles that light colors are remapped
   toward. Default `#181a1b` / `#e8e6e3`.
-- `brightness` / `contrast` / `sepia` / `grayscale` — filter adjustments applied on
+- `brightness` / `contrast` / `sepia` / `grayscale`: filter adjustments applied on
   top of the remap. Default `100` / `100` / `0` / `0`.
-- `ignore?: Array<string | { selector: string; properties: string[] }>` — opt elements
-  out of theming. A **string** selector keeps its matching elements and their descendants
-  (via `closest`) fully original — e.g. coloured chips or badges. An **object** skips only
-  the listed `properties` on elements matching its `selector` (via `matches`), leaving those
-  to CSS — e.g. `{ selector: ".foo", properties: ["border-color"] }` lets a stylesheet set
-  the border colour, which the engine's inline override would otherwise win over.
-  `"border-color"` covers all four sides. The skip applies across every path the engine
-  darkens a property from — the inline override, `::before`/`::after` pseudo rules, and the
-  darkened `:hover`/`:focus` state rules — so an ignored property stays with CSS in every
+- `ignore?: Array<string | { selector: string; properties: string[] }>`: opts
+  elements out of theming. A **string** selector keeps its matching elements and
+  their descendants fully original, matched with `closest` — colored chips or
+  badges, for example. An **object** skips only the listed `properties` on
+  elements matching its `selector`, matched with `matches`, and leaves those
+  properties to CSS. `{ selector: ".foo", properties: ["border-color"] }` lets a
+  stylesheet set the border color, which the engine's inline override would
+  otherwise win over, and `"border-color"` covers all four sides. The skip
+  applies across every path the engine darkens a property from — the inline
+  override, the `::before` and `::after` pseudo rules, and the darkened `:hover`
+  and `:focus` state rules — so an ignored property stays with CSS in every
   state.
-- `observe?: boolean` — watch the subtree and keep theming content added later, and
-  re-theme an element when its class changes (so state-driven styles, like a shadow
-  a sticky toolbar gains on scroll, are darkened too). Defaults to `true`; call
-  `revert()` or `destroy()` to disconnect.
-- `css?: string` — CSS injected into the document while the theme is active and
-  removed on `revert()`/`destroy()`. Use it for rules the inline-override engine can't
-  reach — `:hover`/`:focus` backgrounds, `::before` icons — scoped with the
-  `[data-dark-theme]` attribute so they apply only where the engine has themed.
-- `invertImageUrls?: string[]` — URL prefixes of dark monochrome icons (an element's
-  `background-image`, or a pseudo-element's `content`/`background-image`) to
-  blank-invert with `filter: invert(1)`. A pragmatic stand-in for pixel analysis when
-  the icon is cross-origin (CORS-tainted) and can't be inspected — e.g. a site's
-  material-icon CDN path. Matched by `startsWith`.
-- `invertImageExcludeFilenames?: string[]` — filenames (the last path segment of the
-  url) that `invertImageUrls` should skip even when their prefix matches — for a
-  coloured icon variant sharing the same path as the monochrome ones, which inverting
-  would wrongly recolour.
+- `observe?: boolean`: watches the subtree and keeps theming content added later,
+  and re-themes an element when its class changes, so that state-driven styles
+  are darkened too — a shadow that a sticky toolbar gains on scroll, for example.
+  Defaults to `true`. Call `revert()` or `destroy()` to disconnect.
+- `css?: string`: CSS injected into the document while the theme is active and
+  removed on `revert()` or `destroy()`. Use it for rules the inline-override
+  engine can't reach, such as `:hover` and `:focus` backgrounds or `::before`
+  icons, scoped with the `[data-dark-theme]` attribute so that they apply only
+  where the engine has themed.
+- `invertImageUrls?: string[]`: URL prefixes of dark monochrome icons to
+  blank-invert with `filter: invert(1)`, covering an element's `background-image`
+  and a pseudo-element's `content` or `background-image`. It's a pragmatic
+  stand-in for pixel analysis when the icon is cross-origin, and therefore
+  CORS-tainted and impossible to inspect — a site's material-icon CDN path, for
+  example. Matched with `startsWith`.
+- `invertImageExcludeFilenames?: string[]`: filenames, meaning the last path
+  segment of the URL, that `invertImageUrls` skips even when their prefix
+  matches. Use it for a colored icon variant that shares a path with the
+  monochrome ones, which inverting would recolor wrongly.
 
 ## Controller
 
-- `revert()` — disconnect the observer, restore every element's original inline
-  styles, and release references. Use on a **still-live** subtree.
-- `destroy()` — disconnect the observer and release references **without** restoring
-  styles. Use when the subtree is being discarded (restoring would be wasted work).
+- `revert()`: disconnects the observer, restores every element's original inline
+  styles, and releases references. Use it on a **still-live** subtree.
+- `destroy()`: disconnects the observer and releases references **without**
+  restoring styles. Use it when the subtree is being discarded, because restoring
+  would be wasted work.
 
 ## Behavior notes
 
 - Light-valued CSS custom properties declared or referenced in the document's
   **same-origin** stylesheets are darkened and re-declared scoped to
-  `[data-dark-theme]`, so surfaces painted via `var(--token)` are covered even in
-  states the element walk never observes (a variable inherits, so the dark value
-  cascades into the themed subtree and stops at its boundary). Properties declared
-  only in cross-origin stylesheets are missed (the same CORS wall as images). A
-  `css` override for the same property still wins, so hand-tune exceptions there.
-- `::before`/`::after` pseudo-elements are darkened too: their non-inheriting paint
-  (background, border, box-shadow, and gradient background-images) is remapped and
-  emitted into an injected stylesheet keyed to the owning element. Their `color`
-  isn't touched — it inherits the element's own themed color. A pseudo **content
-  image** can't be colour-inspected when it's cross-origin (the same CORS limit as
-  `<img>`); if its URL matches `invertImageUrls` it's blank-inverted, otherwise left
-  alone. The invert decision is re-evaluated when the element's class/state changes, so an
-  icon whose URL swaps on toggle (e.g. a star) gains or loses the invert to match.
-- `:hover`/`:focus`/`:active` styles — which a computed-style snapshot can't see,
-  since the state isn't active at theme time — are read from the document's
+  `[data-dark-theme]`, so surfaces painted through `var(--token)` are covered even
+  in states the element walk never observes. A variable inherits, so the dark
+  value cascades into the themed subtree and stops at its boundary. Properties
+  declared only in cross-origin stylesheets are missed, the same CORS limit that
+  applies to images. A `css` override for the same property still wins, so
+  hand-tune exceptions there.
+- The `::before` and `::after` pseudo-elements are darkened too. Their
+  non-inheriting paint — background, border, box-shadow, and gradient
+  background-images — is remapped and emitted into an injected stylesheet keyed to
+  the owning element. Their `color` isn't touched, because it inherits the
+  element's own themed color. A pseudo content image can't be color-inspected
+  when it's cross-origin, the same CORS limit that applies to `<img>`. If its URL
+  matches `invertImageUrls` it's blank-inverted, and otherwise left alone. The
+  invert decision is re-evaluated when the element's class or state changes, so an
+  icon whose URL swaps on toggle, such as a star, gains or loses the invert to
+  match.
+- The `:hover`, `:focus`, and `:active` styles are read from the document's
   **same-origin** author rules, darkened, and re-emitted with each selector kept
-  verbatim inside a CSS `@scope (root)` block, so they apply only within the themed
-  subtree. Rules declared only in cross-origin stylesheets are missed (same CORS
-  limit).
-- Colors apply synchronously; image analysis resolves shortly after (async).
-- Idempotent — re-invoking only themes not-yet-themed elements, so it's safe to call
-  again as the subtree grows.
-- Overrides are inline `!important`; use `ignore` for elements that must keep their
-  own colors (a stylesheet rule can't override an inline `!important`).
-- Cross-origin images need CORS to be analyzed; otherwise they're left untouched.
+  verbatim inside a CSS `@scope (root)` block, so that they apply only within the
+  themed subtree. A computed-style snapshot can't see them, because the state
+  isn't active at theme time. Rules declared only in cross-origin stylesheets are
+  missed, the same CORS limit.
+- Colors apply synchronously. Image analysis is asynchronous and resolves shortly
+  after.
+- Calling `applyDarkTheme` again themes only the elements not yet themed, so it's
+  safe to call as the subtree grows.
+- Overrides are inline `!important`. Use `ignore` for elements that must keep
+  their own colors, because a stylesheet rule can't override an inline
+  `!important`.
+- Cross-origin images need CORS to be analyzed, and are otherwise left untouched.

--- a/packages/dark-theme/index.ts
+++ b/packages/dark-theme/index.ts
@@ -48,40 +48,40 @@ type ColorSnapshot = {
 };
 
 export type DarkThemeOptions = Partial<Theme> & {
-  // Opt elements out of theming. A string selector keeps its matching elements and
-  // their descendants (via closest) fully original — e.g. coloured chips or badges. An
-  // object skips only the listed properties on elements matching its selector (via
-  // matches), leaving those to CSS — e.g. a border colour set in a stylesheet, which the
-  // engine's inline override would otherwise win over.
+  // Opts elements out of theming. A string selector keeps its matching elements and
+  // their descendants fully original, matched with closest — colored chips or badges,
+  // for example. An object skips only the listed properties on elements matching its
+  // selector, matched with matches, and leaves those properties to CSS — a border color
+  // set in a stylesheet, which the engine's inline override would otherwise win over.
   ignore?: Array<string | IgnorePropertyRule>;
-  // Watch the subtree and keep theming content added later, and re-theme an
-  // element when its class or aria state changes so state-driven styles (a
-  // scroll shadow, an icon that swaps on toggle) are re-evaluated. Defaults to
-  // true; when enabled, call the returned controller's revert() to disconnect.
+  // Watches the subtree and keeps theming content added later, and re-themes an
+  // element when its class or aria state changes, so that state-driven styles are
+  // re-evaluated — a scroll shadow, or an icon that swaps on toggle. Defaults to
+  // true. When enabled, call the returned controller's revert() to disconnect.
   observe?: boolean;
   // CSS injected into the document while the theme is active and removed on
-  // revert()/destroy(). Use for rules the inline-override engine can't reach —
-  // e.g. :hover backgrounds or ::before icons — scoped with [data-dark-theme].
+  // revert() or destroy(). Use it for rules the inline-override engine can't reach,
+  // such as :hover backgrounds or ::before icons, scoped with [data-dark-theme].
   css?: string;
-  // URL prefixes of dark monochrome icons (element background-images, or a
-  // pseudo-element's content/background-image) to blank-invert with
-  // `filter: invert(1)`. A pragmatic substitute for pixel analysis when the icon
-  // is cross-origin (CORS-tainted) and so can't be inspected — e.g. a site's
-  // material-icon CDN path. Matched by `startsWith`.
+  // URL prefixes of dark monochrome icons to blank-invert with `filter: invert(1)`,
+  // covering element background-images and a pseudo-element's content or
+  // background-image. It's a pragmatic substitute for pixel analysis when the icon is
+  // cross-origin, and therefore CORS-tainted and impossible to inspect — a site's
+  // material-icon CDN path, for example. Matched with `startsWith`.
   invertImageUrls?: string[];
-  // Filenames (the last path segment of the url) that `invertImageUrls` should
-  // skip even when their prefix matches — e.g. a coloured icon variant sharing the
-  // same CDN path as the monochrome ones, which inverting would wrongly recolour.
+  // Filenames, meaning the last path segment of the URL, that `invertImageUrls` skips
+  // even when their prefix matches. Use it for a colored icon variant that shares a CDN
+  // path with the monochrome ones, which inverting would recolor wrongly.
   invertImageExcludeFilenames?: string[];
 };
 
 export type DarkThemeController = {
-  // Undo theming on a still-live subtree: restore every element's original inline
-  // styles.
+  // Undoes theming on a still-live subtree by restoring every element's original
+  // inline styles.
   revert: () => void;
-  // Tear down without restoring styles: disconnect the observer and release
-  // references. Use when the themed subtree is being discarded (e.g. removed from
-  // the DOM), where restoring inline styles would be wasted work.
+  // Tears down without restoring styles, disconnecting the observer and releasing
+  // references. Use it when the themed subtree is being discarded, for example by
+  // removing it from the DOM, where restoring inline styles would be wasted work.
   destroy: () => void;
 };
 


### PR DESCRIPTION
First of several PRs applying the new `writing-style` and `ui-writing` skills across the repo, one surface per PR. This one covers prose a reader outside the code sees: the two READMEs and the metadata that ships with the app.

## What changed

**Root README.** Two changes only, at your request: alt text on the logo and the screenshot, and the ampersand in the download link written out as a serial comma. Everything else — tagline, description, headings, contributors line, disclaimer — is untouched.

**`packages/dark-theme/README.md`.** Americanized spelling, `e.g.` replaced with "for example", semicolons split into sentences, and the option and controller bullets converted from dash-separated to colon-separated description lists — `writing-style` forbids a dash between a term and its description.

**`packages/dark-theme/index.ts`.** The `DarkThemeOptions` and `DarkThemeController` comments duplicate the README's bullets word for word. They move in this PR so the two don't drift until the comment pass lands.

**Package metadata.** `description`, `linux.synopsis`, and `linux.description` are unchanged. `build/installer.nsh` set `ApplicationDescription` to `Meru` — the name repeated — which is what Windows shows in Default Apps; it now carries the existing `linux.synopsis` string instead.

## Two fixes that aren't copy

- `NSMicrophoneUsageDescription` said "Meru needs access to your **camera**". That string is what macOS shows in the microphone permission prompt. Both purpose strings are also rewritten to the HIG form: a complete sentence saying how and why.
- The nine workspace packages have no `description` field. Left alone — they're private and don't need one.

## Not verified

The macOS permission prompts and the Windows Default Apps entry can't be triggered from this environment; both strings are data read by the OS at install and first use.

## Test plan

1. `bun run types`, `bun run lint`, `bun run fmt:check`, `bun test` — all pass.
2. Open the repo page on GitHub and check the README header renders with the screenshot and both alt texts in place.
3. `grep -rn "colour\|e\.g\." packages/dark-theme` returns nothing.


