### PR TITLE
apply the writing style guide to CLAUDE.md and the skills

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -3,17 +3,17 @@ name: release-notes
 description: Write release notes for Meru. Use when drafting or updating GitHub Release notes, changelogs, or "what changed" summaries for a release.
 ---
 
-# Release Notes
+# Release notes
 
-## Gathering the changes
+## Gather the changes
 
-- The release being written is the one the version commit at `HEAD` bumps to — a commit whose subject is the bare version number, matching `version` in `package.json` (e.g. `3.58.0`, tagged `v3.58.0`). The range runs from the previous release's tag to that commit; `gh release list -L 2` gives both tags.
+- The release being written is the one the version commit at `HEAD` bumps to — a commit whose subject is the bare version number, matching `version` in `package.json`, such as `3.58.0`, tagged `v3.58.0`. The range runs from the previous release's tag to that commit, and `gh release list -L 2` gives both tags.
 - Triage the log before opening a single diff. Drop on the commit subject alone: comment and docs edits, refactors and extractions, `TODO.md` notes, tests, CI, and dependency bumps other than Electron. A release of 40 commits usually has around 10 user-facing ones.
-- For the commits that survive, `gh pr view <number>` is the fastest read — the PR body states what changed for the user, the commit subject often doesn't. Fall back to `git show` when there is no PR.
-- Don't trust a commit message's scope — verify the actual fix from the diff. Messages often name a single platform or quote a GitHub issue title (e.g. "fix window position resetting after Windows reboot") when the underlying bug affects every platform. Only scope a note to a platform with `**macOS:**`/`**Windows:**` when the code confirms the fix is platform-specific.
+- For the commits that survive, `gh pr view <number>` is the fastest read — the PR body states what changed for the user, and the commit subject often doesn't. Fall back to `git show` when there's no PR.
+- Don't trust a commit message's scope — verify the actual fix from the diff. Messages often name a single platform or quote a GitHub issue title, such as "fix window position resetting after Windows reboot", when the underlying bug affects every platform. Only scope a note to a platform with `**macOS:**` or `**Windows:**` when the code confirms the fix is platform-specific.
 - Describe the end state at the tag, not the journey. A feature that landed and was then renamed, redesigned, or extended over several commits in the same release gets one bullet describing how it works now.
 - Drop fixes to code newly introduced in the same release — a bug that only existed between merge and tag is invisible to users upgrading from the previous public release.
-- Skip changes that aren't user-observable given existing constraints (e.g. don't mention gating a feature behind Pro if free-tier limits already made it inaccessible).
+- Skip changes that aren't user-observable given the constraints already in place. Don't mention gating a feature behind Pro, for example, if free-tier limits already put it out of reach.
 
 ## Structure
 
@@ -21,12 +21,12 @@ description: Write release notes for Meru. Use when drafting or updating GitHub 
 - Classify each change correctly:
   - `Added` — new feature or capability
   - `Changed` — intentional change to existing behavior, rename, or default
-  - `Fixed` — resolves a bug or unintended behavior (e.g. windows stacking awkwardly)
-- `## Internal Changes` is essentially only for Electron upgrades — bumping Electron pulls in a new Chromium, which carries performance and security improvements users benefit from. Other dependency, CI, or tooling upgrades (e.g. TypeScript, dnd-kit, electron-builder, build config, `CLAUDE.md`) are not user-observable, so omit them; if Electron wasn't upgraded, there's no `## Internal Changes` section at all.
-- Group related bullets next to each other (e.g. all Workspace Apps changes together).
-- Use sub-bullets for details: options list, defaults, keyboard shortcuts, behavior nuances. Always state the default for new options.
+  - `Fixed` — resolves a bug or unintended behavior, such as windows stacking awkwardly
+- `## Internal Changes` is for Electron upgrades and little else — bumping Electron pulls in a new Chromium, which carries performance and security improvements users benefit from. Other dependency, CI, or tooling upgrades aren't user-observable, so omit them: TypeScript, dnd-kit, electron-builder, build config, and `CLAUDE.md` all fall here. If Electron wasn't upgraded, there's no `## Internal Changes` section at all.
+- Group related bullets next to each other, keeping all the Workspace Apps changes together, for example.
+- Use sub-bullets for details: options list, defaults, keyboard shortcuts, and behavior nuances. Always state the default for new options.
 
-## Writing
+## Write the notes
 
 - Write user-facing, not commit-facing. Describe what changed for the user, not the commit history or implementation. Merge multiple commits for one feature into a single bullet.
 - Lead with outcome, not mechanism. "New windows no longer stack on top of each other" beats "Added cascading window positioning". Avoid internal jargon like "patch-burst" or "debounce".
@@ -35,17 +35,17 @@ description: Write release notes for Meru. Use when drafting or updating GitHub 
 - When reverting or removing a previously released feature, include the reason inline so users who relied on it understand the change.
 - Prefix Pro-only features with `**Meru Pro:**`.
 - Reference settings paths in backticks, with an ellipsis character rather than three dots: `` `Settings… → Section → Option` ``.
-- Wrap keyboard shortcuts in `<kbd>` tags and write them per platform: `<kbd>Cmd</kbd>+<kbd>F</kbd> on macOS, <kbd>Ctrl</kbd>+<kbd>F</kbd> on Windows/Linux`.
+- Wrap keyboard shortcuts in `<kbd>` tags and write them per platform: `<kbd>Cmd</kbd>+<kbd>F</kbd> on macOS, <kbd>Ctrl</kbd>+<kbd>F</kbd> on Windows and Linux`.
 
 ## Review
 
-- Print the drafted notes in chat and ask the user whether anything should be added, removed or reworded before they go onto the release. Ask every time, including when folding changes into notes that already exist.
+- Print the drafted notes in chat and ask the user whether anything should be added, removed, or reworded before they go onto the release. Ask every time, including when folding changes into notes that already exist.
 - Apply the feedback, print the revised notes, and ask again. Only write once the user is happy with them.
 
 ## Output
 
-- Release notes live only on GitHub Releases — do not commit a `RELEASE_NOTES.md` or `CHANGELOG.md` file, and do not write the notes anywhere inside the repo. Match the style of recent published releases at https://github.com/zoidsh/meru/releases.
-- Write the finished notes onto the release for the version commit's tag: `gh release edit v<version> --notes-file <path>`, with the notes in a temporary file outside the repo. Pass a file rather than `--notes` so the markdown, backticks and `<kbd>` tags survive the shell.
+- Release notes live only on GitHub Releases — don't commit a `RELEASE_NOTES.md` or `CHANGELOG.md` file, and don't write the notes anywhere inside the repo. Match the style of recent published releases at https://github.com/zoidsh/meru/releases.
+- Write the finished notes onto the release for the version commit's tag: `gh release edit v<version> --notes-file <path>`, with the notes in a temporary file outside the repo. Pass a file rather than `--notes` so the markdown, backticks, and `<kbd>` tags survive the shell.
 - Read the current body first with `gh release view v<version> --json body -q .body`. When the release already has notes, fold the changes into them — editing replaces the body wholesale, so always pass the complete set of notes, never just the new bullets.
-- If no release exists for the tag yet, stop and ask — creating one triggers the build-and-publish workflow, which is not this skill's job.
+- If no release exists for the tag yet, stop and ask — creating one triggers the build-and-publish workflow, which isn't this skill's job.
 - Share the release URL after writing.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: [major|minor|patch|beta]
 
 # Release
 
-The version commit goes straight onto `main` — no branch, no PR. Publishing the release fires `.github/workflows/release.yml`, which reruns CI and builds and uploads the macOS, Windows and Linux artifacts, so a release is only cut off a `main` that already passes CI.
+The version commit goes straight onto `main` — no branch, no PR. Publishing the release fires `.github/workflows/release.yml`, which reruns CI and builds and uploads the macOS, Windows, and Linux artifacts, so a release is only cut off a `main` that already passes CI.
 
 ## Preconditions
 
@@ -16,48 +16,48 @@ Check all of these first. If one fails, report it and stop — never work around
 - The last `main` workflow run is for the current `HEAD` and passed: `gh run list --workflow=main.yml --branch=main -L 1 --json headSha,status,conclusion,url`.
   - `headSha` must equal `git rev-parse HEAD`. A `HEAD` with no run yet, or a run still `in_progress`, means waiting — say which and ask whether to wait for it.
   - Any `conclusion` other than `success` means `main` is broken. Report the run URL and stop.
-- There is something to release: the range from the last release's tag to `HEAD` is non-empty. For a stable release that's the last stable tag (`gh release list --exclude-pre-releases -L 1`); for a beta it's the last release of any kind (`gh release list -L 1`).
+- There is something to release: the range from the last release's tag to `HEAD` is non-empty. For a stable release that's the last stable tag, from `gh release list --exclude-pre-releases -L 1`. For a beta it's the last release of any kind, from `gh release list -L 1`.
 
-## Choosing the bump
+## Choose the bump
 
 Read `git log --oneline <lastTag>..HEAD` — a release usually runs to a few dozen commits. Triage on subjects; open `gh pr view <number>` only for the few whose subject doesn't reveal whether users see the change.
 
-- **patch** — the range holds nothing but fixes, refactors, docs, tests, CI and dependency bumps. Also the answer when the only user-facing changes fix something already released (`3.56.1`, `3.56.2`, `3.56.3` were all this).
+- **patch** — the range holds nothing but fixes, refactors, docs, tests, CI, and dependency bumps. Also the answer when the only user-facing changes fix something already released (`3.56.1`, `3.56.2`, `3.56.3` were all this).
 - **minor** — anything users gain or notice: a new feature, a new setting, a renamed or changed default, an Electron upgrade. This is the usual answer.
-- **major** — never propose one unprompted. It is for breaking changes (a config migration that drops data, dropping an OS). If the range looks like it contains one, say so and let the user decide.
+- **major** — never propose one unprompted. It's for breaking changes, such as a config migration that drops data or dropping an OS. If the range looks like it contains one, say so and let the user decide.
 
 Arguments naming a level or an explicit version override this triage — take them, and still confirm.
 
 ## Beta releases
 
-A `beta` argument (or an explicit `-beta.N` version) cuts a pre-release for the beta update channel instead of a stable release. Only cut one when asked — never propose a beta unprompted.
+A `beta` argument, or an explicit `-beta.N` version, cuts a pre-release for the beta update channel instead of a stable release. Only cut one when asked — never propose a beta unprompted.
 
-- The version is the next stable version per the triage above with `-beta.N` appended: the first beta of a cycle is `X.Y.Z-beta.1`, each further beta before that stable ships increments `N`.
+- The version is the next stable version per the triage above with `-beta.N` appended: the first beta of a cycle is `X.Y.Z-beta.1`. Each further beta before that stable ships increments `N`.
 - Everything else follows the stable flow, with two differences: `gh release create` gets `--prerelease`, and the triage range runs from the last release of any kind, not the last stable.
-- Promoting a beta to stable is just the normal stable flow with the suffix dropped (`3.60.0-beta.2` → `3.60.0`); beta users are moved onto the stable build automatically.
+- Promoting a beta to stable is the normal stable flow with the suffix dropped, as in `3.60.0-beta.2` → `3.60.0`. Beta users are moved onto the stable build automatically.
 
-## Confirming
+## Confirm the bump
 
 Always confirm before editing `package.json`, even when the bump is obvious.
 
 - Show the current version, the proposed version and its level, the number of commits in the range, and the handful of user-facing commits that drive the choice — not the whole log.
 - Wait for an explicit yes. If the user names a different level or version instead, take it without re-arguing.
 
-## Committing the bump
+## Commit the bump
 
 - Edit `version` in the root `package.json` and nothing else — workspace packages stay at `0.0.0`, and `bun.lock` doesn't record the version.
-- Don't reach for `npm version` or `bun pm version`; they commit and tag on their own terms.
+- Don't reach for `npm version` or `bun pm version`, because they commit and tag on their own terms.
 - Commit that one file with the bare version as the subject — no prefix, no body: `git commit -m "3.59.0"`.
 - `git push`.
 
-## Creating the release
+## Create the release
 
 - `gh release create v<version> --target "$(git rev-parse HEAD)" --notes ""`.
   - `--target` pins the tag to the version commit rather than wherever `main` has drifted to.
-  - For a beta, add `--prerelease` — it keeps the release off `/releases/latest` (so stable users never see it) and makes `release.yml` publish `beta*.yml` update metadata instead of `latest*.yml`.
-  - No `--title`: every prior release leaves the title empty so GitHub shows the tag.
+  - For a beta, add `--prerelease`. It keeps the release off `/releases/latest`, so stable users never see it, and it makes `release.yml` publish `beta*.yml` update metadata instead of `latest*.yml`.
+  - Pass no `--title`. Every prior release leaves the title empty, so GitHub shows the tag.
   - Empty notes are deliberate — the next step writes them. Don't pass `--generate-notes`.
-- Never create it as a draft. `release.yml` triggers on `released`/`prereleased` only, so a draft never builds.
+- Never create it as a draft. `release.yml` triggers on `released` or `prereleased` only, so a draft never builds.
 
 ## Notes and reporting
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Meru – Claude Code Guidelines
+# Meru Claude Code guidelines
 
 ## Setup
 
@@ -16,39 +16,39 @@ bun run fmt:check  # oxfmt check; `bun run fmt` writes
 bun test           # tests across every package
 ```
 
-- `bun run types`, `bun run lint` and `bun run fmt:check` must pass before pushing.
+- `bun run types`, `bun run lint`, and `bun run fmt:check` must pass before pushing.
 
 ## Docs
 
-- `docs/` is a separately cloned private docs repo, gitignored here; it may be absent on fresh checkouts. When present, read `docs/README.md` for what lives where.
+- `docs/` is a separately cloned private docs repo, gitignored here, and it might be absent on fresh checkouts. When it's present, read `docs/README.md` for what lives where.
 - Check `docs/decisions.md` before reopening a settled design decision.
-- Keep `docs/architecture/` current when changing the app's structure; larger features start as a design doc in `docs/features/` before implementation.
+- Keep `docs/architecture/` current when changing the app's structure. Larger features start as a design doc in `docs/features/` before implementation.
 - When renaming a main-process class or file, grep `docs/` for the old name and fix every reference — the docs repo has no other mechanism to catch renames.
 
 ## Dependencies
 
-- Always install packages as dev dependencies with `bun add -d <package>`. Rolldown/Vite bundle everything at build time, and Electron builder re-bundles anything in `dependencies` into the shipped app, so normal deps would ship duplicated. The only exception is packages with native modules that Electron needs to load at runtime — those must go in `dependencies` so electron-builder can package them correctly.
+- Always install packages as dev dependencies with `bun add -d <package>`. Rolldown and Vite bundle everything at build time, and Electron builder re-bundles anything in `dependencies` into the shipped app, so normal deps would ship duplicated. The only exception is packages with native modules that Electron needs to load at runtime — those must go in `dependencies` so electron-builder can package them correctly.
 
-## UI Components
+## UI components
 
-- Components in `packages/ui` follow shadcn conventions. Many are compound components with named sub-components (e.g. `Item` → `ItemContent`, `ItemActions`, `ItemTitle`, `ItemDescription`). Always read the component file before use to find available sub-components and use them instead of plain `<div>` wrappers.
+- Components in `packages/ui` follow shadcn conventions. Many are compound components with named sub-components — `Item` → `ItemContent`, `ItemActions`, `ItemTitle`, `ItemDescription`, for example. Always read the component file before use to find available sub-components and use them instead of plain `<div>` wrappers.
 - Never repeat shared classes across the branches of a conditional `className`. Hoist them and merge with the `cn` helper (`@meru/ui/lib/utils`): `cn("absolute hidden", isWide ? "size-5" : "size-4")`.
-- Consider the platform when showing platform-specific information (modifier keys, OS names): branch on the existing `platform` helper — `@/lib/utils` in the renderer, `@electron-toolkit/utils` in the main process — e.g. `platform.isMacOS ? "Cmd" : "Ctrl"`.
+- Consider the platform when showing platform-specific information such as modifier keys and OS names. Branch on the existing `platform` helper — `@/lib/utils` in the renderer, `@electron-toolkit/utils` in the main process — as in `platform.isMacOS ? "Cmd" : "Ctrl"`.
 - Render keyboard keys in user-facing text with the `Kbd` component (`@meru/ui/components/kbd`), not as plain text: `Hold <Kbd>Shift</Kbd> to …`.
-- Child `WebContentsView`s always paint above the main window's HTML, so renderer-drawn overlays (dropdowns, tooltips, dialogs) get covered wherever a view sits. Keep overlays inside the regions the renderer owns (titlebar, vertical tabs) — e.g. vertical tabs menus open with `side="top"` at anchor width. For overlays over view content, use a native `Menu.popup` or a dedicated `WebContentsView` (see `Popup` in `packages/app/lib/popup.ts`).
+- Child `WebContentsView`s always paint above the main window's HTML, so renderer-drawn overlays such as dropdowns, tooltips, and dialogs get covered wherever a view sits. Keep overlays inside the regions the renderer owns, meaning the titlebar and the vertical tabs — vertical tabs menus open with `side="top"` at anchor width, for example. For overlays over view content, use a native `Menu.popup` or a dedicated `WebContentsView`. See `Popup` in `packages/app/lib/popup.ts`.
 
-## Settings UI Patterns
+## Settings UI patterns
 
-- Structure settings fields as: `Field` > `FieldLabel` + `FieldDescription` + control component.
-- Render config-backed fields with the existing wrapper components rather than hand-rolling `Field` + control: `ConfigSwitchField` for a boolean key, `ConfigSelectField` for a string-union key (both in `packages/renderer/components/`). Each enforces its key's type at runtime, so the value type dictates the component — a fixed set of named choices should be modeled as a string union + `ConfigSelectField`, not a boolean + switch.
+- Structure settings fields like this: `Field` > `FieldLabel` + `FieldDescription` + control component.
+- Render config-backed fields with the existing wrapper components rather than hand-rolling `Field` + control: `ConfigSwitchField` for a boolean key, `ConfigSelectField` for a string-union key, both in `packages/renderer/components/`. Each enforces its key's type at runtime, so the value type dictates the component — a fixed set of named choices must be modeled as a string union with `ConfigSelectField`, not a boolean with a switch.
 - In a `ConfigSelectField`, list the option matching the config default first in `items`.
-- Access config via `useConfig()` and persist changes via `useConfigMutation()`.
+- Read the config with `useConfig()` and persist changes with `useConfigMutation()`.
 - Use `toast.error()` for validation errors — never throw or console.error for user-facing feedback.
 
-## Config Keys
+## Config keys
 
-- Follow the existing `"section.camelCase"` dot-notation pattern (e.g. `"notifications.times"`).
-- When combining a global config check with more specific conditions (e.g. per-account flags, counts, or local state), always check the global setting first so it short-circuits the rest:
+- Follow the existing `"section.camelCase"` dot-notation pattern, as in `"notifications.times"`.
+- When combining a global config check with more specific conditions such as per-account flags, counts, or local state, always check the global setting first so that it short-circuits the rest:
 
   ```ts
   // correct
@@ -58,15 +58,15 @@ bun test           # tests across every package
   if (accounts.length > 1 && config.get("unifiedInbox.enabled")) { ... }
   ```
 
-## Config Change Listeners
+## Config change listeners
 
-- Register a `config.onDidChange("some.key", ...)` listener once at the manager/collection level (e.g. in `Accounts.init`) and iterate over instances inside the handler. Never register one listener per view/instance — that creates N duplicate listeners for the same key. See the `spellchecker.languages` listener in `packages/app/accounts.ts`.
+- Register a `config.onDidChange("some.key", ...)` listener once at the manager or collection level, as in `Accounts.init`, and iterate over instances inside the handler. Never register one listener per view or instance — that creates N duplicate listeners for the same key. See the `spellchecker.languages` listener in `packages/app/accounts.ts`.
 
-## Shared Utilities
+## Shared utilities
 
-- For time/duration values, import `ms` from `@meru/shared/ms` — do not install or import the `ms` npm package. Example: `import { ms } from "@meru/shared/ms"; const delay = ms("1d");`
+- For time and duration values, import `ms` from `@meru/shared/ms` — don't install or import the `ms` npm package. Example: `import { ms } from "@meru/shared/ms"; const delay = ms("1d");`
 
-## Scope and Review Bandwidth
+## Scope and review bandwidth
 
-- When the full feature spans several concerns (e.g. IPC wiring, UI, state broadcasting), land the plumbing first, then each consumer in its own turn. Track the follow-ups in the conversation, the PR description, or the feature's doc in `docs/features/` so they aren't lost.
-- Open items to pick up in a **new session** — work unrelated enough to the current feature's goal that it shouldn't ride along with it — go to `docs/todo.md`: short entries linking into `docs/` for context. It is not a backlog for the in-progress feature, and it holds no knowledge: settled decisions go to `docs/decisions.md`, feature roadmaps and handoffs to `docs/features/`.
+- When the full feature spans several concerns such as IPC wiring, UI, and state broadcasting, land the plumbing first, then each consumer in its own turn. Track the follow-ups in the conversation, the PR description, or the feature's doc in `docs/features/` so they aren't lost.
+- Open items to pick up in a **new session** — work unrelated enough to the current feature's goal that it shouldn't ride along with it — go to `docs/todo.md`, as short entries linking into `docs/` for context. It isn't a backlog for the in-progress feature, and it holds no knowledge: settled decisions go to `docs/decisions.md`, and feature roadmaps and handoffs to `docs/features/`.


### PR DESCRIPTION
Second of the writing-pass PRs. Independent of #868 — the file sets don't overlap, so the two can land in either order.

Covers the prose in the repo that steers agent sessions: `CLAUDE.md` and the two skills under `.claude/skills/`.

## What changed

Wording only. Every instruction keeps its exact meaning: these files are read as rules, so a reworded rule would be a changed rule. The edits are the mechanical half of `writing-style`:

- Sentence case on headings, and bare infinitives on the task ones — "Choose the bump" rather than "Choosing the bump".
- Serial commas, contractions, and "for example" or "such as" in place of `e.g.`
- Semicolons and comma splices split into sentences.
- Slashes written out: `released`/`prereleased` → `released` or `prereleased`, `Windows/Linux` → Windows and Linux.
- Parentheses opened up where they held something the reader needs.
- `via` → `with`, and `access the config` → `read the config`.
- The `–` in the `CLAUDE.md` title was an en dash, which the guide rules out.

One wording change worth a second look: `## Internal Changes is essentially only for Electron upgrades` became `is for Electron upgrades and little else`. "Essentially only" was hedging in two directions at once; the replacement keeps the hedge but says it once.

## Test plan

1. `bun run types`, `bun run lint`, `bun run fmt:check`, `bun test` — all pass.
2. Read the `CLAUDE.md` diff for meaning drift, particularly the Settings UI Patterns bullet where "should be modeled as" became "must be modeled as" — the surrounding text reads as a rule, so `should` was the wrong strength, but that's a judgment call.
3. Run `/release --help`-style dry read of `.claude/skills/release/SKILL.md` and confirm the precondition and bump-choice steps still say what they said.
