### PR TITLE
apply the UI writing guide to the settings pages

### DIFF
--- a/packages/renderer/routes/settings/about.tsx
+++ b/packages/renderer/routes/settings/about.tsx
@@ -66,11 +66,11 @@ function ExportLogsField() {
     mutationFn: () => ipc.main.invoke("about.exportLogs"),
     onSuccess: ({ canceled }) => {
       if (!canceled) {
-        toast("Logs exported successfully");
+        toast("Logs exported");
       }
     },
     onError: () => {
-      toast.error("Failed to export logs");
+      toast.error("Couldn't export the logs.");
     },
   });
 
@@ -78,7 +78,7 @@ function ExportLogsField() {
     <Field>
       <FieldLabel>Logs</FieldLabel>
       <FieldDescription>
-        Export application logs to a file to help diagnose issues or share with support.
+        Export the application logs to a file, to diagnose a problem or to share with support.
       </FieldDescription>
       <div>
         <Button

--- a/packages/renderer/routes/settings/accounts.tsx
+++ b/packages/renderer/routes/settings/accounts.tsx
@@ -88,7 +88,7 @@ function AccountForm({
                       <SelectValue>
                         {(value: keyof typeof accountColorsMap | null) => {
                           if (!value) {
-                            return "Optional";
+                            return "None";
                           }
 
                           const { label, className } = accountColorsMap[value];
@@ -339,7 +339,7 @@ function SortableAccountItem({
             className="size-8 p-0"
             variant="outline"
             onClick={() => {
-              const confirmed = window.confirm(`Are you sure you want to remove ${account.label}?`);
+              const confirmed = window.confirm(`Remove ${account.label}?`);
 
               if (confirmed) {
                 ipc.main.send("accounts.removeAccount", account.id);

--- a/packages/renderer/routes/settings/advanced.tsx
+++ b/packages/renderer/routes/settings/advanced.tsx
@@ -33,14 +33,14 @@ export function AdvancedSettings() {
             <FieldGroup>
               <ConfigSwitchField
                 label="Hardware Acceleration"
-                description="Enabling hardware acceleration can improve performance but can also cause compatibility issues on some systems."
+                description="Render with the GPU. This can improve performance, and can also cause compatibility problems on some systems."
                 configKey="app.hardwareAcceleration"
                 restartRequired
               />
               {platform.isMacOS && (
                 <ConfigSwitchField
                   label="Use Custom User Agent"
-                  description="Some Gmail or Workspace app features may not work with the default user agent. Enabling this option will use a custom user agent and may help resolve issues, but can also cause others. Disable this option if you experience instability."
+                  description="Send a custom user agent, for the Gmail and Workspace Apps features that don't work with the default one. It resolves some problems and can cause others, so turn it off if the app becomes unstable."
                   configKey="customUserAgent"
                   restartRequired
                 />

--- a/packages/renderer/routes/settings/appearance.tsx
+++ b/packages/renderer/routes/settings/appearance.tsx
@@ -45,7 +45,7 @@ export function AppearanceSettings() {
   const renderPlatformIconSettings = () => {
     const selectAccountWithUnreadField = (
       <ConfigSwitchField
-        label="Select Account with Unread on Click"
+        label="Select First Unread Account on Click"
         description={`Automatically select the first account with unread emails when clicking the ${platform.isMacOS ? "menu bar" : "system tray"} icon.`}
         configKey="tray.selectAccountWithUnread"
         disabled={!config["tray.enabled"]}
@@ -163,7 +163,7 @@ export function AppearanceSettings() {
             <FieldLegend>Accounts</FieldLegend>
             <ConfigSwitchField
               label="Show Unread Badges"
-              description="Hide all unread badges if disabled regardless of individual account settings."
+              description="Show unread badges, following each account's own setting."
               configKey="accounts.unreadBadge"
               restartRequired
             />
@@ -175,7 +175,7 @@ export function AppearanceSettings() {
             <FieldLegend>Window</FieldLegend>
             <ConfigSwitchField
               label="Restrict Minimum Window Size"
-              description="Limit the minimum size of the application window to prevent it from being too small."
+              description="Stop the application window from being resized below a usable minimum."
               configKey="window.restrictMinimumSize"
             />
           </FieldSet>

--- a/packages/renderer/routes/settings/blocker.tsx
+++ b/packages/renderer/routes/settings/blocker.tsx
@@ -21,7 +21,7 @@ export function BlockerSettings() {
         <FieldGroup>
           <ConfigSwitchField
             label="Enable Blocker"
-            description="Use blocker to improve your privacy by blocking unwanted content and network requests."
+            description="Block unwanted content and network requests."
             configKey="blocker.enabled"
             licenseKeyRequired
             restartRequired
@@ -29,7 +29,7 @@ export function BlockerSettings() {
           <FieldSeparator />
           <ConfigSwitchField
             label="Block Ads"
-            description="Remove disruptive advertisements."
+            description="Block advertisements on the pages you open."
             configKey="blocker.ads"
             disabled={!config["blocker.enabled"]}
             licenseKeyRequired
@@ -37,7 +37,7 @@ export function BlockerSettings() {
           />
           <ConfigSwitchField
             label="Block Trackers"
-            description="Enhance your privacy."
+            description="Block the scripts that follow you from site to site."
             configKey="blocker.tracking"
             disabled={!config["blocker.enabled"]}
             licenseKeyRequired

--- a/packages/renderer/routes/settings/downloads.tsx
+++ b/packages/renderer/routes/settings/downloads.tsx
@@ -31,21 +31,19 @@ export function DownloadsSettings() {
           <FieldLegend>General</FieldLegend>
           <ConfigSwitchField
             label="Show Save As Dialog Before Downloading"
-            description="Prompt for a location each time before a file is downloaded."
+            description="Ask where to save each file before it downloads."
             configKey="downloads.saveAs"
             restartRequired
           />
           <ConfigSwitchField
             label="Open Folder When Done"
-            description="Automatically open the folder containing the downloaded file when the download is complete."
+            description="Open the folder containing the file when a download finishes."
             configKey="downloads.openFolderWhenDone"
             restartRequired
           />
           <Field>
             <FieldLabel>Default Download Location</FieldLabel>
-            <FieldDescription>
-              This is the default location where downloaded files are saved.
-            </FieldDescription>
+            <FieldDescription>Where downloaded files are saved.</FieldDescription>
             <div className="flex gap-2">
               <Input value={config["downloads.location"]} readOnly />
               <Button
@@ -58,7 +56,7 @@ export function DownloadsSettings() {
                   }
                 }}
               >
-                Change
+                Change…
               </Button>
             </div>
           </Field>

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -86,7 +86,7 @@ function OnePasswordSetupSteps() {
       <li>
         {platform.isMacOS
           ? "Choose Meru in the Applications folder."
-          : "Choose Meru in the C:\\Program Files folder."}
+          : "Choose Meru in C:\\Program Files."}
       </li>
       <li>Restart Meru.</li>
     </>
@@ -107,8 +107,8 @@ function OnePasswordSetupDialog({
           <DialogTitle>Connect 1Password</DialogTitle>
         </DialogHeader>
         <DialogDescription>
-          Filling passwords and passkeys needs the 1Password desktop app — Meru stores no vault data
-          of its own. Trust Meru in 1Password's settings to connect them.
+          Filling passwords and passkeys needs the 1Password desktop app, because Meru stores no
+          vault data of its own. Trust Meru in 1Password's settings to connect the two.
         </DialogDescription>
         <ol className="ml-4 list-decimal space-y-2 marker:text-muted-foreground">
           <OnePasswordSetupSteps />
@@ -198,7 +198,7 @@ function ExtensionItem({
                 setIsSetupDialogOpen(true);
               }}
             >
-              Set up desktop app
+              Set Up Desktop App
             </Button>
           )}
         </ItemContent>
@@ -229,8 +229,8 @@ function PasskeysAlert() {
         <AlertTitle>Meru can sign you in with a Touch ID passkey</AlertTitle>
         <AlertDescription>
           Add a passkey to your Google account from its security settings inside Meru and sign in
-          with Touch ID — lighter than running an extension. Existing iCloud passkeys can't be used,
-          and filling passwords still needs a password manager.
+          with Touch ID — lighter than running an extension. iCloud passkeys don't work here, and
+          filling passwords still needs a password manager.
         </AlertDescription>
       </Alert>
     );
@@ -290,7 +290,7 @@ function UpdateExtensionsButton() {
             break;
           }
           case "failed": {
-            toast.error(`Failed to update ${name}: ${result.error}`);
+            toast.error(`Couldn't update ${name}: ${result.error}`);
 
             break;
           }

--- a/packages/renderer/routes/settings/general.tsx
+++ b/packages/renderer/routes/settings/general.tsx
@@ -50,7 +50,7 @@ function LaunchAtLoginField() {
       <FieldContent>
         <FieldLabel htmlFor={fieldId}>Launch at Login</FieldLabel>
         <FieldDescription>
-          Enable this option to automatically start the application when you log into your computer.
+          Start the application automatically when you log in to your computer.
         </FieldDescription>
       </FieldContent>
       <Switch
@@ -99,7 +99,7 @@ function DefaultMailClientField() {
         </FieldLabel>
         <FieldDescription>
           {isDefaultMailtoClient
-            ? "Meru is set as default mail client."
+            ? "Meru is set as the default mail client."
             : "Set Meru as the default mail client to handle email links and related protocols."}
         </FieldDescription>
       </FieldContent>
@@ -135,7 +135,7 @@ export function GeneralSettings() {
             <LaunchAtLoginField />
             <ConfigSwitchField
               label="Launch Minimized"
-              description="Enable this option to start the application in a minimized state."
+              description="Start the application minimized."
               configKey="launchMinimized"
             />
           </FieldSet>

--- a/packages/renderer/routes/settings/gmail/index.tsx
+++ b/packages/renderer/routes/settings/gmail/index.tsx
@@ -50,34 +50,34 @@ export function GmailSettings() {
             <FieldLegend>Appearance</FieldLegend>
             <ConfigSwitchField
               label="Hide Gmail Logo"
-              description="Hides the Gmail logo on the top left corner."
+              description="Hide the Gmail logo in the top left corner."
               configKey="gmail.hideGmailLogo"
               restartRequired
             />
             <ConfigSwitchField
-              label="Hide Out of Office Banner"
-              description="Hides the out of office banner at the top of the window."
+              label="Hide Out-of-Office Banner"
+              description="Hide the out-of-office banner at the top of the window."
               configKey="gmail.hideOutOfOfficeBanner"
               restartRequired
               licenseKeyRequired
             />
             <ConfigSwitchField
               label="Hide Promotional Banner"
-              description="Hides promotional banners at the top of the message list, such as the Google Workspace upgrade offer."
+              description="Hide the promotional banners at the top of the message list, such as the Google Workspace upgrade offer."
               configKey="gmail.hidePromoBanner"
               restartRequired
               licenseKeyRequired
             />
             <ConfigSwitchField
               label="Hide Upgrade Button"
-              description="Hides the Upgrade button in Gmail."
+              description="Hide the Upgrade button in Gmail."
               configKey="gmail.hideUpgradeButton"
               restartRequired
               licenseKeyRequired
             />
             <ConfigSwitchField
               label="Extend Dark Theme"
-              description="Extends Gmail's native dark theme to emails and the compose window. Requires Gmail's theme to be set to dark. This feature is in beta — if you run into any issues, please report them so it can be improved."
+              description="Extend Gmail's own dark theme to emails and the compose window. Gmail's theme has to be set to dark. The feature is in beta, so report anything it gets wrong."
               configKey="gmail.extendDarkTheme"
               restartRequired
               licenseKeyRequired
@@ -89,14 +89,14 @@ export function GmailSettings() {
             <FieldLegend>Compose</FieldLegend>
             <ConfigSwitchField
               label="Always Compose New Emails in New Window"
-              description="Opens a new window for composing emails instead of inside Gmail."
+              description="Open a new window to compose an email, instead of composing inside Gmail."
               configKey="gmail.openComposeInNewWindow"
               restartRequired
               licenseKeyRequired
             />
             <ConfigSwitchField
               label="Close Compose Window After Send"
-              description="Automatically closes the compose window after pressing the send button."
+              description="Close the compose window after you send."
               configKey="gmail.closeComposeWindowAfterSend"
               restartRequired
               licenseKeyRequired
@@ -107,21 +107,21 @@ export function GmailSettings() {
             <FieldLegend>Conversation</FieldLegend>
             <ConfigSwitchField
               label="Reverse Conversation"
-              description="Displays email conversations in reverse order, showing the latest message at the top."
+              description="Show email conversations in reverse order, with the latest message at the top."
               configKey="gmail.reverseConversation"
               restartRequired
               licenseKeyRequired
             />
             <ConfigSwitchField
               label="Move Attachments to Top"
-              description="Moves email attachments to the top of the email."
+              description="Move email attachments to the top of the email."
               configKey="gmail.moveAttachmentsToTop"
               restartRequired
               licenseKeyRequired
             />
             <ConfigSwitchField
-              label="Always Reply/Forward in Pop-Out"
-              description="Opens reply and forward in a pop-out instead of below the message."
+              label="Always Reply and Forward in a Pop-Out"
+              description="Open replies and forwards in a pop-out instead of below the message."
               configKey="gmail.replyForwardInPopOut"
               restartRequired
               licenseKeyRequired
@@ -132,7 +132,7 @@ export function GmailSettings() {
             <FieldLegend>Inbox</FieldLegend>
             <ConfigSwitchField
               label="Hide Inbox Footer"
-              description="Hides the footer at the bottom of the inbox."
+              description="Hide the footer at the bottom of the inbox."
               configKey="gmail.hideInboxFooter"
               restartRequired
             />
@@ -146,18 +146,18 @@ export function GmailSettings() {
             <ConfigSelectField
               configKey="gmail.unreadCountPreference"
               label="Unread Count Preference"
-              description="When using multiple inboxes, sets which sections contribute to the unread count shown on the app. Default combines all sections."
+              description="With multiple inboxes, choose which sections count toward the unread count shown in the app. The default combines every section."
               items={unreadCountPreferenceItems}
-              placeholder="Select unread count preference"
+              placeholder="Select preference"
               licenseKeyRequired
               restartRequired
             />
             <ConfigSelectField
               configKey="gmail.inboxCategoriesToMonitor"
               label="Categories to Monitor"
-              description="If using an inbox with categories, choose which inbox categories are monitored for new email notifications and included in the unified inbox."
+              description="With a categorized inbox, choose which categories are watched for new email notifications and included in the unified inbox."
               items={inboxCategoriesToMonitorItems}
-              placeholder="Select inbox categories to monitor"
+              placeholder="Select categories"
               licenseKeyRequired
               restartRequired
             />
@@ -180,8 +180,8 @@ export function GmailSettings() {
                   <LicenseKeyRequiredFieldBadge />
                 </FieldLabel>
                 <FieldDescription>
-                  Add your own custom CSS to further personalize the Gmail interface. A restart is
-                  required after making changes.
+                  Add your own CSS to personalize the Gmail interface further. Changes take effect
+                  after a restart.
                 </FieldDescription>
               </FieldContent>
               <div className="flex gap-2">

--- a/packages/renderer/routes/settings/gmail/label-colors.tsx
+++ b/packages/renderer/routes/settings/gmail/label-colors.tsx
@@ -33,7 +33,7 @@ import { useConfig, useConfigMutation } from "@/lib/react-query";
 const HEX_COLOR_REGEXP = /^#[0-9a-fA-F]{6}$/;
 
 const textColorItems: { value: GmailLabelTextColor; label: string }[] = [
-  { value: "auto", label: "Auto (contrast)" },
+  { value: "auto", label: "Auto" },
   { value: "white", label: "White" },
   { value: "black", label: "Black" },
 ];
@@ -222,8 +222,8 @@ export function GmailLabelColors() {
   return (
     <Field>
       <FieldDescription>
-        Recolor Gmail labels by their exact name. The text color defaults to automatic contrast
-        against the background, or can be forced to white or black.
+        Recolor Gmail labels by their exact name. The text color defaults to whatever contrasts with
+        the background, and can be set to white or black instead.
       </FieldDescription>
       {config["gmail.labelColors"].length > 0 && (
         <ItemGroup className="grid grid-cols-2 gap-2">
@@ -258,9 +258,7 @@ export function GmailLabelColors() {
                   className="size-8 p-0"
                   variant="outline"
                   onClick={() => {
-                    const confirmed = window.confirm(
-                      `Are you sure you want to delete the color for ${labelColor.label}?`,
-                    );
+                    const confirmed = window.confirm(`Delete the color for ${labelColor.label}?`);
 
                     if (confirmed) {
                       configMutation.mutate({

--- a/packages/renderer/routes/settings/license.tsx
+++ b/packages/renderer/routes/settings/license.tsx
@@ -103,7 +103,7 @@ function ActivateLicenseDialog({
           <DialogTitle>{variant === "activate" ? "Activate" : "Change"} License Key</DialogTitle>
         </DialogHeader>
         <DialogDescription>
-          Please enter the license key you received at your email address after your purchase.
+          Enter the license key sent to your email address after your purchase.
         </DialogDescription>
         <LicenseKeyForm
           onSubmit={async ({ licenseKey }) => {
@@ -163,7 +163,7 @@ export function LicenseSettings() {
 
       formApi.reset();
 
-      toast("Device label updated successfully");
+      toast("Device label updated");
     },
   });
 
@@ -176,8 +176,8 @@ export function LicenseSettings() {
       return (
         <div className="space-y-4">
           <div className="text-sm">
-            You're using Meru Pro with professional features and for commercial use. Thank you for
-            supporting Meru!
+            You're using Meru Pro, with the professional features and a license for commercial use.
+            Thank you for supporting Meru.
           </div>
           <div>
             <FieldGroup>
@@ -185,7 +185,7 @@ export function LicenseSettings() {
                 <FieldLabel>License Key</FieldLabel>
                 <div className="flex gap-2">
                   <Input
-                    placeholder="Click to reveal license key"
+                    placeholder="Click to reveal the license key"
                     value={isLicenseKeyRevealed ? config.licenseKey : ""}
                     onFocus={() => {
                       setIsLicenseKeyRevealed(true);
@@ -209,7 +209,7 @@ export function LicenseSettings() {
                           if (config.licenseKey) {
                             navigator.clipboard.writeText(config.licenseKey);
 
-                            toast("Copied license key to clipboard");
+                            toast("License key copied to clipboard");
                           }
                         }}
                       >

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -89,7 +89,7 @@ export function NotificationsSettings() {
     const slot = findFreeSlot(times);
 
     if (!slot) {
-      toast.error("No free time slot available to add a new window.");
+      toast.error("No free time slot left for another window. Remove or shorten one first.");
 
       return;
     }
@@ -103,7 +103,7 @@ export function NotificationsSettings() {
     const newTimes = times.map((time) => (time.id === id ? { ...time, [field]: value } : time));
 
     if (hasOverlap(newTimes)) {
-      toast.error("Notification times overlap. Please adjust the time windows.");
+      toast.error("Notification times overlap. Adjust the windows so that none of them do.");
 
       return;
     }
@@ -173,8 +173,9 @@ export function NotificationsSettings() {
                       {!isLicenseKeyValid && <Badge variant="secondary">Meru Pro Required</Badge>}
                     </FieldLabel>
                     <FieldDescription>
-                      Configure time windows when notifications are active. Outside these windows,
-                      notifications will be silenced. Leave empty to always allow notifications.
+                      Set the time windows when notifications are active. Outside them,
+                      notifications stay silent. Leave the list empty to allow notifications at any
+                      time.
                     </FieldDescription>
                     {times.map((time) => (
                       <Item key={time.id} variant="muted">
@@ -237,16 +238,14 @@ export function NotificationsSettings() {
                   <Field>
                     <FieldLabel>Test Notification</FieldLabel>
                     <FieldDescription>
-                      Show a test notification to see how notifications will appear.
+                      Show a test notification to see how notifications appear.
                     </FieldDescription>
                     <div>
                       <Button
                         variant="outline"
                         onClick={() => {
                           if (config["doNotDisturb.enabled"]) {
-                            toast.error(
-                              "Unable show test notification while Do Not Disturb is enabled.",
-                            );
+                            toast.error("Turn off Do Not Disturb to show a test notification.");
 
                             return;
                           }
@@ -268,7 +267,7 @@ export function NotificationsSettings() {
             <FieldGroup>
               <ConfigSwitchField
                 label="Show Notification"
-                description="Show a notification when a download is completed, cancelled or failed."
+                description="Show a notification when a download is completed, canceled, or failed."
                 configKey="notifications.downloadCompleted"
               />
               {config["notifications.downloadCompleted"] && (
@@ -290,8 +289,8 @@ export function NotificationsSettings() {
             <FieldLegend>Workspace Apps</FieldLegend>
             <FieldGroup>
               <ConfigSwitchField
-                label="Workspace Apps"
-                description="Allow notifications from Workspace Apps like Calendar, Meet, Chat, etc."
+                label="Show Notifications"
+                description="Show notifications from Workspace Apps such as Calendar, Meet, and Chat."
                 configKey="notifications.allowFromWorkspaceApps"
                 licenseKeyRequired
               />

--- a/packages/renderer/routes/settings/phishing-protection.tsx
+++ b/packages/renderer/routes/settings/phishing-protection.tsx
@@ -45,7 +45,9 @@ export function PhishingProtectionSettings() {
                 <FieldContent>
                   <FieldLabel>Trusted Hosts</FieldLabel>
                   {config["externalLinks.trustedHosts"].length === 0 && (
-                    <FieldDescription>No trusted hosts added.</FieldDescription>
+                    <FieldDescription>
+                      No trusted hosts yet. Choosing "Trust all links" in the link prompt adds one.
+                    </FieldDescription>
                   )}
                 </FieldContent>
                 {config["externalLinks.trustedHosts"].length > 0 && (

--- a/packages/renderer/routes/settings/saved-searches.tsx
+++ b/packages/renderer/routes/settings/saved-searches.tsx
@@ -229,9 +229,7 @@ function SortableSavedSearchItem({
           className="size-8 p-0"
           variant="outline"
           onClick={() => {
-            const confirmed = window.confirm(
-              `Are you sure you want to delete ${savedSearch.label}?`,
-            );
+            const confirmed = window.confirm(`Delete ${savedSearch.label}?`);
 
             if (confirmed) {
               onDelete();

--- a/packages/renderer/routes/settings/unified-inbox.tsx
+++ b/packages/renderer/routes/settings/unified-inbox.tsx
@@ -20,7 +20,7 @@ export function UnifiedInboxSettings() {
         <LicenseKeyRequiredBanner />
         <FieldGroup>
           <ConfigSwitchField
-            label="Enabled"
+            label="Enable Unified Inbox"
             description="Show all unread messages from every account in a single unified inbox."
             configKey="unifiedInbox.enabled"
             licenseKeyRequired

--- a/packages/renderer/routes/settings/updates.tsx
+++ b/packages/renderer/routes/settings/updates.tsx
@@ -17,8 +17,8 @@ export function UpdatesSettings() {
       <SettingsContent>
         <FieldGroup>
           <ConfigSwitchField
-            label="Check For Updates Automatically"
-            description="Automatically check for updates periodically."
+            label="Check for Updates Automatically"
+            description="Check for updates in the background."
             configKey="updates.autoCheck"
             restartRequired
           />
@@ -35,9 +35,9 @@ export function UpdatesSettings() {
             placeholder="Select channel"
             confirmation={{
               when: (value) => value === "beta",
-              title: "Switch to the beta channel?",
+              title: "Switch to the Beta Channel?",
               description:
-                "Beta releases are pre-release builds of upcoming versions. They may contain bugs or unfinished features. You can switch back to the stable channel at any time.",
+                "Beta releases are pre-release builds of upcoming versions. They might contain bugs or unfinished features. You can switch back to the stable channel at any time.",
               confirmLabel: "Switch to Beta",
             }}
           />

--- a/packages/renderer/routes/settings/verification-codes.tsx
+++ b/packages/renderer/routes/settings/verification-codes.tsx
@@ -26,31 +26,28 @@ export function VerificationCodesSettings() {
         <LicenseKeyRequiredBanner />
         <FieldGroup>
           <ConfigSwitchField
-            label="Automatically Copy Verification Code to Clipboard"
-            description="Verification code received via email will be automatically copied
-							to your clipboard for easy and instant pasting."
+            label="Copy Codes to Clipboard"
+            description="Copy a verification code to your clipboard as soon as it arrives by email."
             configKey="verificationCodes.autoCopy"
             licenseKeyRequired
           />
           <ConfigSelectField
             configKey="verificationCodes.confidence"
-            label="Verification Code Detection Confidence"
-            description="Choose the confidence level for detecting verification codes. Medium may result in false positives, while High checks for explicit keywords, but may miss some codes."
+            label="Detection Confidence"
+            description="Choose how certain Meru has to be before it treats something as a verification code. Medium can pick up codes that aren't there. High looks for explicit keywords and can miss some."
             items={verificationCodeConfidenceItems}
             placeholder="Select confidence"
             licenseKeyRequired
           />
           <ConfigSwitchField
-            label="Automatically Mark Email as Read After Copying Verification Code"
-            description="Email containing verification code will be automatically marked as read
-							after the code has been copied to your clipboard."
+            label="Mark Email as Read After Copying"
+            description="Mark the email as read once its verification code has been copied."
             configKey="verificationCodes.autoMarkAsRead"
             licenseKeyRequired
           />
           <ConfigSwitchField
-            label="Automatically Delete Email After Copying Verification Code"
-            description="Email containing verification code will be automatically deleted
-							after the code has been copied to your clipboard."
+            label="Delete Email After Copying"
+            description="Delete the email once its verification code has been copied."
             configKey="verificationCodes.autoDelete"
             licenseKeyRequired
           />

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -139,7 +139,7 @@ export function WorkspaceAppsSettings() {
         <FieldGroup>
           <ConfigSwitchField
             label="Open in App"
-            description="Open Workspace Apps in app instead of external browser."
+            description="Open Workspace Apps in the app instead of the external browser."
             configKey="workspaceApps.openInApp"
             licenseKeyRequired
             restartRequired
@@ -150,8 +150,8 @@ export function WorkspaceAppsSettings() {
                 label="Mode"
                 description={
                   <>
-                    How Workspace Apps open: as tabs in the main window (default), or each in its
-                    own window with no tab strip. In Tabs, hold{" "}
+                    How Workspace Apps open. Tabs, the default, opens them in the main window. New
+                    Windows gives each one its own window with no tab strip. In Tabs, hold{" "}
                     <Kbd>{platform.isMacOS ? "Cmd" : "Ctrl"}</Kbd> to open a background tab or{" "}
                     <Kbd>Shift</Kbd> to open a new window.
                   </>
@@ -169,11 +169,11 @@ export function WorkspaceAppsSettings() {
                   title: "Switch to New Windows?",
                   description: (
                     <>
-                      Workspace Apps will open in their own window from now on.
+                      Workspace Apps open in their own window from now on.
                       {hasOpenWorkspaceAppTabs &&
-                        " The tabs you already have open stay as they are, and the tab strip hides once you have closed them, or after a restart."}
+                        " The tabs you already have open stay as they are, and the tab strip hides after you close them, or after a restart."}
                       {hasLoadOnLaunchWorkspaceApps &&
-                        " Pinned apps set to load on launch will open as windows the next time you start Meru."}
+                        " Pinned apps set to load on launch open as windows the next time you start Meru."}
                     </>
                   ),
                   confirmLabel: "Switch to New Windows",
@@ -186,8 +186,7 @@ export function WorkspaceAppsSettings() {
                     {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
                   </FieldLabel>
                   <FieldDescription>
-                    Select which Workspace Apps should open in the external browser instead of the
-                    app.
+                    Select the Workspace Apps that open in the external browser instead of the app.
                   </FieldDescription>
                 </FieldContent>
                 <DropdownMenu>
@@ -239,7 +238,7 @@ export function WorkspaceAppsSettings() {
                 />
                 <ConfigSelectField
                   label="Width"
-                  description="How wide the vertical tabs sidebar is. Auto switches between narrow and wide automatically based on the open tabs. The button at the bottom of the sidebar switches between narrow and wide for that account until Meru quits, leaving this setting as it is. Right-click the sidebar and choose Reset Width to hand it back."
+                  description="How wide the vertical tabs sidebar is. Auto switches between narrow and wide based on the open tabs. The button at the bottom of the sidebar switches between narrow and wide for that account until Meru quits, leaving this setting as it is. Right-click the sidebar and choose Reset Width to hand it back."
                   configKey="verticalTabs.width"
                   placeholder="Select width"
                   licenseKeyRequired
@@ -256,13 +255,13 @@ export function WorkspaceAppsSettings() {
                 />
                 <ConfigSwitchField
                   label="Hide Gmail Unread Badge When Active"
-                  description="Hide the unread badge on the Gmail tab while it is the active tab, since the inbox is already in front. Accounts that need attention are still flagged."
+                  description="Hide the unread badge on the Gmail tab while it is the active tab, because the inbox is already in front. Accounts that need attention are still flagged."
                   configKey="verticalTabs.hideUnreadBadgeWhenActive"
                   licenseKeyRequired
                 />
                 <ConfigSwitchField
                   label="Show App Links Badge"
-                  description="Mark the tab that opens all of an app's links, set from the tab's context menu. With this off the tab still takes the links, and its tooltip still says so."
+                  description="Mark the tab that opens all of an app's links, set from the tab's context menu. With this off, the tab still takes the links, and its tooltip still says so."
                   configKey="verticalTabs.showAppLinksBadge"
                   licenseKeyRequired
                 />
@@ -274,13 +273,13 @@ export function WorkspaceAppsSettings() {
             <FieldLegend>Windows</FieldLegend>
             <ConfigSwitchField
               label="Show Account Label"
-              description="Show the account label in the titlebar of Workspace Apps windows if using more than one account."
+              description="Show the account label in the titlebar of Workspace Apps windows, with more than one account."
               configKey="workspaceApps.showAccountLabel"
               licenseKeyRequired
             />
             <ConfigSwitchField
               label="Show Account Color"
-              description="Show a colored indicator on top of Workspace Apps windows to indicate which account is being used when an account has a color configured."
+              description="Show a colored indicator on top of a Workspace Apps window, naming the account in use. It appears only for accounts that have a color."
               configKey="workspaceApps.showAccountColor"
               licenseKeyRequired
             />
@@ -297,7 +296,7 @@ export function WorkspaceAppsSettings() {
             label="Hibernate Idle Tabs"
             description="Unload tabs that have been sitting unused, giving back the memory they hold. A hibernated tab keeps its place in the sidebar and loads again when you click it, on the page you left. Selected Tabs only hibernates the tabs you mark with Hibernate When Idle in the tab's context menu."
             configKey="workspaceApps.hibernation"
-            placeholder="Select tabs"
+            placeholder="Select which tabs"
             licenseKeyRequired
             items={Object.entries(workspaceAppsHibernations).map(([value, label]) => ({
               value,
@@ -306,7 +305,7 @@ export function WorkspaceAppsSettings() {
           />
           <ConfigSelectField
             label="Hibernate After"
-            description="How long a tab has to go unused before it hibernates. The active tab, tabs in their own window and tabs playing audio are left alone."
+            description="How long a tab has to go unused before it hibernates. The active tab, tabs in their own window, and tabs playing audio are left alone."
             configKey="workspaceApps.hibernationTimeout"
             placeholder="Select timeout"
             licenseKeyRequired
@@ -325,7 +324,7 @@ export function WorkspaceAppsSettings() {
                   {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
                 </FieldLabel>
                 <FieldDescription>
-                  Add Workspace Apps to the Workspace Apps launcher in the titlebar on the right.
+                  Add Workspace Apps to the launcher on the right of the titlebar.
                 </FieldDescription>
               </FieldContent>
               <div className="flex flex-col gap-4">
@@ -333,7 +332,7 @@ export function WorkspaceAppsSettings() {
                   <div className="text-xs font-medium text-muted-foreground">In Launcher</div>
                   {launcherApps.length === 0 ? (
                     <p className="rounded-lg border border-dashed px-3 py-4 text-center text-sm text-muted-foreground">
-                      No apps in the launcher. Add apps from Available below.
+                      No apps in the launcher yet. Add one from Available.
                     </p>
                   ) : (
                     <DragDropProvider
@@ -396,7 +395,7 @@ export function WorkspaceAppsSettings() {
             </Field>
             <ConfigSelectField
               label="Launcher Display"
-              description="How launcher apps are shown in the titlebar. Auto expands up to three apps into individual buttons and collapses beyond that. Collapsed always keeps them behind a single button, Expanded always shows them as individual buttons."
+              description="How launcher apps are shown in the titlebar. Auto expands up to three apps into individual buttons and collapses beyond that. Collapsed always keeps them behind a single button, and Expanded always shows them as individual buttons."
               configKey="workspaceApps.launcherDisplay"
               placeholder="Select display"
               licenseKeyRequired
@@ -408,7 +407,7 @@ export function WorkspaceAppsSettings() {
             {config["workspaceApps.mode"] === "tabs" && (
               <ConfigSelectField
                 label="Placement"
-                description="Where the launcher and the bookmarks button sit. Auto moves them to the bottom of the vertical tabs sidebar while it is shown, Sidebar keeps them there and holds the sidebar open even with a single tab, Titlebar keeps them in the titlebar at all times."
+                description="Where the launcher and the bookmarks button sit. Auto moves them to the bottom of the vertical tabs sidebar while it is shown. Sidebar keeps them there and holds the sidebar open even with a single tab, and Titlebar keeps them in the titlebar at all times."
                 configKey="workspaceApps.launcherAndBookmarksPlacement"
                 placeholder="Select placement"
                 licenseKeyRequired


### PR DESCRIPTION
Third of the writing-pass PRs, and the largest copy surface. Independent of #868 and #869 — no overlapping files.

Two conventions are settled here and applied across every settings page:

- **Capitalization.** Field labels and buttons stay Title Case. Descriptions, placeholders, toasts, and empty states are sentence case.
- **Mood.** A description says what the setting does when it's on, in the base form: "Hide the Gmail logo in the top left corner."

## The substantive changes

**Mood.** `gmail/index.tsx` was the only page in third person ("Hides the Gmail logo…", "Opens a new window…"), and it switched to imperative twice within itself. The whole page moves to base form, matching the other 17 pages.

**Two outright errors.**

- `notifications.tsx` — "Unable show test notification while Do Not Disturb is enabled" was missing a word. It's now "Turn off Do Not Disturb to show a test notification", which says how to fix it rather than what failed.
- `gmail/index.tsx` — "Hides the Gmail logo **on** the top left corner" → "in".

**Missing articles.** The verification-codes descriptions all opened with a bare noun ("Verification code received via email will…"), as did `blocker.tsx` ("Use blocker"), `general.tsx` ("Meru is set as default mail client"), and `workspace-apps.tsx` ("in app instead of external browser").

**Labels.** `Check For Updates Automatically` capitalized a preposition. `Set up desktop app` was the only sentence-case button in settings. `Enabled` on the unified inbox page was a bare adjective where every sibling is `Enable X`. The four verification-codes labels ran up to 63 characters and repeated their own descriptions; they're now `Copy Codes to Clipboard`, `Detection Confidence`, `Mark Email as Read After Copying`, `Delete Email After Copying`.

**Punctuation.** Comma splices in the `Launcher Display` and `Placement` descriptions. Missing serial commas. `cancelled` → `canceled`. `Auto (contrast)` → `Auto`, the only non-Title-Case select option.

**Filler removed.** "Please" from three strings, "etc." from the Workspace Apps notification description, and "Enable this option to…" from the two `general.tsx` descriptions, which described the switch rather than its effect.

**`window.confirm` prompts.** "Are you sure you want to remove X?" → "Remove X?" in the accounts, saved-searches, and label-colors lists. The alert can't carry a verb on its buttons, so the message does the work.

## Deliberately not in this PR

`version-history.tsx` isn't touched. Its title is one of the three names that one destination carries (`What's New` in the sidebar, `Version History` as the page title, `What's New?` in the update banner), and renaming it here would leave main inconsistent between this PR and the next one. All three move together in the renderer-chrome PR.

## Not verified

I couldn't run the app: this sandbox has no display server, so `bun run dev` can't start Electron. The copy is verified statically only — types, lint, format, tests, and greps for the conventions. Nobody has looked at these pages rendered.

## Test plan

1. Open Settings and walk every page, checking that no description now overflows its row or reads oddly at the app's default window width — the Gmail and Workspace Apps pages changed most.
2. On Settings → Notifications, turn on Do Not Disturb and press **Show Test Notification**. The toast should read "Turn off Do Not Disturb to show a test notification."
3. On Settings → Verification Codes, confirm the four shortened labels still read unambiguously under the page title.
4. Remove an account from Settings → Accounts and confirm the confirmation reads "Remove <label>?"