### PR TITLE
apply the UI writing guide to the renderer chrome

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -660,7 +660,7 @@ export class AppMenu {
         role: "help",
         submenu: [
           {
-            label: "Version History",
+            label: "What's New",
             click: () => {
               main.navigate("/settings/version-history");
             },

--- a/packages/renderer/bookmarks.tsx
+++ b/packages/renderer/bookmarks.tsx
@@ -57,7 +57,7 @@ function Bookmark({
         size="icon"
         data-sortable-action
         className="absolute inset-y-0 right-1 my-auto size-5 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
-        title="Remove Bookmark"
+        title="Remove bookmark"
         onClick={() => {
           ipc.main.send("bookmarks.removeBookmark", accountId, id);
         }}

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -73,7 +73,7 @@ function RecentDownloadHistoryButton() {
       onMouseLeave={() => {
         ipc.main.send("downloads.setDownloadHistoryPopupOnBlurEnabled", true);
       }}
-      title="Recent Download History"
+      title="Recent download history"
     >
       <DownloadIcon />
     </TitlebarIconButton>
@@ -127,7 +127,7 @@ function Trial() {
               : "less than a day"}
         </span>
         <span className="absolute inset-0 items-center justify-center opacity-0 fade-in group-hover:inline-flex group-hover:opacity-100">
-          Upgrade to Pro
+          Upgrade to Meru Pro
         </span>
       </a>
     </Badge>
@@ -313,7 +313,7 @@ export function AppTitlebar() {
                 ipc.main.send("appUpdater.openVersionHistory");
               }}
             >
-              What's New?
+              What's New
             </Button>
           </div>
         </div>
@@ -367,7 +367,7 @@ export function AppTitlebar() {
                   variant="ghost"
                   size="icon-sm"
                   className="draggable-none"
-                  title="Out of Office"
+                  title="Out of office"
                   onClick={() => {
                     ipc.main.send("gmail.navigateTo", "settings");
                   }}

--- a/packages/renderer/components/download-history.tsx
+++ b/packages/renderer/components/download-history.tsx
@@ -38,9 +38,9 @@ export function DownloadHistoryList({ limit }: { limit?: number }) {
             <DownloadIcon />
           </EmptyMedia>
           <EmptyTitle>No downloads yet</EmptyTitle>
-          <EmptyDescription>Your downloaded files will appear here.</EmptyDescription>
+          <EmptyDescription>Downloaded files appear here.</EmptyDescription>
           <EmptyDescription>
-            Downloads older than 30 days will be automatically removed from the history.
+            Downloads older than 30 days are removed from the history automatically.
           </EmptyDescription>
         </EmptyHeader>
       </Empty>

--- a/packages/renderer/components/find-in-page.tsx
+++ b/packages/renderer/components/find-in-page.tsx
@@ -81,7 +81,7 @@ export function FindInPage({
           onClick={() => {
             onFind(text, { forward: false, findNext: false });
           }}
-          title="Find Previous Match"
+          title="Find previous match"
         >
           <ChevronUpIcon />
         </Button>
@@ -91,11 +91,11 @@ export function FindInPage({
           onClick={() => {
             onFind(text, { findNext: false });
           }}
-          title="Find Next Match"
+          title="Find next match"
         >
           <ChevronDownIcon />
         </Button>
-        <Button variant="ghost" size="icon-sm" onClick={onClose} title="Close Find in Page">
+        <Button variant="ghost" size="icon-sm" onClick={onClose} title="Close find in page">
           <XIcon />
         </Button>
       </div>

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -160,7 +160,7 @@ function VerticalTab({
   );
 
   const tooltip = tab.opensLinksForApp
-    ? `${tab.title} — Opens ${workspaceApps[tab.opensLinksForApp].label} Links`
+    ? `${tab.title} — opens ${workspaceApps[tab.opensLinksForApp].label} links`
     : tab.title;
 
   return (
@@ -238,7 +238,7 @@ function VerticalTab({
               ? "bg-transparent text-muted-foreground group-hover:bg-secondary group-hover:text-secondary-foreground"
               : "opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
           )}
-          title={tab.bookmarked ? "Remove Bookmark" : "Bookmark"}
+          title={tab.bookmarked ? "Remove bookmark" : "Bookmark"}
           onClick={() => {
             ipc.main.send("workspaceApp.toggleBookmark", tab.id);
           }}
@@ -360,7 +360,7 @@ function VerticalTabsWidthToggle({
         "mt-auto text-muted-foreground transition-[color,background-color]",
         isWide && "self-end",
       )}
-      title={isWide ? "Narrow Tabs" : "Wide Tabs"}
+      title={isWide ? "Narrow tabs" : "Wide tabs"}
       onClick={() => {
         ipc.main.send("tabs.setVerticalTabsWidth", accountId, isWide ? "narrow" : "wide");
       }}

--- a/packages/renderer/components/workspace-apps-launcher.tsx
+++ b/packages/renderer/components/workspace-apps-launcher.tsx
@@ -116,7 +116,7 @@ export function VerticalTabsWorkspaceAppsLauncher({
               "text-muted-foreground transition-colors",
               isWide && "w-full justify-start",
             )}
-            title="Open App"
+            title="Open app"
           >
             <LayoutGridIcon />
             {isWide && "Open App"}

--- a/packages/renderer/lib/stores.ts
+++ b/packages/renderer/lib/stores.ts
@@ -26,8 +26,8 @@ ipc.renderer.on("accounts.openAddAccountDialog", async (_event) => {
   const config = await getConfig();
 
   if (!config.licenseKey && !useTrialStore.getState().daysLeft) {
-    toast.error("Meru Pro required", {
-      description: "Please upgrade to Meru Pro to add more accounts.",
+    toast.error("Meru Pro Required", {
+      description: "Upgrade to Meru Pro to add more accounts.",
     });
 
     return;

--- a/packages/renderer/lib/toast.ts
+++ b/packages/renderer/lib/toast.ts
@@ -2,7 +2,7 @@ import { ipc } from "@meru/shared/renderer/ipc";
 import { toast } from "sonner";
 
 export function restartRequiredToast() {
-  toast.info("A restart is required for the changes to take full effect.", {
+  toast.info("Restart Meru to apply the changes.", {
     id: "restart-required",
     duration: Number.POSITIVE_INFINITY,
     action: {

--- a/packages/renderer/routes/download-history.tsx
+++ b/packages/renderer/routes/download-history.tsx
@@ -22,7 +22,7 @@ function DownloadHistoryClearAllButton() {
       }}
       disabled={config["downloads.history"].length === 0}
     >
-      Clear all
+      Clear All
     </Button>
   );
 }

--- a/packages/renderer/routes/settings/version-history.tsx
+++ b/packages/renderer/routes/settings/version-history.tsx
@@ -59,7 +59,7 @@ export function VersionHistorySettings() {
       return (
         <Empty>
           <EmptyHeader>
-            <EmptyTitle>Failed to load version history</EmptyTitle>
+            <EmptyTitle>Couldn't load what's new</EmptyTitle>
           </EmptyHeader>
           <EmptyContent>
             <Button
@@ -84,7 +84,7 @@ export function VersionHistorySettings() {
         <ItemContent>
           <div className="flex items-center justify-between gap-2">
             <ItemTitle className="text-2xl font-semibold">{release.tag_name}</ItemTitle>
-            {release.tag_name === currentTagName ? <Badge>Current version</Badge> : null}
+            {release.tag_name === currentTagName ? <Badge>Current Version</Badge> : null}
           </div>
           <ItemDescription>{dayjs(release.published_at).fromNow()}</ItemDescription>
           <div className="prose dark:prose-invert prose-h3:text-lg prose-li:marker:text-white prose-li:pl-0 mt-6 text-sm">
@@ -106,7 +106,7 @@ export function VersionHistorySettings() {
   return (
     <>
       <SettingsHeader className="flex-col items-start justify-start gap-1">
-        <SettingsTitle>Version History</SettingsTitle>
+        <SettingsTitle>What's New</SettingsTitle>
         {info ? <SettingsDescription>Current version: v{info.version}</SettingsDescription> : null}
       </SettingsHeader>
       <div className="space-y-8">{renderContent()}</div>

--- a/packages/renderer/routes/unified-inbox.tsx
+++ b/packages/renderer/routes/unified-inbox.tsx
@@ -422,10 +422,10 @@ export function UnifiedInbox() {
               <EmptyMedia variant="icon">
                 <InboxIcon />
               </EmptyMedia>
-              <EmptyTitle>No Unread Messages</EmptyTitle>
+              <EmptyTitle>No unread messages</EmptyTitle>
               <EmptyDescription>
-                Your unified inbox will show all your unread messages in one place. Once you read a
-                message, it will disappear from the unified inbox.
+                The unified inbox shows every unread message from your accounts in one place. A
+                message leaves the list after you read it.
               </EmptyDescription>
             </EmptyHeader>
           </Empty>

--- a/packages/renderer/workspace-app.tsx
+++ b/packages/renderer/workspace-app.tsx
@@ -31,7 +31,7 @@ function RecentDownloadHistoryButton() {
       onMouseLeave={() => {
         ipc.main.send("downloads.setDownloadHistoryPopupOnBlurEnabled", true);
       }}
-      title="Recent Download History"
+      title="Recent download history"
     >
       <DownloadIcon />
     </TitlebarIconButton>
@@ -70,7 +70,7 @@ function BookmarkButton({ workspaceAppId }: { workspaceAppId: string }) {
 
   return (
     <TitlebarIconButton
-      title={bookmarkState.bookmarked ? "Remove Bookmark" : "Bookmark"}
+      title={bookmarkState.bookmarked ? "Remove bookmark" : "Bookmark"}
       onClick={() => {
         ipc.main.send("workspaceApp.toggleBookmark", workspaceAppId);
       }}
@@ -210,7 +210,7 @@ function WorkspaceApp() {
           <BookmarkButton workspaceAppId={workspaceAppId} />
           <RecentDownloadHistoryButton />
           <TitlebarIconButton
-            title="More Options"
+            title="More options"
             onClick={() => {
               ipc.main.send("workspaceApp.showMenu", workspaceAppId);
             }}


### PR DESCRIPTION
Fourth of the writing-pass PRs: titlebar, vertical tabs, bookmarks, download history, empty states, and the toasts the renderer raises. Independent of #868, #869, and #870.

## Tooltips move to sentence case

The HIG rule for tooltips is sentence case with no ending punctuation. The app was Title Case everywhere except `download-history.tsx`, which was already sentence case — so the convention was inconsistent either way. This settles it on the HIG side.

Feature names the app capitalizes elsewhere keep their case, because the tooltip is naming a thing rather than describing an action: **Bookmarks**, **Unified Inbox**, **Saved Searches**, **Do Not Disturb**, **Workspace Apps**, **Extensions**. Everything else is sentence case — `Find next match`, `Recent download history`, `Remove bookmark`, `Narrow tabs`, `More options`.

Worth knowing: this means `Show in folder` (tooltip, download history) and `Show in Folder` (select option, notification settings) name the same action in two cases. That's the per-element-type rule working as intended, not an oversight — options are Title Case, tooltips aren't.

## One destination, one name

`What's New` in the sidebar, `Version History` as the page title, `Version History` in the Help menu, `What's New?` in the update banner. All four now read **What's New**.

That's why this PR touches one line of `packages/app/menu.ts`, which otherwise belongs to the menus PR — splitting a rename across two PRs would leave main inconsistent in between.

## The rest

- Empty states get one shape: sentence-case title, present tense, no future "will". `No Unread Messages` → `No unread messages`; "Your downloaded files will appear here" → "Downloaded files appear here".
- `Clear all` → `Clear All`, the only sentence-case button among its siblings.
- `Meru Pro required` toast → `Meru Pro Required`, matching the badge that says the same three words, and its description loses "Please".
- `Upgrade to Pro` in the trial badge → `Upgrade to Meru Pro`, matching both banners.
- The restart toast said "A restart is required for the changes to take full effect." It now says what to do: "Restart Meru to apply the changes."
- `Current version` badge → `Current Version`.

`packages/ui/components/` is deliberately untouched. Those are vendored shadcn primitives and are better kept close to upstream; the only copy in them is `No emoji found.` and `Select an emoji…`.

## Not verified

No display server in this sandbox, so `bun run dev` can't start Electron. Nothing here has been seen rendered — in particular, whether the sentence-case tooltips still read right next to the Title Case feature-name ones.

## Test plan

1. Hover the titlebar and vertical-tabs controls and read the tooltips as a set. The mix of `Bookmarks` and `Remove bookmark` is the deliberate part — check it doesn't look like a mistake.
2. Open Settings → What's New and confirm the sidebar item, the page title, and the Help → What's New menu item all agree.
3. Trigger the update banner, or press the **Update Available** button, and confirm its third button reads `What's New` and opens the page.
4. Clear the download history and the bookmarks list and read both empty states.