### PR TITLE
use a real ellipsis in the menu labels that open a dialog

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -244,7 +244,7 @@ export class AppMenu {
             },
           },
           {
-            label: "Check for Updates...",
+            label: "Check for Updates…",
             click: () => {
               appUpdater.checkForUpdates();
             },
@@ -253,14 +253,14 @@ export class AppMenu {
             type: "separator",
           },
           {
-            label: "Settings...",
+            label: "Settings…",
             accelerator: "CommandOrControl+,",
             click: () => {
               main.navigate("/settings/general");
             },
           },
           {
-            label: "Gmail Settings...",
+            label: "Gmail Settings…",
             accelerator: "Command+Shift+,",
             click: () => {
               ipc.renderer.send(
@@ -351,7 +351,7 @@ export class AppMenu {
             type: "separator",
           },
           {
-            label: "Find...",
+            label: "Find…",
             accelerator: "CommandOrControl+F",
             enabled: isFindInPageEnabled,
             click: () => {
@@ -632,7 +632,7 @@ export class AppMenu {
             type: "separator",
           },
           {
-            label: "Manage Accounts...",
+            label: "Manage Accounts…",
             click: () => {
               main.navigate("/settings/accounts");
             },
@@ -740,7 +740,7 @@ export class AppMenu {
                 },
               },
               {
-                label: "Reset App",
+                label: "Reset App…",
                 click: async () => {
                   const { response } = await dialog.showMessageBox({
                     type: "warning",


### PR DESCRIPTION
Fifth of the writing-pass PRs, and the smallest. Independent of the others.

The application menu was already uniform on the things the HIG cares about — Title Case throughout, verbs on the action items, no shortcut baked into a label — so this is one convention:

- **Real ellipsis.** `Check for Updates...`, `Settings...`, `Gmail Settings...`, `Find...`, and `Manage Accounts...` used three ASCII periods. They now use U+2026, which the app already uses in `emoji-picker.tsx`.
- **`Reset App` gains one.** It shows a confirmation before it does anything, so it needs more from you before it can complete.

## Two things deliberately left alone

**`Clear Cache` keeps no ellipsis.** It clears the cache, then offers a restart. The dialog is a consequence of the action, not input the action needs, so the ellipsis would be misleading.

**`Ask Question`, `Request Feature`, `Report Issue` keep their missing articles.** These read clipped, and my first instinct was "Ask a Question". But the HIG is explicit that menu item labels drop articles — *a*, *an*, and *the* alike — and the three are parallel with each other as they stand. Flagging it because it's the one place in this pass where the guide and ordinary English disagree, and I followed the guide. Say the word and I'll flip them.

The tray menu, the page context menu, the tab and workspace-app context menus, and the Do Not Disturb duration list were all already consistent. Nothing to change there.

## Not verified

No display server in this sandbox, so the menus haven't been opened. The risk is low — these are six string literals — but the ellipsis character's rendering in the native menu on each platform is exactly the sort of thing worth a glance.

## Test plan

1. Open the app menu on macOS and confirm `Settings…` and `Check for Updates…` render the single ellipsis glyph rather than a box or three separate dots.
2. Same check on Windows and Linux, where the menu is drawn by a different toolkit.
3. Choose Help → Troubleshooting → `Reset App…` and confirm the confirmation dialog still appears and Cancel still cancels.