### PR TITLE
apply the UI writing guide to the dialogs and notifications

### DIFF
--- a/packages/app/dialogs.ts
+++ b/packages/app/dialogs.ts
@@ -1,13 +1,14 @@
+import { WEBSITE_URL } from "@meru/shared/constants";
 import { type SupportedWorkspaceApp, workspaceApps } from "@meru/shared/workspace-apps";
 import { app, dialog } from "electron";
 import { main } from "./main";
+import { openExternalUrl } from "./url";
 
 export async function showRestartDialog() {
   const { response } = await dialog.showMessageBox({
     type: "info",
     buttons: ["Restart", "Later"],
-    message: "Restart required to apply changes",
-    detail: "Do you want to restart the app now?",
+    message: "Restart Meru to apply the changes?",
     defaultId: 0,
     cancelId: 1,
   });
@@ -28,10 +29,24 @@ export async function confirmAppLinksTabHandover(
     type: "info",
     buttons: ["Open Links Here", "Cancel"],
     message: `Open ${appLabel} links in this tab?`,
-    detail: `“${appLinksTabTitle}” opens all ${appLabel} links right now. It will stop doing so.`,
+    detail: `“${appLinksTabTitle}” opens all ${appLabel} links right now, and gives them up to this tab.`,
     defaultId: 0,
     cancelId: 1,
   });
 
   return response === 0;
+}
+
+export async function showProUpgradeDialog(message: string) {
+  const { response } = await dialog.showMessageBox(main.window, {
+    type: "warning",
+    buttons: ["Upgrade to Meru Pro", "Cancel"],
+    message,
+    defaultId: 0,
+    cancelId: 1,
+  });
+
+  if (response === 0) {
+    openExternalUrl(`${WEBSITE_URL}/#pricing`, { skipTrustedHostCheck: true });
+  }
 }

--- a/packages/app/downloads.ts
+++ b/packages/app/downloads.ts
@@ -82,10 +82,10 @@ class Downloads {
             config.get("notifications.onClickDownloadCompleted") === "openFile";
 
           createNotification({
-            title: `Downloaded: ${fileName}`,
+            title: `Downloaded ${fileName}`,
             body: shouldOpenFile
-              ? "Click to open the file"
-              : `Click to show the file in ${FILE_MANAGER_NAME}`,
+              ? "Click to open the file."
+              : `Click to show the file in ${FILE_MANAGER_NAME}.`,
             click: () => {
               if (shouldOpenFile) {
                 shell.openPath(filePath);

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -846,7 +846,7 @@ export class Gmail {
               type: "button",
             },
             {
-              text: "Mark as read",
+              text: "Mark as Read",
               type: "button",
             },
             {
@@ -854,7 +854,7 @@ export class Gmail {
               type: "button",
             },
             {
-              text: "Mark as spam",
+              text: "Mark as Spam",
               type: "button",
             },
           ],

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -749,8 +749,8 @@ class Ipc {
     ipc.main.on("notifications.showTestNotification", () => {
       createNewEmailNotification({
         title: "Tim from Meru",
-        subtitle: "Your Test Notification Request",
-        body: "This is a test notification to show how notifications will appear.",
+        subtitle: "Your test notification request",
+        body: "This is a test notification, to show how a notification appears.",
       });
     });
 
@@ -1051,7 +1051,7 @@ class Ipc {
       }
 
       if (!isCuratedExtensionId(extensionId)) {
-        return { error: "This extension is not part of the extensions Meru offers" };
+        return { error: "Meru doesn't offer this extension." };
       }
 
       try {
@@ -1062,7 +1062,7 @@ class Ipc {
         log.error("Failed to install extension", { extensionId, error: serializeError(error) });
 
         return {
-          error: `Failed to install extension: ${error instanceof Error ? error.message : String(error)}`,
+          error: `Couldn't install the extension: ${error instanceof Error ? error.message : String(error)}`,
         };
       }
     });
@@ -1078,7 +1078,7 @@ class Ipc {
         log.error("Failed to uninstall extension", { extensionId, error: serializeError(error) });
 
         return {
-          error: `Failed to uninstall extension: ${error instanceof Error ? error.message : String(error)}`,
+          error: `Couldn't uninstall the extension: ${error instanceof Error ? error.message : String(error)}`,
         };
       }
     });

--- a/packages/app/license-key.ts
+++ b/packages/app/license-key.ts
@@ -13,7 +13,7 @@ class LicenseKey {
   showActivationError(options: Omit<MessageBoxOptions, "type" | "message">) {
     return dialog.showMessageBox({
       type: "warning",
-      message: "Failed to activate license key",
+      message: "Couldn't activate the license key.",
       ...options,
     });
   }
@@ -45,7 +45,7 @@ class LicenseKey {
         if (error.code === "MAX_DEVICE_ACTIVATIONS_REACHED") {
           const { response } = await this.showActivationError({
             detail:
-              "This license key has reached its maximum number of device activations. Go to the Meru Portal to remove a device linked to this license key or contact support for further help.",
+              "This license key is activated on the maximum number of devices. Remove one in the Meru Portal, or contact support.",
             buttons: ["Open Meru Portal", "Cancel"],
             defaultId: 0,
             cancelId: 1,
@@ -56,7 +56,7 @@ class LicenseKey {
           }
         } else {
           await this.showActivationError({
-            detail: `${errorMessages[error.code]}. Please use another license key or contact support for further help.`,
+            detail: `${errorMessages[error.code]}. Use another license key, or contact support.`,
           });
         }
       } else {
@@ -72,8 +72,8 @@ class LicenseKey {
 
         await this.showActivationError({
           detail: (await isOnline())
-            ? `Please try again or contact support for further help with the error: ${error.message} (${error.cause}) - Hint: Could a VPN or firewall block the connection?`
-            : "It seems you are currently offline. Please connect to the internet and try again or contact support for further help.",
+            ? `Try again, or contact support. A VPN or a firewall can block the connection.\n\n${error.message} (${error.cause})`
+            : "Meru can't reach the internet. Connect and try again.",
         });
       }
 
@@ -84,8 +84,8 @@ class LicenseKey {
 
     const { response } = await dialog.showMessageBox({
       type: "info",
-      message: "License key activated",
-      detail: "A restart is required to apply the changes.",
+      message: "License key activated.",
+      detail: "Restart Meru to apply the changes.",
       buttons: ["Restart", "Later"],
       defaultId: 0,
       cancelId: 1,
@@ -102,7 +102,7 @@ class LicenseKey {
   showValidationError(options: Omit<MessageBoxOptions, "type" | "message">) {
     return dialog.showMessageBox({
       type: "warning",
-      message: "Failed to validate license key",
+      message: "Couldn't validate the license key.",
       ...options,
     });
   }
@@ -124,15 +124,15 @@ class LicenseKey {
     if (error) {
       if (isDefined) {
         const errorMessages: Record<typeof error.code, string> = {
-          LICENSE_KEY_INVALID: "The license key is invalid",
-          LICENSE_DISABLED: "The license key has been disabled",
-          LICENSE_EXPIRED: "The license key has expired",
-          DEVICE_NOT_ACTIVATED: "The license key is not activated for this device",
+          LICENSE_KEY_INVALID: "This license key is invalid",
+          LICENSE_DISABLED: "This license key has been disabled",
+          LICENSE_EXPIRED: "This license key has expired",
+          DEVICE_NOT_ACTIVATED: "This license key isn't activated for this device",
         };
 
         const { response } = await this.showValidationError({
-          detail: `${errorMessages[error.code]} and will be removed on this device. Contact support if you need further help.`,
-          buttons: ["Continue", "Quit"],
+          detail: `${errorMessages[error.code]}, and Meru removes it from this device. Contact support if you need help.`,
+          buttons: ["Remove and Restart", "Quit"],
           defaultId: 0,
           cancelId: 1,
         });
@@ -155,8 +155,8 @@ class LicenseKey {
 
         const { response } = await this.showValidationError({
           detail: (await isOnline())
-            ? `Please restart the app to try again or contact support for further help with the error: ${error.message} (${error.cause}) - Hint: Could a VPN or firewall block the connection?`
-            : "It seems you are currently offline. Please connect to the internet and restart the app to try again or contact support for further help.",
+            ? `Restart Meru to try again, or contact support. A VPN or a firewall can block the connection.\n\n${error.message} (${error.cause})`
+            : "Meru can't reach the internet. Connect, then restart Meru to try again.",
           buttons: ["Restart", "Quit"],
           defaultId: 0,
           cancelId: 1,

--- a/packages/app/protocol.ts
+++ b/packages/app/protocol.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { platform } from "@electron-toolkit/utils";
 import { app, dialog } from "electron";
 import { accounts } from "./accounts";
+import { showProUpgradeDialog } from "./dialogs";
 import { ipc } from "./ipc";
 import { licenseKey } from "./license-key";
 import { main } from "./main";
@@ -22,10 +23,7 @@ export function isMailtoUrl(url: string) {
 
 export async function handleMailtoUrl(url: string) {
   if (!licenseKey.isValid) {
-    dialog.showMessageBox(main.window, {
-      type: "warning",
-      message: "Meru Pro is required to use Meru as default mail client",
-    });
+    showProUpgradeDialog("Meru Pro is required to set Meru as the default mail client.");
 
     return;
   }
@@ -43,8 +41,7 @@ export async function handleMailtoUrl(url: string) {
 
     const { response } = await dialog.showMessageBox(main.window, {
       type: "question",
-      message: "Compose new email",
-      detail: "Which account would you like to use?",
+      message: "Which account should compose this email?",
       buttons: [...accountConfigs.map((account) => account.label), "Cancel"],
       cancelId,
     });
@@ -99,10 +96,7 @@ export function isMeruUrl(url: string) {
 
 export function handleMeruUrl(url: string) {
   if (!licenseKey.isValid) {
-    dialog.showMessageBox(main.window, {
-      type: "warning",
-      message: "Meru Pro is required to open Meru links",
-    });
+    showProUpgradeDialog("Meru Pro is required to open Meru links.");
 
     return;
   }

--- a/packages/app/trial.ts
+++ b/packages/app/trial.ts
@@ -37,10 +37,10 @@ class Trial {
 
       const { response } = await dialog.showMessageBox({
         type: "error",
-        message: "Failed to validate Meru Pro trial",
+        message: "Couldn't validate your Meru Pro trial.",
         detail: (await isOnline())
-          ? `Please restart the app to try again or contact support for further help with the error: ${error.message} (${error.cause}) - Hint: Could a VPN or firewall block the connection?`
-          : "It seems you are currently offline. Please connect to the internet and restart the app to try again.",
+          ? `Restart Meru to try again, or contact support. A VPN or a firewall can block the connection.\n\n${error.message} (${error.cause})`
+          : "Meru can't reach the internet. Connect, then restart Meru to try again.",
         buttons: ["Restart", "Quit"],
         defaultId: 0,
         cancelId: 1,
@@ -64,9 +64,9 @@ class Trial {
 
       const { response } = await dialog.showMessageBox({
         type: "info",
-        message: "Your Meru Pro trial has ended",
-        detail: "Upgrade to Pro to keep using all features or continue with the free version.",
-        buttons: ["Upgrade to Pro", "Continue with Free", "Quit"],
+        message: "Your Meru Pro trial has ended.",
+        detail: "Upgrade to Meru Pro to keep every feature, or continue with the free version.",
+        buttons: ["Upgrade to Meru Pro", "Continue with Free", "Quit"],
         defaultId: 0,
         cancelId: 2,
       });

--- a/packages/app/url.ts
+++ b/packages/app/url.ts
@@ -26,11 +26,11 @@ export async function openExternalUrl(
       const { response, checkboxChecked } = await dialog.showMessageBox({
         type: "info",
         buttons: ["Open Link", "Copy Link", "Cancel"],
-        message: "Do you want to open this external link in your default browser?",
+        message: "Open this link in your default browser?",
         checkboxLabel: `Trust all links on ${origin}`,
         detail:
           cleanUrl.length > MAX_EXTERNAL_URL_LENGTH
-            ? `${cleanUrl.slice(0, MAX_EXTERNAL_URL_LENGTH - 3)}...`
+            ? `${cleanUrl.slice(0, MAX_EXTERNAL_URL_LENGTH - 1)}…`
             : cleanUrl,
       });
 

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -187,10 +187,10 @@ export class WorkspaceApp {
     const { checkboxChecked } = await dialog.showMessageBox({
       type: "info",
       message: touchIdAvailable
-        ? "Only passkeys created in Meru work here"
-        : "Passkey sign-in isn't supported on this platform yet",
+        ? "Only passkeys created in Meru work here."
+        : "Passkey sign-in isn't supported on this platform yet.",
       detail: touchIdAvailable
-        ? "Continue with Touch ID if you've created a passkey in Meru. Passkeys from Chrome, iCloud or your phone can't be used here — sign in with your password or another second factor, then create a passkey for Meru in your Google account's security settings."
+        ? "Continue with Touch ID if you've created a passkey in Meru. Passkeys from Chrome, iCloud, or your phone don't work here — sign in with your password or another second factor, then create a passkey for Meru in your Google account's security settings."
         : "Sign in with your password or another available second factor. If the account has no password, add one at myaccount.google.com in a browser first, then sign in here.",
       checkboxLabel: "Don't show again",
     });


### PR DESCRIPTION
Sixth of the writing-pass PRs, and the one where the HIG has most to say. Independent of #868, #869, #870, #871, and #872.

## Errors lead with what to do

`Failed to activate license key`, `Failed to validate license key`, and `Failed to validate Meru Pro trial` all led with the machine's failure. They now read `Couldn't activate the license key.` and so on, with the detail carrying the fix.

The network-error detail was:

> Please try again or contact support for further help with the error: {message} ({cause}) - Hint: Could a VPN or firewall block the connection?

It now reads:

> Try again, or contact support. A VPN or a firewall can block the connection.
>
> {message} ({cause})

The raw error stays — support needs it — but it's out of the middle of the sentence, and `Hint:` is a debug affordance that doesn't belong in an alert.

`It seems you are currently offline. Please connect to the internet and try again or contact support for further help.` → `Meru can't reach the internet. Connect and try again.`

## A button that hid what it did

On a failed license validation the buttons were `["Continue", "Quit"]`. Choosing **Continue** deletes the license key from the config and relaunches. It now reads **Remove and Restart**.

## Two alerts had their halves the wrong way round

The HIG puts what happened, and the question, in the title:

- `Restart required to apply changes` / `Do you want to restart the app now?` → title `Restart Meru to apply the changes?`, no detail — it was saying the same thing twice.
- `Compose new email` / `Which account would you like to use?` → title `Which account should compose this email?` The old title also read like a menu command rather than an alert.

## The Pro upsells were dead ends

`Meru Pro is required to use Meru as default mail client` and `Meru Pro is required to open Meru links` passed no `buttons` array, so each got a lone OS-default **OK** on a warning dialog, with no detail and no way to reach Pro. Both now go through a `showProUpgradeDialog` helper in `dialogs.ts` with `["Upgrade to Meru Pro", "Cancel"]`, opening the pricing page the same way `trial.ts` already does. This is the one behavior change in the PR, not just copy — the plan called it out and you approved it, but it's the part to look at hardest.

Also restores the missing article: "as **the** default mail client".

## Smaller

- `Mark as read` / `Mark as spam` notification actions → Title Case, matching `Archive` and `Delete`.
- `Downloaded: {file}` → `Downloaded {file}`, and the notification bodies get the period that notification content takes.
- The external-link prompt's URL truncation used `...`; it now uses `…`, which also buys back two characters of URL.
- `Do you want to open this external link in your default browser?` → `Open this link in your default browser?`
- `This extension is not part of the extensions Meru offers` said "extension" three times → `Meru doesn't offer this extension.`
- The passkey dialog's "Passkeys from Chrome, iCloud or your phone can't be used here" → "don't work here", and gains the serial comma.
- The app-links handover detail ended "It will stop doing so", where "It" read as the tab you just clicked rather than the one named. It now names what happens: "…and gives them up to this tab."
- The test notification's subtitle was the only Title Case notification subtitle in the app.

## Not verified

No display server in this sandbox, so nothing here has been seen rendered, and most of these dialogs can't be reached without state I don't have: the license alerts need a real license key in each failure mode, the trial alert needs an expiring trial, the passkey dialog needs a Google account without a passkey. The restart, external-link, app-links, and mailto dialogs are reachable in normal use.

## Test plan

1. Change a setting that needs a restart and confirm the dialog reads `Restart Meru to apply the changes?` with **Restart** and **Later**, and that **Later** still dismisses without restarting.
2. Without a license key, open a `mailto:` link from another app. The alert should offer **Upgrade to Meru Pro**, and choosing it should open the pricing page in your browser — this is the new code path.
3. With two or more accounts and a valid license, open a `mailto:` link and confirm the account picker's title reads as a question and the account buttons are unchanged.
4. Click an external link in an email and confirm the prompt and its truncated URL still render, with the single-glyph ellipsis at the end of a long one.