### PR TITLE
apply the writing style guide to the app comments

### DIFF
--- a/packages/app/blocker/hosts.ts
+++ b/packages/app/blocker/hosts.ts
@@ -20,9 +20,10 @@ const GOOGLE_TRACKER_HOSTS = [
   "getgoogletagmanager.com",
 ];
 
-// Google telemetry lives on first-party hosts the Workspace apps need, so it can only
-// be matched by these path/query markers rather than by hostname. gen_204/csi beacons
-// fire across every Workspace app (Docs, Calendar, Drive, Meet, …), not just Gmail.
+// Google telemetry lives on first-party hosts the Workspace Apps need, so it can only
+// be matched by these path and query markers rather than by hostname. The gen_204 and
+// csi beacons fire across every Workspace App, such as Docs, Calendar, Drive, and
+// Meet, not only Gmail.
 const GOOGLE_TELEMETRY_PATHS = [
   "generate_204",
   "gen_204",
@@ -519,7 +520,7 @@ function escapeRegExp(value: string) {
 
 function createHostBoundaryPattern(hosts: string[]) {
   // Match a blocked host only at a hostname label boundary in the URL authority,
-  // so paths and lookalike hosts (e.g. evildoubleclick.net) never match.
+  // so paths and lookalike hosts such as evildoubleclick.net never match.
   return new RegExp(`://(?:[a-z0-9-]+\\.)*(?:${hosts.map(escapeRegExp).join("|")})(?=[:/?#]|$)`);
 }
 

--- a/packages/app/extension-actions.ts
+++ b/packages/app/extension-actions.ts
@@ -32,7 +32,7 @@ function createMenuIcon(iconDataUrl: string) {
  * and the popup picking one from that list opens.
  *
  * Extensions load into every account, so every titlebar shows the same list —
- * the session a window belongs to only decides which of an extension's
+ * the session a window belongs to only determines which of an extension's
  * per-account instances the popup runs against.
  */
 class ExtensionActions {

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -212,7 +212,7 @@ async function init() {
       main.isQuittingApp = true;
     }
 
-    // Taken down before the windows they hang on, so quitting never reaches
+    // Taken down before the windows they depend on, so quitting never reaches
     // into a view the window destroyed underneath it
     bookmarks.popup.close();
 

--- a/packages/app/lib/hibernation.ts
+++ b/packages/app/lib/hibernation.ts
@@ -1,5 +1,5 @@
 /**
- * What the idle sweep reads off a tab to decide whether it may unload it. A
+ * What the idle sweep reads off a tab to determine whether it can unload it. A
  * `WorkspaceApp` satisfies it; nothing else is needed to make the call.
  */
 type HibernatableTab = {

--- a/packages/app/lib/popup.ts
+++ b/packages/app/lib/popup.ts
@@ -61,7 +61,7 @@ function isSameAnchor(anchor: PopupAnchor | undefined, otherAnchor: PopupAnchor 
  * A renderer page pads itself by `BASE_SPACING`, and the view spans that much
  * past the popup on every side, so the popup sits where the gaps put it and its
  * entrance animation has room to move without being cut off at the view edge.
- * Any other page fills its view instead — an extension's popup knows nothing of
+ * Any other page fills its view instead — an extension's popup doesn't account for
  * Meru's gaps and would paint over them.
  */
 export class Popup {
@@ -161,7 +161,7 @@ export class Popup {
    * Quitting tears the window down underneath an open popup, and the blur that
    * comes with it lands here while the window and the view are already going
    * away — so the state is dropped up front and every native object is checked
-   * before it is touched, leaving nothing half torn down to hang the quit on.
+   * before it is touched, leaving nothing half torn down to stall the quit.
    */
   close = () => {
     const { view, parentWindow } = this;

--- a/packages/app/lib/web-contents.ts
+++ b/packages/app/lib/web-contents.ts
@@ -74,7 +74,7 @@ export function broadcastFoundInPageResults(
  * "current-render-view-deleted" listener on its opener when the view was
  * created via a window open handler. Removing the "destroyed" listener leaves
  * the opener-side listener dangling, which then crashes the app by calling into
- * this destroyed webContents (e.g. on quit).
+ * this destroyed webContents, on quit for example.
  */
 export function removeWebContentsListeners(webContents: WebContents) {
   for (const registeredEvent of webContents.eventNames()) {

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -313,7 +313,7 @@ export class Tabs {
       app: dormantTab.app,
       zoomFactor: dormantTab.zoomFactor,
       // A URL passed in wins: the tab is being woken to take that link, which
-      // the history it hibernated with knows nothing about.
+      // the history it hibernated with doesn't contain.
       navigationHistory: url ? undefined : dormantTab.restorableNavigationHistory,
     });
 
@@ -636,8 +636,8 @@ export class Tabs {
   }
 
   /**
-   * Opens a URL in the tab designated for its app, and returns that tab so the
-   * caller knows the URL was taken. Apps that may not open inside Meru are left
+   * Opens a URL in the tab designated for its app, and returns that tab to signal
+   * that the URL was taken. Apps that aren't allowed to open inside Meru are left
    * to the caller, which falls back to the default browser.
    */
   openInAppLinksTab(url: string) {


### PR DESCRIPTION
Seventh of the writing-pass PRs: the comments in `packages/app`. Wording only — no comment is deleted, per the scope you set. Independent of the other six.

## What I expected to find, and didn't

`packages/app` carries 345 comment blocks. I went in expecting a large diff and found the comments are already close to house style:

- No British spellings anywhere.
- No `etc.`, no `i.e.`, and only two `e.g.`
- Ten uses of `would`, and every one is a real counterfactual — "the window Electron **would** otherwise create", "closing it again **would** drop what was pinned". The guide rules out the hypothetical `would`, not this one, so they stay.
- No slashes standing in for words, no filler, no idioms beyond the one below.

So this is a small diff. That's the finding, not a shortcut.

## What did change

**Anthropomorphism.** Software returns and reports; it doesn't know or decide.

- `lib/popup.ts` — "an extension's popup **knows nothing of** Meru's gaps" → "doesn't account for"
- `tabs.ts` — "the history it hibernated with **knows nothing about**" → "doesn't contain"
- `tabs.ts` — "returns that tab so the caller **knows** the URL was taken" → "to signal that the URL was taken"
- `extension-actions.ts` — "the session a window belongs to only **decides**" → "determines"
- `lib/hibernation.ts` — "reads off a tab to **decide** whether it **may** unload it" → "to determine whether it can unload it"

**"Hang" in its violent sense**, which the guide rules out along with "kill":

- `index.ts` — "the windows they **hang on**" → "depend on"
- `lib/popup.ts` — "nothing half torn down to **hang the quit on**" → "to stall the quit"

**Ambiguous "may".** `tabs.ts` — "Apps that **may not** open inside Meru" meant permission, not possibility → "aren't allowed to open".

**Two `e.g.`** in `blocker/hosts.ts` and `lib/web-contents.ts`, plus the trailing `…` in that file's example list, which the guide handles by signalling in the introduction rather than trailing off. `Workspace app` also became `Workspace Apps` there, matching the product name everywhere else.

## Test plan

1. `bun run types`, `bun run lint`, `bun run fmt:check`, `bun test` — all pass. Nothing outside a comment changed, so the risk here is a typo in a comment, not behaviour.
2. Read `packages/app/blocker/hosts.ts:22-25`, the only block that was rewritten rather than reworded, and confirm it still says what it said about the gen_204 and csi beacons.