### PR TITLE
apply the writing style guide to the electron-extensions comments

### DIFF
--- a/packages/electron-extensions/bridge/bridge.ts
+++ b/packages/electron-extensions/bridge/bridge.ts
@@ -29,7 +29,7 @@ type ExtensionBridgeSession = {
  * per session, answered here and routed by path to whichever `chrome.*`
  * implementation registered it. The bridge owns what every route needs alike —
  * telling which extension is calling from the request's token, and turning
- * anything else away — so a route handler only ever sees an authenticated
+ * anything else away — so a route handler only ever receives an authenticated
  * caller.
  */
 export class ExtensionBridge {
@@ -81,8 +81,8 @@ export class ExtensionBridge {
       const body = JSON.parse(bodySource) as ExtensionBridgeRequest & Record<string, unknown>;
 
       // Everything else in the session — Gmail, workspace apps, any page a user
-      // navigated to — can reach this scheme just as well, and only the loaded
-      // extensions know a token
+      // navigated to — can reach this scheme too, and only the loaded extensions
+      // hold a token.
       const extensionId = this.sessions.get(session)?.getExtensionId(body.token);
 
       if (!extensionId) {

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -210,7 +210,7 @@ async function readStampSourceDir(stampPath: string) {
  * to its source but its stamp, so a copy without one is unaccounted for and
  * goes too.
  *
- * Meant to run once the embedder knows its load list, which is also why it is
+ * Meant to run once the embedder has its load list, which is also why it is
  * safe to delete: a copy still in use belongs to a source that is on the list.
  */
 export async function pruneDerivedExtensions({

--- a/packages/electron-extensions/derive/manifest.ts
+++ b/packages/electron-extensions/derive/manifest.ts
@@ -52,7 +52,7 @@ function createServiceWorkerWrapper(
  * once for `webRequest` and once per event on it, in every extension context.
  * That is a `DumpWithoutCrashing` in the builds Meru ships and a fatal check in
  * others, and it costs the extension nothing to avoid: extension-side
- * `webRequest` listeners never see a request in Electron, measured in the spike.
+ * `webRequest` listeners never receive a request in Electron, measured in the spike.
  *
  * Dropped from the derived copy, the namespace is missing rather than broken,
  * and the facade's noop `webRequest` stands in for it.
@@ -174,7 +174,7 @@ export function deriveManifest(
     facadeFileName: string;
     serviceWorkerFileName: string;
     bridgeConnectSource: string;
-    /** Manifest keys to leave out of the copy, e.g. `content_scripts`. */
+    /** Manifest keys to leave out of the copy, such as `content_scripts`. */
     strippedManifestKeys?: string[];
     /**
      * Match patterns to write over every content script's own. Without them the

--- a/packages/electron-extensions/facade/api/native-messaging.ts
+++ b/packages/electron-extensions/facade/api/native-messaging.ts
@@ -21,7 +21,7 @@ type NativeMessagingPort = {
 
 /**
  * `chrome.runtime.lastError` the way Chrome exposes it: set for the duration of
- * the callback that has to see it, gone again afterwards.
+ * the callback that reads it, gone again afterwards.
  */
 function withLastError(runtime: ChromeNamespace, error: string | undefined, run: () => void) {
   if (error === undefined) {
@@ -55,8 +55,8 @@ function createPort(runtime: ChromeNamespace, hostName: string): NativeMessaging
   let markOpened = () => {};
 
   /**
-   * Resolves once the bridge has answered the connect request, which is when it
-   * knows the port id. Extensions post the moment `connectNative` returns, and
+   * Resolves once the bridge has answered the connect request, which is when the
+   * port id arrives. Extensions post the moment `connectNative` returns, and
    * two fetches have no order between them, so everything sent waits here and
    * then goes out in the order it was written.
    */

--- a/packages/electron-extensions/facade/api/web-navigation.ts
+++ b/packages/electron-extensions/facade/api/web-navigation.ts
@@ -5,7 +5,7 @@ import { createNoopEvent } from "../lib/event";
 import { createBridgedMethod } from "../lib/method";
 
 /**
- * A frame query answered by the main process, since only it sees the session's
+ * A frame query answered by the main process, since only it holds the session's
  * frame tree. `null` is Chrome's own answer for a frame or tab it cannot find,
  * and extensions handle it — so it also stands in when the bridge cannot be
  * reached.

--- a/packages/electron-extensions/facade/lib/chrome.ts
+++ b/packages/electron-extensions/facade/lib/chrome.ts
@@ -1,6 +1,6 @@
 /**
- * The facade never knows what Electron's own `chrome` object holds, so every
- * namespace is treated as an opaque bag of values it may add to.
+ * What Electron's own `chrome` object holds isn't knowable from here, so every
+ * namespace is treated as an opaque bag of values the facade can add to.
  */
 export type ChromeNamespace = Record<string, unknown>;
 

--- a/packages/electron-extensions/facade/lib/method.ts
+++ b/packages/electron-extensions/facade/lib/method.ts
@@ -25,7 +25,7 @@ export function createNoopMethod(createResult: (callArguments: unknown[]) => unk
 
 /**
  * A method answered elsewhere — over the bridge, typically — with the same
- * callback-or-promise duality as a noop. `produceResult` sees the call's
+ * callback-or-promise duality as a noop. `produceResult` receives the call's
  * arguments without any trailing callback. A rejection reaches a promise-style
  * caller as its own, the way Chrome's APIs reject; a callback-style caller is
  * answered `undefined`, never left waiting on a callback that no longer fires.

--- a/packages/electron-extensions/install/omaha.ts
+++ b/packages/electron-extensions/install/omaha.ts
@@ -5,7 +5,7 @@ export type CrxDownloadOptions = {
   /**
    * The Chrome version the request speaks for, `process.versions.chrome` in an
    * Electron app. The endpoint answers 204 No Content without it, since it has
-   * no way to tell which package a browser it knows nothing about can run.
+   * no way to tell which package an unidentified browser can run.
    */
   chromeVersion: string;
 };
@@ -86,7 +86,7 @@ export type FetchCrxOptions = CrxDownloadOptions & {
  * Downloads the newest package for an extension id. The endpoint answers with a
  * redirect to Google's CDN, so redirects have to be followed.
  *
- * Nothing here decides whether the bytes are a package worth having: an answer
+ * Nothing here judges whether the bytes are a package worth having: an answer
  * that is not a CRX signed for this id fails in `verifyCrx`, which is the only
  * place allowed to say a package is good.
  */
@@ -183,7 +183,7 @@ export type FetchCrxUpdateOptions = UpdateCheckOptions & {
  * a check cheap enough to run on a schedule and on a button.
  *
  * The version it answers with is the endpoint's word rather than a verified
- * one, and nothing installs off it: it only decides whether `fetchCrx` runs,
+ * one, and nothing installs off it: it only gates whether `fetchCrx` runs,
  * and the package that brings back still has to pass `verifyCrx`.
  */
 export async function fetchCrxUpdate({

--- a/packages/electron-extensions/native-messaging/host-manifest.ts
+++ b/packages/electron-extensions/native-messaging/host-manifest.ts
@@ -142,8 +142,8 @@ export function getExtensionOrigin(extensionId: string) {
 
 /**
  * Whether the host itself accepts this extension. The check is the host's, not
- * the browser's — it is how a host decides which extensions may drive it, and
- * skipping it would hand every loaded extension every host on the machine.
+ * the browser's — it is how a host declares which extensions can drive it, and
+ * skipping it would give every loaded extension every host on the machine.
  */
 export function isExtensionAllowed(manifest: NativeMessagingHostManifest, extensionId: string) {
   return manifest.allowed_origins.includes(getExtensionOrigin(extensionId));

--- a/packages/electron-extensions/native-messaging/host.ts
+++ b/packages/electron-extensions/native-messaging/host.ts
@@ -125,8 +125,8 @@ export class NativeMessagingHost {
   }
 
   /**
-   * Ends the host. Closing stdin is how a host is told to shut down, and the
-   * kill is what covers hosts that ignore it.
+   * Ends the host. Closing stdin is how a host is told to shut down, and
+   * terminating the process covers the hosts that ignore it.
    */
   kill() {
     if (this.isClosed) {

--- a/packages/electron-extensions/native-messaging/native-messaging.ts
+++ b/packages/electron-extensions/native-messaging/native-messaging.ts
@@ -23,9 +23,9 @@ const HOST_NOT_FOUND_ERROR = "Specified native messaging host not found.";
 const HOST_FORBIDDEN_ERROR = "Access to the specified native messaging host is forbidden.";
 
 /**
- * Whether an extension may drive this host. The host's own `allowed_origins`
- * has already said yes by the time this is asked; an embedder that wants a
- * narrower rule than "whatever the host trusts" says no here.
+ * Whether an extension can drive this host. The host's own `allowed_origins`
+ * has already allowed it by the time this runs, so an embedder needing a rule
+ * narrower than "whatever the host trusts" denies it here.
  */
 export type NativeMessagingHostPolicy = (details: {
   session: Session;
@@ -59,14 +59,14 @@ type NativeMessagingPort = {
  * `chrome.runtime.connectNative` and `sendNativeMessage` for extensions loaded
  * into Electron sessions.
  *
- * Electron ships Chromium's native messaging plumbing with the door nailed
- * shut: `ElectronMessagingDelegate::IsNativeMessagingHostAllowed` returns
+ * Electron ships Chromium's native messaging plumbing with its entry points
+ * disabled: `ElectronMessagingDelegate::IsNativeMessagingHostAllowed` returns
  * `DISALLOW` and `CreateReceiverForNativeApp` returns nullptr, so the built-in
  * `connectNative` disconnects every port with "Access to the native messaging
  * host was disabled by the system administrator" no matter where a host
  * manifest sits. The facade therefore replaces both methods and they land here
  * over the extension bridge, which finds the host manifest the way Chromium
- * would, honours its `allowed_origins`, and runs one host process per port.
+ * would, honors its `allowed_origins`, and runs one host process per port.
  */
 export class NativeMessaging {
   private options: NativeMessagingOptions;
@@ -251,7 +251,7 @@ export class NativeMessaging {
     try {
       port.controller.enqueue(encodeNativeMessage(frame));
     } catch {
-      // The stream no longer accepts frames when the extension cancelled it —
+      // The stream no longer accepts frames when the extension canceled it —
       // a closed page, a restarted service worker — and a throw out of here
       // would keep `closePort` from killing the port's host process
       return;
@@ -279,7 +279,7 @@ export class NativeMessaging {
     try {
       port.controller.close();
     } catch {
-      // The stream is already gone when the extension cancelled it
+      // The stream is already gone when the extension canceled it
     }
 
     this.options.logger?.info("Disconnected native messaging host", {

--- a/packages/electron-extensions/web-navigation/web-navigation.ts
+++ b/packages/electron-extensions/web-navigation/web-navigation.ts
@@ -10,9 +10,9 @@ import {
 const MAIN_FRAME_ID = 0;
 
 /**
- * The id an extension knows a frame by: Chromium's frame-tree-node id, with the
- * main frame pinned to 0 — which is why the main frame never answers to its own
- * node id.
+ * The id an extension addresses a frame by: Chromium's frame-tree-node id, with
+ * the main frame pinned to 0 — which is why the main frame never answers to its
+ * own node id.
  */
 function getExtensionFrameId(frame: WebFrameMain) {
   return frame.parent ? frame.frameTreeNodeId : MAIN_FRAME_ID;


### PR DESCRIPTION
Eighth of the writing-pass PRs: the comments in `packages/electron-extensions`, 225 blocks. Wording only — no comment is deleted. Independent of the other seven.

This package documents constraints that Chromium and Electron impose, and it does so in the most figurative register in the codebase. That's where the diff is.

## Anthropomorphism

Software returns and reports; it doesn't know, see, want, or decide.

- `facade/lib/chrome.ts` — "The facade never **knows** what Electron's own `chrome` object holds" → "What Electron's own `chrome` object holds isn't knowable from here"
- `bridge/bridge.ts` — "a route handler only ever **sees** an authenticated caller" → "receives"
- `bridge/bridge.ts` — "only the loaded extensions **know** a token" → "hold a token"
- `facade/lib/method.ts` — "`produceResult` **sees** the call's arguments" → "receives"
- `facade/api/native-messaging.ts` — "which is when it **knows** the port id" → "when the port id arrives"
- `facade/api/web-navigation.ts` — "since only it **sees** the session's frame tree" → "holds"
- `web-navigation/web-navigation.ts` — "The id an extension **knows** a frame by" → "addresses a frame by"
- `native-messaging/host-manifest.ts` — "how a host **decides** which extensions may drive it" → "declares which extensions can drive it"
- `install/omaha.ts` — "a browser it **knows nothing about**" → "an unidentified browser"; "Nothing here **decides** whether the bytes are a package worth having" → "judges"; "it only **decides** whether `fetchCrx` runs" → "gates"
- `derive/index.ts` — "once the embedder **knows** its load list" → "has its load list"
- `native-messaging/native-messaging.ts` — "`allowed_origins` has already **said yes**… an embedder that **wants** a narrower rule **says no** here" → "has already allowed it… an embedder needing a rule narrower than that denies it here"

## Metaphor and violent language

- `native-messaging/native-messaging.ts` — "Electron ships Chromium's native messaging plumbing with **the door nailed shut**" → "with its entry points disabled". The sentence that follows already names the exact C++ symbols, so the metaphor was carrying nothing the reader needed.
- `native-messaging/host.ts` — "Closing stdin is how a host is told to shut down, and **the kill** is what covers hosts that ignore it" → "and terminating the process covers the hosts that ignore it". The method is still called `kill()`; only the prose changed.

## Mechanics

- Two `cancelled` → `canceled`, and one `honours` → `honors`. My first spelling sweep missed these because I grepped for the obvious `-our` and `-ise` words and not for `-lled`; the second pass caught them, and also found two in `packages/renderer` that go in the next PR.
- One `e.g.` in `derive/manifest.ts`.
- Ambiguous `may` → `can` wherever it meant capability rather than permission.

## Left alone

The dated measurements ("measured 2026-08-16", "measured in the spike"), the Chromium symbol names, the `NOTREACHED` and `DumpWithoutCrashing` references, and the `cancelled` **identifier** in `packages/dark-theme` — that one is a variable name, not prose.

## Test plan

1. `bun run types`, `bun run lint`, `bun run fmt:check`, `bun test` — all pass. Nothing outside a comment changed.
2. Read the `native-messaging.ts` header block, which is the one substantive rewrite, and confirm it still tells the next reader why the facade replaces `connectNative` at all.