### PR TITLE
apply the writing style guide to the remaining comments

### DIFF
--- a/packages/dark-theme/color.ts
+++ b/packages/dark-theme/color.ts
@@ -193,8 +193,8 @@ type ComponentSpan = {
 
 // Reads the numeric components of a color function body: each span covers a
 // number and an optional trailing unit, and components are scaled so a value in
-// units maps onto its bound (e.g. 50% of 255 → 127.5). Bounds above 1 mark
-// integer channels and round; the alpha bound of 1 keeps fractions intact.
+// units maps onto its bound, so 50% of 255 becomes 127.5. Bounds above 1 mark
+// integer channels and round, and the alpha bound of 1 keeps fractions intact.
 function readColorComponents(
   functionText: string,
   componentBounds: number[],

--- a/packages/dark-theme/image.ts
+++ b/packages/dark-theme/image.ts
@@ -47,7 +47,7 @@ let analysisContext: CanvasRenderingContext2D | null = null;
 // steady-state footprint stays at icon size instead of a fixed worst-case
 // allocation. Resizing a canvas resets its context state, so smoothing is
 // re-disabled after every growth — smoothed downscales would change the pixels
-// the classifier sees.
+// the classifier reads.
 function getAnalysisContext(
   requiredWidth: number,
   requiredHeight: number,
@@ -265,8 +265,8 @@ export function isImageElementLarge(image: HTMLImageElement): boolean {
 
 // A dark, mostly-transparent image is treated as a logo or icon that would
 // vanish against the dark background, so it gets inverted — unless it is large
-// or spans a photographic tonal range, which marks it as a photo (e.g. a dark
-// product shot on a transparent background) that inverting would ruin.
+// or spans a photographic tonal range, which marks it as a photo that inverting
+// would ruin — a dark product shot on a transparent background, for example.
 export function shouldInvertDarkImage(details: ImageDetails): boolean {
   return (
     details.isDark &&
@@ -279,7 +279,7 @@ export function shouldInvertDarkImage(details: ImageDetails): boolean {
 
 // Only the classifications that end up as a filtered SVG replacement (a dark
 // transparent icon to invert, a light non-solid image to darken) ever read the
-// dataURL, so it is built just for those instead of for every analyzed image.
+// dataURL, so it is built only for those instead of for every analyzed image.
 function shouldBuildDataURL(details: ImageDetails): boolean {
   if (details.isLarge) {
     return false;
@@ -292,7 +292,7 @@ function shouldBuildDataURL(details: ImageDetails): boolean {
   return details.isLight && !details.isTransparent && !details.solidColor;
 }
 
-// Bounded by total text length, not just entry count: an entry can carry a
+// Bounded by total text length, not by entry count: an entry can carry a
 // base64 dataURL of the full image, and a data: source url is itself the whole
 // image (it is the cache key even when analysis fails), so counting entries
 // alone would let a few hundred multi-megabyte strings pin tens of megabytes in

--- a/packages/dark-theme/index.ts
+++ b/packages/dark-theme/index.ts
@@ -160,14 +160,14 @@ export function applyDarkTheme(root: HTMLElement, options?: DarkThemeOptions): D
 
   // Pseudo-elements can't be reached by inline styles, so their darkened paint is
   // collected into one injected stylesheet. Each element keeps a stable id so its
-  // rules can be rebuilt when a class change alters its pseudo styles — e.g. a star
-  // icon whose url, and so whether it's inverted, depends on its state.
+  // rules can be rebuilt when a class change alters its pseudo styles — a star
+  // icon, say, whose url, and so whether it's inverted, depends on its state.
   const pseudoIds = new WeakMap<HTMLElement, string>();
   const pseudoRulesById = new Map<string, string[]>();
   let pseudoRuleCounter = 0;
   let pseudoStyleElement: HTMLStyleElement | null = null;
 
-  // A pseudo-element's darkened colour paint is captured once and reused on
+  // A pseudo-element's darkened color paint is captured once and reused on
   // refresh: re-reading its computed style after we've injected the darkened rule
   // would return our own output and darken it again toward black on every state
   // change. Only the invert-image decision (below) is re-evaluated, since that

--- a/packages/dark-theme/state-rules.ts
+++ b/packages/dark-theme/state-rules.ts
@@ -132,8 +132,8 @@ function getDarkenedStateRules(collection: StylesheetCollection, theme: Theme) {
   return darkenedRules;
 }
 
-// `:hover`/`:focus` styles live in author rules a getComputedStyle snapshot never
-// sees (the state isn't active at theme time), so they leak light. This rewrites
+// `:hover` and `:focus` styles live in author rules a getComputedStyle snapshot
+// never captures, because the state isn't active at theme time, so they leak light. This rewrites
 // those rules' color-bearing declarations — darkened — keeping each selector
 // verbatim and wrapping the whole set in `@scope (scopeSelector)` so they apply
 // only inside the themed subtree, never the natively-dark Gmail shell around it.

--- a/packages/dark-theme/variables.ts
+++ b/packages/dark-theme/variables.ts
@@ -67,9 +67,9 @@ function darkenLightValue(value: string, theme: Theme) {
   return darkenedValue;
 }
 
-// Gmail's reading pane paints many surfaces via CSS custom properties (e.g.
-// `background: var(--pkw-background, #fff)`); a getComputedStyle snapshot of a
-// real element can't see the ones that only resolve in a state the walk never
+// Gmail's reading pane paints many surfaces through CSS custom properties, such
+// as `background: var(--pkw-background, #fff)`. A getComputedStyle snapshot of a
+// real element can't reach the ones that only resolve in a state the walk never
 // observes, so they leak light. Custom properties inherit, so redefining the
 // light ones — darkened — on the themed root cascades the dark value into the
 // whole subtree and stops at its boundary, without touching the natively-dark

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -231,7 +231,7 @@ function VerticalTab({
           size="icon"
           data-sortable-action
           className={cn(
-            // Centred with margins rather than a transform, which the button's
+            // Centered with margins rather than a transform, which the button's
             // own press nudge would overwrite
             "absolute inset-y-0 right-1 my-auto size-5 transition-colors",
             tab.bookmarked
@@ -459,7 +459,7 @@ export function VerticalTabs() {
       className={cn(
         // The one gutter on every edge of both widths is the narrow strip's own
         // measure: it leaves exactly an icon button's width between its sides,
-        // which is what a 32px button centred in a 64px strip already sat on.
+        // which is what a 32px button centered in a 64px strip already sat on.
         // The column therefore hinges on its left edge as the strip resizes,
         // and the controls at the foot — the width toggle above all, which does
         // the resizing — stay put rather than stepping out from under the
@@ -488,7 +488,7 @@ export function VerticalTabs() {
        * many are open.
        *
        * They then divide what is left between them in the pinned section's
-       * favour. Pinning heavily therefore squeezes the normal tabs into a thin
+       * favor. Pinning heavily therefore squeezes the normal tabs into a thin
        * scrolling column rather than costing the pinned ones a row, but it can
        * no longer squeeze them out of sight.
        */}
@@ -503,13 +503,13 @@ export function VerticalTabs() {
           {/*
            * Yields to nothing until the normal tabs are down to the room held
            * for them, and reaching that is the one case where this section
-           * scrolls rather than takes the height it wants.
+           * scrolls rather than takes the height it needs.
            *
            * That room is held open from up here, as a ceiling on this section
            * rather than a floor under that one. A floor would hold its room
            * open at rest as well, standing between the last tab and the
            * launcher, and being a minimum it could not give way on a window too
-           * short to honour it — it would run the two sections over the very
+           * short to honor it — it would run the two sections over the very
            * controls this is all in aid of. A ceiling only ever takes room
            * away, so it can push nothing out of the strip; where the room held
            * isn't there to hold, it stands aside and the two sections halve

--- a/packages/renderer/components/workspace-app-icon.tsx
+++ b/packages/renderer/components/workspace-app-icon.tsx
@@ -9,7 +9,7 @@ export function WorkspaceAppIcon({
   // resolves to the first matching id in the document. Without a per-instance
   // suffix, two icons rendered at once share one set of definitions — and an
   // icon inside a `display: none` subtree has no definitions at all, so
-  // whichever copy comes first in the DOM decides whether the rest render.
+  // whichever copy comes first in the DOM determines whether the rest render.
   const instanceId = useId().replace(/[^a-zA-Z0-9]/g, "");
 
   switch (app) {

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -60,7 +60,7 @@ export function useSelectedAccountTabs() {
 
 /**
  * What the vertical tabs strip renders and the width it takes up. The titlebar
- * reads it too, to know whether the strip is there to host the Workspace Apps
+ * reads it too, to determine whether the strip is there to host the Workspace Apps
  * launcher.
  */
 export function useVerticalTabs() {


### PR DESCRIPTION
Ninth and last of the writing-pass PRs: the comments in `packages/dark-theme`, `packages/renderer`, `packages/shared`, and the three preload packages. Wording only — no comment is deleted. Independent of the other eight.

`packages/shared` and all three preload packages came back clean. `packages/ui` has no comments at all.

## British spellings

Four in `vertical-tabs.tsx` — `Centred`, `centred`, `favour`, `honour` — and one in `dark-theme/index.ts`, `colour`. These are the ones my first sweep missed, which is what prompted the wider grep in #875.

## Examples written as sentences

Five `e.g.` in `dark-theme` carried real examples rather than throwaways, so each is rewritten rather than just substituted:

- `color.ts` — "(e.g. 50% of 255 → 127.5)" → "so 50% of 255 becomes 127.5", and the semicolon after it becomes a conjunction.
- `image.ts` — "which marks it as a photo (e.g. a dark product shot on a transparent background) that inverting would ruin" → the parenthesis moves out to the end of the sentence, where it doesn't split the subject from its relative clause.
- `variables.ts` — "custom properties (e.g. `background: var(--pkw-background, #fff)`); a getComputedStyle snapshot…" → "such as", and the semicolon becomes a sentence break.

## Anthropomorphism

- `image.ts` — "the pixels the classifier **sees**" → "reads"
- `state-rules.ts` — "author rules a getComputedStyle snapshot never **sees**" → "never captures"
- `variables.ts` — "a snapshot of a real element can't **see** the ones that only resolve…" → "can't reach"
- `vertical-tabs.tsx` — "scrolls rather than takes the height it **wants**" → "needs"
- `workspace-app-icon.tsx` — "whichever copy comes first in the DOM **decides** whether the rest render" → "determines"
- `lib/hooks.ts` — "The titlebar reads it too, to **know** whether the strip is there" → "to determine whether"

## Deliberately left alone

**`dark-theme/index.ts` lines 50–85.** The `DarkThemeOptions` and `DarkThemeController` comments duplicate the package README's option list word for word, and they move with it in #868. Editing them here as well would conflict.

**`hang` in `vertical-tabs.tsx`** — "the badges the icons hang over their corners". The guide rules out `hang` in its violent sense; this is the physical one, and no other word describes it as well.

**The `cancelled` identifier** in `dark-theme/index.ts` is a variable name, not prose.

## Test plan

1. `bun run types`, `bun run lint`, `bun run fmt:check`, `bun test` — all pass. Nothing outside a comment changed.
2. Read the two rewritten sentences in `dark-theme/variables.ts` and `dark-theme/state-rules.ts` and confirm they still say why a `getComputedStyle` snapshot is insufficient — that's the reason the whole file exists.