### PR TITLE
give the Gmail Settings menu item a shortcut on Windows and Linux

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -261,7 +261,7 @@ export class AppMenu {
           },
           {
             label: "Gmail Settings…",
-            accelerator: "Command+Shift+,",
+            accelerator: "CommandOrControl+Shift+,",
             click: () => {
               ipc.renderer.send(
                 selectedAccount.instance.gmail.view.webContents,


### PR DESCRIPTION
The **Gmail Settings…** menu item bound the accelerator `Command+Shift+,`. Electron only resolves `Command` on macOS, so the item had no keyboard shortcut on Windows and Linux. It now uses `CommandOrControl+Shift+,`, matching the **Settings…** item directly above it.

Three other defects from the same survey are being fixed in parallel branches, so this change is limited to the one accelerator.

Not verified: the shortcut wasn't exercised in a running app on Windows or Linux.

## Test plan

1. Run `bun run dev` on Linux and open the app menu — **Gmail Settings…** shows `Ctrl+Shift+,` as its shortcut.
2. Press `Ctrl+Shift+,` with an account selected — the window comes to the front and the Gmail view navigates to its settings.