### PR TITLE
remove the title from the Reset App confirmation

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -746,7 +746,6 @@ export class AppMenu {
                     type: "warning",
                     buttons: ["Cancel", "Reset"],
                     defaultId: 1,
-                    title: "Reset App",
                     message: "Are you sure you want to reset the app?",
                     detail:
                       "This will clear all your accounts, settings, and data. This action cannot be undone.",


### PR DESCRIPTION
The "Reset App" confirmation in `packages/app/menu.ts` was the only `dialog.showMessageBox` call in the app that set a `title`. macOS ignores the option, so the title appeared on Windows and Linux alone, where every other dialog in the app shows none.

A survey of all 12 `showMessageBox` call sites across `packages/` — `menu.ts`, `dialogs.ts` (3), `trial.ts` (2), `url.ts`, `license-key.ts` (3), `protocol.ts`, `workspace-app.ts` — confirmed this was the sole outlier. The two `license-key.ts` helpers that spread caller options were checked too; no caller passes a `title` through them. Dropping the one title is the smaller change, so the app is now consistent with no titles anywhere.

## Test plan

1. On Windows or Linux, open Meru ▸ Reset App… — the dialog's window title bar shows the app name rather than "Reset App", matching the Restart and license dialogs.
2. Confirm the dialog still defaults to "Reset" and that cancelling leaves the app untouched.

Not verified: the dialog wasn't exercised on a running Windows or Linux build.