### PR TITLE
use Alt in the hidden paste and match style accelerator

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -337,7 +337,7 @@ export class AppMenu {
           },
           {
             role: "pasteAndMatchStyle",
-            accelerator: "CommandOrControl+Option+Shift+V",
+            accelerator: "CommandOrControl+Alt+Shift+V",
             visible: false,
             acceleratorWorksWhenHidden: platform.isMacOS,
           },


### PR DESCRIPTION
The hidden `pasteAndMatchStyle` item in `packages/app/menu.ts` bound `CommandOrControl+Option+Shift+V`. Electron's accelerator docs, now in `docs/tutorial/keyboard-shortcuts.md`, list `Option` as N/A on Windows and Linux and say to use `Alt`, which maps to the right modifier on every platform. Electron parses both to `VKEY_MENU`, so macOS still gets Command+Option+Shift+V.

The item sets `acceleratorWorksWhenHidden` on macOS only, so nobody loses a shortcut either way. This is about the string being cross-platform.

Only that one accelerator changed. The other `Command+Option` bindings in the file sit inside `platform.isMacOS` branches and are a separate question.

## Test plan

1. On macOS, focus a Gmail compose field and press Command+Option+Shift+V. The clipboard text pastes without formatting, same as before.
2. Run `bun run types`, `bun run lint`, and `bun run fmt:check`. All pass.

Not verified: the Windows and Linux behavior, which I have no machine for here. The accelerator stays hidden and unregistered there because `acceleratorWorksWhenHidden` is `platform.isMacOS`.