### PR TITLE
order the hibernation timeouts by duration

### DIFF
--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -97,8 +97,8 @@ export type WorkspaceAppsHibernation = keyof typeof workspaceAppsHibernations;
 
 /** Keys double as durations for `ms`. */
 export const workspaceAppsHibernationTimeouts = {
-  "1h": "1 Hour",
   "30m": "30 Minutes",
+  "1h": "1 Hour",
   "3h": "3 Hours",
   "6h": "6 Hours",
 } as const;


### PR DESCRIPTION
`workspaceAppsHibernationTimeouts` in `packages/shared/workspace-apps.ts` was declared `1h, 30m, 3h, 6h`, so the Hibernate After dropdown in Workspace Apps settings rendered 30 Minutes second. The map now runs `30m, 1h, 3h, 6h`, and the dropdown builds its items from `Object.entries`, so it follows.

This breaks the `ConfigSelectField` convention in `CLAUDE.md` that the option matching the config default comes first: the default for `workspaceApps.hibernationTimeout` is `1h`, which now sits second. Ascending duration order was chosen deliberately for this field. The default itself is unchanged.

## Test plan

1. Open Settings › Workspace Apps and expand the Hibernate After dropdown. The options read 30 Minutes, 1 Hour, 3 Hours, 6 Hours, top to bottom.
2. With the setting untouched, confirm the closed dropdown still shows 1 Hour — the default did not move with the reordering.