### PR TITLE
make the type-only and duplicate imports consistent

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -17,13 +17,13 @@ import { clamp, wait } from "@meru/shared/utils";
 import type { SupportedWorkspaceApp } from "@meru/shared/workspace-apps";
 import {
   app,
-  BrowserWindow,
+  type BrowserWindow,
   clipboard,
   type Session,
   type WebContentsView,
   type WebContentsViewConstructorOptions,
 } from "electron";
-import z from "zod";
+import { z } from "zod";
 import { subscribeWithSelector } from "zustand/middleware";
 import { createStore } from "zustand/vanilla";
 import { accounts } from "@/accounts";

--- a/packages/app/lib/window.ts
+++ b/packages/app/lib/window.ts
@@ -7,7 +7,7 @@ import {
   type BrowserWindowConstructorOptions,
   nativeTheme,
   screen,
-  WebContentsView,
+  type WebContentsView,
 } from "electron";
 import { shouldOpenDevToolsOnLaunch } from "./dev-tools";
 import { isLinuxWindowControlsEnabled } from "./linux";

--- a/packages/electron-extensions/web-navigation/web-navigation.ts
+++ b/packages/electron-extensions/web-navigation/web-navigation.ts
@@ -1,3 +1,4 @@
+import type * as electron from "electron";
 import type { Session, WebContents, WebFrameMain } from "electron";
 import type { ExtensionBridge } from "../bridge/bridge";
 import {
@@ -40,7 +41,7 @@ export type WebNavigationOptions = {
  * outside Electron, which is where this module's tests run.
  */
 function getElectronWebContentsById(tabId: number) {
-  const { webContents } = require("electron") as typeof import("electron");
+  const { webContents } = require("electron") as typeof electron;
 
   return webContents.fromId(tabId);
 }

--- a/packages/renderer/routes/settings/accounts.tsx
+++ b/packages/renderer/routes/settings/accounts.tsx
@@ -3,8 +3,11 @@ import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { accountColorsMap } from "@meru/shared/accounts";
 import { ipc } from "@meru/shared/renderer/ipc";
-import type { AccountConfig } from "@meru/shared/schemas";
-import { type AccountConfigInput, accountConfigInputSchema } from "@meru/shared/schemas";
+import {
+  type AccountConfig,
+  type AccountConfigInput,
+  accountConfigInputSchema,
+} from "@meru/shared/schemas";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import {

--- a/packages/renderer/routes/settings/version-history.tsx
+++ b/packages/renderer/routes/settings/version-history.tsx
@@ -8,7 +8,7 @@ import { Skeleton } from "@meru/ui/components/skeleton";
 import { useQuery } from "@tanstack/react-query";
 import Markdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
-import z from "zod";
+import { z } from "zod";
 import { SettingsDescription, SettingsHeader, SettingsTitle } from "@/components/settings";
 import { dayjs } from "@/lib/date";
 import { useConfig } from "@/lib/react-query";


### PR DESCRIPTION
`typescript/consistent-type-imports`, `import/no-duplicates` and `import/no-named-as-default` from the new shared config.

- `BrowserWindow` and `WebContentsView` are only used as types, so they take the inline `type` specifier the neighbouring Electron imports already use. Oxlint's own fix hoists them into a separate `import type` statement instead, which isn't how the rest of these files read, so they're written by hand.
- `web-navigation.ts` typed its lazy `require("electron")` with an inline `import()` annotation. It now uses a namespace type import, which is erased the same way and keeps the require lazy — the reason the module doesn't import Electron for value in the first place.
- `accounts.tsx` imported `@meru/shared/schemas` twice, and two files imported zod's `z` as a default import. `import { z }` is what the other two zod importers in the repo use.

## Test plan

1. `bun run types` — passes, confirming the namespace type import in `web-navigation.ts` types `webContents.fromId` the same way `typeof import("electron")` did.
2. `bun test packages/electron-extensions` — passes, so the require stayed lazy and the tests still run outside Electron.
