### PR TITLE
modernize the string, array and undefined checks

### DIFF
--- a/packages/app/blocker/hosts.ts
+++ b/packages/app/blocker/hosts.ts
@@ -515,7 +515,7 @@ const EMAIL_TRACKER_PATTERNS = [
 ];
 
 function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return value.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function createHostBoundaryPattern(hosts: string[]) {
@@ -536,8 +536,7 @@ export function createBlockMatcher({ ads, tracking }: { ads: boolean; tracking: 
   if (tracking) {
     const literals = [...GOOGLE_TELEMETRY_PATHS, ...EMAIL_TRACKER_SUBSTRINGS].map(escapeRegExp);
 
-    patterns.push(new RegExp(literals.join("|")));
-    patterns.push(new RegExp(EMAIL_TRACKER_PATTERNS.join("|")));
+    patterns.push(new RegExp(literals.join("|")), new RegExp(EMAIL_TRACKER_PATTERNS.join("|")));
   }
 
   if (!patterns.length) {

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -150,13 +150,13 @@ export const config = new Store<Config>({
 
         for (const account of accounts) {
           // @ts-expect-error: `unreadBadge` is now under 'gmail'
-          if (typeof account.unreadBadge === "undefined") {
+          if (account.unreadBadge === undefined) {
             // @ts-expect-error
             account.unreadBadge = true;
             accountsMigrated = true;
           }
 
-          if (typeof account.notifications === "undefined") {
+          if (account.notifications === undefined) {
             account.notifications = true;
             accountsMigrated = true;
           }
@@ -186,7 +186,7 @@ export const config = new Store<Config>({
         let accountsMigrated = false;
 
         for (const account of accounts) {
-          if (typeof account.gmail === "undefined") {
+          if (account.gmail === undefined) {
             // @ts-expect-error: `unreadBadge` is now under 'gmail'
             account.gmail = {
               delegatedAccountId: null,
@@ -223,7 +223,7 @@ export const config = new Store<Config>({
     },
     ">=3.18.0": (store) => {
       // @ts-expect-error: `app.doNotDisturb` is now 'doNotDisturb.enabled'
-      if (typeof store.get("app.doNotDisturb") !== "undefined") {
+      if (store.get("app.doNotDisturb") !== undefined) {
         // @ts-expect-error
         store.delete("app.doNotDisturb");
       }
@@ -235,7 +235,7 @@ export const config = new Store<Config>({
         let accountsMigrated = false;
 
         for (const account of accounts) {
-          if (typeof account.color === "undefined") {
+          if (account.color === undefined) {
             account.color = null;
 
             accountsMigrated = true;
@@ -257,7 +257,7 @@ export const config = new Store<Config>({
           if (
             // @ts-expect-error: `unreadBadge` is now under 'gmail'
             typeof account.unreadBadge === "boolean" &&
-            typeof account.gmail.unreadBadge === "undefined"
+            account.gmail.unreadBadge === undefined
           ) {
             // @ts-expect-error
             account.gmail.unreadBadge = account.unreadBadge;
@@ -353,7 +353,7 @@ export const config = new Store<Config>({
         // @ts-expect-error: `googleApps.*` keys are now 'workspaceApps.*'
         const value = store.get(previousKey);
 
-        if (typeof value !== "undefined") {
+        if (value !== undefined) {
           // @ts-expect-error
           store.set(renamedKey, value);
         }
@@ -368,7 +368,7 @@ export const config = new Store<Config>({
       // @ts-expect-error: `workspaceApps.pinnedApps` is now 'workspaceApps.launcherApps'
       const pinnedApps = store.get("workspaceApps.pinnedApps");
 
-      if (typeof pinnedApps !== "undefined") {
+      if (pinnedApps !== undefined) {
         // @ts-expect-error
         store.set("workspaceApps.launcherApps", pinnedApps);
 
@@ -380,7 +380,7 @@ export const config = new Store<Config>({
 
       if (Array.isArray(accounts)) {
         for (const account of accounts) {
-          if (typeof account.workspaceApps === "undefined") {
+          if (account.workspaceApps === undefined) {
             account.workspaceApps = { savedTabs: [], bookmarks: [] };
           }
         }
@@ -404,7 +404,7 @@ export const config = new Store<Config>({
       // @ts-expect-error: `gmail.fullDarkTheme` is now 'gmail.extendDarkTheme'
       const fullDarkTheme = store.get("gmail.fullDarkTheme");
 
-      if (typeof fullDarkTheme !== "undefined") {
+      if (fullDarkTheme !== undefined) {
         // @ts-expect-error
         store.set("gmail.extendDarkTheme", fullDarkTheme);
       }

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -148,7 +148,7 @@ function extractVerificationCode(texts: string[]) {
     const verificationCodeMatch = text.match(/\b([0-9]{3}[\s-][0-9]{3})\b/);
 
     if (verificationCodeMatch?.[1]) {
-      return verificationCodeMatch[1].replace(/[\s-]/g, "");
+      return verificationCodeMatch[1].replaceAll(/[\s-]/g, "");
     }
   }
 
@@ -156,7 +156,7 @@ function extractVerificationCode(texts: string[]) {
     const verificationCodeMatch = text.match(/\b([0-9]{2}[\s-][0-9]{2}[\s-][0-9]{2})\b/);
 
     if (verificationCodeMatch?.[1]) {
-      return verificationCodeMatch[1].replace(/[\s-]/g, "");
+      return verificationCodeMatch[1].replaceAll(/[\s-]/g, "");
     }
   }
 
@@ -173,7 +173,7 @@ function extractVerificationCode(texts: string[]) {
     const verificationCodeMatch = text.match(/\b([0-9]{4}[\s-][0-9]{4})\b/);
 
     if (verificationCodeMatch?.[1]) {
-      return verificationCodeMatch[1].replace(/[\s-]/g, "");
+      return verificationCodeMatch[1].replaceAll(/[\s-]/g, "");
     }
   }
 
@@ -183,7 +183,7 @@ function extractVerificationCode(texts: string[]) {
     );
 
     if (verificationCodeMatch?.[1]) {
-      return verificationCodeMatch[1].replace(/[\s-]/g, "");
+      return verificationCodeMatch[1].replaceAll(/[\s-]/g, "");
     }
   }
 
@@ -203,7 +203,7 @@ function extractVerificationCode(texts: string[]) {
     const verificationCodeMatch = text.match(/\b([0-9]{2}[\s-][0-9]{2})\b/);
 
     if (verificationCodeMatch?.[1]) {
-      return verificationCodeMatch[1].replace(/[\s-]/g, "");
+      return verificationCodeMatch[1].replaceAll(/[\s-]/g, "");
     }
   }
 

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -1122,7 +1122,7 @@ class Ipc {
     this.main.on("gmail.unreadCountChanged", (event, unreadCountString) => {
       const parsedUnreadCountString = unreadCountString
         .split(":")
-        .map((count) => Number(count.replace(/\D/g, "")) || 0);
+        .map((count) => Number(count.replaceAll(/\D/g, "")) || 0);
 
       const unreadCountPreference = config.get("gmail.unreadCountPreference");
 

--- a/packages/app/lib/linux.ts
+++ b/packages/app/lib/linux.ts
@@ -17,7 +17,7 @@ async function getGtkDecorationLayout() {
       { timeout: 3000 },
     );
 
-    return layout.trim().replace(/^'|'$/g, "");
+    return layout.trim().replaceAll(/^'|'$/g, "");
   } catch {
     // gsettings not available or schema not installed
   }

--- a/packages/dark-theme/color.ts
+++ b/packages/dark-theme/color.ts
@@ -126,7 +126,7 @@ function formatFixed(value: number, digits = 0): string {
 
   const dotIndex = fixed.indexOf(".");
 
-  if (dotIndex < 0) {
+  if (dotIndex === -1) {
     return fixed;
   }
 

--- a/packages/dark-theme/image.ts
+++ b/packages/dark-theme/image.ts
@@ -229,8 +229,8 @@ function loadImage(url: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const image = new Image();
     image.crossOrigin = "anonymous";
-    image.onload = () => resolve(image);
-    image.onerror = () => reject(new Error(`Unable to load image ${url}`));
+    image.addEventListener("load", () => resolve(image));
+    image.addEventListener("error", () => reject(new Error(`Unable to load image ${url}`)));
     image.src = url;
   });
 }
@@ -414,7 +414,7 @@ const xmlEscapes: Record<string, string> = {
 };
 
 function escapeXML(text: string): string {
-  return text.replace(/[<>&'"]/g, (character) => xmlEscapes[character] ?? character);
+  return text.replaceAll(/[<>&'"]/g, (character) => xmlEscapes[character] ?? character);
 }
 
 export function getFilteredImageURL(details: ImageDetails, theme: Theme): string {

--- a/packages/electron-extensions/derive/web-accessible.ts
+++ b/packages/electron-extensions/derive/web-accessible.ts
@@ -9,7 +9,7 @@ export type WebAccessibleResources = (
 )[];
 
 function escapeRegExp(literal: string) {
-  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return literal.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /**

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -119,7 +119,7 @@ function createSession({
       },
     },
     clearStorageData: async ({ origin, storages }: ClearStorageDataOptions) => {
-      sessionEvents.push(`clearStorageData ${origin} ${storages?.join()}`);
+      sessionEvents.push(`clearStorageData ${origin} ${storages?.join(",")}`);
     },
     getStoragePath: () => storagePath,
     serviceWorkers: {

--- a/packages/electron-extensions/native-messaging/windows-registry.ts
+++ b/packages/electron-extensions/native-messaging/windows-registry.ts
@@ -18,7 +18,7 @@ export function expandEnvironmentVariables(
     Object.entries(environment).map(([name, variableValue]) => [name.toLowerCase(), variableValue]),
   );
 
-  return value.replace(
+  return value.replaceAll(
     /%([^%]+)%/g,
     (reference, name: string) => valuesByLowerCaseName.get(name.toLowerCase()) ?? reference,
   );

--- a/packages/renderer/components/workspace-app-icon.tsx
+++ b/packages/renderer/components/workspace-app-icon.tsx
@@ -10,7 +10,7 @@ export function WorkspaceAppIcon({
   // suffix, two icons rendered at once share one set of definitions — and an
   // icon inside a `display: none` subtree has no definitions at all, so
   // whichever copy comes first in the DOM determines whether the rest render.
-  const instanceId = useId().replace(/[^a-zA-Z0-9]/g, "");
+  const instanceId = useId().replaceAll(/[^a-zA-Z0-9]/g, "");
 
   switch (app) {
     case "admin": {

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -99,7 +99,7 @@ export function useUnifiedInbox() {
   const accounts = useAccountsStore((state) => state.accounts);
 
   const messages: UnifiedInboxMessage[] = accounts
-    .map((account) =>
+    .flatMap((account) =>
       account.gmail.unreadInbox.map((mail) => ({
         account: {
           id: account.config.id,
@@ -109,7 +109,6 @@ export function useUnifiedInbox() {
         ...mail,
       })),
     )
-    .flat()
     .sort((a, b) => (b.receivedAt > a.receivedAt ? 1 : -1));
 
   return { messages };

--- a/packages/shared/color.ts
+++ b/packages/shared/color.ts
@@ -8,7 +8,7 @@ function parseHexColor(input: string): Rgb | null {
   let hex = input.slice(1);
 
   if (hex.length === 3 || hex.length === 4) {
-    hex = hex.replace(/./g, (channel) => channel + channel);
+    hex = hex.replaceAll(/./g, (channel) => channel + channel);
   }
 
   if (hex.length !== 6 && hex.length !== 8) {

--- a/packages/shared/gmail.ts
+++ b/packages/shared/gmail.ts
@@ -131,7 +131,7 @@ export function generateGmailLabelColorsCss(labelColors: GmailLabelColors) {
   return labelColors
     .filter(({ label, color }) => label && isValidCssColorInput(color))
     .flatMap(({ label, color, textColor }) => {
-      const escapedLabel = label.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+      const escapedLabel = label.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
 
       const resolvedTextColor = resolveGmailLabelTextColor(color, textColor);
 


### PR DESCRIPTION
The mechanical half of the new shared config's `unicorn` rules, applied with `oxlint --fix` and reviewed hunk by hunk.

- `String#replace` with a global regex becomes `replaceAll` in ten places. In `generateGmailLabelColorsCss` the two single-character regexes become plain string arguments, which `replaceAll` treats literally.
- `typeof x === "undefined"` becomes `x === undefined` throughout the config migrations.
- `.map(…).flat()` in `useUnifiedInbox` becomes `.flatMap(…)`, two adjacent `patterns.push` calls in the blocker become one, `storages?.join()` spells its `","` out, and `dotIndex < 0` becomes `dotIndex === -1`.
- `loadImage` assigns `onload`/`onerror` handlers, which `unicorn/prefer-add-event-listener` flags and has no fix for; those are `addEventListener` calls now.

No behavior changes — every rewrite here is an equivalent spelling.

## Test plan

1. Open Settings → Gmail → Label Colors and add a label whose name contains a `"` or a `\` — the generated CSS still escapes it, covering the `replaceAll` calls that swapped a regex for a string pattern.
2. Trigger a Gmail notification with a verification code in it — `extractVerificationCode` strips the spaces and dashes through five `replaceAll` calls now.
3. Open a Gmail message with images while the dark theme extension is on — `loadImage` resolves through the new `addEventListener` handlers.
