### PR TITLE
drop async from the two functions that never await

### DIFF
--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -175,7 +175,7 @@ export class Account {
 
   private registerSessionDisplayMediaRequestHandler() {
     this.session.setDisplayMediaRequestHandler(
-      async (_request, callback) => {
+      (_request, callback) => {
         const googleMeetParentWindow = this.findGoogleMeetParentWindow();
 
         if (!googleMeetParentWindow) {

--- a/packages/preload-gmail/compose.ts
+++ b/packages/preload-gmail/compose.ts
@@ -19,7 +19,7 @@ const composeButtonElementSelector = createNotMatchingAttributeSelector(
   composeButtonProcessedAttribute,
 );
 
-export async function openComposeInNewWindow() {
+export function openComposeInNewWindow() {
   if (!isOpenComposeInNewWindowEnabled) {
     return;
   }


### PR DESCRIPTION
`typescript/require-await` reports 32 functions. Thirty are test doubles declared `async` to satisfy a promise-returning contract, and dropping the keyword there would turn a rejection into a synchronous throw — those are handled by turning the rule off for test files in the shared config (timche/oxc-configs#3), not here.

The two remaining ones are real:

- `openComposeInNewWindow` is one of the entries in the preload's `features` array, which `runFeatures` calls inside a `try`/`catch`. Being `async` meant a throw escaped that `catch` as an unhandled rejection instead.
- The `setDisplayMediaRequestHandler` callback never awaits, and everything it calls — `createBrowserWindow`, `loadRenderer`, the IPC listeners — is synchronous. Electron types the handler as void-returning.

## Test plan

1. Turn on Settings → Gmail → Open Compose in New Window, then click Compose in Gmail — it opens in its own window, so the preload feature still runs.
2. Start a Google Meet call and share a screen — the picker window opens, choosing a source starts the share, and closing the picker cancels it.
