### PR TITLE
share the tsconfig bases so toSorted and toReversed type-check

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -101,6 +101,10 @@
       "name": "@meru/shared",
       "version": "0.0.0",
     },
+    "packages/tsconfig": {
+      "name": "@meru/tsconfig",
+      "version": "0.0.0",
+    },
     "packages/ui": {
       "name": "@meru/ui",
       "version": "0.0.0",
@@ -295,6 +299,8 @@
     "@meru/renderer": ["@meru/renderer@workspace:packages/renderer"],
 
     "@meru/shared": ["@meru/shared@workspace:packages/shared"],
+
+    "@meru/tsconfig": ["@meru/tsconfig@workspace:packages/tsconfig"],
 
     "@meru/ui": ["@meru/ui@workspace:packages/ui"],
 

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -97,7 +97,7 @@ class Accounts {
   }
 
   async createViews() {
-    const accounts = this.getAccounts().sort((a, b) => {
+    const accounts = this.getAccounts().toSorted((a, b) => {
       if (a.config.selected && !b.config.selected) {
         return 1;
       }

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -754,7 +754,7 @@ export class Gmail {
 
       const hasMultipleAccounts = accounts.getAccountConfigs().length > 1;
 
-      for (const newMailIndex of newMailIndexes.reverse()) {
+      for (const newMailIndex of newMailIndexes.toReversed()) {
         const newMail = unreadInbox[newMailIndex];
 
         if (!newMail) {

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@total-typescript/tsconfig/bundler/no-dom",
+  "extends": "@meru/tsconfig/node",
   "compilerOptions": {
     "paths": {
       "@/*": ["./*"]

--- a/packages/dark-theme/tsconfig.json
+++ b/packages/dark-theme/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@total-typescript/tsconfig/bundler/dom",
+  "extends": "@meru/tsconfig/dom",
   "exclude": ["**/*.test.ts"]
 }

--- a/packages/electron-extensions/action.ts
+++ b/packages/electron-extensions/action.ts
@@ -80,7 +80,7 @@ function pickIconPath(icons: Record<string, string> | undefined) {
   const sizedIcons = Object.entries(icons)
     .map(([size, iconPath]) => ({ size: Number(size), iconPath }))
     .filter(({ size }) => Number.isFinite(size) && size > 0)
-    .sort((a, b) => a.size - b.size);
+    .toSorted((a, b) => a.size - b.size);
 
   const pickedIcon = sizedIcons.find(({ size }) => size >= ICON_SIZE) ?? sizedIcons.at(-1);
 

--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -115,7 +115,7 @@ describe("deriveExtension", () => {
   test("never writes to the directory it was handed", async () => {
     await derive();
 
-    expect((await readdir(sourceDir)).sort()).toEqual([
+    expect((await readdir(sourceDir)).toSorted()).toEqual([
       "background",
       "manifest.json",
       "popup.html",
@@ -377,7 +377,7 @@ describe("pruneDerivedExtensions", () => {
 
     await pruneDerivedExtensions({ derivedExtensionsDir, keptSourceDirs: [otherSourceDir] });
 
-    expect((await readdir(derivedExtensionsDir)).sort()).toEqual([
+    expect((await readdir(derivedExtensionsDir)).toSorted()).toEqual([
       path.basename(otherDerivedDir),
       `${path.basename(otherDerivedDir)}.json`,
     ]);

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -63,7 +63,7 @@ async function hashSourceTree(sourceDir: string) {
     fileEntries.push(`${relativePath}\0${stats.size}\0${stats.mtimeMs}`);
   }
 
-  return hash(fileEntries.sort().join("\n"));
+  return hash(fileEntries.toSorted().join("\n"));
 }
 
 async function readStamp(stampPath: string) {

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -183,7 +183,7 @@ async function createPartitionDir(entryPaths: string[]) {
 async function listPartitionDir(partitionPath: string) {
   const entryPaths = await fs.readdir(partitionPath, { recursive: true });
 
-  return entryPaths.sort();
+  return entryPaths.toSorted();
 }
 
 describe("Extensions", () => {

--- a/packages/electron-extensions/install/installer.test.ts
+++ b/packages/electron-extensions/install/installer.test.ts
@@ -74,7 +74,7 @@ function createFetch({ crx, servedVersion }: { crx?: Uint8Array; servedVersion?:
 
 async function readEntryNames(dirPath: string) {
   try {
-    return (await readdir(dirPath, { recursive: true })).sort();
+    return (await readdir(dirPath, { recursive: true })).toSorted();
   } catch {
     return [];
   }

--- a/packages/electron-extensions/install/installer.ts
+++ b/packages/electron-extensions/install/installer.ts
@@ -191,7 +191,7 @@ export async function getInstalledExtension({
 }: InstalledExtensionOptions): Promise<InstalledExtension | undefined> {
   const extensionInstallDir = path.join(installDir, extensionId);
 
-  const [version] = (await readInstalledVersions(extensionInstallDir)).sort(
+  const [version] = (await readInstalledVersions(extensionInstallDir)).toSorted(
     (version, otherVersion) => compareExtensionVersions(otherVersion, version),
   );
 

--- a/packages/electron-extensions/scan.ts
+++ b/packages/electron-extensions/scan.ts
@@ -25,7 +25,7 @@ export function findExtensionDirs(dirPath: string) {
   }
 
   return entryNames
-    .sort()
+    .toSorted()
     .map((entryName) => path.join(dirPath, entryName))
     .filter((extensionDir) => fs.existsSync(path.join(extensionDir, MANIFEST_FILE_NAME)))
     .map((extensionDir) => fs.realpathSync(extensionDir));

--- a/packages/electron-extensions/tsconfig.json
+++ b/packages/electron-extensions/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@total-typescript/tsconfig/bundler/no-dom",
+  "extends": "@meru/tsconfig/node",
   "exclude": ["**/*.test.ts"]
 }

--- a/packages/preload-gmail/tsconfig.json
+++ b/packages/preload-gmail/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@total-typescript/tsconfig/bundler/dom",
+  "extends": "@meru/tsconfig/dom",
   "compilerOptions": {
     "jsx": "react-jsx",
     "paths": {

--- a/packages/preload-renderer/tsconfig.json
+++ b/packages/preload-renderer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@total-typescript/tsconfig/bundler/dom",
+  "extends": "@meru/tsconfig/dom",
   "compilerOptions": {
     "paths": {
       "@/*": ["./*"]

--- a/packages/preload-workspace-app/tsconfig.json
+++ b/packages/preload-workspace-app/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@total-typescript/tsconfig/bundler/dom",
+  "extends": "@meru/tsconfig/dom",
   "compilerOptions": {
     "paths": {
       "@/*": ["./*"]

--- a/packages/renderer/lib/hooks.ts
+++ b/packages/renderer/lib/hooks.ts
@@ -109,7 +109,7 @@ export function useUnifiedInbox() {
         ...mail,
       })),
     )
-    .sort((a, b) => (b.receivedAt > a.receivedAt ? 1 : -1));
+    .toSorted((a, b) => (b.receivedAt > a.receivedAt ? 1 : -1));
 
   return { messages };
 }

--- a/packages/renderer/routes/settings/languages.tsx
+++ b/packages/renderer/routes/settings/languages.tsx
@@ -63,7 +63,7 @@ export function LanguagesSettings() {
   const languages = availableLanguages
     .filter((code) => code !== osLocale)
     .map((code) => ({ code, label: getLanguageLabel(code) }))
-    .sort((a, b) => a.label.localeCompare(b.label));
+    .toSorted((a, b) => a.label.localeCompare(b.label));
 
   function toggleLanguage(code: string, checked: boolean) {
     const updated = checked ? [...selected, code] : selected.filter((l) => l !== code);

--- a/packages/renderer/tsconfig.json
+++ b/packages/renderer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@total-typescript/tsconfig/bundler/dom",
+  "extends": "@meru/tsconfig/dom",
   "compilerOptions": {
     "jsx": "react-jsx",
     "paths": {

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@total-typescript/tsconfig/bundler/dom",
+  "extends": "@meru/tsconfig/dom",
   "compilerOptions": {
     "jsx": "react-jsx",
     "paths": {

--- a/packages/tsconfig/dom.json
+++ b/packages/tsconfig/dom.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@total-typescript/tsconfig/bundler/dom",
+  "compilerOptions": {
+    "lib": ["es2023", "dom", "dom.iterable"]
+  }
+}

--- a/packages/tsconfig/node.json
+++ b/packages/tsconfig/node.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@total-typescript/tsconfig/bundler/no-dom",
+  "compilerOptions": {
+    "lib": ["es2023"]
+  }
+}

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@meru/tsconfig",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    "./dom": "./dom.json",
+    "./node": "./node.json"
+  }
+}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@total-typescript/tsconfig/bundler/dom",
+  "extends": "@meru/tsconfig/dom",
   "compilerOptions": {
     "jsx": "react-jsx"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "@total-typescript/tsconfig/bundler/no-dom",
+  "extends": "@meru/tsconfig/node",
   "exclude": ["packages"]
 }


### PR DESCRIPTION
`unicorn/no-array-sort` and `no-array-reverse` want `toSorted` and `toReversed`, which are ES2023. Every `tsconfig.json` extended `@total-typescript/tsconfig` directly at `lib: ["es2022"]`, so the rewrite didn't type-check.

Rather than repeat a `lib` override in nine files, this adds a `@meru/tsconfig` workspace package with a `node` and a `dom` base. Each extends the `@total-typescript` preset it was already using and raises `lib` to `es2023`; the ten `tsconfig.json` files now extend those. The `tsconfig.test.json` files inherit it through their package's config.

Electron 43 and Bun both ship these methods, so nothing changes at runtime.

Two of the twelve rewrites stop mutating an array in place:

- `Gmail#fetchInboxFeed` reversed `newMailIndexes` before iterating it. Nothing reads the array afterwards, so the order it's left in doesn't matter today.
- `Accounts#createViews` sorted the result of `getAccounts()`, which builds a fresh array on every call, so nothing observed that either.

The other ten already sorted a freshly built array.

## Test plan

1. `bun run dev` — the dev server boots and the app opens, confirming the tsconfig indirection doesn't break the build.
2. Open Settings → Languages — the list is still sorted by label, through `toSorted` now.
3. Receive two or more new mails at once — the notifications still arrive oldest first, which is what reversing the indexes was for.
