### PR TITLE
mark the deliberately unawaited promises with void

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -48,7 +48,7 @@ class Accounts {
 
     config.onDidChange("gmail.labelColors", () => {
       for (const account of accounts.instances.values()) {
-        account.gmail.applyLabelColors();
+        void account.gmail.applyLabelColors();
       }
     });
 
@@ -335,7 +335,7 @@ class Accounts {
 
     const instance = new Account(createdAccount);
 
-    instance.gmail.createView();
+    void instance.gmail.createView();
 
     this.instances.set(createdAccount.id, instance);
 

--- a/packages/app/context-menu.ts
+++ b/packages/app/context-menu.ts
@@ -63,7 +63,7 @@ export function setupWindowContextMenu(window: BrowserWindow | WebContentsView) 
           {
             label: "Open in Default Browser",
             click: () => {
-              openExternalUrl(window.webContents.getURL(), {
+              void openExternalUrl(window.webContents.getURL(), {
                 skipTrustedHostCheck: true,
               });
             },

--- a/packages/app/dialogs.ts
+++ b/packages/app/dialogs.ts
@@ -47,6 +47,6 @@ export async function showProUpgradeDialog(message: string) {
   });
 
   if (response === 0) {
-    openExternalUrl(`${WEBSITE_URL}/#pricing`, { skipTrustedHostCheck: true });
+    void openExternalUrl(`${WEBSITE_URL}/#pricing`, { skipTrustedHostCheck: true });
   }
 }

--- a/packages/app/downloads.ts
+++ b/packages/app/downloads.ts
@@ -88,7 +88,7 @@ class Downloads {
               : `Click to show the file in ${FILE_MANAGER_NAME}.`,
             click: () => {
               if (shouldOpenFile) {
-                shell.openPath(filePath);
+                void shell.openPath(filePath);
               } else {
                 shell.showItemInFolder(filePath);
               }

--- a/packages/app/extension-actions.ts
+++ b/packages/app/extension-actions.ts
@@ -120,7 +120,7 @@ class ExtensionActions {
     // none of the app's navigation policing
     if (opened) {
       this.popup.webContents?.setWindowOpenHandler(({ url }) => {
-        openExternalUrl(url);
+        void openExternalUrl(url);
 
         return { action: "deny" };
       });

--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -210,11 +210,11 @@ class ExtensionUpdater {
     // re-reads the opt-ins, so an extension installed mid-session is kept up to
     // date without a restart
     if (config.get("extensions.installed").length > 0) {
-      this.checkForUpdates();
+      void this.checkForUpdates();
     }
 
     setInterval(() => {
-      this.checkForUpdates();
+      void this.checkForUpdates();
     }, ms("3h"));
   }
 

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -425,18 +425,18 @@ export class Gmail {
 
     this.view.webContents.on("dom-ready", () => {
       if (this.view.webContents.getURL().startsWith(GMAIL_URL)) {
-        this.view.webContents.insertCSS(gmailCSS);
+        void this.view.webContents.insertCSS(gmailCSS);
 
         if (licenseKey.isValid && GMAIL_USER_STYLES) {
-          this.view.webContents.insertCSS(GMAIL_USER_STYLES);
+          void this.view.webContents.insertCSS(GMAIL_USER_STYLES);
         }
 
         this.labelColorsCssKey = null;
 
-        this.applyLabelColors();
+        void this.applyLabelColors();
       }
 
-      this.view.webContents.insertCSS(meruCSS);
+      void this.view.webContents.insertCSS(meruCSS);
     });
 
     this.view.webContents.on("page-title-updated", (_event, pageTitle, explicitSet) => {
@@ -498,7 +498,7 @@ export class Gmail {
 
   private registerNavigationHandler(window: BrowserWindow | WebContentsView) {
     window.webContents.on("did-navigate", (_event, url) => {
-      WorkspaceApp.handleNavigate(url, this.session);
+      void WorkspaceApp.handleNavigate(url, this.session);
 
       if (window === this.view) {
         this.store.setState({
@@ -628,7 +628,7 @@ export class Gmail {
         const gmailDelegatedAccountId = url.match(GMAIL_DELEGATED_ACCOUNT_URL_REGEXP)?.[1];
 
         if (gmailDelegatedAccountId) {
-          loadUrl(window.webContents, url);
+          void loadUrl(window.webContents, url);
 
           this.setDelegatedAccountId(gmailDelegatedAccountId);
 
@@ -636,7 +636,7 @@ export class Gmail {
         }
 
         if (url === `${GMAIL_URL}/`) {
-          loadUrl(window.webContents, url);
+          void loadUrl(window.webContents, url);
 
           const account = accounts.getAccount(this.accountId);
 
@@ -698,7 +698,7 @@ export class Gmail {
 
         await wait(ms("1s"));
 
-        this.fetchInboxFeed(fetchAttempt + 1);
+        void this.fetchInboxFeed(fetchAttempt + 1);
 
         return;
       }
@@ -999,7 +999,7 @@ export class Gmail {
   }
 
   search(query: string) {
-    this.view.webContents.executeJavaScript(`window.location.hash = "#search/${query}"`);
+    void this.view.webContents.executeJavaScript(`window.location.hash = "#search/${query}"`);
   }
 
   navigateToHash(urlOrHash: string) {
@@ -1009,6 +1009,6 @@ export class Gmail {
       return;
     }
 
-    this.view.webContents.executeJavaScript(`window.location.hash = ${JSON.stringify(hash)}`);
+    void this.view.webContents.executeJavaScript(`window.location.hash = ${JSON.stringify(hash)}`);
   }
 }

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -121,7 +121,7 @@ async function init() {
 
   main.loadURL();
 
-  accounts.createViews();
+  void accounts.createViews();
 
   ipc.init();
 
@@ -137,13 +137,13 @@ async function init() {
 
   extensionUpdater.init();
 
-  pruneDerivedExtensionCopies();
+  void pruneDerivedExtensionCopies();
 
   doNotDisturb.init();
 
   if (!platform.isMacOS) {
     if (PROCESS_MAILTO_URL_ARG) {
-      handleMailtoUrl(PROCESS_MAILTO_URL_ARG);
+      void handleMailtoUrl(PROCESS_MAILTO_URL_ARG);
     } else if (PROCESS_MERU_URL_ARG) {
       handleMeruUrl(PROCESS_MERU_URL_ARG);
     }
@@ -156,7 +156,7 @@ async function init() {
       const mailtoUrlArg = findMailtoUrlArg(argv);
 
       if (mailtoUrlArg) {
-        handleMailtoUrl(mailtoUrlArg);
+        void handleMailtoUrl(mailtoUrlArg);
 
         return;
       }
@@ -184,7 +184,7 @@ async function init() {
 
     app.on("open-url", (_event, url) => {
       if (isMailtoUrl(url)) {
-        handleMailtoUrl(url);
+        void handleMailtoUrl(url);
       }
 
       if (isMeruUrl(url)) {
@@ -222,4 +222,4 @@ async function init() {
   });
 }
 
-init();
+void init();

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -136,7 +136,7 @@ class Ipc {
     });
 
     this.main.on("accounts.removeAccount", (_event, selectedAccountId) => {
-      accounts.removeAccount(selectedAccountId);
+      void accounts.removeAccount(selectedAccountId);
     });
 
     this.main.on("accounts.updateAccount", (_event, updatedAccount) => {
@@ -217,7 +217,7 @@ class Ipc {
         return;
       }
 
-      shell.openPath(filePath);
+      void shell.openPath(filePath);
     });
 
     ipc.main.on("downloads.showFileInFolder", async (_event, { id, filePath }) => {
@@ -473,7 +473,7 @@ class Ipc {
               return;
             }
 
-            openExternalUrl(tab.url, { skipTrustedHostCheck: true });
+            void openExternalUrl(tab.url, { skipTrustedHostCheck: true });
           },
         },
         ...(tabApp
@@ -821,7 +821,7 @@ class Ipc {
       }
 
       if (!canOpenWorkspaceAppInApp(app)) {
-        openExternalUrl(getWorkspaceAppUrl(app), {
+        void openExternalUrl(getWorkspaceAppUrl(app), {
           skipTrustedHostCheck: true,
           focusBrowser: modifierOpenBehavior !== "backgroundTab",
         });
@@ -890,7 +890,7 @@ class Ipc {
       }
 
       if (openIn === "editor") {
-        shell.openPath(GMAIL_USER_STYLES_PATH);
+        void shell.openPath(GMAIL_USER_STYLES_PATH);
       } else {
         shell.showItemInFolder(GMAIL_USER_STYLES_PATH);
       }
@@ -1099,7 +1099,7 @@ class Ipc {
       }
 
       if (downloads.toggleRecentDownloadHistoryPopup(parentWindow)) {
-        downloads.checkDownloadHistoryItems(MAX_RECENT_DOWNLOAD_HISTORY_ITEMS);
+        void downloads.checkDownloadHistoryItems(MAX_RECENT_DOWNLOAD_HISTORY_ITEMS);
       }
     });
 
@@ -1116,7 +1116,7 @@ class Ipc {
 
       main.navigate("/download-history");
 
-      downloads.checkDownloadHistoryItems();
+      void downloads.checkDownloadHistoryItems();
     });
 
     this.main.on("gmail.unreadCountChanged", (event, unreadCountString) => {
@@ -1141,7 +1141,7 @@ class Ipc {
         if (event.sender.id === account.gmail.view.webContents.id) {
           account.gmail.setUnreadCount(unreadCount);
 
-          account.gmail.fetchInboxFeed();
+          void account.gmail.fetchInboxFeed();
 
           break;
         }

--- a/packages/app/lib/popup.ts
+++ b/packages/app/lib/popup.ts
@@ -243,7 +243,7 @@ export class Popup {
     if (isPage) {
       loadRenderer(this.view, { page: content.page });
     } else {
-      loadUrl(this.view.webContents, content.url);
+      void loadUrl(this.view.webContents, content.url);
     }
 
     parentWindow.contentView.addChildView(this.view);

--- a/packages/app/lib/web-contents.ts
+++ b/packages/app/lib/web-contents.ts
@@ -46,7 +46,7 @@ export function logLoadFailures(webContents: WebContents, name: string) {
 
 export function applyViewZoomLimits(view: WebContentsView) {
   view.webContents.on("dom-ready", () => {
-    view.webContents.setVisualZoomLevelLimits(1, 3);
+    void view.webContents.setVisualZoomLevelLimits(1, 3);
   });
 }
 

--- a/packages/app/lib/window.ts
+++ b/packages/app/lib/window.ts
@@ -151,13 +151,16 @@ export function loadRenderer(
   searchParams.set("darkMode", nativeTheme.shouldUseDarkColors ? "true" : "false");
 
   if (is.dev) {
-    loadUrl(window.webContents, `http://localhost:3000/${pageFileName}?${searchParams.toString()}`);
+    void loadUrl(
+      window.webContents,
+      `http://localhost:3000/${pageFileName}?${searchParams.toString()}`,
+    );
 
     if (shouldOpenDevToolsOnLaunch) {
       window.webContents.openDevTools({ mode: "detach" });
     }
   } else {
-    window.webContents.loadFile(path.join("build-js", "renderer", pageFileName), {
+    void window.webContents.loadFile(path.join("build-js", "renderer", pageFileName), {
       search: searchParams.toString(),
     });
   }

--- a/packages/app/license-key.ts
+++ b/packages/app/license-key.ts
@@ -52,7 +52,7 @@ class LicenseKey {
           });
 
           if (response === 0) {
-            openExternalUrl("https://portal.meru.so");
+            void openExternalUrl("https://portal.meru.so");
           }
         } else {
           await this.showActivationError({

--- a/packages/app/main.ts
+++ b/packages/app/main.ts
@@ -136,7 +136,7 @@ class Main {
     });
 
     this.window.webContents.setWindowOpenHandler(({ url }) => {
-      openExternalUrl(url, { skipTrustedHostCheck: true });
+      void openExternalUrl(url, { skipTrustedHostCheck: true });
 
       return {
         action: "deny",
@@ -194,7 +194,7 @@ class Main {
     }
 
     if (app.dock?.isVisible) {
-      app.dock.show();
+      void app.dock.show();
     }
   }
 

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -421,7 +421,7 @@ export class AppMenu {
 
               main.navigate("/download-history");
 
-              downloads.checkDownloadHistoryItems();
+              void downloads.checkDownloadHistoryItems();
             },
           },
           {
@@ -671,13 +671,13 @@ export class AppMenu {
           {
             label: "Website",
             click: () => {
-              openExternalUrl(WEBSITE_URL);
+              void openExternalUrl(WEBSITE_URL);
             },
           },
           {
             label: "Source Code",
             click: () => {
-              openExternalUrl(GITHUB_REPO_URL);
+              void openExternalUrl(GITHUB_REPO_URL);
             },
           },
           {
@@ -686,7 +686,7 @@ export class AppMenu {
           {
             label: "Gmail Keyboard Shortcuts",
             click: () => {
-              openExternalUrl("https://support.google.com/mail/answer/6594");
+              void openExternalUrl("https://support.google.com/mail/answer/6594");
             },
           },
           {
@@ -723,7 +723,7 @@ export class AppMenu {
               {
                 label: "Edit Config",
                 click: () => {
-                  config.openInEditor();
+                  void config.openInEditor();
                 },
               },
               {
@@ -736,7 +736,7 @@ export class AppMenu {
                     accounts.getAccounts().map((account) => account.instance.session.clearCache()),
                   );
 
-                  showRestartDialog();
+                  void showRestartDialog();
                 },
               },
               {
@@ -768,7 +768,7 @@ export class AppMenu {
               {
                 label: "View Logs",
                 click: () => {
-                  shell.openPath(log.transports.file.getFile().path);
+                  void shell.openPath(log.transports.file.getFile().path);
                 },
               },
             ],

--- a/packages/app/protocol.ts
+++ b/packages/app/protocol.ts
@@ -23,7 +23,7 @@ export function isMailtoUrl(url: string) {
 
 export async function handleMailtoUrl(url: string) {
   if (!licenseKey.isValid) {
-    showProUpgradeDialog("Meru Pro is required to set Meru as the default mail client.");
+    void showProUpgradeDialog("Meru Pro is required to set Meru as the default mail client.");
 
     return;
   }
@@ -96,7 +96,7 @@ export function isMeruUrl(url: string) {
 
 export function handleMeruUrl(url: string) {
   if (!licenseKey.isValid) {
-    showProUpgradeDialog("Meru Pro is required to open Meru links.");
+    void showProUpgradeDialog("Meru Pro is required to open Meru links.");
 
     return;
   }

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -284,7 +284,7 @@ export class Tabs {
     // A designated tab is woken on the link's app, which is not necessarily the
     // one it was saved on.
     if (!canOpenWorkspaceAppInApp(url ? getWorkspaceAppFromUrl(url) : dormantTab.app)) {
-      openExternalUrl(url ?? dormantTab.url, { skipTrustedHostCheck: true });
+      void openExternalUrl(url ?? dormantTab.url, { skipTrustedHostCheck: true });
 
       return;
     }
@@ -518,7 +518,7 @@ export class Tabs {
    */
   openUrl(url: string) {
     if (!canOpenWorkspaceAppInApp(getWorkspaceAppFromUrl(url))) {
-      openExternalUrl(url, { skipTrustedHostCheck: true });
+      void openExternalUrl(url, { skipTrustedHostCheck: true });
 
       return;
     }

--- a/packages/app/trial.ts
+++ b/packages/app/trial.ts
@@ -72,7 +72,7 @@ class Trial {
       });
 
       if (response === 0) {
-        openExternalUrl("https://meru.so/#pricing", { skipTrustedHostCheck: true });
+        void openExternalUrl("https://meru.so/#pricing", { skipTrustedHostCheck: true });
       }
 
       if (response === 2) {
@@ -94,7 +94,7 @@ class Trial {
 
     this.validationInterval = setInterval(
       () => {
-        this.validate();
+        void this.validate();
       },
       1000 * 60 * 60 * 3,
     );

--- a/packages/app/updater.ts
+++ b/packages/app/updater.ts
@@ -41,11 +41,11 @@ class AppUpdater {
       return;
     }
 
-    autoUpdater.checkForUpdates();
+    void autoUpdater.checkForUpdates();
 
     setInterval(
       () => {
-        autoUpdater.checkForUpdates();
+        void autoUpdater.checkForUpdates();
       },
       1000 * 60 * 60 * 3,
     );
@@ -56,7 +56,7 @@ class AppUpdater {
       return;
     }
 
-    autoUpdater.checkForUpdates();
+    void autoUpdater.checkForUpdates();
   }
 
   quitAndInstall() {

--- a/packages/app/url.ts
+++ b/packages/app/url.ts
@@ -48,5 +48,5 @@ export async function openExternalUrl(
     }
   }
 
-  shell.openExternal(cleanUrl, { activate: options?.focusBrowser });
+  void shell.openExternal(cleanUrl, { activate: options?.focusBrowser });
 }

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -210,7 +210,7 @@ export class WorkspaceApp {
 
     event.preventDefault();
 
-    loadUrl(webContents, `${GOOGLE_ACCOUNTS_URL}/ServiceLogin?service=mail`);
+    void loadUrl(webContents, `${GOOGLE_ACCOUNTS_URL}/ServiceLogin?service=mail`);
   }
 
   static handleWindowOpen({
@@ -244,7 +244,7 @@ export class WorkspaceApp {
               return;
             }
 
-            openExternalUrl(navigationUrl);
+            void openExternalUrl(navigationUrl);
 
             newWindow.webContents.close();
 
@@ -354,7 +354,7 @@ export class WorkspaceApp {
       return { action: "deny" };
     }
 
-    openExternalUrl(url, {
+    void openExternalUrl(url, {
       skipTrustedHostCheck: Boolean(matchedSupportedWorkspaceApp),
       focusBrowser: disposition !== "background-tab",
     });
@@ -622,9 +622,9 @@ export class WorkspaceApp {
     });
 
     if (navigationHistory) {
-      restoreNavigationHistory(view.webContents, navigationHistory);
+      void restoreNavigationHistory(view.webContents, navigationHistory);
     } else {
-      loadUrl(view.webContents, url);
+      void loadUrl(view.webContents, url);
     }
 
     openViewDevToolsOnLaunch(view);
@@ -848,7 +848,7 @@ export class WorkspaceApp {
   private handleDidNavigate = (_event: Electron.Event, url: string) => {
     this.updateAppFromNavigation(url);
 
-    WorkspaceApp.handleNavigate(url, this.account.instance.session);
+    void WorkspaceApp.handleNavigate(url, this.account.instance.session);
   };
 
   private handleGoogleRedirect = (event: Electron.Event, url: string) => {
@@ -979,7 +979,7 @@ export class WorkspaceApp {
   }
 
   navigate(url: string) {
-    loadUrl(this.view.webContents, url);
+    void loadUrl(this.view.webContents, url);
   }
 
   reload() {
@@ -1103,7 +1103,7 @@ export class WorkspaceApp {
   }
 
   openInBrowser() {
-    openExternalUrl(this.view.webContents.getURL(), { skipTrustedHostCheck: true });
+    void openExternalUrl(this.view.webContents.getURL(), { skipTrustedHostCheck: true });
   }
 
   get account() {

--- a/packages/dark-theme/background-image.ts
+++ b/packages/dark-theme/background-image.ts
@@ -162,7 +162,7 @@ export function modifyBackgroundImage(
     return;
   }
 
-  Promise.all(
+  void Promise.all(
     layers.map(async (layer) => {
       const imageUrl = readUrlLayerTarget(layer);
 

--- a/packages/dark-theme/index.ts
+++ b/packages/dark-theme/index.ts
@@ -724,7 +724,7 @@ function invertDarkImageElement(image: HTMLImageElement, theme: Theme, isCancell
       return;
     }
 
-    getImageDetails(source).then((details) => {
+    void getImageDetails(source).then((details) => {
       if (isCancelled() || !details) {
         return;
       }

--- a/packages/electron-extensions/facade/lib/method.test.ts
+++ b/packages/electron-extensions/facade/lib/method.test.ts
@@ -33,7 +33,7 @@ describe("createBridgedMethod", () => {
 
     const { promise: answered, resolve } = Promise.withResolvers<unknown>();
 
-    method("a", resolve);
+    void method("a", resolve);
 
     expect(await answered).toBeUndefined();
   });

--- a/packages/renderer/components/copy-button.tsx
+++ b/packages/renderer/components/copy-button.tsx
@@ -17,7 +17,7 @@ export function CopyButton({
       size={size}
       {...props}
       onClick={() => {
-        navigator.clipboard.writeText(value);
+        void navigator.clipboard.writeText(value);
 
         markCopied();
       }}

--- a/packages/renderer/desktop-sources.tsx
+++ b/packages/renderer/desktop-sources.tsx
@@ -13,7 +13,7 @@ function DesktopSources() {
   const [selectedDesktopSourceId, setSelectedDesktopSourceId] = useState<string>("");
 
   useEffect(() => {
-    (async () => {
+    void (async () => {
       setDesktopSources(await ipc.main.invoke("desktopSources.getSources"));
     })();
   }, []);

--- a/packages/renderer/lib/extension-actions.ts
+++ b/packages/renderer/lib/extension-actions.ts
@@ -19,6 +19,6 @@ ipc.renderer.on("extensions.actionsChanged", (_event, actions) => {
 
 // Extensions finish loading on their own schedule, and a window can open long
 // after they did, so what is already there is asked for rather than waited for
-ipc.main.invoke("extensions.getActions").then((actions) => {
+void ipc.main.invoke("extensions.getActions").then((actions) => {
   useExtensionActionsStore.setState({ actions });
 });

--- a/packages/renderer/lib/notifications/index.ts
+++ b/packages/renderer/lib/notifications/index.ts
@@ -24,5 +24,5 @@ export function playNotificationSound({
 
   audio.volume = volume;
 
-  audio.play();
+  void audio.play();
 }

--- a/packages/renderer/routes/settings/accounts.tsx
+++ b/packages/renderer/routes/settings/accounts.tsx
@@ -72,7 +72,7 @@ function AccountForm({
       onSubmit={(event) => {
         event.preventDefault();
 
-        form.handleSubmit();
+        void form.handleSubmit();
       }}
     >
       <FieldGroup>

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -155,7 +155,7 @@ function ExtensionItem({
         return;
       }
 
-      queryClient.invalidateQueries({
+      void queryClient.invalidateQueries({
         queryKey: installedExtensionsQueryKey,
       });
 
@@ -298,7 +298,7 @@ function UpdateExtensionsButton() {
       }
 
       if (updatedAny) {
-        queryClient.invalidateQueries({
+        void queryClient.invalidateQueries({
           queryKey: installedExtensionsQueryKey,
         });
 

--- a/packages/renderer/routes/settings/general.tsx
+++ b/packages/renderer/routes/settings/general.tsx
@@ -33,7 +33,7 @@ function LaunchAtLoginField() {
     mutationFn: (settings: Partial<LoginItemSettings>) =>
       ipc.main.invoke("app.setLoginItemSettings", settings),
     onSuccess: () => {
-      queryClient.invalidateQueries({
+      void queryClient.invalidateQueries({
         queryKey,
       });
     },
@@ -77,7 +77,7 @@ function DefaultMailClientField() {
   const isDefaultMailtoClientMutation = useMutation({
     mutationFn: () => ipc.main.invoke("app.setAsDefaultMailtoClient"),
     onSuccess: () => {
-      queryClient.invalidateQueries({
+      void queryClient.invalidateQueries({
         queryKey,
       });
     },

--- a/packages/renderer/routes/settings/gmail/label-colors.tsx
+++ b/packages/renderer/routes/settings/gmail/label-colors.tsx
@@ -63,7 +63,7 @@ function LabelColorForm({
       onSubmit={(event) => {
         event.preventDefault();
 
-        form.handleSubmit();
+        void form.handleSubmit();
       }}
     >
       <form.Field name="label">

--- a/packages/renderer/routes/settings/license.tsx
+++ b/packages/renderer/routes/settings/license.tsx
@@ -56,7 +56,7 @@ function LicenseKeyForm({
       onSubmit={(event) => {
         event.preventDefault();
 
-        form.handleSubmit();
+        void form.handleSubmit();
       }}
     >
       <FieldGroup>
@@ -207,7 +207,7 @@ export function LicenseSettings() {
                       <DropdownMenuItem
                         onClick={() => {
                           if (config.licenseKey) {
-                            navigator.clipboard.writeText(config.licenseKey);
+                            void navigator.clipboard.writeText(config.licenseKey);
 
                             toast("License key copied to clipboard");
                           }
@@ -236,7 +236,7 @@ export function LicenseSettings() {
                   e.preventDefault();
                   e.stopPropagation();
 
-                  deviceInfoForm.handleSubmit();
+                  void deviceInfoForm.handleSubmit();
                 }}
               >
                 <deviceInfoForm.Field name="label">

--- a/packages/renderer/routes/settings/saved-searches.tsx
+++ b/packages/renderer/routes/settings/saved-searches.tsx
@@ -62,7 +62,7 @@ export function SavedSearchForm({
       onSubmit={(event) => {
         event.preventDefault();
 
-        form.handleSubmit();
+        void form.handleSubmit();
       }}
     >
       <FieldGroup>

--- a/packages/renderer/routes/settings/version-history.tsx
+++ b/packages/renderer/routes/settings/version-history.tsx
@@ -64,7 +64,7 @@ export function VersionHistorySettings() {
           <EmptyContent>
             <Button
               onClick={() => {
-                refetch();
+                void refetch();
               }}
             >
               Try Again

--- a/packages/renderer/workspace-app.tsx
+++ b/packages/renderer/workspace-app.tsx
@@ -59,7 +59,7 @@ function BookmarkButton({ workspaceAppId }: { workspaceAppId: string }) {
       setBookmarkState(state);
     });
 
-    ipc.main.invoke("workspaceApp.getBookmarkState", workspaceAppId).then(setBookmarkState);
+    void ipc.main.invoke("workspaceApp.getBookmarkState", workspaceAppId).then(setBookmarkState);
 
     return unsubscribe;
   }, [workspaceAppId]);
@@ -98,7 +98,7 @@ function NavigationControls({ workspaceAppId }: { workspaceAppId: string }) {
       setIsLoading(loading);
     });
 
-    ipc.main.invoke("workspaceApp.getLoadingState", workspaceAppId).then(setIsLoading);
+    void ipc.main.invoke("workspaceApp.getLoadingState", workspaceAppId).then(setIsLoading);
 
     return unsubscribe;
   }, [workspaceAppId]);


### PR DESCRIPTION
`typescript/no-floating-promises` reports 84 calls whose promise nobody holds on to — menu clicks that open a URL or a file, `init()` at the bottom of the main entry, `queryClient.invalidateQueries` in mutation callbacks, `form.handleSubmit()` in submit handlers.

Every one of them takes a `void` operator. That says the promise is deliberately dropped and leaves behavior exactly as it was: awaiting instead would need the surrounding Electron `click` and React handlers to become async, which they're typed void-returning for, and would only trade this rule for `strict-void-return`.

Rejections stay unhandled, the same as before this PR. Turning them into logged failures is a change worth making on its own terms, not inside a lint sweep.

Applied with `oxlint --fix` and reviewed hunk by hunk; the diff is 84 identical insertions.

## Test plan

1. Help → Website, Help → Source Code, and Advanced → View Logs — each still opens, covering the `openExternalUrl` and `shell.openPath` call sites.
2. Advanced → Clear Cache — the restart dialog still appears afterwards; that call sits inside an already-async click handler and was left unawaited rather than awaited.
3. Add an account in Settings → Accounts — the form still submits, covering `void form.handleSubmit()`.
