### PR TITLE
rename the variables that shadowed an outer one

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -367,9 +367,9 @@ class Accounts {
 
     const updatedAccounts = config
       .get("accounts")
-      .filter((account) => account.id !== selectedAccountId);
+      .filter((accountConfig) => accountConfig.id !== selectedAccountId);
 
-    if (updatedAccounts.every((account) => account.selected === false)) {
+    if (updatedAccounts.every((accountConfig) => accountConfig.selected === false)) {
       if (!updatedAccounts[0]) {
         throw new Error("Could not find first account");
       }

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -681,13 +681,13 @@ export class Gmail {
         await this.view.webContents.executeJavaScript("window.GM_INBOX_TYPE"),
       );
 
-      const body = await this.session
+      const inboxFeedXml = await this.session
         .fetch(
           `${GMAIL_INBOX_FEED_URL}${inboxType === "SECTIONED" && config.get("gmail.inboxCategoriesToMonitor") === "primary" ? "/^sq_ig_i_personal" : ""}?t=${Date.now()}`,
         )
         .then((res) => res.text());
 
-      const { feed } = inboxFeedSchema.parse(xmlParser.parse(body));
+      const { feed } = inboxFeedSchema.parse(xmlParser.parse(inboxFeedXml));
 
       const feedEntries = Array.isArray(feed.entry) ? feed.entry : feed.entry ? [feed.entry] : [];
 

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -32,13 +32,13 @@ import { spellchecker } from "./spellchecker";
 import { trial } from "./trial";
 
 async function resetApp() {
-  const accounts = config.get("accounts");
+  const accountConfigs = config.get("accounts");
 
   await app.whenReady();
 
   await Promise.all(
-    accounts.map((account) => {
-      const accountSession = session.fromPartition(`persist:${account.id}`);
+    accountConfigs.map((accountConfig) => {
+      const accountSession = session.fromPartition(`persist:${accountConfig.id}`);
 
       return Promise.all([
         accountSession.clearCache(),

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -815,13 +815,13 @@ class Ipc {
       });
     });
 
-    ipc.main.on("workspaceApps.openApp", (_event, app, modifierOpenBehavior) => {
+    ipc.main.on("workspaceApps.openApp", (_event, workspaceApp, modifierOpenBehavior) => {
       if (!licenseKey.isValid) {
         return;
       }
 
-      if (!canOpenWorkspaceAppInApp(app)) {
-        void openExternalUrl(getWorkspaceAppUrl(app), {
+      if (!canOpenWorkspaceAppInApp(workspaceApp)) {
+        void openExternalUrl(getWorkspaceAppUrl(workspaceApp), {
           skipTrustedHostCheck: true,
           focusBrowser: modifierOpenBehavior !== "backgroundTab",
         });
@@ -834,18 +834,18 @@ class Ipc {
       const selectedAccount = accounts.getSelectedAccount();
 
       if (openBehavior === "newWindow") {
-        selectedAccount.instance.tabs.openWindowedTab(getWorkspaceAppUrl(app));
+        selectedAccount.instance.tabs.openWindowedTab(getWorkspaceAppUrl(workspaceApp));
 
         return;
       }
 
-      const workspaceApp = selectedAccount.instance.tabs.openTab(getWorkspaceAppUrl(app));
+      const openedTab = selectedAccount.instance.tabs.openTab(getWorkspaceAppUrl(workspaceApp));
 
       if (openBehavior === "backgroundTab") {
         return;
       }
 
-      selectedAccount.instance.tabs.activateTab(workspaceApp.id);
+      selectedAccount.instance.tabs.activateTab(openedTab.id);
 
       accounts.refreshSelectedAccountView();
     });

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -355,11 +355,12 @@ export class AppMenu {
             accelerator: "CommandOrControl+F",
             enabled: isFindInPageEnabled,
             click: () => {
-              const focusedWindow = BrowserWindow.getFocusedWindow();
+              const windowFocusedOnClick = BrowserWindow.getFocusedWindow();
 
               const targetWebContents =
-                focusedWindow && WorkspaceApp.tryFromWebContents(focusedWindow.webContents)
-                  ? focusedWindow.webContents
+                windowFocusedOnClick &&
+                WorkspaceApp.tryFromWebContents(windowFocusedOnClick.webContents)
+                  ? windowFocusedOnClick.webContents
                   : main.window.webContents;
 
               ipc.renderer.send(targetWebContents, "findInPage.activate");

--- a/packages/app/tray.ts
+++ b/packages/app/tray.ts
@@ -131,13 +131,13 @@ export class AppTray {
     const mainWindowIsVisible = main.window.isVisible();
 
     const trayMenuTemplate: Electron.MenuItemConstructorOptions[] = [
-      ...accounts.getAccounts().map(({ config, instance }) => {
+      ...accounts.getAccounts().map(({ config: accountConfig, instance }) => {
         const unreadCount = instance.gmail.store.getState().unreadCount;
 
         return {
-          label: unreadCount ? `${config.label} (${unreadCount})` : config.label,
+          label: unreadCount ? `${accountConfig.label} (${unreadCount})` : accountConfig.label,
           click: () => {
-            accounts.selectAccount(config.id);
+            accounts.selectAccount(accountConfig.id);
 
             main.show();
           },

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -65,12 +65,12 @@ const GOOGLE_PDF_VIEWER_URL_REGEXP = /googleusercontent\.com\/viewer\/secure\/pd
  * is the single place that answers it. An unrecognised URL only has the switch
  * to go on.
  */
-export function canOpenWorkspaceAppInApp(app: SupportedWorkspaceApp | undefined) {
+export function canOpenWorkspaceAppInApp(workspaceApp: SupportedWorkspaceApp | undefined) {
   if (!config.get("workspaceApps.openInApp")) {
     return false;
   }
 
-  return !app || !config.get("workspaceApps.openInAppExcludedApps").includes(app);
+  return !workspaceApp || !config.get("workspaceApps.openInAppExcludedApps").includes(workspaceApp);
 }
 
 export function resolveWorkspaceAppOpenBehavior(
@@ -395,12 +395,12 @@ export class WorkspaceApp {
     globalShortcut.unregister(GOOGLE_MEET_TOGGLE_CAMERA_ACCELERATOR);
   }
 
-  static resolveTitle(pageTitle: string, app: SupportedWorkspaceApp | undefined) {
-    if (!app) {
+  static resolveTitle(pageTitle: string, workspaceApp: SupportedWorkspaceApp | undefined) {
+    if (!workspaceApp) {
       return pageTitle;
     }
 
-    const appLabel = workspaceApps[app].label;
+    const appLabel = workspaceApps[workspaceApp].label;
 
     if (!pageTitle) {
       return appLabel;
@@ -506,12 +506,12 @@ export class WorkspaceApp {
     loadOnLaunch,
     hibernatesWhenIdle,
     opensLinksForApp,
-    app,
+    app: workspaceApp,
     zoomFactor,
     navigationHistory,
   }: WorkspaceAppOptions) {
     this.accountId = accountId;
-    this.app = app ?? getWorkspaceAppFromUrl(url);
+    this.app = workspaceApp ?? getWorkspaceAppFromUrl(url);
     this.pinned = Boolean(pinned);
     this.loadOnLaunch = Boolean(loadOnLaunch);
     this.hibernatesWhenIdle = Boolean(hibernatesWhenIdle);

--- a/packages/electron-extensions/install/installer.ts
+++ b/packages/electron-extensions/install/installer.ts
@@ -191,15 +191,18 @@ export async function getInstalledExtension({
 }: InstalledExtensionOptions): Promise<InstalledExtension | undefined> {
   const extensionInstallDir = path.join(installDir, extensionId);
 
-  const [version] = (await readInstalledVersions(extensionInstallDir)).toSorted(
+  const [latestVersion] = (await readInstalledVersions(extensionInstallDir)).toSorted(
     (version, otherVersion) => compareExtensionVersions(otherVersion, version),
   );
 
-  if (!version) {
+  if (!latestVersion) {
     return undefined;
   }
 
-  return { version, extensionDir: path.join(extensionInstallDir, version) };
+  return {
+    version: latestVersion,
+    extensionDir: path.join(extensionInstallDir, latestVersion),
+  };
 }
 
 /**

--- a/packages/renderer/components/config-select-field.tsx
+++ b/packages/renderer/components/config-select-field.tsx
@@ -117,9 +117,9 @@ export function ConfigSelectField({
           <SelectValue placeholder={placeholder} />
         </SelectTrigger>
         <SelectContent>
-          {items.map(({ value, label }) => (
-            <SelectItem key={value} value={value}>
-              {label}
+          {items.map(({ value: itemValue, label: itemLabel }) => (
+            <SelectItem key={itemValue} value={itemValue}>
+              {itemLabel}
             </SelectItem>
           ))}
         </SelectContent>

--- a/packages/renderer/components/config-switch-field.tsx
+++ b/packages/renderer/components/config-switch-field.tsx
@@ -60,9 +60,9 @@ export function ConfigSwitchField({
         id={configKey}
         checked={disabled ? false : licenseKeyRequired && !isLicenseKeyValid ? false : checked}
         disabled={disabled || (licenseKeyRequired && !isLicenseKeyValid)}
-        onCheckedChange={(checked) => {
+        onCheckedChange={(newChecked) => {
           configMutation.mutate({
-            [configKey]: checked,
+            [configKey]: newChecked,
           });
         }}
       />

--- a/packages/renderer/components/find-in-page.tsx
+++ b/packages/renderer/components/find-in-page.tsx
@@ -23,8 +23,8 @@ export function FindInPage({
 
   const [text, setText] = useState("");
 
-  const debouncedOnFind = useDebouncedCallback((text: string) => {
-    onFind(text, { findNext: true });
+  const debouncedOnFind = useDebouncedCallback((searchText: string) => {
+    onFind(searchText, { findNext: true });
   }, 250);
 
   useEffect(() => {

--- a/packages/renderer/routes/settings/saved-searches.tsx
+++ b/packages/renderer/routes/settings/saved-searches.tsx
@@ -299,14 +299,17 @@ export function SavedSearchesSettings() {
 
                   configMutation.mutate({
                     "gmail.savedSearches": config["gmail.savedSearches"].filter(
-                      (savedSearch) => savedSearch.id !== deleteSavedSearchId,
+                      (existingSavedSearch) => existingSavedSearch.id !== deleteSavedSearchId,
                     ),
                   });
                 }}
                 onEdit={(editedSavedSearch) => {
                   configMutation.mutate({
-                    "gmail.savedSearches": config["gmail.savedSearches"].map((savedSearch) =>
-                      savedSearch.id === editedSavedSearch.id ? editedSavedSearch : savedSearch,
+                    "gmail.savedSearches": config["gmail.savedSearches"].map(
+                      (existingSavedSearch) =>
+                        existingSavedSearch.id === editedSavedSearch.id
+                          ? editedSavedSearch
+                          : existingSavedSearch,
                     ),
                   });
                 }}

--- a/packages/renderer/routes/settings/version-history.tsx
+++ b/packages/renderer/routes/settings/version-history.tsx
@@ -26,8 +26,8 @@ export function VersionHistorySettings() {
   const { data, isPending, isError, refetch } = useQuery({
     queryKey: ["github", "releases"],
     queryFn: async () => {
-      const res = await fetch("https://api.github.com/repos/zoidsh/meru/releases").then((res) =>
-        res.json(),
+      const res = await fetch("https://api.github.com/repos/zoidsh/meru/releases").then(
+        (response) => response.json(),
       );
 
       return z


### PR DESCRIPTION
`no-shadow` reports 22 bindings. Four are in `packages/shared/ms.ts`, a vendored copy of vercel/ms, and are left alone — the last PR in the stack exempts that file. The other 18 are renamed to say what they hold:

- Three `SupportedWorkspaceApp` parameters named `app` shadowed Electron's imported `app`; they're `workspaceApp` now. In the `workspaceApps.openApp` IPC handler that name was already taken by the tab it opens, which is `openedTab`.
- `AccountConfig` values named `account` or `config` shadowed the `accounts` manager and the `config` store; they're `accountConfig` / `accountConfigs`.
- In `fetchInboxFeed`, the feed's response text and a notification's body were both `body`. The response is `inboxFeedXml`.
- The rest are callback parameters shadowing the value they're derived from: `focusedWindow`, `savedSearch`, `text`, `checked`, `value`/`label`, `version`, `res`.

Renames only.

## Test plan

1. Open a workspace app from the launcher in a tab, in a background tab, and in a new window — that IPC handler took the largest rename.
2. Remove an account in Settings → Accounts — the remaining accounts survive and one of them ends up selected, covering the `removeAccount` filter and `every` callbacks.
3. Open the tray menu with unread mail on more than one account — each account still shows its own label and count, and clicking one selects it.
