### PR TITLE
remove the conditions that can never change the outcome

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -465,6 +465,9 @@ export class Gmail {
 
     const loaded = await loadUrl(this.view.webContents, this.url);
 
+    // `destroy` clears `_view`, which the load above gives it time to do — the
+    // narrowing the check before it left behind no longer holds.
+    // oxlint-disable-next-line typescript/no-unnecessary-condition
     if (loaded || !this._view || this._view.webContents.isDestroyed()) {
       return;
     }

--- a/packages/dark-theme/background-image.ts
+++ b/packages/dark-theme/background-image.ts
@@ -53,7 +53,7 @@ function isGradientLayer(layer: string): boolean {
   for (const opener of gradientFunctionOpeners) {
     let searchFrom = 0;
 
-    while (true) {
+    for (;;) {
       const openerIndex = layerLowercase.indexOf(opener, searchFrom);
 
       if (openerIndex === -1) {

--- a/packages/dark-theme/css-value.ts
+++ b/packages/dark-theme/css-value.ts
@@ -220,7 +220,7 @@ export function substituteVarFallbacks(value: string): string {
   let substitutedValue = value;
   let searchFrom = 0;
 
-  while (true) {
+  for (;;) {
     const varStart = substitutedValue.indexOf("var(", searchFrom);
 
     if (varStart === -1) {

--- a/packages/dark-theme/index.ts
+++ b/packages/dark-theme/index.ts
@@ -154,7 +154,7 @@ export function applyDarkTheme(root: HTMLElement, options?: DarkThemeOptions): D
     const styleElement = root.ownerDocument.createElement("style");
     styleElement.setAttribute(INJECTED_STYLE_ATTRIBUTE, "");
     styleElement.textContent = styleText;
-    root.ownerDocument.head?.appendChild(styleElement);
+    root.ownerDocument.head.appendChild(styleElement);
     injectedStyleElements.push(styleElement);
   };
 
@@ -496,7 +496,7 @@ export function applyDarkTheme(root: HTMLElement, options?: DarkThemeOptions): D
     if (!pseudoStyleElement) {
       pseudoStyleElement = root.ownerDocument.createElement("style");
       pseudoStyleElement.setAttribute(INJECTED_STYLE_ATTRIBUTE, "");
-      root.ownerDocument.head?.appendChild(pseudoStyleElement);
+      root.ownerDocument.head.appendChild(pseudoStyleElement);
       injectedStyleElements.push(pseudoStyleElement);
     }
 

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -212,7 +212,7 @@ export function AppTitlebar() {
     );
   }
 
-  if (!config || !accounts) {
+  if (!config) {
     return;
   }
 

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -353,6 +353,9 @@ export function ExtensionsSettings() {
           <PasskeysAlert />
           <ItemGroup>
             {curatedExtensions
+              // `passwordManager` is the only category so far, so the comparison
+              // is constant until a second one arrives.
+              // oxlint-disable-next-line typescript/no-unnecessary-condition
               .filter(({ category }) => category === "passwordManager")
               .map((extension) => (
                 <ExtensionItem

--- a/packages/renderer/routes/settings/license.tsx
+++ b/packages/renderer/routes/settings/license.tsx
@@ -109,7 +109,7 @@ function ActivateLicenseDialog({
           onSubmit={async ({ licenseKey }) => {
             const { success } = await ipc.main.invoke("licenseKey.activate", licenseKey);
 
-            if (success && props.onOpenChange) {
+            if (success) {
               props.onOpenChange(false);
             }
           }}

--- a/packages/ui/components/field.tsx
+++ b/packages/ui/components/field.tsx
@@ -182,7 +182,7 @@ function FieldError({
 
     const uniqueErrors = [...new Map(errors.map((error) => [error?.message, error])).values()];
 
-    if (uniqueErrors?.length == 1) {
+    if (uniqueErrors.length === 1) {
       return uniqueErrors[0]?.message;
     }
 


### PR DESCRIPTION
`typescript/no-unnecessary-condition` on the conditions that can only answer one way:

- `!accounts` in the titlebar and `props.onOpenChange &&` in the license dialog were guarding against a value the type says is always there.
- `root.ownerDocument.head?.` and `uniqueErrors?.length` optional-chained through something non-nullish. The `Field` line also had `==` where the rest of the file uses `===`.
- Two `while (true)` loops become `for (;;)`, which is the spelling the rule accepts for a deliberate one.

Two conditions stay, each with a comment saying why and a rule directive naming it:

- `Gmail#loadURL` re-checks `_view` after awaiting the load. `destroy` clears it, which the await gives it time to do, so the narrowing from the check before it no longer holds — the type system just can't see that.
- The extensions page filters curated extensions by `category === "passwordManager"`. `CuratedExtensionCategory` has one member so far, so the comparison is constant until a second one arrives; the filter should outlive that.

The eleven reports in `packages/app/config.ts` are left for the last PR in the stack, which turns the rule off for that file — the migrations read and write keys `Config` no longer has, which is what every `@ts-expect-error` in there is for.

## Test plan

1. Open Settings while the app is still loading its config — the titlebar renders once the config arrives rather than blanking, covering the dropped `!accounts` guard.
2. Activate a license key from Settings → License — the dialog closes on success.
3. Open a Gmail message with a background image while the dark theme is on — `substituteVarFallbacks` and `isGradientLayer` still walk their loops to the end.
