### PR TITLE
use nullish coalescing where the fallback is about absence

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -380,9 +380,7 @@ export const config = new Store<Config>({
 
       if (Array.isArray(accounts)) {
         for (const account of accounts) {
-          if (account.workspaceApps === undefined) {
-            account.workspaceApps = { savedTabs: [], bookmarks: [] };
-          }
+          account.workspaceApps ??= { savedTabs: [], bookmarks: [] };
         }
 
         store.set("accounts", accounts);

--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -219,11 +219,9 @@ class ExtensionUpdater {
   }
 
   checkForUpdates() {
-    if (!this.runningCheck) {
-      this.runningCheck = this.updateOptedInExtensions().finally(() => {
-        this.runningCheck = undefined;
-      });
-    }
+    this.runningCheck ??= this.updateOptedInExtensions().finally(() => {
+      this.runningCheck = undefined;
+    });
 
     return this.runningCheck;
   }

--- a/packages/dark-theme/stylesheets.ts
+++ b/packages/dark-theme/stylesheets.ts
@@ -211,7 +211,7 @@ export function getStylesheetCollection(ownerDocument: Document): StylesheetColl
   const fingerprint = getStylesheetFingerprint(ownerDocument);
   const cached = collectionCache.get(ownerDocument);
 
-  if (cached && cached.fingerprint === fingerprint) {
+  if (cached?.fingerprint === fingerprint) {
     return cached.collection;
   }
 

--- a/packages/dark-theme/variables.ts
+++ b/packages/dark-theme/variables.ts
@@ -96,7 +96,7 @@ export function buildDarkVariableOverrides(
 
   for (const name of customPropertyNames) {
     const resolvedValue = rootStyle.getPropertyValue(name).trim();
-    const value = resolvedValue || customPropertyFallbacks.get(name) || "";
+    const value = resolvedValue || customPropertyFallbacks.get(name);
 
     if (!value) {
       continue;

--- a/packages/preload-gmail/unread-count.ts
+++ b/packages/preload-gmail/unread-count.ts
@@ -5,7 +5,7 @@ let previousUnreadCountString: string = "";
 
 export function observeUnreadCount() {
   const currentUnreadCountString =
-    document.querySelector(`div:has(> ${inboxAnchorElementSelector}) .bsU`)?.textContent || "";
+    document.querySelector(`div:has(> ${inboxAnchorElementSelector}) .bsU`)?.textContent ?? "";
 
   if (currentUnreadCountString !== previousUnreadCountString) {
     ipc.main.send("gmail.unreadCountChanged", currentUnreadCountString);

--- a/packages/renderer/routes/settings/license.tsx
+++ b/packages/renderer/routes/settings/license.tsx
@@ -147,7 +147,7 @@ export function LicenseSettings() {
 
   const deviceInfoForm = useTanStackForm({
     defaultValues: {
-      label: deviceInfo?.label || "",
+      label: deviceInfo?.label ?? "",
     },
     validators: {
       onSubmit: z.object({


### PR DESCRIPTION
`typescript/prefer-nullish-coalescing` and `prefer-optional-chain`, on the six expressions where the fallback really is about absence.

Two `if (x === undefined) { x = … }` blocks become `??=`, `cached && cached.fingerprint === …` becomes `cached?.fingerprint === …`, and three `|| ""` become `?? ""` where an empty string and a missing value mean the same thing to the caller.

`buildDarkVariableOverrides` keeps its `||` on the resolved value — an empty custom property has to fall through to the fallback — and drops the trailing `|| ""` instead, since the `if (!value)` right below it already covers the missing case.

The rule reports five more `||` in the renderer that are plain boolean disjunctions, where `false ?? other` would keep the `false` and a control would stop disabling itself. Those are handled in the shared config with `ignorePrimitives: { boolean: true }` rather than here.

## Test plan

1. Open Settings → Extensions and press Check for Updates twice in a row — the second press joins the first check instead of starting another, covering `runningCheck ??=`.
2. Open a Gmail message with a dark theme applied — custom properties that resolve to nothing still fall back to the stylesheet's declared value.
