### PR TITLE
keep the handlers in void-returning slots synchronous

### DIFF
--- a/packages/app/lib/linux.ts
+++ b/packages/app/lib/linux.ts
@@ -5,6 +5,9 @@ import { join } from "node:path";
 import { promisify } from "node:util";
 import { platform } from "@electron-toolkit/utils";
 
+// Node types `execFile` as returning the ChildProcess, which `promisify`'s
+// signature expects to be void.
+// oxlint-disable-next-line typescript/strict-void-return
 const execFile = promisify(childProcess.execFile);
 
 let linuxWindowControlsEnabled: boolean | null = null;

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -23,6 +23,32 @@ import { WorkspaceApp } from "@/workspace-app";
 import { licenseKey } from "./license-key";
 import { createMeruMessageUrl } from "./protocol";
 
+async function clearCache() {
+  await Promise.all(accounts.getAccounts().map((account) => account.instance.session.clearCache()));
+
+  void showRestartDialog();
+}
+
+async function resetApp() {
+  const { response } = await dialog.showMessageBox({
+    type: "warning",
+    buttons: ["Cancel", "Reset"],
+    defaultId: 1,
+    message: "Are you sure you want to reset the app?",
+    detail: "This will clear all your accounts, settings, and data. This action cannot be undone.",
+  });
+
+  if (response === 0) {
+    return;
+  }
+
+  config.set("resetApp", true);
+
+  app.relaunch();
+
+  app.quit();
+}
+
 export class AppMenu {
   private _menu: Menu | undefined;
 
@@ -732,35 +758,14 @@ export class AppMenu {
               },
               {
                 label: "Clear Cache",
-                click: async () => {
-                  await Promise.all(
-                    accounts.getAccounts().map((account) => account.instance.session.clearCache()),
-                  );
-
-                  void showRestartDialog();
+                click: () => {
+                  void clearCache();
                 },
               },
               {
                 label: "Reset App…",
-                click: async () => {
-                  const { response } = await dialog.showMessageBox({
-                    type: "warning",
-                    buttons: ["Cancel", "Reset"],
-                    defaultId: 1,
-                    message: "Are you sure you want to reset the app?",
-                    detail:
-                      "This will clear all your accounts, settings, and data. This action cannot be undone.",
-                  });
-
-                  if (response === 0) {
-                    return;
-                  }
-
-                  config.set("resetApp", true);
-
-                  app.relaunch();
-
-                  app.quit();
+                click: () => {
+                  void resetApp();
                 },
               },
               {

--- a/packages/electron-extensions/native-messaging/native-messaging.test.ts
+++ b/packages/electron-extensions/native-messaging/native-messaging.test.ts
@@ -138,7 +138,9 @@ async function waitForProcessExit(pid: number) {
       return;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
   }
 
   throw new Error(`Process ${pid} is still running`);

--- a/packages/electron-extensions/native-messaging/windows-registry.ts
+++ b/packages/electron-extensions/native-messaging/windows-registry.ts
@@ -1,6 +1,9 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
+// Node types `execFile` as returning the ChildProcess, which `promisify`'s
+// signature expects to be void.
+// oxlint-disable-next-line typescript/strict-void-return
 const execFileAsync = promisify(execFile);
 
 /**

--- a/packages/preload-gmail/ipc.ts
+++ b/packages/preload-gmail/ipc.ts
@@ -10,10 +10,14 @@ ipc.renderer.on("gmail.openMessage", (_event, messageId: string) => {
   window.location.hash = `#inbox/${messageId}`;
 });
 
-ipc.renderer.on("gmail.handleMessage", async (_event, messageId, action) => {
+async function handleMessage(messageId: string, action: Parameters<typeof sendMailAction>[1]) {
   await sendMailAction(messageId, action);
 
   refreshInbox();
+}
+
+ipc.renderer.on("gmail.handleMessage", (_event, messageId, action) => {
+  void handleMessage(messageId, action);
 });
 
 ipc.renderer.on("gmail.showMessageSentNotification", (_event, browserWindowId: number) => {

--- a/packages/renderer/lib/stores.ts
+++ b/packages/renderer/lib/stores.ts
@@ -22,7 +22,7 @@ ipc.renderer.on("accounts.changed", (_event, accounts) => {
   useAccountsStore.setState({ accounts });
 });
 
-ipc.renderer.on("accounts.openAddAccountDialog", async (_event) => {
+async function openAddAccountDialog() {
   const config = await getConfig();
 
   if (!config.licenseKey && !useTrialStore.getState().daysLeft) {
@@ -34,6 +34,10 @@ ipc.renderer.on("accounts.openAddAccountDialog", async (_event) => {
   }
 
   useAccountsStore.setState({ isAddAccountDialogOpen: true });
+}
+
+ipc.renderer.on("accounts.openAddAccountDialog", () => {
+  void openAddAccountDialog();
 });
 
 export const useTabsStore = create<{

--- a/packages/renderer/routes/settings/downloads.tsx
+++ b/packages/renderer/routes/settings/downloads.tsx
@@ -14,6 +14,14 @@ import { SettingsHeader, SettingsTitle } from "@/components/settings";
 import { useConfig } from "@/lib/react-query";
 import { restartRequiredToast } from "@/lib/toast";
 
+async function setDownloadLocation() {
+  const { canceled } = await ipc.main.invoke("downloads.setLocation");
+
+  if (!canceled) {
+    restartRequiredToast();
+  }
+}
+
 export function DownloadsSettings() {
   const { config } = useConfig();
 
@@ -48,12 +56,8 @@ export function DownloadsSettings() {
               <Input value={config["downloads.location"]} readOnly />
               <Button
                 variant="outline"
-                onClick={async () => {
-                  const { canceled } = await ipc.main.invoke("downloads.setLocation");
-
-                  if (!canceled) {
-                    restartRequiredToast();
-                  }
+                onClick={() => {
+                  void setDownloadLocation();
                 }}
               >
                 Change…

--- a/packages/renderer/routes/settings/license.tsx
+++ b/packages/renderer/routes/settings/license.tsx
@@ -86,6 +86,14 @@ function LicenseKeyForm({
   );
 }
 
+async function activateLicenseKey(licenseKey: string, onOpenChange: (open: boolean) => void) {
+  const { success } = await ipc.main.invoke("licenseKey.activate", licenseKey);
+
+  if (success) {
+    onOpenChange(false);
+  }
+}
+
 function ActivateLicenseDialog({
   variant = "activate",
   children,
@@ -106,12 +114,8 @@ function ActivateLicenseDialog({
           Enter the license key sent to your email address after your purchase.
         </DialogDescription>
         <LicenseKeyForm
-          onSubmit={async ({ licenseKey }) => {
-            const { success } = await ipc.main.invoke("licenseKey.activate", licenseKey);
-
-            if (success) {
-              props.onOpenChange(false);
-            }
+          onSubmit={({ licenseKey }) => {
+            void activateLicenseKey(licenseKey, props.onOpenChange);
           }}
         />
       </DialogContent>

--- a/packages/shared/utils.ts
+++ b/packages/shared/utils.ts
@@ -1,5 +1,7 @@
 export function wait(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
 export function clamp(num: number, min: number, max: number) {


### PR DESCRIPTION
`strict-void-return` and `no-misused-promises` report async callbacks handed to slots typed as returning void — `ipc.renderer.on` handlers, React `onClick`, Electron menu `click`. A `void` operator doesn't answer these the way it did for the floating promises: the function itself has to stop being async.

Each one becomes a named async function beside its handler, called with `void`:

```ts
async function openAddAccountDialog() { … }

ipc.renderer.on("accounts.openAddAccountDialog", () => {
  void openAddAccountDialog();
});
```

Behavior is unchanged — the work still runs unawaited — and the extracted names say what each handler does.

Two more are their own thing:

- `wait` and a test helper passed `setTimeout(resolve, ms)` as a promise executor's body, which returns the timer id. Both take a block now, which also answers `no-promise-executor-return`.
- `promisify(execFile)` in two places: Node types `execFile` as returning the ChildProcess where `promisify`'s signature wants void. Those keep a directive with the reason.

## Test plan

1. With no license key and the trial expired, use Add Account — the Meru Pro toast still appears instead of the dialog.
2. Settings → Downloads → Change… — picking a folder still raises the restart toast, and cancelling raises nothing.
3. Archive or delete a message from a Meru notification — `gmail.handleMessage` still refreshes the inbox afterwards.
4. Advanced → Reset App… — Cancel leaves everything alone, Reset relaunches.
