### PR TITLE
give the lists stable keys and the defaults stable references

### DIFF
--- a/packages/renderer/components/app-sidebar.tsx
+++ b/packages/renderer/components/app-sidebar.tsx
@@ -145,14 +145,15 @@ export function AppSidebar() {
             .filter((item) => !item.hidden)
             .map(({ type, label, path }, index) => {
               if (type === "separator") {
-                // biome-ignore lint/suspicious/noArrayIndexKey: Key is acceptable here
+                // A separator carries nothing of its own to key on, and the list
+                // is a fixed one that never reorders.
+                // oxlint-disable-next-line react/no-array-index-key
                 return <Separator key={index} />;
               }
 
               return (
                 <Button
-                  // biome-ignore lint/suspicious/noArrayIndexKey: Key is acceptable here
-                  key={index}
+                  key={path}
                   onClick={() => {
                     navigate(path);
                   }}

--- a/packages/renderer/components/find-in-page.tsx
+++ b/packages/renderer/components/find-in-page.tsx
@@ -27,6 +27,9 @@ export function FindInPage({
     onFind(searchText, { findNext: true });
   }, 250);
 
+  // Reactivating is the only thing that should re-run the search from here:
+  // typing goes through `debouncedOnFind` instead.
+  // oxlint-disable react/exhaustive-effect-dependencies, react-hooks/exhaustive-deps
   useEffect(() => {
     if (isActive && text) {
       onFind(text, { findNext: true });
@@ -35,8 +38,8 @@ export function FindInPage({
         inputRef.current.select();
       }
     }
-    // biome-ignore lint/correctness/useExhaustiveDependencies: refire when reactivated
   }, [isActive]);
+  // oxlint-enable react/exhaustive-effect-dependencies, react-hooks/exhaustive-deps
 
   if (!isActive) {
     return;

--- a/packages/renderer/components/popup-window.tsx
+++ b/packages/renderer/components/popup-window.tsx
@@ -2,9 +2,13 @@ import { Toaster } from "@meru/ui/components/sonner";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useThemeStore } from "@/lib/theme";
 
+function closeWindow() {
+  window.close();
+}
+
 export function PopupWindow({
   children,
-  onClose = () => window.close(),
+  onClose = closeWindow,
 }: {
   children: React.ReactNode;
   onClose?: () => void;

--- a/packages/renderer/main.tsx
+++ b/packages/renderer/main.tsx
@@ -16,6 +16,8 @@ function Main() {
   useMouseAccountSwitching();
 
   return (
+    // Wouter takes the location hook as a value and calls it itself.
+    // oxlint-disable-next-line react/hooks
     <Router hook={useHashLocation}>
       <div className="flex h-screen flex-col">
         <AppTitlebar />

--- a/packages/renderer/routes/settings/accounts.tsx
+++ b/packages/renderer/routes/settings/accounts.tsx
@@ -40,13 +40,15 @@ import { useConfig, useConfigMutation } from "@/lib/react-query";
 import { useAccountsStore, useTrialStore } from "@/lib/stores";
 import { restartRequiredToast } from "@/lib/toast";
 
+const EMPTY_ACCOUNT: AccountConfigInput = {
+  label: "",
+  color: null,
+  gmail: { unreadBadge: true, unifiedInbox: true },
+  notifications: true,
+};
+
 function AccountForm({
-  account = {
-    label: "",
-    color: null,
-    gmail: { unreadBadge: true, unifiedInbox: true },
-    notifications: true,
-  },
+  account = EMPTY_ACCOUNT,
   placeholder = "Work",
   onSubmit,
   type,

--- a/packages/renderer/routes/settings/gmail/label-colors.tsx
+++ b/packages/renderer/routes/settings/gmail/label-colors.tsx
@@ -38,8 +38,14 @@ const textColorItems: { value: GmailLabelTextColor; label: string }[] = [
   { value: "black", label: "Black" },
 ];
 
+const EMPTY_LABEL_COLOR: GmailLabelColorInput = {
+  label: "",
+  color: "#1a73e8",
+  textColor: "auto",
+};
+
 function LabelColorForm({
-  labelColor = { label: "", color: "#1a73e8", textColor: "auto" },
+  labelColor = EMPTY_LABEL_COLOR,
   type,
   onSubmit,
 }: {

--- a/packages/renderer/routes/settings/saved-searches.tsx
+++ b/packages/renderer/routes/settings/saved-searches.tsx
@@ -33,8 +33,10 @@ import { SettingsContent, SettingsHeader, SettingsTitle } from "@/components/set
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useConfig, useConfigMutation } from "@/lib/react-query";
 
+const EMPTY_SAVED_SEARCH: GmailSavedSearchInput = { label: "", query: "" };
+
 export function SavedSearchForm({
-  savedSearch = { label: "", query: "" },
+  savedSearch = EMPTY_SAVED_SEARCH,
   labelPlaceholder = "Friends",
   queryPlaceholder = "label:friends is:unread",
   type,

--- a/packages/renderer/routes/unified-inbox.tsx
+++ b/packages/renderer/routes/unified-inbox.tsx
@@ -158,6 +158,9 @@ function UnifiedInboxTable({
 
   const columns = useMemo(() => createColumns({ showSenderIcons }), [showSenderIcons]);
 
+  // TanStack Table hands back functions the React Compiler can't memoize, so it
+  // skips memoizing this component rather than risk stale rows.
+  // oxlint-disable-next-line react/incompatible-library
   const table = useReactTable({
     data: messages,
     columns,

--- a/packages/ui/components/emoji-picker.tsx
+++ b/packages/ui/components/emoji-picker.tsx
@@ -56,6 +56,7 @@ function EmojiPickerRow({ children, ...props }: EmojiPickerListRowProps) {
 function EmojiPickerEmoji({ emoji, className, ...props }: EmojiPickerListEmojiProps) {
   return (
     <button
+      type="button"
       {...props}
       className={cn(
         "flex size-7 items-center justify-center rounded-sm text-base data-[active]:bg-accent",

--- a/packages/ui/components/field.tsx
+++ b/packages/ui/components/field.tsx
@@ -188,7 +188,9 @@ function FieldError({
 
     return (
       <ul className="ml-4 flex list-disc flex-col gap-1">
-        {uniqueErrors.map((error, index) => error?.message && <li key={index}>{error.message}</li>)}
+        {uniqueErrors.map(
+          (error) => error?.message && <li key={error.message}>{error.message}</li>,
+        )}
       </ul>
     );
   }, [children, errors]);


### PR DESCRIPTION
The `react` plugin's rules, which the new shared config turns on.

- **`no-object-type-as-default-prop`** (4): object and function literals as default props are rebuilt on every render, so `AccountForm`, `SavedSearchForm`, `LabelColorForm` and `PopupWindow` now default to a module-level constant.
- **`no-array-index-key`** (3): the sidebar's buttons key on their `path`, and `FieldError` keys on the message it renders — the list is deduplicated by message, so those are unique. The sidebar's separators keep the index, since a separator carries nothing else, with a directive saying so.
- **`button-has-type`** (1): the emoji picker's button gets `type="button"` ahead of its prop spread, so a caller can still override it.

Two React Compiler rules report a library rather than a mistake, and each keeps a directive with the reason: `useReactTable` hands back functions the compiler can't memoize, and wouter's `<Router hook={useHashLocation}>` takes a hook as a value by design.

`find-in-page` had a `biome-ignore` for an effect that deliberately depends on `isActive` alone — typing goes through `debouncedOnFind`, so adding `text` and `onFind` would re-run the search on every keystroke. Biome is gone, so that becomes an oxlint directive; the sidebar had two stale ones too.

## Test plan

1. Open Settings → Accounts → Add Account, close it, and open it again — the form is empty both times, covering the hoisted default.
2. Press Cmd/Ctrl+F, type a query, then close and reopen Find — the search re-runs against what's still in the box.
3. Open the emoji picker from an account label and pick an emoji — it appends rather than submitting the form, which is what the button's type decides.
