### PR TITLE
throw the right error type and keep the cause

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -993,7 +993,7 @@ export class Gmail {
   }
 
   createComposeWindow(url: string) {
-    new WorkspaceApp({
+    return new WorkspaceApp({
       accountId: this.accountId,
       url: `${GMAIL_URL}/?extsrc=mailto&url=${encodeURIComponent(url)}`,
       window: { width: 800, height: 600 },

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -267,6 +267,8 @@ export class WorkspaceApp {
     }
 
     if (GOOGLE_PDF_VIEWER_URL_REGEXP.test(url) && disposition !== "background-tab") {
+      // The instance registers itself, so opening the window is all there is to do.
+      // oxlint-disable-next-line no-new
       new WorkspaceApp({ accountId, url, asWindow: true });
 
       return { action: "deny" };

--- a/packages/electron-extensions/facade/api/native-messaging.ts
+++ b/packages/electron-extensions/facade/api/native-messaging.ts
@@ -179,8 +179,8 @@ function createSendNativeMessage(runtime: ChromeNamespace) {
       (response) => {
         (callback as (response: unknown) => void)(response);
       },
-      (error: Error) => {
-        withLastError(runtime, error.message, () => {
+      (error: unknown) => {
+        withLastError(runtime, error instanceof Error ? error.message : String(error), () => {
           (callback as (response: unknown) => void)(undefined);
         });
       },

--- a/packages/electron-extensions/install/installer.ts
+++ b/packages/electron-extensions/install/installer.ts
@@ -57,7 +57,7 @@ function readCrxPackage(crx: Uint8Array, extensionId: string): ExtensionPackage 
   const manifest = JSON.parse(new TextDecoder().decode(manifestSource)) as ExtensionManifest;
 
   if (typeof manifest.version !== "string") {
-    throw new Error(`CRX for ${extensionId} carries a manifest without a version`);
+    throw new TypeError(`CRX for ${extensionId} carries a manifest without a version`);
   }
 
   // An unpacked extension without a `key` loads under an id derived from its

--- a/packages/electron-extensions/native-messaging/framing.ts
+++ b/packages/electron-extensions/native-messaging/framing.ts
@@ -81,7 +81,7 @@ export class NativeMessageDecoder {
     try {
       return JSON.parse(textDecoder.decode(body)) as unknown;
     } catch (error) {
-      throw new Error(`Native message is not valid JSON: ${String(error)}`);
+      throw new Error(`Native message is not valid JSON: ${String(error)}`, { cause: error });
     }
   }
 }

--- a/packages/electron-extensions/native-messaging/host-manifest.ts
+++ b/packages/electron-extensions/native-messaging/host-manifest.ts
@@ -123,7 +123,7 @@ export function parseHostManifest(source: string, hostName: string): NativeMessa
   }
 
   if (!Array.isArray(manifest.allowed_origins)) {
-    throw new Error("Host manifest has no allowed_origins");
+    throw new TypeError("Host manifest has no allowed_origins");
   }
 
   return {

--- a/packages/preload-workspace-app/apps/docs.ts
+++ b/packages/preload-workspace-app/apps/docs.ts
@@ -23,7 +23,7 @@ function markDocsOfflineExtensionAsInstalled() {
 export function initDocsPreload() {
   webFrame
     .executeJavaScript(`(${markDocsOfflineExtensionAsInstalled.toString()})()`)
-    .catch((error) => {
+    .catch((error: unknown) => {
       console.error("Failed to mark the Docs Offline extension as installed:", error);
     });
 }

--- a/packages/preload-workspace-app/service-worker-notifications.ts
+++ b/packages/preload-workspace-app/service-worker-notifications.ts
@@ -29,7 +29,7 @@ export function initServiceWorkerNotifications() {
     },
   );
 
-  webFrame.executeJavaScript(`(${patchShowNotification.toString()})()`).catch((error) => {
+  webFrame.executeJavaScript(`(${patchShowNotification.toString()})()`).catch((error: unknown) => {
     console.error("Failed to patch service worker notifications:", error);
   });
 }

--- a/packages/renderer/components/config-select-field.tsx
+++ b/packages/renderer/components/config-select-field.tsx
@@ -75,7 +75,7 @@ export function ConfigSelectField({
   const value = config[configKey];
 
   if (typeof value !== "string") {
-    throw new Error(`ConfigSelectField: Config key "${configKey}" is not a string`);
+    throw new TypeError(`ConfigSelectField: Config key "${configKey}" is not a string`);
   }
 
   const isDisabled = disabled || (licenseKeyRequired && !isLicenseKeyValid);

--- a/packages/renderer/components/config-switch-field.tsx
+++ b/packages/renderer/components/config-switch-field.tsx
@@ -43,7 +43,7 @@ export function ConfigSwitchField({
   const checked = config[configKey];
 
   if (typeof checked !== "boolean") {
-    throw new Error(`ConfigSwitchField: Config key "${configKey}" is not a boolean`);
+    throw new TypeError(`ConfigSwitchField: Config key "${configKey}" is not a boolean`);
   }
 
   return (


### PR DESCRIPTION
Four rules about thrown and caught values.

- **`unicorn/prefer-type-error`** (4): a throw that follows a `typeof` check is a `TypeError`. `ConfigSwitchField` and `ConfigSelectField` guarding their config key, the CRX manifest without a version, and the host manifest without `allowed_origins`.
- **`eslint/preserve-caught-error`** (1): the native-messaging framing decoder rethrew a JSON parse failure with the message interpolated but the error itself dropped. It now passes `{ cause: error }` as well, so the stack survives.
- **`typescript/use-unknown-in-catch-callback-variable`** (3): `.catch((error) => …)` and a `then` rejection handler take `unknown`. The one that read `error.message` narrows with `instanceof Error` first, matching the five places in the repo that already do.
- **`eslint/no-new`** (2): `createComposeWindow` returns the `WorkspaceApp` it builds rather than dropping it. The PDF-viewer window can't — `handleWindowOpen` has to answer with a window-open action — so that one keeps a directive saying the instance registers itself.

## Test plan

1. Compose a message from the Meru menu (Gmail → Compose) — the compose window still opens, covering the changed return.
2. Open a PDF from Drive or a Gmail attachment — the viewer still opens in its own window.
3. With 1Password installed, sign in to a Google account through it — the native messaging host still connects, covering the framing decoder's rethrow path.
