### PR TITLE
spell out the string conversions and drop the deprecated build option

### DIFF
--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -124,6 +124,9 @@ export class Account {
         return;
       }
 
+      // Electron's permission list is long, grows between releases, and is
+      // answered default-deny — naming every one it refuses says nothing.
+      // oxlint-disable-next-line typescript/switch-exhaustiveness-check
       switch (permission) {
         case "clipboard-read":
         case "clipboard-sanitized-write":

--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -22,7 +22,7 @@ class Accounts {
   instances: Map<string, Account> = new Map();
 
   init() {
-    let accountConfigs = config.get("accounts");
+    const accountConfigs = config.get("accounts");
 
     if (!licenseKey.isValid && accountConfigs.length > 1 && accountConfigs[0]?.selected === false) {
       for (const [index, accountConfig] of accountConfigs.entries()) {

--- a/packages/app/do-not-disturb.ts
+++ b/packages/app/do-not-disturb.ts
@@ -78,6 +78,10 @@ export class DoNotDisturb {
       clearInterval(this.timer);
     }
 
+    // The default branch answers for the fixed durations, and `ms(duration)` is
+    // what holds it to those: an option this can't parse fails to compile here
+    // rather than reaching the branch.
+    // oxlint-disable-next-line typescript/switch-exhaustiveness-check
     switch (duration) {
       case "indefinite": {
         config.set("doNotDisturb.until", null);

--- a/packages/app/license-key.ts
+++ b/packages/app/license-key.ts
@@ -72,7 +72,7 @@ class LicenseKey {
 
         await this.showActivationError({
           detail: (await isOnline())
-            ? `Try again, or contact support. A VPN or a firewall can block the connection.\n\n${error.message} (${error.cause})`
+            ? `Try again, or contact support. A VPN or a firewall can block the connection.\n\n${error.message} (${String(error.cause)})`
             : "Meru can't reach the internet. Connect and try again.",
         });
       }
@@ -155,7 +155,7 @@ class LicenseKey {
 
         const { response } = await this.showValidationError({
           detail: (await isOnline())
-            ? `Restart Meru to try again, or contact support. A VPN or a firewall can block the connection.\n\n${error.message} (${error.cause})`
+            ? `Restart Meru to try again, or contact support. A VPN or a firewall can block the connection.\n\n${error.message} (${String(error.cause)})`
             : "Meru can't reach the internet. Connect, then restart Meru to try again.",
           buttons: ["Restart", "Quit"],
           defaultId: 0,
@@ -187,7 +187,7 @@ class LicenseKey {
     const { error, data } = await (
       useFallback ? apiFallbackClient : apiClient
     ).v2.license.getDeviceInfo({
-      licenseKey: licenseKey,
+      licenseKey,
       deviceId: await machineId(),
     });
 
@@ -221,7 +221,7 @@ class LicenseKey {
     const { error } = await (
       useFallback ? apiFallbackClient : apiClient
     ).v2.license.updateDeviceInfo({
-      licenseKey: licenseKey,
+      licenseKey,
       deviceId: await machineId(),
       label: input.label,
     });

--- a/packages/app/trial.ts
+++ b/packages/app/trial.ts
@@ -39,7 +39,7 @@ class Trial {
         type: "error",
         message: "Couldn't validate your Meru Pro trial.",
         detail: (await isOnline())
-          ? `Restart Meru to try again, or contact support. A VPN or a firewall can block the connection.\n\n${error.message} (${error.cause})`
+          ? `Restart Meru to try again, or contact support. A VPN or a firewall can block the connection.\n\n${error.message} (${String(error.cause)})`
           : "Meru can't reach the internet. Connect, then restart Meru to try again.",
         buttons: ["Restart", "Quit"],
         defaultId: 0,

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -607,6 +607,7 @@ export class WorkspaceApp {
           ...options?.webPreferences,
           // Docs cuts, copies and pastes from its Edit menu through
           // `document.execCommand`, which Electron gates behind this preference
+          // oxlint-disable-next-line typescript/no-deprecated
           enableDeprecatedPaste: true,
         },
       },

--- a/packages/electron-extensions/install/omaha.ts
+++ b/packages/electron-extensions/install/omaha.ts
@@ -41,7 +41,7 @@ export function buildCrxDownloadUrl({ extensionId, chromeVersion }: CrxDownloadO
     x: `id=${extensionId}&installsource=ondemand&uc`,
   });
 
-  return `${CRX_UPDATE_ENDPOINT}?${searchParams}`;
+  return `${CRX_UPDATE_ENDPOINT}?${searchParams.toString()}`;
 }
 
 export type UpdateCheckOptions = CrxDownloadOptions & {
@@ -64,7 +64,7 @@ export function buildUpdateCheckUrl({
     x: `id=${extensionId}&v=${installedVersion}&uc`,
   });
 
-  return `${CRX_UPDATE_ENDPOINT}?${searchParams}`;
+  return `${CRX_UPDATE_ENDPOINT}?${searchParams.toString()}`;
 }
 
 /**

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -152,7 +152,7 @@ async function buildRenderer(rendererName: string, port: number) {
     build: {
       outDir: path.join(process.cwd(), "build-js", rendererName),
       target: browserTarget,
-      rollupOptions: {
+      rolldownOptions: {
         input: pageFileNames.map((pageFileName) => path.join(rendererRoot, pageFileName)),
       },
     },
@@ -204,7 +204,7 @@ if (args.values.dev) {
     startElectron();
   };
 
-  await startElectron();
+  startElectron();
 
   const watcher = watch("./packages", { recursive: true });
 


### PR DESCRIPTION
What's left of the smaller rules.

- **`typescript/restrict-template-expressions`** (5): `${error.cause}` is `unknown` and `${searchParams}` is a `URLSearchParams`. Both say `String(...)` / `.toString()` now, which is what they were relying on implicitly.
- **`typescript/no-deprecated`** (2): `build.rollupOptions` is `build.rolldownOptions` under Vite 8. `enableDeprecatedPaste` stays — Docs cuts and pastes through `document.execCommand`, which Electron gates behind exactly that preference — and keeps a directive with the reason the comment above it already gives.
- **`typescript/await-thenable`** and **`no-confusing-void-expression`** (2): `startElectron()` returns nothing, so the `await` in the dev script came off.
- **`eslint/object-shorthand`** (2) and **`prefer-const`** (1): as reported.
- **`typescript/switch-exhaustiveness-check`** (2): both switches already answer through a `default`, and each now says why, with a directive naming the rule.

  `Account`'s permission handler switches on Electron's permission list, which is long, grows between releases, and is answered default-deny — naming every permission it refuses says nothing.

  `DoNotDisturb#enable` is the more interesting one. Its `default` branch calls `ms(duration)`, and that call is what holds the branch to the fixed durations: a new option `ms` can't parse fails to compile there rather than reaching the branch at runtime. Checked by adding an `"until monday"` option — `tsc` reports `TS2769: No overload matches this call` at that line, so the invariant is enforced rather than assumed.

`oxc/no-map-spread` (6) isn't fixed here. Spreading in a `map` is how the config-state updates are written, and the in-place mutation the rule asks for is the thing they're avoiding; that one is turned off in the shared config.

## Test plan

1. `bun run build:js` — the renderer builds all its entry pages, so `rolldownOptions.input` is being read (verified).
2. `bun run dev` — the dev server comes up and Electron starts, covering the dropped `await` in the watch loop.
3. Turn on Do Not Disturb for 30 minutes, then Indefinitely, then Until Tomorrow — each sets its own expiry and the timer clears between them.
4. Join a Google Meet call and grant camera and microphone — the permission handler still allows `media` and refuses what isn't listed.
