### PR TITLE
type the values that were reaching the code as any

### DIFF
--- a/build/hooks/afterPack.js
+++ b/build/hooks/afterPack.js
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
+/** @param {import("electron-builder").AfterPackContext} context */
 export default async (context) => {
   if (context.packager.platform.name === "mac") {
     console.log("\n---------\n");

--- a/build/hooks/beforePack.js
+++ b/build/hooks/beforePack.js
@@ -10,6 +10,8 @@ import path from "node:path";
 // provisioning profile embedded in the app authorizes it, and the profile only binds to the app
 // through the application and team identifiers below. `@electron/osx-sign` adds those two itself,
 // but only for sandboxed apps, so they are written out here too.
+// electron-builder hands `beforePack` and `afterPack` the same context.
+/** @param {import("electron-builder").AfterPackContext} context */
 export default async (context) => {
   if (context.packager.platform.name !== "mac") {
     return;

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@types/bun": "^1.3.12",
         "@types/react": "^19.1.16",
         "@types/react-dom": "^19.1.9",
+        "@types/semver": "^7.8.0",
         "@vitejs/plugin-react": "^6.0.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -571,6 +572,8 @@
     "@types/react-dom": ["@types/react-dom@19.1.9", "", { "peerDependencies": { "@types/react": "^19.0.0" } }, "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ=="],
 
     "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
+
+    "@types/semver": ["@types/semver@7.8.0", "", {}, "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ=="],
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/bun": "^1.3.12",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",
+    "@types/semver": "^7.8.0",
     "@vitejs/plugin-react": "^6.0.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/packages/electron-extensions/bridge/bridge.ts
+++ b/packages/electron-extensions/bridge/bridge.ts
@@ -112,7 +112,10 @@ export class ExtensionBridge {
       return "";
     }
 
-    const reader = request.body.getReader();
+    // The ambient types leave the request body's stream unparameterized.
+    const body: ReadableStream<Uint8Array> = request.body;
+
+    const reader = body.getReader();
 
     const chunks: Uint8Array[] = [];
 

--- a/packages/electron-extensions/facade/api/context-menus.ts
+++ b/packages/electron-extensions/facade/api/context-menus.ts
@@ -18,6 +18,10 @@ function takeMenuItemId(createProperties: unknown) {
   return createdMenuItemCount;
 }
 
+function isCreatedCallback(value: unknown): value is () => void {
+  return typeof value === "function";
+}
+
 /**
  * The one method here that answers synchronously with the id it assigned, using
  * its optional callback only to signal that the item was created.
@@ -27,7 +31,7 @@ function createMenuItem(...callArguments: unknown[]) {
 
   const callback = callArguments.at(-1);
 
-  if (typeof callback === "function") {
+  if (isCreatedCallback(callback)) {
     queueMicrotask(() => {
       callback();
     });

--- a/packages/electron-extensions/facade/api/native-messaging.ts
+++ b/packages/electron-extensions/facade/api/native-messaging.ts
@@ -116,7 +116,10 @@ function createPort(runtime: ChromeNamespace, hostName: string): NativeMessaging
 
     markOpened();
 
-    const reader = response.body.getReader();
+    // The ambient types leave the response body's stream unparameterized.
+    const body: ReadableStream<Uint8Array> = response.body;
+
+    const reader = body.getReader();
 
     const decoder = new NativeMessageDecoder();
 

--- a/packages/preload-gmail/types/modules.d.ts
+++ b/packages/preload-gmail/types/modules.d.ts
@@ -1,1 +1,4 @@
-declare module "*.css";
+declare module "*.css" {
+  const content: string;
+  export default content;
+}

--- a/packages/preload-workspace-app/types/modules.d.ts
+++ b/packages/preload-workspace-app/types/modules.d.ts
@@ -1,1 +1,4 @@
-declare module "*.css";
+declare module "*.css" {
+  const content: string;
+  export default content;
+}

--- a/packages/renderer/lib/stores.ts
+++ b/packages/renderer/lib/stores.ts
@@ -6,12 +6,18 @@ import { create } from "zustand";
 import { getConfig } from "./react-query";
 import { accountsSearchParam, trialDaysLeftSearchParam } from "./search-params";
 
+// The main process serializes these into the window's URL, so the shape is its
+// own and only needs saying again here.
+const initialAccounts = (
+  accountsSearchParam ? JSON.parse(accountsSearchParam) : []
+) as AccountInstances;
+
 export const useAccountsStore = create<{
   accounts: AccountInstances;
   isAddAccountDialogOpen: boolean;
   setIsAddAccountDialogOpen: (isOpen: boolean) => void;
 }>((set) => ({
-  accounts: accountsSearchParam ? JSON.parse(accountsSearchParam) : [],
+  accounts: initialAccounts,
   isAddAccountDialogOpen: false,
   setIsAddAccountDialogOpen: (isOpen) => {
     set({ isAddAccountDialogOpen: isOpen });

--- a/packages/renderer/routes/settings/version-history.tsx
+++ b/packages/renderer/routes/settings/version-history.tsx
@@ -26,7 +26,7 @@ export function VersionHistorySettings() {
   const { data, isPending, isError, refetch } = useQuery({
     queryKey: ["github", "releases"],
     queryFn: async () => {
-      const res = await fetch("https://api.github.com/repos/zoidsh/meru/releases").then(
+      const res: unknown = await fetch("https://api.github.com/repos/zoidsh/meru/releases").then(
         (response) => response.json(),
       );
 

--- a/packages/ui/components/slider.tsx
+++ b/packages/ui/components/slider.tsx
@@ -12,10 +12,19 @@ function Slider({
   max = 100,
   ...props
 }: SliderPrimitive.Root.Props) {
-  const _values = React.useMemo(
-    () => (Array.isArray(value) ? value : Array.isArray(defaultValue) ? defaultValue : [min, max]),
-    [value, defaultValue, min, max],
-  );
+  // `Array.isArray` widens a `readonly number[]` to `any[]`, so the array case
+  // is picked out by `typeof` instead.
+  const _values = React.useMemo<readonly number[]>(() => {
+    if (typeof value === "object") {
+      return value;
+    }
+
+    if (typeof defaultValue === "object") {
+      return defaultValue;
+    }
+
+    return [min, max];
+  }, [value, defaultValue, min, max]);
 
   return (
     <SliderPrimitive.Root


### PR DESCRIPTION
The `typescript/no-unsafe-*` family — values reaching typed code as `any` or as an unresolved type. Most of the 23 reports came from three missing declarations rather than from the code at the call sites.

- **`@types/semver`.** `electron-updater` types `currentVersion` as `SemVer` from `semver`, which ships no types of its own, so `autoUpdater.currentVersion.prerelease` was an unsafe member access on an error type. Adding the types resolves it properly.
- **`declare module "*.css"`.** `packages/preload-gmail` and `packages/preload-workspace-app` declared the module with no body, which makes every CSS import `any` — four reports across the dark theme, the toaster and the Mail preload. They now declare `const content: string` the way `packages/app` already did.
- **The electron-builder hooks.** `beforePack.js` and `afterPack.js` take an untyped `context`; a JSDoc `@param` naming `AfterPackContext` clears eight reports.

The rest are individual:

- Both bridge readers annotate the body as `ReadableStream<Uint8Array>` — the ambient types leave the stream unparameterized, so the chunks arrived as `any`.
- `chrome.contextMenus.create`'s trailing callback narrows through a type predicate, since `typeof x === "function"` only gets you `Function`, which isn't callable safely.
- The slider picks the array case with `typeof value === "object"` rather than `Array.isArray`, which widens a `readonly number[]` to `any[]`.
- The GitHub releases response and the accounts search param are `unknown` and an explicit assertion rather than implicit `any`; zod already validates the first.

The single report left is in `packages/app/config.ts`, which the last PR in the stack exempts along with the rest of the migrations.

## Test plan

1. Switch Settings → General → Update Channel to a pre-release and back — `allowDowngrade` is computed from `currentVersion.prerelease`, which is only properly typed with this change.
2. Open a Gmail message and a compose window with the dark theme on, and open a Google Doc — each loads its injected CSS, covering the three module declarations.
3. Adjust the notification volume slider in Settings → Notifications — it still shows one thumb and sets the value.
