### PR TITLE
keep the key types through Object.keys and Object.entries

### DIFF
--- a/packages/renderer/routes/settings/accounts.tsx
+++ b/packages/renderer/routes/settings/accounts.tsx
@@ -8,6 +8,7 @@ import {
   type AccountConfigInput,
   accountConfigInputSchema,
 } from "@meru/shared/schemas";
+import { objectEntries } from "@meru/shared/utils";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import {
@@ -32,7 +33,6 @@ import { cn } from "@meru/ui/lib/utils";
 import { useForm } from "@tanstack/react-form";
 import { GripVerticalIcon, PencilIcon, TrashIcon, XIcon } from "lucide-react";
 import { useState } from "react";
-import type { Entries } from "type-fest";
 import { EmojiPickerButton } from "@/components/emoji-picker-button";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
@@ -108,16 +108,14 @@ function AccountForm({
                       </SelectValue>
                     </SelectTrigger>
                     <SelectContent>
-                      {(Object.entries(accountColorsMap) as Entries<typeof accountColorsMap>).map(
-                        ([colorKey, { label, className }]) => (
-                          <SelectItem key={colorKey} value={colorKey}>
-                            <div className="flex items-center gap-2">
-                              <div className={`size-2 rounded-full ${className}`} />
-                              {label}
-                            </div>
-                          </SelectItem>
-                        ),
-                      )}
+                      {objectEntries(accountColorsMap).map(([colorKey, { label, className }]) => (
+                        <SelectItem key={colorKey} value={colorKey}>
+                          <div className="flex items-center gap-2">
+                            <div className={`size-2 rounded-full ${className}`} />
+                            {label}
+                          </div>
+                        </SelectItem>
+                      ))}
                     </SelectContent>
                   </Select>
                   {field.state.value && (

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -2,6 +2,7 @@ import { move } from "@dnd-kit/helpers";
 import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { GMAIL_TAB_ID, verticalTabsWidths } from "@meru/shared/tabs";
+import { objectEntries, objectKeys } from "@meru/shared/utils";
 import {
   launcherAndBookmarksPlacements,
   type LauncherWorkspaceApp,
@@ -33,7 +34,6 @@ import {
 } from "@meru/ui/components/field";
 import { Kbd } from "@meru/ui/components/kbd";
 import { ChevronDownIcon, GripVerticalIcon, PlusIcon, XIcon } from "lucide-react";
-import type { Entries } from "type-fest";
 import { ConfigSelectField } from "@/components/config-select-field";
 import { ConfigSwitchField } from "@/components/config-switch-field";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
@@ -108,13 +108,13 @@ export function WorkspaceAppsSettings() {
 
   const launcherApps = config["workspaceApps.launcherApps"];
 
-  const availableApps = (Object.keys(launcherWorkspaceApps) as LauncherWorkspaceApp[]).filter(
+  const availableApps = objectKeys(launcherWorkspaceApps).filter(
     (app) => !launcherApps.includes(app),
   );
 
   const excludedApps = config["workspaceApps.openInAppExcludedApps"];
 
-  const excludedAppLabels = (Object.keys(workspaceApps) as SupportedWorkspaceApp[])
+  const excludedAppLabels = objectKeys(workspaceApps)
     .filter((app) => excludedApps.includes(app))
     .map((app) => workspaceApps[app].label);
 
@@ -200,7 +200,7 @@ export function WorkspaceAppsSettings() {
                     }
                   />
                   <DropdownMenuContent align="end">
-                    {(Object.entries(workspaceApps) as Entries<typeof workspaceApps>)
+                    {objectEntries(workspaceApps)
                       .filter(([, { singleInstance }]) => !singleInstance)
                       .map(([app, { label }]) => (
                         <DropdownMenuCheckboxItem

--- a/packages/shared/google.ts
+++ b/packages/shared/google.ts
@@ -1,3 +1,4 @@
+import { objectKeys } from "./utils";
 import { type SupportedWorkspaceApp, workspaceApps } from "./workspace-apps";
 
 export function getWorkspaceAppUrl(app: SupportedWorkspaceApp) {
@@ -9,7 +10,7 @@ export function getGoogleDomainFaviconUrl(domain: string, size: number) {
 }
 
 const workspaceAppsBySubdomain = new Map<string, SupportedWorkspaceApp>(
-  (Object.keys(workspaceApps) as SupportedWorkspaceApp[]).map((workspaceApp) => [
+  objectKeys(workspaceApps).map((workspaceApp) => [
     new URL(getWorkspaceAppUrl(workspaceApp)).hostname.replace(".google.com", ""),
     workspaceApp,
   ]),

--- a/packages/shared/utils.ts
+++ b/packages/shared/utils.ts
@@ -1,3 +1,21 @@
+import type { Entries } from "type-fest";
+
+/**
+ * `Object.keys` and `Object.entries` widen the key back to `string`, because a
+ * value can always carry more properties than its type lists. A record declared
+ * from a literal here has exactly the keys it names, so the narrower type holds
+ * — and saying so once beats an assertion at every call.
+ */
+export function objectKeys<Value extends object>(value: Value) {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return Object.keys(value) as (keyof Value)[];
+}
+
+export function objectEntries<Value extends object>(value: Value) {
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return Object.entries(value) as Entries<Value>;
+}
+
 export function wait(ms: number) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);


### PR DESCRIPTION
`Object.keys` and `Object.entries` widen the key back to `string`, because a value can always carry more properties than its type lists. Five places worked around that with an assertion, which `typescript/no-unsafe-type-assertion` reports.

`objectKeys` and `objectEntries` in `@meru/shared/utils` say it once instead, with the reason and a rule directive on the one line that needs it. The records they're used on here are all declared from a literal, so they have exactly the keys they name.

Six assertions across the settings pages and `shared/google.ts` come out, and the `type-fest` `Entries` import goes with them.

## Test plan

1. Settings → Accounts → Add Account — the colour dropdown lists all fifteen colours.
2. Settings → Workspace Apps — the launcher's app picker and the Open in App exclusion list are both fully populated.
3. Open a link to a Google app from Gmail — `workspaceAppsBySubdomain` still resolves it, which is built from `objectKeys` now.
