### PR TITLE
check the values crossing into typed code instead of asserting them

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -9,6 +9,7 @@ import { getWorkspaceAppUrl } from "@meru/shared/google";
 import { ms } from "@meru/shared/ms";
 import { GMAIL_TAB_ID } from "@meru/shared/tabs";
 import type { IpcMainEvents, IpcRendererEvent } from "@meru/shared/types";
+import { objectEntries } from "@meru/shared/utils";
 import { workspaceApps } from "@meru/shared/workspace-apps";
 import {
   app,
@@ -667,9 +668,9 @@ class Ipc {
     ipc.main.handle("spellchecker.getOsLocale", () => app.getLocale());
 
     ipc.main.handle("config.setConfig", (_event, keyValues) => {
-      Object.entries(keyValues).forEach(([key, value]) => {
-        config.set(key as keyof typeof keyValues, value);
-      });
+      for (const [key, value] of objectEntries(keyValues)) {
+        config.set(key, value);
+      }
     });
 
     ipc.main.handle("downloads.setLocation", async () => {

--- a/packages/electron-extensions/bridge/bridge.ts
+++ b/packages/electron-extensions/bridge/bridge.ts
@@ -10,11 +10,11 @@ import { EXTENSION_BRIDGE_SCHEME, type ExtensionBridgeRequest } from "./protocol
  */
 export const MAX_BRIDGE_REQUEST_BYTES = 64 * 1024 * 1024;
 
-export type ExtensionBridgeHandler = (request: {
+export type ExtensionBridgeHandler<Body = Record<string, unknown>> = (request: {
   session: Session;
   /** The extension whose facade copy carried the request's token. */
   extensionId: string;
-  body: Record<string, unknown>;
+  body: Body;
   /** For the handler's `Response`, so every answer carries the CORS headers. */
   headers: Record<string, string>;
 }) => Promise<Response> | Response;
@@ -43,8 +43,13 @@ export class ExtensionBridge {
     this.logger = logger;
   }
 
-  handle(pathname: string, handler: ExtensionBridgeHandler) {
-    this.routes.set(pathname, handler);
+  /**
+   * `Body` is the shape the route expects of the JSON it is sent. Nothing has
+   * checked it — the bridge only vouches for who is calling.
+   */
+  handle<Body = Record<string, unknown>>(pathname: string, handler: ExtensionBridgeHandler<Body>) {
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    this.routes.set(pathname, handler as ExtensionBridgeHandler);
   }
 
   setupSession(session: Session, sessionOptions: ExtensionBridgeSession) {
@@ -78,6 +83,7 @@ export class ExtensionBridge {
         return new Response(null, { status: 413, headers });
       }
 
+      // oxlint-disable-next-line typescript/no-unsafe-type-assertion
       const body = JSON.parse(bodySource) as ExtensionBridgeRequest & Record<string, unknown>;
 
       // Everything else in the session — Gmail, workspace apps, any page a user

--- a/packages/electron-extensions/crx/protobuf.ts
+++ b/packages/electron-extensions/crx/protobuf.ts
@@ -19,7 +19,11 @@ function readVarint(message: Uint8Array, offset: number) {
   let cursor = offset;
 
   while (cursor < message.byteLength) {
-    const byte = message[cursor] as number;
+    const byte = message[cursor];
+
+    if (byte === undefined) {
+      break;
+    }
 
     cursor += 1;
 

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -117,6 +117,8 @@ export async function deriveExtension({
 }: DeriveExtensionOptions) {
   const manifestSource = await readFile(path.join(sourceDir, MANIFEST_FILE_NAME), "utf8");
 
+  // Nothing has checked the manifest; what this reads off it is checked below.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const sourceManifest = JSON.parse(manifestSource) as ExtensionManifest;
 
   const extensionId = getExtensionIdFromManifestKey(sourceManifest.key);
@@ -197,6 +199,8 @@ async function readStampSourceDir(stampPath: string) {
   }
 
   try {
+    // The stamp is this package's own, and a malformed one falls to the catch.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
     return (JSON.parse(stamp) as { sourceDir?: string }).sourceDir;
   } catch {
     return undefined;

--- a/packages/electron-extensions/derive/manifest.ts
+++ b/packages/electron-extensions/derive/manifest.ts
@@ -88,9 +88,9 @@ export function allowConnectSource(contentSecurityPolicy: string, source: string
 
   const connectIndex = findDirective(directives, "connect-src");
 
-  if (connectIndex !== -1) {
-    const connectDirective = directives[connectIndex] as string;
+  const connectDirective = connectIndex === -1 ? undefined : directives[connectIndex];
 
+  if (connectDirective !== undefined) {
     if (connectDirective.split(/\s+/).includes(source)) {
       return contentSecurityPolicy;
     }
@@ -102,12 +102,14 @@ export function allowConnectSource(contentSecurityPolicy: string, source: string
 
   const defaultIndex = findDirective(directives, "default-src");
 
+  const defaultDirective = defaultIndex === -1 ? undefined : directives[defaultIndex];
+
   // Without either directive nothing restricts connections in the first place
-  if (defaultIndex === -1) {
+  if (defaultDirective === undefined) {
     return contentSecurityPolicy;
   }
 
-  const inheritedSources = (directives[defaultIndex] as string)
+  const inheritedSources = defaultDirective
     .split(/\s+/)
     .slice(1)
     // `'none'` alongside another source is ignored rather than obeyed

--- a/packages/electron-extensions/facade/api/context-menus.ts
+++ b/packages/electron-extensions/facade/api/context-menus.ts
@@ -1,6 +1,6 @@
 import type { ChromeNamespace } from "../lib/chrome";
 import { createNoopEvent } from "../lib/event";
-import { createNoopMethod } from "../lib/method";
+import { createNoopMethod, isExtensionCallback } from "../lib/method";
 
 let createdMenuItemCount = 0;
 
@@ -18,10 +18,6 @@ function takeMenuItemId(createProperties: unknown) {
   return createdMenuItemCount;
 }
 
-function isCreatedCallback(value: unknown): value is () => void {
-  return typeof value === "function";
-}
-
 /**
  * The one method here that answers synchronously with the id it assigned, using
  * its optional callback only to signal that the item was created.
@@ -31,9 +27,9 @@ function createMenuItem(...callArguments: unknown[]) {
 
   const callback = callArguments.at(-1);
 
-  if (isCreatedCallback(callback)) {
+  if (isExtensionCallback(callback)) {
     queueMicrotask(() => {
-      callback();
+      callback(undefined);
     });
   }
 

--- a/packages/electron-extensions/facade/api/native-messaging.ts
+++ b/packages/electron-extensions/facade/api/native-messaging.ts
@@ -6,6 +6,7 @@ import { NativeMessageDecoder } from "../../native-messaging/framing";
 import { postBridge } from "../lib/bridge";
 import type { ChromeNamespace } from "../lib/chrome";
 import { createEvent } from "../lib/event";
+import { isExtensionCallback } from "../lib/method";
 
 const DISCONNECTED_PORT_ERROR = "Attempting to use a disconnected port object";
 
@@ -39,8 +40,23 @@ function withLastError(runtime: ChromeNamespace, error: string | undefined, run:
   }
 }
 
+function isChromeNamespace(value: unknown): value is ChromeNamespace {
+  return typeof value === "object" && value !== null;
+}
+
+/** The bridge writes these, so an unrecognised one means a version skew. */
+function isNativeMessagingFrame(value: unknown): value is NativeMessagingFrame {
+  return isChromeNamespace(value) && (value.type === "message" || value.type === "disconnect");
+}
+
 function getLastErrorMessage(runtime: ChromeNamespace) {
-  return (runtime.lastError as { message?: string } | undefined)?.message;
+  const { lastError } = runtime;
+
+  if (!isChromeNamespace(lastError) || typeof lastError.message !== "string") {
+    return undefined;
+  }
+
+  return lastError.message;
 }
 
 function createPort(runtime: ChromeNamespace, hostName: string): NativeMessagingPort {
@@ -130,7 +146,7 @@ function createPort(runtime: ChromeNamespace, hostName: string): NativeMessaging
         return;
       }
 
-      for (const frame of decoder.push(value) as NativeMessagingFrame[]) {
+      for (const frame of decoder.push(value).filter(isNativeMessagingFrame)) {
         if (frame.type === "message") {
           onMessage.emit(frame.message, port);
         } else {
@@ -174,17 +190,17 @@ function createSendNativeMessage(runtime: ChromeNamespace) {
       port.postMessage(message);
     });
 
-    if (typeof callback !== "function") {
+    if (!isExtensionCallback(callback)) {
       return reply;
     }
 
     reply.then(
       (response) => {
-        (callback as (response: unknown) => void)(response);
+        callback(response);
       },
       (error: unknown) => {
         withLastError(runtime, error instanceof Error ? error.message : String(error), () => {
-          (callback as (response: unknown) => void)(undefined);
+          callback(undefined);
         });
       },
     );
@@ -202,9 +218,9 @@ function createSendNativeMessage(runtime: ChromeNamespace) {
  * administrator". The replacements reach the package's own bridge instead.
  */
 export function installNativeMessaging(extensionApi: ChromeNamespace) {
-  const runtime = extensionApi.runtime as ChromeNamespace | undefined;
+  const { runtime } = extensionApi;
 
-  if (!runtime) {
+  if (!isChromeNamespace(runtime)) {
     return;
   }
 

--- a/packages/electron-extensions/facade/api/native-messaging.ts
+++ b/packages/electron-extensions/facade/api/native-messaging.ts
@@ -146,7 +146,15 @@ function createPort(runtime: ChromeNamespace, hostName: string): NativeMessaging
         return;
       }
 
-      for (const frame of decoder.push(value).filter(isNativeMessagingFrame)) {
+      for (const frame of decoder.push(value)) {
+        // Anything the bridge sends that isn't a frame closes the port, the same
+        // as a disconnect frame does — it means the two ends disagree.
+        if (!isNativeMessagingFrame(frame)) {
+          disconnected();
+
+          return;
+        }
+
         if (frame.type === "message") {
           onMessage.emit(frame.message, port);
         } else {

--- a/packages/electron-extensions/facade/index.ts
+++ b/packages/electron-extensions/facade/index.ts
@@ -14,6 +14,7 @@ import type { ChromeNamespace } from "./lib/chrome";
  * Both are filled from one facade, so a namespace promoted to a real
  * implementation later has one set of listeners, whichever global reached it.
  */
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion
 const extensionGlobals = globalThis as unknown as Record<string, ChromeNamespace | undefined>;
 
 const facade = createChromeFacade();

--- a/packages/electron-extensions/facade/lib/bridge.ts
+++ b/packages/electron-extensions/facade/lib/bridge.ts
@@ -6,6 +6,8 @@ import { EXTENSION_BRIDGE_ORIGIN, EXTENSION_BRIDGE_TOKEN_GLOBAL } from "../../br
  * extension is calling, since the request itself carries no sender.
  */
 export function postBridge(pathName: string, body: Record<string, unknown>) {
+  // The derived copy of the facade writes the token onto the global itself.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const token = (globalThis as unknown as Record<string, string | undefined>)[
     EXTENSION_BRIDGE_TOKEN_GLOBAL
   ];

--- a/packages/electron-extensions/facade/lib/method.ts
+++ b/packages/electron-extensions/facade/lib/method.ts
@@ -1,4 +1,14 @@
 /**
+ * The trailing callback of a callback-style call. Chrome passes the result to
+ * it and nothing reads what it answers.
+ */
+export type ExtensionCallback = (callbackResult: unknown) => void;
+
+export function isExtensionCallback(value: unknown): value is ExtensionCallback {
+  return typeof value === "function";
+}
+
+/**
  * A method that does nothing and answers with `createResult`, the way Chrome
  * would: extensions written against MV3 await a promise, while
  * `webextension-polyfill` and older code pass a callback as the last argument
@@ -11,9 +21,9 @@ export function createNoopMethod(createResult: (callArguments: unknown[]) => unk
 
     const callback = callArguments.at(-1);
 
-    if (typeof callback === "function") {
+    if (isExtensionCallback(callback)) {
       queueMicrotask(() => {
-        (callback as (callbackResult: unknown) => void)(result);
+        callback(result);
       });
 
       return undefined;
@@ -34,13 +44,13 @@ export function createBridgedMethod(produceResult: (callArguments: unknown[]) =>
   return (...callArguments: unknown[]) => {
     const callback = callArguments.at(-1);
 
-    if (typeof callback === "function") {
+    if (isExtensionCallback(callback)) {
       produceResult(callArguments.slice(0, -1)).then(
         (result) => {
-          (callback as (callbackResult: unknown) => void)(result);
+          callback(result);
         },
         () => {
-          (callback as (callbackResult: unknown) => void)(undefined);
+          callback(undefined);
         },
       );
 

--- a/packages/electron-extensions/install/installer.ts
+++ b/packages/electron-extensions/install/installer.ts
@@ -54,6 +54,8 @@ function readCrxPackage(crx: Uint8Array, extensionId: string): ExtensionPackage 
     throw new Error(`CRX for ${extensionId} carries no ${MANIFEST_FILE_NAME}`);
   }
 
+  // Straight out of the CRX, so the fields this reads are checked below.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const manifest = JSON.parse(new TextDecoder().decode(manifestSource)) as ExtensionManifest;
 
   if (typeof manifest.version !== "string") {

--- a/packages/electron-extensions/native-messaging/host-manifest.ts
+++ b/packages/electron-extensions/native-messaging/host-manifest.ts
@@ -108,7 +108,9 @@ export function isValidHostName(hostName: string) {
 }
 
 export function parseHostManifest(source: string, hostName: string): NativeMessagingHostManifest {
-  // A manifest off disk, so every field it names is checked before it is used.
+  // A manifest off disk. The fields the connection turns on — `name`, `type`,
+  // `path` and `allowed_origins` — are checked below; `description` is carried
+  // through as whatever it was.
   // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const manifest = JSON.parse(source) as Partial<NativeMessagingHostManifest>;
 

--- a/packages/electron-extensions/native-messaging/host-manifest.ts
+++ b/packages/electron-extensions/native-messaging/host-manifest.ts
@@ -108,6 +108,8 @@ export function isValidHostName(hostName: string) {
 }
 
 export function parseHostManifest(source: string, hostName: string): NativeMessagingHostManifest {
+  // A manifest off disk, so every field it names is checked before it is used.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const manifest = JSON.parse(source) as Partial<NativeMessagingHostManifest>;
 
   if (manifest.name !== hostName) {

--- a/packages/electron-extensions/native-messaging/native-messaging.ts
+++ b/packages/electron-extensions/native-messaging/native-messaging.ts
@@ -86,34 +86,33 @@ export class NativeMessaging {
   }
 
   registerRoutes(bridge: ExtensionBridge) {
-    bridge.handle(NATIVE_MESSAGING_PATHS.connect, ({ session, extensionId, body, headers }) =>
-      this.handleConnect(
-        session,
-        extensionId,
-        body as unknown as NativeMessagingConnectRequest,
-        headers,
-      ),
+    bridge.handle<NativeMessagingConnectRequest>(
+      NATIVE_MESSAGING_PATHS.connect,
+      ({ session, extensionId, body, headers }) =>
+        this.handleConnect(session, extensionId, body, headers),
     );
 
-    bridge.handle(NATIVE_MESSAGING_PATHS.post, ({ session, extensionId, body, headers }) => {
-      this.handlePost(session, extensionId, body as unknown as NativeMessagingPostRequest);
+    bridge.handle<NativeMessagingPostRequest>(
+      NATIVE_MESSAGING_PATHS.post,
+      ({ session, extensionId, body, headers }) => {
+        this.handlePost(session, extensionId, body);
 
-      return new Response(null, { status: 204, headers });
-    });
+        return new Response(null, { status: 204, headers });
+      },
+    );
 
-    bridge.handle(NATIVE_MESSAGING_PATHS.disconnect, ({ session, extensionId, body, headers }) => {
-      const port = this.getPort(
-        session,
-        extensionId,
-        (body as unknown as NativeMessagingDisconnectRequest).portId,
-      );
+    bridge.handle<NativeMessagingDisconnectRequest>(
+      NATIVE_MESSAGING_PATHS.disconnect,
+      ({ session, extensionId, body, headers }) => {
+        const port = this.getPort(session, extensionId, body.portId);
 
-      if (port) {
-        this.closePort(port);
-      }
+        if (port) {
+          this.closePort(port);
+        }
 
-      return new Response(null, { status: 204, headers });
-    });
+        return new Response(null, { status: 204, headers });
+      },
+    );
   }
 
   teardownSession(session: Session) {

--- a/packages/electron-extensions/web-navigation/web-navigation.ts
+++ b/packages/electron-extensions/web-navigation/web-navigation.ts
@@ -41,6 +41,8 @@ export type WebNavigationOptions = {
  * outside Electron, which is where this module's tests run.
  */
 function getElectronWebContentsById(tabId: number) {
+  // `require` answers `any`, and this module is the one place that calls it.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const { webContents } = require("electron") as typeof electron;
 
   return webContents.fromId(tabId);
@@ -66,14 +68,16 @@ export class WebNavigation {
   }
 
   registerRoutes(bridge: ExtensionBridge) {
-    bridge.handle(WEB_NAVIGATION_PATHS.getFrame, ({ session, body, headers }) =>
-      Response.json(this.getFrame(session, body.details as WebNavigationFrameQuery), { headers }),
+    bridge.handle<{ details: WebNavigationFrameQuery }>(
+      WEB_NAVIGATION_PATHS.getFrame,
+      ({ session, body, headers }) =>
+        Response.json(this.getFrame(session, body.details), { headers }),
     );
 
-    bridge.handle(WEB_NAVIGATION_PATHS.getAllFrames, ({ session, body, headers }) =>
-      Response.json(this.getAllFrames(session, body.details as WebNavigationFrameQuery), {
-        headers,
-      }),
+    bridge.handle<{ details: WebNavigationFrameQuery }>(
+      WEB_NAVIGATION_PATHS.getAllFrames,
+      ({ session, body, headers }) =>
+        Response.json(this.getAllFrames(session, body.details), { headers }),
     );
   }
 

--- a/packages/renderer/lib/stores.ts
+++ b/packages/renderer/lib/stores.ts
@@ -8,6 +8,7 @@ import { accountsSearchParam, trialDaysLeftSearchParam } from "./search-params";
 
 // The main process serializes these into the window's URL, so the shape is its
 // own and only needs saying again here.
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion
 const initialAccounts = (
   accountsSearchParam ? JSON.parse(accountsSearchParam) : []
 ) as AccountInstances;

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -7,7 +7,6 @@ import {
   launcherAndBookmarksPlacements,
   type LauncherWorkspaceApp,
   launcherWorkspaceApps,
-  type SupportedWorkspaceApp,
   workspaceApps,
   workspaceAppsHibernations,
   workspaceAppsHibernationTimeouts,

--- a/packages/renderer/workspace-app.tsx
+++ b/packages/renderer/workspace-app.tsx
@@ -1,5 +1,8 @@
 import { ipc } from "@meru/shared/renderer/ipc";
-import type { SupportedWorkspaceApp, WorkspaceAppBookmarkState } from "@meru/shared/workspace-apps";
+import {
+  isSupportedWorkspaceApp,
+  type WorkspaceAppBookmarkState,
+} from "@meru/shared/workspace-apps";
 import { cn } from "@meru/ui/lib/utils";
 import { DownloadIcon, EllipsisVerticalIcon, StarIcon } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -181,7 +184,9 @@ function WorkspaceApp() {
     (accountConfig) => accountConfig.id === searchParams.get("accountId"),
   );
 
-  const workspaceApp = searchParams.get("workspaceApp") as SupportedWorkspaceApp | null;
+  const workspaceAppParam = searchParams.get("workspaceApp");
+
+  const workspaceApp = isSupportedWorkspaceApp(workspaceAppParam) ? workspaceAppParam : null;
 
   const workspaceAppId = searchParams.get("workspaceAppId");
 

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -1,4 +1,5 @@
 import { GMAIL_URL } from "./gmail";
+import { objectEntries } from "./utils";
 
 type WorkspaceAppDefinition = {
   label: string;
@@ -43,11 +44,18 @@ export type LauncherWorkspaceApp = {
 export const workspaceApps: Record<SupportedWorkspaceApp, WorkspaceAppDefinition> =
   workspaceAppDefinitions;
 
+// `Object.fromEntries` answers with an index signature; the entries it is given
+// here come from `workspaceApps`, so the keys are the ones the type names.
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion
 export const launcherWorkspaceApps = Object.fromEntries(
-  Object.entries(workspaceApps)
+  objectEntries(workspaceApps)
     .filter(([, workspaceAppDefinition]) => workspaceAppDefinition.availableInLauncher !== false)
     .map(([workspaceApp, workspaceAppDefinition]) => [workspaceApp, workspaceAppDefinition.label]),
 ) as Record<LauncherWorkspaceApp, string>;
+
+export function isSupportedWorkspaceApp(value: unknown): value is SupportedWorkspaceApp {
+  return typeof value === "string" && Object.hasOwn(workspaceApps, value);
+}
 
 const LAUNCHER_EXPANDED_APPS_THRESHOLD = 3;
 

--- a/packages/ui/components/input-group.tsx
+++ b/packages/ui/components/input-group.tsx
@@ -52,7 +52,7 @@ function InputGroupAddon({
       data-align={align}
       className={cn(inputGroupAddonVariants({ align }), className)}
       onClick={(e) => {
-        if ((e.target as HTMLElement).closest("button")) {
+        if (e.target instanceof HTMLElement && e.target.closest("button")) {
           return;
         }
         e.currentTarget.parentElement?.querySelector("input")?.focus();

--- a/packages/ui/components/input-group.tsx
+++ b/packages/ui/components/input-group.tsx
@@ -52,7 +52,9 @@ function InputGroupAddon({
       data-align={align}
       className={cn(inputGroupAddonVariants({ align }), className)}
       onClick={(e) => {
-        if (e.target instanceof HTMLElement && e.target.closest("button")) {
+        // `Element`, not `HTMLElement`: a click landing on an icon inside an
+        // addon button targets the `<svg>`, which is an `SVGElement`.
+        if (e.target instanceof Element && e.target.closest("button")) {
           return;
         }
         e.currentTarget.parentElement?.querySelector("input")?.focus();

--- a/packages/ui/components/sonner.tsx
+++ b/packages/ui/components/sonner.tsx
@@ -9,6 +9,16 @@ import {
 } from "lucide-react";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
+// React's `CSSProperties` lists the known properties only, so the custom ones
+// have to be handed over as such.
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion
+const toasterStyle = {
+  "--normal-bg": "var(--popover)",
+  "--normal-text": "var(--popover-foreground)",
+  "--normal-border": "var(--border)",
+  "--border-radius": "var(--radius)",
+} as React.CSSProperties;
+
 const Toaster = ({ theme, ...props }: ToasterProps) => {
   return (
     <Sonner
@@ -21,14 +31,7 @@ const Toaster = ({ theme, ...props }: ToasterProps) => {
         error: <OctagonXIcon className="size-4" />,
         loading: <Loader2Icon className="size-4 animate-spin" />,
       }}
-      style={
-        {
-          "--normal-bg": "var(--popover)",
-          "--normal-text": "var(--popover-foreground)",
-          "--normal-border": "var(--border)",
-          "--border-radius": "var(--radius)",
-        } as React.CSSProperties
-      }
+      style={toasterStyle}
       {...props}
     />
   );

--- a/scripts/download-extensions.ts
+++ b/scripts/download-extensions.ts
@@ -78,6 +78,9 @@ async function downloadExtension(extension: CuratedExtension) {
 
   const manifestPath = path.join(stagingDir, MANIFEST_FILE_NAME);
 
+  // The manifest of an extension this script just unpacked; a wrong shape here
+  // fails the download rather than reaching the app.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
   const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
     version: string;
     key: string;


### PR DESCRIPTION
The rest of `typescript/no-unsafe-type-assertion`, in the places where untyped data crosses into typed code.

**Checked instead of asserted**, where a check was cheap and honest:

- The `workspaceApp` URL parameter goes through `isSupportedWorkspaceApp` rather than an assertion, so an unrecognised value now reads as none instead of sailing through as a valid app.
- The facade's trailing callbacks narrow through `isExtensionCallback`, and `chrome.runtime` and `runtime.lastError` through `isChromeNamespace` — `typeof x === "function"` only gets you `Function`, and `ChromeNamespace` is `Record<string, unknown>`, so both needed a predicate.
- Native messaging frames off the bridge go through `isNativeMessagingFrame` rather than being asserted wholesale. Anything that isn't a frame closes the port, the same as a disconnect frame — which is what the old assertion did once the value fell through to the `else`.
- `readVarint` and the CSP directive rewrites read their indexed values and handle the missing case, rather than asserting past `noUncheckedIndexedAccess`.
- `InputGroupAddon` narrows its click target with `instanceof Element` — `HTMLElement` would miss a click landing on the `<svg>` inside an addon button, which is what the guard is for.

**Typed at the boundary**, so the call sites don't have to assert:

- `ExtensionBridge.handle` is generic over the body a route expects. The five routes in native messaging and web navigation name their request type instead of casting `body`, and the one assertion lives in `handle` with a comment saying nothing has checked the JSON — the bridge only vouches for who is calling.
- The Toaster's CSS custom properties move to a named constant, since React's `CSSProperties` lists only the known properties.

**Left as assertions**, each with a directive naming the rule and a comment saying why: the six `JSON.parse` results whose fields are checked immediately afterwards, `require("electron")` in the module that loads it lazily, and the two reads of a global that the derived facade writes.

## Test plan

1. With 1Password installed, unlock it in Meru and fill a Google sign-in — that exercises native messaging connect/post/disconnect and web navigation's frame queries, which are the routes that changed shape.
2. Open a workspace app in its own window, then open one from a URL naming an app that doesn't exist — the first loads as before, the second falls back rather than being treated as a real app.
3. Install and remove an extension from Settings → Extensions — the CRX manifest and derive paths still read their versions.
