### PR TITLE
fix the interface text the writing guide flags

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -750,7 +750,7 @@ class Ipc {
       createNewEmailNotification({
         title: "Tim from Meru",
         subtitle: "Your test notification request",
-        body: "This is a test notification, to show how a notification appears.",
+        body: "This is what a new email notification looks like.",
       });
     });
 

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -746,9 +746,9 @@ export class AppMenu {
                     type: "warning",
                     buttons: ["Cancel", "Reset"],
                     defaultId: 1,
-                    message: "Are you sure you want to reset the app?",
+                    message: "Reset Meru to its original state?",
                     detail:
-                      "This will clear all your accounts, settings, and data. This action cannot be undone.",
+                      "This signs out of every account and clears all settings and data on this device. It can't be undone.",
                   });
 
                   if (response === 0) {

--- a/packages/renderer/lib/stores.ts
+++ b/packages/renderer/lib/stores.ts
@@ -26,7 +26,7 @@ ipc.renderer.on("accounts.openAddAccountDialog", async (_event) => {
   const config = await getConfig();
 
   if (!config.licenseKey && !useTrialStore.getState().daysLeft) {
-    toast.error("Meru Pro Required", {
+    toast.error("Meru Pro required", {
       description: "Upgrade to Meru Pro to add more accounts.",
     });
 

--- a/packages/renderer/routes/settings/advanced.tsx
+++ b/packages/renderer/routes/settings/advanced.tsx
@@ -40,7 +40,7 @@ export function AdvancedSettings() {
               {platform.isMacOS && (
                 <ConfigSwitchField
                   label="Use Custom User Agent"
-                  description="Send a custom user agent, for the Gmail and Workspace Apps features that don't work with the default one. It resolves some problems and can cause others, so turn it off if the app becomes unstable."
+                  description="Send a custom user agent for the Gmail and Workspace Apps features that don't work with the default one. It resolves some problems and can cause others, so turn it off if the app becomes unstable."
                   configKey="customUserAgent"
                   restartRequired
                 />

--- a/packages/renderer/routes/settings/license.tsx
+++ b/packages/renderer/routes/settings/license.tsx
@@ -151,7 +151,7 @@ export function LicenseSettings() {
     },
     validators: {
       onSubmit: z.object({
-        label: z.string().min(1, "Device label is required"),
+        label: z.string().min(1, "Enter a device label"),
       }),
     },
     onSubmit: async ({ value, formApi }) => {

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -267,7 +267,7 @@ export function NotificationsSettings() {
             <FieldGroup>
               <ConfigSwitchField
                 label="Show Notification"
-                description="Show a notification when a download is completed, canceled, or failed."
+                description="Show a notification when a download finishes."
                 configKey="notifications.downloadCompleted"
               />
               {config["notifications.downloadCompleted"] && (

--- a/packages/renderer/routes/settings/phishing-protection.tsx
+++ b/packages/renderer/routes/settings/phishing-protection.tsx
@@ -46,7 +46,7 @@ export function PhishingProtectionSettings() {
                   <FieldLabel>Trusted Hosts</FieldLabel>
                   {config["externalLinks.trustedHosts"].length === 0 && (
                     <FieldDescription>
-                      No trusted hosts yet. Choosing "Trust all links" in the link prompt adds one.
+                      No trusted hosts yet. Choosing “Trust all links” in the link prompt adds one.
                     </FieldDescription>
                   )}
                 </FieldContent>

--- a/packages/renderer/routes/settings/saved-searches.tsx
+++ b/packages/renderer/routes/settings/saved-searches.tsx
@@ -14,7 +14,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@meru/ui/components/dialog";
-import { Field, FieldGroup, FieldLabel } from "@meru/ui/components/field";
+import { Field, FieldError, FieldGroup, FieldLabel } from "@meru/ui/components/field";
 import { Input } from "@meru/ui/components/input";
 import {
   Item,
@@ -86,6 +86,7 @@ export function SavedSearchForm({
                   modal
                 />
               </div>
+              <FieldError errors={field.state.meta.errors} />
             </Field>
           )}
         </form.Field>
@@ -101,6 +102,7 @@ export function SavedSearchForm({
                 onChange={(event) => field.handleChange(event.target.value)}
                 placeholder={queryPlaceholder}
               />
+              <FieldError errors={field.state.meta.errors} />
             </Field>
           )}
         </form.Field>

--- a/packages/shared/schemas.ts
+++ b/packages/shared/schemas.ts
@@ -105,8 +105,8 @@ export type AccountInstances = AccountInstance[];
 
 export const gmailSavedSearchSchema = z.object({
   id: z.string(),
-  label: z.string().min(1),
-  query: z.string().min(1),
+  label: z.string().min(1, "Enter a label"),
+  query: z.string().min(1, "Enter a search query"),
 });
 
 export const gmailSavedSearchInputSchema = gmailSavedSearchSchema.omit({
@@ -125,8 +125,11 @@ export type GmailLabelTextColor = (typeof gmailLabelTextColors)[number];
 
 export const gmailLabelColorSchema = z.object({
   id: z.string(),
-  label: z.string().min(1),
-  color: z.string().min(1).refine(isValidCssColorInput, "Enter a valid hex, rgb, or rgba color"),
+  label: z.string().min(1, "Enter a label"),
+  color: z
+    .string()
+    .min(1, "Enter a color")
+    .refine(isValidCssColorInput, "Enter a valid hex, rgb, or rgba color"),
   textColor: z.enum(gmailLabelTextColors),
 });
 


### PR DESCRIPTION
A pass over the interface text with the `ui-writing` guide. Capitalization stays as it is here; the sentence-case sweep lands in its own PRs on top of this one.

**The Downloads notification setting described behavior that doesn't exist.** It read "Show a notification when a download is completed, canceled, or failed", and `Downloads.init` notifies only on `state === "completed"`. It now reads "Show a notification when a download finishes", which matches the **Open Folder When Done** description in the same section.

**The Reset App confirmation opened with "Are you sure you want to".** The guide replaces that with the action itself and puts the consequence in the detail:

- `Reset Meru to its original state?`
- `This signs out of every account and clears all settings and data on this device. It can't be undone.`

**An empty field showed Zod's own error text, or none at all.** The label color form renders `FieldError`, and neither `label` nor `color` passed a message to `min(1)`, so an empty field reported "Too small: expected string to have >=1 characters". They now read `Enter a label` and `Enter a color`. The saved search form had the same gap and rendered no error at all, so submitting an empty form did nothing the reader could see; it now renders the error next to the field, as the label color form does. The device label message changes from "Device label is required" to "Enter a device label", matching the imperative the color message already used.

Four single strings:

- The Meru Pro toast title was Title Case, where the conventions put toasts in sentence case.
- The trusted hosts description quoted the link prompt with straight quotes, and the app uses curly ones.
- The custom user agent description had a comma in front of a restrictive clause.
- The test notification body described itself — "This is a test notification, to show how a notification appears" — and now shows what a real one looks like.

Running the app verifies none of this: every change is a string or a validation message, checked by reading. `bun run types`, `bun run lint`, `bun run fmt:check`, and `bun test` pass.

Two findings I left alone, both behavior rather than text, now tracked in `docs/todo.md`:

- Download notifications never appear while **Open Folder When Done** is on, because `electronDl` receives `onStarted` only when that setting is off.
- The Reset App confirmation makes **Reset** the default button, which the guide advises against for a destructive action.
