### PR TITLE
name the icon-only controls

### DIFF
--- a/packages/renderer/components/app-main.tsx
+++ b/packages/renderer/components/app-main.tsx
@@ -18,7 +18,13 @@ function CloseButton() {
 
   return (
     <div className="flex flex-col items-center gap-2">
-      <Button variant="outline" size="icon" onClick={closeSettings} className="rounded-full">
+      <Button
+        variant="outline"
+        size="icon"
+        onClick={closeSettings}
+        className="rounded-full"
+        title="Close settings"
+      >
         <XIcon />
       </Button>
       <div className="text-xs font-semibold text-muted-foreground">ESC</div>

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -93,6 +93,7 @@ function AppMenuButton({ className }: { className?: string }) {
         onClick={() => {
           ipc.main.send("titleBar.toggleAppMenu");
         }}
+        title="App menu"
       >
         <EllipsisVerticalIcon />
       </Button>

--- a/packages/renderer/components/emoji-picker-button.tsx
+++ b/packages/renderer/components/emoji-picker-button.tsx
@@ -20,7 +20,7 @@ export function EmojiPickerButton({
     <Popover onOpenChange={setIsOpen} open={isOpen} {...props}>
       <PopoverTrigger
         render={
-          <Button variant="outline" size="icon">
+          <Button variant="outline" size="icon" title="Pick emoji">
             <SmileIcon />
           </Button>
         }

--- a/packages/renderer/routes/settings/accounts.tsx
+++ b/packages/renderer/routes/settings/accounts.tsx
@@ -122,6 +122,7 @@ function AccountForm({
                       onClick={() => {
                         form.setFieldValue("color", null);
                       }}
+                      title="Clear color"
                     >
                       <XIcon />
                     </Button>
@@ -253,7 +254,7 @@ function EditAccountButton({ account }: { account: AccountConfig }) {
     <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
       <DialogTrigger
         render={
-          <Button size="icon" className="size-8 p-0" variant="outline">
+          <Button size="icon" className="size-8 p-0" variant="outline" title="Edit account">
             <PencilIcon />
           </Button>
         }
@@ -338,6 +339,7 @@ function SortableAccountItem({
             size="icon"
             className="size-8 p-0"
             variant="outline"
+            title="Remove account"
             onClick={() => {
               const confirmed = window.confirm(`Remove ${account.label}?`);
 

--- a/packages/renderer/routes/settings/gmail/label-colors.tsx
+++ b/packages/renderer/routes/settings/gmail/label-colors.tsx
@@ -185,7 +185,7 @@ function EditLabelColorButton({
     <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
       <DialogTrigger
         render={
-          <Button size="icon" className="size-8 p-0" variant="outline">
+          <Button size="icon" className="size-8 p-0" variant="outline" title="Edit label color">
             <PencilIcon />
           </Button>
         }
@@ -257,6 +257,7 @@ export function GmailLabelColors() {
                   size="icon"
                   className="size-8 p-0"
                   variant="outline"
+                  title="Delete label color"
                   onClick={() => {
                     const confirmed = window.confirm(`Delete the color for ${labelColor.label}?`);
 

--- a/packages/renderer/routes/settings/license.tsx
+++ b/packages/renderer/routes/settings/license.tsx
@@ -198,7 +198,7 @@ export function LicenseSettings() {
                   <DropdownMenu>
                     <DropdownMenuTrigger
                       render={
-                        <Button size="icon" variant="secondary">
+                        <Button size="icon" variant="secondary" title="More options">
                           <MoreHorizontalIcon />
                         </Button>
                       }

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -223,6 +223,7 @@ export function NotificationsSettings() {
                             size="icon"
                             onClick={() => removeTime(time.id)}
                             disabled={!isLicenseKeyValid}
+                            title="Remove time window"
                           >
                             <X />
                           </Button>

--- a/packages/renderer/routes/settings/saved-searches.tsx
+++ b/packages/renderer/routes/settings/saved-searches.tsx
@@ -167,7 +167,7 @@ function EditSavedSearchButton({
     <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
       <DialogTrigger
         render={
-          <Button size="icon" className="size-8 p-0" variant="outline">
+          <Button size="icon" className="size-8 p-0" variant="outline" title="Edit saved search">
             <PencilIcon />
           </Button>
         }
@@ -230,6 +230,7 @@ function SortableSavedSearchItem({
           size="icon"
           className="size-8 p-0"
           variant="outline"
+          title="Delete saved search"
           onClick={() => {
             const confirmed = window.confirm(`Delete ${savedSearch.label}?`);
 

--- a/packages/renderer/routes/unified-inbox.tsx
+++ b/packages/renderer/routes/unified-inbox.tsx
@@ -370,6 +370,7 @@ function UnifiedInboxTable({
             size="icon"
             variant="outline"
             onClick={() => table.firstPage()}
+            title="First page"
             disabled={!table.getCanPreviousPage()}
           >
             <ChevronsLeftIcon />
@@ -378,6 +379,7 @@ function UnifiedInboxTable({
             size="icon"
             variant="outline"
             onClick={() => table.previousPage()}
+            title="Previous page"
             disabled={!table.getCanPreviousPage()}
           >
             <ChevronLeftIcon />
@@ -386,6 +388,7 @@ function UnifiedInboxTable({
             size="icon"
             variant="outline"
             onClick={() => table.nextPage()}
+            title="Next page"
             disabled={!table.getCanNextPage()}
           >
             <ChevronRightIcon />
@@ -394,6 +397,7 @@ function UnifiedInboxTable({
             size="icon"
             variant="outline"
             onClick={() => table.lastPage()}
+            title="Last page"
             disabled={!table.getCanNextPage()}
           >
             <ChevronsRightIcon />


### PR DESCRIPTION
Thirteen icon-only buttons carry no text of any kind, so a screen reader announces each as "button" and a pointer gets no tooltip:

- the settings close button
- the app menu button in the titlebar on Windows and Linux
- the emoji picker button in the account and saved search forms
- the license key menu
- **Edit** and **Delete** on accounts, saved searches, and label colors
- the button that clears an account color
- the notification time window remove button
- the four unified inbox pagination buttons

Each one gets a `title`, the pattern the download history, the bookmarks list, and the vertical tabs already use: it names the control for assistive technology and shows as a tooltip. The wording follows the tooltip convention in `docs/decisions.md`, so sentence case, with feature names keeping their own case.

Running the app verifies none of this; the names are checked by reading. `bun run types`, `bun run lint`, `bun run fmt:check`, and `bun test` pass.

One item for a separate change, tracked in `docs/todo.md`: `FieldLabel` is a plain `Label`, and several fields in Accounts, Saved Searches, Appearance, and Downloads render it without `htmlFor`, so the label isn't tied to its control. That's markup across the settings pages rather than writing.
