### PR TITLE
put the window chrome in sentence case

### DIFF
--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -173,7 +173,7 @@ function DoNotDisturb() {
 
         ipc.main.send("doNotDisturb.showOptions");
       }}
-      title="Do Not Disturb"
+      title="Do not disturb"
     >
       <MoonIcon
         className={cn({
@@ -355,7 +355,7 @@ export function AppTitlebar() {
                 onClick={() => {
                   navigate("/unified-inbox");
                 }}
-                title="Unified Inbox"
+                title="Unified inbox"
               >
                 <InboxIcon />
               </Button>
@@ -402,7 +402,7 @@ export function AppTitlebar() {
             <ExtensionActions />
             {shouldShowSavedSearchesButton && (
               <TitlebarDropdownMenu
-                title="Saved Searches"
+                title="Saved searches"
                 icon={<MailSearchIcon />}
                 side="left"
                 disabled={isUnifiedInboxLocation || isWorkspaceAppTabActive}

--- a/packages/renderer/components/workspace-apps-launcher.tsx
+++ b/packages/renderer/components/workspace-apps-launcher.tsx
@@ -72,7 +72,7 @@ export function WorkspaceAppsLauncher({
 
   return (
     <TitlebarDropdownMenu
-      title="Workspace Apps"
+      title="Workspace apps"
       icon={<LayoutGridIcon />}
       side="left"
       disabled={disabled}
@@ -119,7 +119,7 @@ export function VerticalTabsWorkspaceAppsLauncher({
             title="Open app"
           >
             <LayoutGridIcon />
-            {isWide && "Open App"}
+            {isWide && "Open app"}
           </Button>
         }
       />

--- a/packages/renderer/recent-download-history.tsx
+++ b/packages/renderer/recent-download-history.tsx
@@ -10,7 +10,7 @@ import { renderApp } from "@/lib/react";
 function RecentDownloadHistory() {
   return (
     <>
-      <div className="p-4 font-semibold">Recent Download History</div>
+      <div className="p-4 font-semibold">Recent download history</div>
       <Button
         size="icon"
         variant="ghost"


### PR DESCRIPTION
Second of five PRs dropping title case, stacked on #908. This one covers the window chrome.

The titlebar tooltips and the launcher follow the settings pages:

- **Do Not Disturb** becomes **Do not disturb**
- **Unified Inbox** becomes **Unified inbox**
- **Saved Searches** becomes **Saved searches**
- **Workspace Apps** becomes **Workspace apps**, and the wide launcher's **Open App** becomes **Open app**
- the recent download history popup heading becomes **Recent download history**

The tooltips that were already sentence case, such as **Show in folder** and **Remove bookmark**, are untouched.

Running the app verifies none of this; the strings are checked by reading. `bun run types`, `bun run lint`, `bun run fmt:check`, and `bun test` pass.
