### PR TITLE
put the menus in sentence case

### DIFF
--- a/packages/app/context-menu.ts
+++ b/packages/app/context-menu.ts
@@ -34,7 +34,7 @@ export function setupWindowContextMenu(window: BrowserWindow | WebContentsView) 
 
           menuItems.push(
             {
-              label: "Copy Message Link",
+              label: "Copy message link",
               click: () => {
                 clipboard.writeText(meruMessageUrl);
               },
@@ -55,13 +55,13 @@ export function setupWindowContextMenu(window: BrowserWindow | WebContentsView) 
       if (window !== selectedAccount.instance.gmail.view) {
         menuItems.push(
           {
-            label: "Copy Link",
+            label: "Copy link",
             click: () => {
               clipboard.writeText(window.webContents.getURL());
             },
           },
           {
-            label: "Open in Default Browser",
+            label: "Open in default browser",
             click: () => {
               openExternalUrl(window.webContents.getURL(), {
                 skipTrustedHostCheck: true,
@@ -75,7 +75,7 @@ export function setupWindowContextMenu(window: BrowserWindow | WebContentsView) 
       }
 
       menuItems.push({
-        label: "Inspect Element",
+        label: "Inspect element",
         click: () => {
           window.webContents.inspectElement(parameters.x, parameters.y);
 

--- a/packages/app/do-not-disturb.ts
+++ b/packages/app/do-not-disturb.ts
@@ -9,43 +9,43 @@ export class DoNotDisturb {
       duration: "indefinite",
     },
     {
-      label: "5 Minutes",
+      label: "5 minutes",
       duration: "5m",
     },
     {
-      label: "10 Minutes",
+      label: "10 minutes",
       duration: "10m",
     },
     {
-      label: "15 Minutes",
+      label: "15 minutes",
       duration: "15m",
     },
     {
-      label: "30 Minutes",
+      label: "30 minutes",
       duration: "30m",
     },
     {
-      label: "1 Hour",
+      label: "1 hour",
       duration: "1h",
     },
     {
-      label: "2 Hours",
+      label: "2 hours",
       duration: "2h",
     },
     {
-      label: "4 Hours",
+      label: "4 hours",
       duration: "4h",
     },
     {
-      label: "8 Hours",
+      label: "8 hours",
       duration: "8h",
     },
     {
-      label: "12 Hours",
+      label: "12 hours",
       duration: "12h",
     },
     {
-      label: "Until Tomorrow",
+      label: "Until tomorrow",
       duration: "until tomorrow",
     },
   ] as const;

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -267,7 +267,7 @@ class Ipc {
           ? []
           : [
               {
-                label: "Move to Tab",
+                label: "Move to tab",
                 click: () => {
                   workspaceApp.adoptIntoTabs();
                 },
@@ -279,7 +279,7 @@ class Ipc {
         ...(workspaceApp.isSavable
           ? [
               {
-                label: "Load on Launch",
+                label: "Load on launch",
                 type: "checkbox" as const,
                 checked: workspaceApp.pinned && workspaceApp.loadOnLaunch,
                 click: () => {
@@ -302,13 +302,13 @@ class Ipc {
             ]
           : []),
         {
-          label: "Copy Link",
+          label: "Copy link",
           click: () => {
             workspaceApp.copyUrl();
           },
         },
         {
-          label: "Open in Default Browser",
+          label: "Open in default browser",
           click: () => {
             workspaceApp.openInBrowser();
           },
@@ -391,7 +391,7 @@ class Ipc {
         ...(tabApp && !workspaceApps[tabApp].singleInstance
           ? [
               {
-                label: `New ${workspaceApps[tabApp].label} ${isWindowsMode ? "Window" : "Tab"}`,
+                label: `New ${workspaceApps[tabApp].label} ${isWindowsMode ? "window" : "tab"}`,
                 click: () => {
                   openWorkspaceAppUrl(getWorkspaceAppUrl(tabApp));
                 },
@@ -422,7 +422,7 @@ class Ipc {
         ...(tab instanceof WorkspaceApp && tab.isWindowed
           ? [
               {
-                label: "Move to Tab",
+                label: "Move to tab",
                 click: () => {
                   if (tab instanceof WorkspaceApp) {
                     tab.adoptIntoTabs();
@@ -436,7 +436,7 @@ class Ipc {
             ]
           : [
               {
-                label: "Move to New Window",
+                label: "Move to new window",
                 enabled: tab instanceof WorkspaceApp && !tab.isWindowed,
                 click: () => {
                   if (tab instanceof WorkspaceApp) {
@@ -453,7 +453,7 @@ class Ipc {
           type: "separator",
         },
         {
-          label: "Copy Link",
+          label: "Copy link",
           click: () => {
             if (tab instanceof WorkspaceApp) {
               tab.copyUrl();
@@ -465,7 +465,7 @@ class Ipc {
           },
         },
         {
-          label: "Open in Default Browser",
+          label: "Open in default browser",
           click: () => {
             if (tab instanceof WorkspaceApp) {
               tab.openInBrowser();
@@ -488,7 +488,7 @@ class Ipc {
                 },
               },
               {
-                label: bookmarks.isBookmarked(accountId, tab.url) ? "Remove Bookmark" : "Bookmark",
+                label: bookmarks.isBookmarked(accountId, tab.url) ? "Remove bookmark" : "Bookmark",
                 click: () => {
                   bookmarks.toggle(accountId, {
                     app: tabApp,
@@ -500,7 +500,7 @@ class Ipc {
               ...(tab.pinned
                 ? [
                     {
-                      label: "Load on Launch",
+                      label: "Load on launch",
                       type: "checkbox" as const,
                       checked: tab.loadOnLaunch,
                       click: () => {
@@ -516,7 +516,7 @@ class Ipc {
               ...(config.get("workspaceApps.hibernation") === "selected"
                 ? [
                     {
-                      label: "Hibernate When Idle",
+                      label: "Hibernate when idle",
                       type: "checkbox" as const,
                       checked: tab.hibernatesWhenIdle,
                       click: () => {
@@ -540,8 +540,8 @@ class Ipc {
               // which then needs a separator to sit under.
               ...(tabApp ? [] : [{ type: "separator" as const }]),
               {
-                label: `Open ${workspaceApps[appLinksApp].label} Links in This ${
-                  tab instanceof WorkspaceApp && tab.isWindowed ? "Window" : "Tab"
+                label: `Open ${workspaceApps[appLinksApp].label} links in this ${
+                  tab instanceof WorkspaceApp && tab.isWindowed ? "window" : "tab"
                 }`,
                 type: "checkbox" as const,
                 checked: Boolean(tab.opensLinksForApp),
@@ -600,7 +600,7 @@ class Ipc {
               },
             ]),
         {
-          label: "Close Other Tabs",
+          label: "Close other tabs",
           enabled: hasOtherClosableTabs,
           click: () => {
             account.instance.tabs.closeOtherTabs(tabId);
@@ -611,7 +611,7 @@ class Ipc {
           },
         },
         {
-          label: "Close Tabs Below",
+          label: "Close tabs below",
           enabled: hasClosableTabsBelow,
           click: () => {
             account.instance.tabs.closeTabsBelow(tabId);
@@ -629,7 +629,7 @@ class Ipc {
 
       Menu.buildFromTemplate([
         {
-          label: "Reopen Closed Tab",
+          label: "Reopen closed tab",
           enabled: account.instance.tabs.hasRecentlyClosedTabs,
           click: () => {
             if (account.instance.tabs.reopenClosedTab() && account.config.selected) {
@@ -644,7 +644,7 @@ class Ipc {
         // Width setting's to give — and there is nothing to reset to on `auto`,
         // where picking it again in settings changes nothing.
         {
-          label: "Reset Width",
+          label: "Reset width",
           enabled: Boolean(account.instance.verticalTabsWidth),
           click: () => {
             accounts.setVerticalTabsWidth(accountId, null);

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -95,11 +95,11 @@ export class AppMenu {
         role: "hide",
       },
       {
-        label: "Hide Others",
+        label: "Hide others",
         role: "hideOthers",
       },
       {
-        label: "Show All",
+        label: "Show all",
         role: "unhide",
       },
       {
@@ -196,7 +196,7 @@ export class AppMenu {
     const selectPinnedTabItems: MenuItemConstructorOptions[] = Array.from(
       { length: 9 },
       (_pinnedTabEntry, pinnedTabIndex) => ({
-        label: `Select Pinned Tab ${pinnedTabIndex + 1} (hidden shortcut)`,
+        label: `Select pinned tab ${pinnedTabIndex + 1} (hidden shortcut)`,
         // Literal Ctrl on every platform, like the Ctrl+Tab pair above:
         // Command+Shift+3..6 are macOS screenshot shortcuts that never reach the
         // app, and Command/Ctrl+1..9 already select accounts.
@@ -244,7 +244,7 @@ export class AppMenu {
             },
           },
           {
-            label: "Check for Updates…",
+            label: "Check for updates…",
             click: () => {
               appUpdater.checkForUpdates();
             },
@@ -260,7 +260,7 @@ export class AppMenu {
             },
           },
           {
-            label: "Gmail Settings…",
+            label: "Gmail settings…",
             accelerator: "CommandOrControl+Shift+,",
             click: () => {
               ipc.renderer.send(
@@ -378,7 +378,7 @@ export class AppMenu {
         visible: licenseKey.isValid,
         submenu: [
           {
-            label: "Copy Message Link",
+            label: "Copy message link",
             enabled: Boolean(copyOrShareMessageLink),
             accelerator: "CommandOrControl+Shift+C",
             click: () => {
@@ -405,7 +405,7 @@ export class AppMenu {
         label: "View",
         submenu: [
           {
-            label: "Unified Inbox",
+            label: "Unified inbox",
             enabled:
               licenseKey.isValid && config.get("unifiedInbox.enabled") && allAccounts.length > 1,
             accelerator: "CommandOrControl+Shift+I",
@@ -428,31 +428,31 @@ export class AppMenu {
             type: "separator",
           },
           {
-            label: "Reset Zoom",
+            label: "Reset zoom",
             accelerator: "CommandOrControl+0",
             click: () => {
               getActiveZoomTarget()?.resetZoom();
             },
           },
           {
-            label: "Zoom In",
+            label: "Zoom in",
             accelerator: "CommandOrControl+Plus",
             click: zoomIn,
           },
           {
-            label: "Zoom In (hidden shortcut 1)",
+            label: "Zoom in (hidden shortcut 1)",
             visible: is.dev,
             acceleratorWorksWhenHidden: true,
             accelerator: "CommandOrControl+numadd",
             click: zoomIn,
           },
           {
-            label: "Zoom Out",
+            label: "Zoom out",
             accelerator: "CommandOrControl+-",
             click: zoomOut,
           },
           {
-            label: "Zoom Out (hidden shortcut 1)",
+            label: "Zoom out (hidden shortcut 1)",
             visible: is.dev,
             accelerator: "CommandOrControl+numsub",
             click: zoomOut,
@@ -468,7 +468,7 @@ export class AppMenu {
             },
           },
           {
-            label: "Hard Reload",
+            label: "Hard reload",
             accelerator: "CommandOrControl+Shift+R",
             click: () => {
               getActiveViewWebContents().reloadIgnoringCache();
@@ -478,7 +478,7 @@ export class AppMenu {
             type: "separator",
           },
           {
-            label: "Developer Tools",
+            label: "Developer tools",
             accelerator: is.dev && platform.isMacOS ? "Command+Alt+I" : undefined,
             click: () => {
               if (focusedWindow && focusedWindow !== main.window) {
@@ -523,24 +523,24 @@ export class AppMenu {
         label: "Tabs",
         submenu: [
           {
-            label: "Select Next Tab",
+            label: "Select next tab",
             accelerator: "Ctrl+Tab",
             click: selectNextTab,
           },
           {
-            label: "Select Next Tab (hidden shortcut 1)",
+            label: "Select next tab (hidden shortcut 1)",
             accelerator: platform.isMacOS ? "Command+Option+Down" : "Ctrl+PageDown",
             visible: is.dev,
             acceleratorWorksWhenHidden: true,
             click: selectNextTab,
           },
           {
-            label: "Select Previous Tab",
+            label: "Select previous tab",
             accelerator: "Ctrl+Shift+Tab",
             click: selectPreviousTab,
           },
           {
-            label: "Select Previous Tab (hidden shortcut 1)",
+            label: "Select previous tab (hidden shortcut 1)",
             accelerator: platform.isMacOS ? "Command+Option+Up" : "Ctrl+PageUp",
             visible: is.dev,
             acceleratorWorksWhenHidden: true,
@@ -551,7 +551,7 @@ export class AppMenu {
             type: "separator",
           },
           {
-            label: "Close Tab",
+            label: "Close tab",
             accelerator: "CommandOrControl+Shift+W",
             enabled: isActiveTabCloseable,
             click: () => {
@@ -563,7 +563,7 @@ export class AppMenu {
             },
           },
           {
-            label: "Reopen Closed Tab",
+            label: "Reopen closed tab",
             accelerator: "CommandOrControl+Shift+T",
             click: () => {
               if (accounts.getSelectedAccount().instance.tabs.reopenClosedTab()) {
@@ -589,7 +589,7 @@ export class AppMenu {
             type: "separator",
           },
           {
-            label: "Select Next Account",
+            label: "Select next account",
             accelerator: platform.isMacOS ? "Command+Shift+]" : undefined,
             click: () => {
               accounts.selectNextAccount();
@@ -598,7 +598,7 @@ export class AppMenu {
             },
           },
           {
-            label: "Select Next Account (hidden shortcut 1)",
+            label: "Select next account (hidden shortcut 1)",
             accelerator: "Command+Option+Right",
             visible: is.dev,
             acceleratorWorksWhenHidden: true,
@@ -609,7 +609,7 @@ export class AppMenu {
             },
           },
           {
-            label: "Select Previous Account",
+            label: "Select previous account",
             accelerator: platform.isMacOS ? "Command+Shift+[" : undefined,
             click: () => {
               accounts.selectPreviousAccount();
@@ -618,7 +618,7 @@ export class AppMenu {
             },
           },
           {
-            label: "Select Previous Account (hidden shortcut 1)",
+            label: "Select previous account (hidden shortcut 1)",
             accelerator: "Command+Option+Left",
             visible: is.dev,
             acceleratorWorksWhenHidden: true,
@@ -632,7 +632,7 @@ export class AppMenu {
             type: "separator",
           },
           {
-            label: "Manage Accounts…",
+            label: "Manage accounts…",
             click: () => {
               main.navigate("/settings/accounts");
             },
@@ -660,7 +660,7 @@ export class AppMenu {
         role: "help",
         submenu: [
           {
-            label: "What's New",
+            label: "What's new",
             click: () => {
               main.navigate("/settings/version-history");
             },
@@ -675,7 +675,7 @@ export class AppMenu {
             },
           },
           {
-            label: "Source Code",
+            label: "Source code",
             click: () => {
               openExternalUrl(GITHUB_REPO_URL);
             },
@@ -684,7 +684,7 @@ export class AppMenu {
             type: "separator",
           },
           {
-            label: "Gmail Keyboard Shortcuts",
+            label: "Gmail keyboard shortcuts",
             click: () => {
               openExternalUrl("https://support.google.com/mail/answer/6594");
             },
@@ -693,13 +693,13 @@ export class AppMenu {
             type: "separator",
           },
           {
-            label: "Ask Question",
+            label: "Ask question",
             click: () => {
               selectedAccount.instance.gmail.createComposeWindow("mailto:tim@meru.so");
             },
           },
           {
-            label: "Request Feature",
+            label: "Request feature",
             click: () => {
               selectedAccount.instance.gmail.createComposeWindow(
                 "mailto:tim@meru.so?subject=Feature%20Request:%20",
@@ -707,7 +707,7 @@ export class AppMenu {
             },
           },
           {
-            label: "Report Issue",
+            label: "Report issue",
             click: () => {
               selectedAccount.instance.gmail.createComposeWindow(
                 "mailto:tim@meru.so?subject=Report Issue:%20",
@@ -721,7 +721,7 @@ export class AppMenu {
             label: "Troubleshooting",
             submenu: [
               {
-                label: "Edit Config",
+                label: "Edit config",
                 click: () => {
                   config.openInEditor();
                 },
@@ -730,7 +730,7 @@ export class AppMenu {
                 type: "separator",
               },
               {
-                label: "Clear Cache",
+                label: "Clear cache",
                 click: async () => {
                   await Promise.all(
                     accounts.getAccounts().map((account) => account.instance.session.clearCache()),
@@ -740,7 +740,7 @@ export class AppMenu {
                 },
               },
               {
-                label: "Reset App…",
+                label: "Reset app…",
                 click: async () => {
                   const { response } = await dialog.showMessageBox({
                     type: "warning",
@@ -766,7 +766,7 @@ export class AppMenu {
                 type: "separator",
               },
               {
-                label: "View Logs",
+                label: "View logs",
                 click: () => {
                   shell.openPath(log.transports.file.getFile().path);
                 },


### PR DESCRIPTION
Third of five PRs dropping title case, stacked on #909. This one covers every menu the app draws.

The macOS menu bar goes with the rest, so **Check for Updates…** becomes **Check for updates…**, **Select Next Tab** becomes **Select next tab**, and **Reopen Closed Tab** becomes **Reopen closed tab**. That breaks with macOS, where every other app title-cases its menu bar, and it's the deliberate call: one rule covers every menu, with no per-surface exception to remember.

The tab and page context menus move too — **Move to tab**, **Load on launch**, **Hibernate when idle**, **Open in default browser**, **Reset width** — along with the Do not disturb durations and the tray menu.

Dynamic labels change in the same way, keeping the app name capitalized: **New Calendar tab**, **Open Calendar links in this window**, **Select pinned tab 2**.

Running the app verifies none of this; the labels are checked by reading. `bun run types`, `bun run lint`, `bun run fmt:check`, and `bun test` pass.
