### PR TITLE
put the dialog buttons and notification actions in sentence case

### DIFF
--- a/packages/app/dialogs.ts
+++ b/packages/app/dialogs.ts
@@ -27,7 +27,7 @@ export async function confirmAppLinksTabHandover(
 
   const { response } = await dialog.showMessageBox(main.window, {
     type: "info",
-    buttons: ["Open Links Here", "Cancel"],
+    buttons: ["Open links here", "Cancel"],
     message: `Open ${appLabel} links in this tab?`,
     detail: `“${appLinksTabTitle}” opens all ${appLabel} links right now, and gives them up to this tab.`,
     defaultId: 0,

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -846,7 +846,7 @@ export class Gmail {
               type: "button",
             },
             {
-              text: "Mark as Read",
+              text: "Mark as read",
               type: "button",
             },
             {
@@ -854,7 +854,7 @@ export class Gmail {
               type: "button",
             },
             {
-              text: "Mark as Spam",
+              text: "Mark as spam",
               type: "button",
             },
           ],

--- a/packages/app/license-key.ts
+++ b/packages/app/license-key.ts
@@ -132,7 +132,7 @@ class LicenseKey {
 
         const { response } = await this.showValidationError({
           detail: `${errorMessages[error.code]}, and Meru removes it from this device. Contact support if you need help.`,
-          buttons: ["Remove and Restart", "Quit"],
+          buttons: ["Remove and restart", "Quit"],
           defaultId: 0,
           cancelId: 1,
         });

--- a/packages/app/trial.ts
+++ b/packages/app/trial.ts
@@ -66,7 +66,7 @@ class Trial {
         type: "info",
         message: "Your Meru Pro trial has ended.",
         detail: "Upgrade to Meru Pro to keep every feature, or continue with the free version.",
-        buttons: ["Upgrade to Meru Pro", "Continue with Free", "Quit"],
+        buttons: ["Upgrade to Meru Pro", "Continue for free", "Quit"],
         defaultId: 0,
         cancelId: 2,
       });

--- a/packages/app/url.ts
+++ b/packages/app/url.ts
@@ -25,7 +25,7 @@ export async function openExternalUrl(
     if (!options?.skipTrustedHostCheck && !trustedHosts.includes(origin)) {
       const { response, checkboxChecked } = await dialog.showMessageBox({
         type: "info",
-        buttons: ["Open Link", "Copy Link", "Cancel"],
+        buttons: ["Open link", "Copy link", "Cancel"],
         message: "Open this link in your default browser?",
         checkboxLabel: `Trust all links on ${origin}`,
         detail:


### PR DESCRIPTION
Fourth of five PRs dropping title case, stacked on #910. This one covers the dialog buttons and the notification actions, the last surfaces still in title case.

- **Open Links Here** becomes **Open links here**
- **Open Link** and **Copy Link** become **Open link** and **Copy link**
- **Remove and Restart** becomes **Remove and restart**
- **Mark as Read** and **Mark as Spam** become **Mark as read** and **Mark as spam**

**Meru Pro** and **Meru Portal** keep their capitals as product names, so **Upgrade to Meru Pro** and **Open Meru Portal** read as they did.

One button changes wording rather than case. The expired-trial dialog offered **Continue with Free**, where title case was the only thing making **Free** read as a name; the free tier has no branded name, so it now reads **Continue for free**.

Running the app verifies none of this; the strings are checked by reading. `bun run types`, `bun run lint`, `bun run fmt:check`, and `bun test` pass.
