### PR TITLE
put the settings text in sentence case

### DIFF
--- a/packages/renderer/components/app-sidebar.tsx
+++ b/packages/renderer/components/app-sidebar.tsx
@@ -52,7 +52,7 @@ export const sidebarNavItems: SidebarNavItemProps[] = [
     component: GmailSettings,
   },
   {
-    label: "Workspace Apps",
+    label: "Workspace apps",
     path: "/settings/workspace-apps",
     component: WorkspaceAppsSettings,
   },
@@ -73,17 +73,17 @@ export const sidebarNavItems: SidebarNavItemProps[] = [
     component: NotificationsSettings,
   },
   {
-    label: "Phishing Protection",
+    label: "Phishing protection",
     path: "/settings/phishing-protection",
     component: PhishingProtectionSettings,
   },
   {
-    label: "Saved Searches",
+    label: "Saved searches",
     path: "/settings/saved-searches",
     component: SavedSearchesSettings,
   },
   {
-    label: "Unified Inbox",
+    label: "Unified inbox",
     path: "/settings/unified-inbox",
     component: UnifiedInboxSettings,
   },
@@ -93,7 +93,7 @@ export const sidebarNavItems: SidebarNavItemProps[] = [
     component: UpdatesSettings,
   },
   {
-    label: "Verification Codes",
+    label: "Verification codes",
     path: "/settings/verification-codes",
     component: VerificationCodesSettings,
   },
@@ -105,7 +105,7 @@ export const sidebarNavItems: SidebarNavItemProps[] = [
   { type: "separator" },
   { label: "License", path: "/settings/license", component: LicenseSettings },
   {
-    label: "What's New",
+    label: "What's new",
     path: "/settings/version-history",
     component: VersionHistorySettings,
   },

--- a/packages/renderer/components/license-key-required-field-badge.tsx
+++ b/packages/renderer/components/license-key-required-field-badge.tsx
@@ -4,5 +4,5 @@ import { useIsLicenseKeyValid } from "@/lib/hooks";
 export function LicenseKeyRequiredFieldBadge() {
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
-  return !isLicenseKeyValid && <Badge variant="secondary">Meru Pro Required</Badge>;
+  return !isLicenseKeyValid && <Badge variant="secondary">Meru Pro required</Badge>;
 }

--- a/packages/renderer/routes/settings/about.tsx
+++ b/packages/renderer/routes/settings/about.tsx
@@ -39,8 +39,8 @@ function DiagnosticInfo() {
   }
 
   const rows = [
-    { label: "Application Version", value: info.version },
-    { label: "Operating System", value: info.os },
+    { label: "Application version", value: info.version },
+    { label: "Operating system", value: info.os },
     { label: "Device ID", value: info.deviceId },
   ];
 
@@ -88,7 +88,7 @@ function ExportLogsField() {
           }}
           disabled={exportLogsMutation.isPending}
         >
-          Export Logs
+          Export logs
         </Button>
       </div>
     </Field>

--- a/packages/renderer/routes/settings/accounts.tsx
+++ b/packages/renderer/routes/settings/accounts.tsx
@@ -171,7 +171,7 @@ function AccountForm({
                   checked={field.state.value}
                   onCheckedChange={field.handleChange}
                 />
-                <FieldLabel>Unread Badge</FieldLabel>
+                <FieldLabel>Unread badge</FieldLabel>
               </Field>
             )}
           </form.Field>
@@ -184,7 +184,7 @@ function AccountForm({
                   checked={field.state.value}
                   onCheckedChange={field.handleChange}
                 />
-                <FieldLabel>Unified Inbox</FieldLabel>
+                <FieldLabel>Unified inbox</FieldLabel>
               </Field>
             )}
           </form.Field>
@@ -232,7 +232,7 @@ function AddAccountButton() {
       <DialogTrigger render={<Button>Add</Button>} />
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Add Account</DialogTitle>
+          <DialogTitle>Add account</DialogTitle>
         </DialogHeader>
         <AccountForm
           onSubmit={(account) => {
@@ -261,7 +261,7 @@ function EditAccountButton({ account }: { account: AccountConfig }) {
       />
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Edit Account</DialogTitle>
+          <DialogTitle>Edit account</DialogTitle>
         </DialogHeader>
         <AccountForm
           account={account}
@@ -326,8 +326,8 @@ function SortableAccountItem({
         </ItemTitle>
         {(account.gmail.unreadBadge || account.notifications) && (
           <div className="flex gap-2">
-            {account.gmail.unreadBadge && <Badge variant="outline">Unread Badge</Badge>}
-            {account.gmail.unifiedInbox && <Badge variant="outline">Unified Inbox</Badge>}
+            {account.gmail.unreadBadge && <Badge variant="outline">Unread badge</Badge>}
+            {account.gmail.unifiedInbox && <Badge variant="outline">Unified inbox</Badge>}
             {account.notifications && <Badge variant="outline">Notifications</Badge>}
           </div>
         )}

--- a/packages/renderer/routes/settings/advanced.tsx
+++ b/packages/renderer/routes/settings/advanced.tsx
@@ -15,10 +15,10 @@ export function AdvancedSettings() {
         <FieldGroup>
           {platform.isMacOS && (
             <FieldSet>
-              <FieldLegend>Screen Sharing</FieldLegend>
+              <FieldLegend>Screen sharing</FieldLegend>
               <FieldGroup>
                 <ConfigSwitchField
-                  label="Use System Picker"
+                  label="Use system picker"
                   description="Use the system's native screen sharing picker when sharing your screen."
                   configKey="screenShare.useSystemPicker"
                   licenseKeyRequired
@@ -32,15 +32,15 @@ export function AdvancedSettings() {
             <FieldLegend>Miscellaneous</FieldLegend>
             <FieldGroup>
               <ConfigSwitchField
-                label="Hardware Acceleration"
+                label="Hardware acceleration"
                 description="Render with the GPU. This can improve performance, and can also cause compatibility problems on some systems."
                 configKey="app.hardwareAcceleration"
                 restartRequired
               />
               {platform.isMacOS && (
                 <ConfigSwitchField
-                  label="Use Custom User Agent"
-                  description="Send a custom user agent for the Gmail and Workspace Apps features that don't work with the default one. It resolves some problems and can cause others, so turn it off if the app becomes unstable."
+                  label="Use custom user agent"
+                  description="Send a custom user agent for the Gmail and Workspace apps features that don't work with the default one. It resolves some problems and can cause others, so turn it off if the app becomes unstable."
                   configKey="customUserAgent"
                   restartRequired
                 />

--- a/packages/renderer/routes/settings/appearance.tsx
+++ b/packages/renderer/routes/settings/appearance.tsx
@@ -45,7 +45,7 @@ export function AppearanceSettings() {
   const renderPlatformIconSettings = () => {
     const selectAccountWithUnreadField = (
       <ConfigSwitchField
-        label="Select First Unread Account on Click"
+        label="Select first unread account on click"
         description={`Automatically select the first account with unread emails when clicking the ${platform.isMacOS ? "menu bar" : "system tray"} icon.`}
         configKey="tray.selectAccountWithUnread"
         disabled={!config["tray.enabled"]}
@@ -56,16 +56,16 @@ export function AppearanceSettings() {
       return (
         <>
           <FieldSet>
-            <FieldLegend>Dock Icon</FieldLegend>
+            <FieldLegend>Dock icon</FieldLegend>
             <FieldGroup>
               <ConfigSwitchField
-                label="Enable Dock Icon"
+                label="Enable dock icon"
                 description="Show the application icon in the dock."
                 configKey="dock.enabled"
                 restartRequired
               />
               <ConfigSwitchField
-                label="Show Unread Badge"
+                label="Show unread badge"
                 description="Show an unread badge on the dock icon when there are unread emails."
                 configKey="dock.unreadBadge"
                 restartRequired
@@ -74,16 +74,16 @@ export function AppearanceSettings() {
           </FieldSet>
           <FieldSeparator />
           <FieldSet>
-            <FieldLegend>Menu Bar Icon</FieldLegend>
+            <FieldLegend>Menu bar icon</FieldLegend>
             <FieldGroup>
               <ConfigSwitchField
-                label="Enable Menu Bar Icon"
+                label="Enable menu bar icon"
                 description="Show the application icon in the menu bar."
                 configKey="tray.enabled"
                 restartRequired
               />
               <ConfigSwitchField
-                label="Show Unread Count"
+                label="Show unread count"
                 description="Show an unread count next to the menu bar icon when there are unread emails."
                 configKey="tray.unreadCount"
                 disabled={!config["tray.enabled"]}
@@ -98,9 +98,9 @@ export function AppearanceSettings() {
 
     return (
       <FieldSet>
-        <FieldLegend>System Tray Icon</FieldLegend>
+        <FieldLegend>System tray icon</FieldLegend>
         <ConfigSwitchField
-          label="Enable System Tray Icon"
+          label="Enable system tray icon"
           description="Show the application icon in the system tray."
           configKey="tray.enabled"
           restartRequired
@@ -162,7 +162,7 @@ export function AppearanceSettings() {
           <FieldSet>
             <FieldLegend>Accounts</FieldLegend>
             <ConfigSwitchField
-              label="Show Unread Badges"
+              label="Show unread badges"
               description="Show unread badges, following each account's own setting."
               configKey="accounts.unreadBadge"
               restartRequired
@@ -174,7 +174,7 @@ export function AppearanceSettings() {
           <FieldSet>
             <FieldLegend>Window</FieldLegend>
             <ConfigSwitchField
-              label="Restrict Minimum Window Size"
+              label="Restrict minimum window size"
               description="Stop the application window from being resized below a usable minimum."
               configKey="window.restrictMinimumSize"
             />

--- a/packages/renderer/routes/settings/blocker.tsx
+++ b/packages/renderer/routes/settings/blocker.tsx
@@ -20,7 +20,7 @@ export function BlockerSettings() {
         <LicenseKeyRequiredBanner />
         <FieldGroup>
           <ConfigSwitchField
-            label="Enable Blocker"
+            label="Enable blocker"
             description="Block unwanted content and network requests."
             configKey="blocker.enabled"
             licenseKeyRequired
@@ -28,7 +28,7 @@ export function BlockerSettings() {
           />
           <FieldSeparator />
           <ConfigSwitchField
-            label="Block Ads"
+            label="Block ads"
             description="Block advertisements on the pages you open."
             configKey="blocker.ads"
             disabled={!config["blocker.enabled"]}
@@ -36,7 +36,7 @@ export function BlockerSettings() {
             restartRequired
           />
           <ConfigSwitchField
-            label="Block Trackers"
+            label="Block trackers"
             description="Block the scripts that follow you from site to site."
             configKey="blocker.tracking"
             disabled={!config["blocker.enabled"]}

--- a/packages/renderer/routes/settings/downloads.tsx
+++ b/packages/renderer/routes/settings/downloads.tsx
@@ -30,19 +30,19 @@ export function DownloadsSettings() {
         <FieldSet>
           <FieldLegend>General</FieldLegend>
           <ConfigSwitchField
-            label="Show Save As Dialog Before Downloading"
+            label="Show Save As dialog before downloading"
             description="Ask where to save each file before it downloads."
             configKey="downloads.saveAs"
             restartRequired
           />
           <ConfigSwitchField
-            label="Open Folder When Done"
+            label="Open folder when done"
             description="Open the folder containing the file when a download finishes."
             configKey="downloads.openFolderWhenDone"
             restartRequired
           />
           <Field>
-            <FieldLabel>Default Download Location</FieldLabel>
+            <FieldLabel>Default download location</FieldLabel>
             <FieldDescription>Where downloaded files are saved.</FieldDescription>
             <div className="flex gap-2">
               <Input value={config["downloads.location"]} readOnly />

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -120,7 +120,7 @@ function OnePasswordSetupDialog({
               ipc.main.send("app.relaunch");
             }}
           >
-            Restart Now
+            Restart now
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -198,7 +198,7 @@ function ExtensionItem({
                 setIsSetupDialogOpen(true);
               }}
             >
-              Set Up Desktop App
+              Set up desktop app
             </Button>
           )}
         </ItemContent>
@@ -316,7 +316,7 @@ function UpdateExtensionsButton() {
       }}
     >
       {updateExtensionsMutation.isPending && <Spinner />}
-      Update Extensions
+      Update extensions
     </Button>
   );
 }
@@ -349,7 +349,7 @@ export function ExtensionsSettings() {
           the official extensions from the Chrome Web Store.
         </FieldDescription>
         <FieldSet>
-          <FieldLegend>Password Managers</FieldLegend>
+          <FieldLegend>Password managers</FieldLegend>
           <PasskeysAlert />
           <ItemGroup>
             {curatedExtensions

--- a/packages/renderer/routes/settings/general.tsx
+++ b/packages/renderer/routes/settings/general.tsx
@@ -48,7 +48,7 @@ function LaunchAtLoginField() {
   return (
     <Field orientation="horizontal">
       <FieldContent>
-        <FieldLabel htmlFor={fieldId}>Launch at Login</FieldLabel>
+        <FieldLabel htmlFor={fieldId}>Launch at login</FieldLabel>
         <FieldDescription>
           Start the application automatically when you log in to your computer.
         </FieldDescription>
@@ -95,7 +95,7 @@ function DefaultMailClientField() {
     <Field orientation="horizontal">
       <FieldContent>
         <FieldLabel htmlFor={fieldId}>
-          Default Mail Client <LicenseKeyRequiredFieldBadge />
+          Default mail client <LicenseKeyRequiredFieldBadge />
         </FieldLabel>
         <FieldDescription>
           {isDefaultMailtoClient
@@ -134,7 +134,7 @@ export function GeneralSettings() {
             <FieldLegend>Startup</FieldLegend>
             <LaunchAtLoginField />
             <ConfigSwitchField
-              label="Launch Minimized"
+              label="Launch minimized"
               description="Start the application minimized."
               configKey="launchMinimized"
             />

--- a/packages/renderer/routes/settings/gmail/index.tsx
+++ b/packages/renderer/routes/settings/gmail/index.tsx
@@ -20,13 +20,13 @@ import { useConfig } from "@/lib/react-query";
 import { GmailLabelColors } from "./label-colors";
 
 const unreadCountPreferenceItems = [
-  { value: "first-section", label: "First Section Only" },
-  { value: "inbox", label: "Inbox Only" },
+  { value: "first-section", label: "First section only" },
+  { value: "inbox", label: "Inbox only" },
 ];
 
 const inboxCategoriesToMonitorItems = [
-  { value: "primary", label: "Primary Only" },
-  { value: "all", label: "All Categories" },
+  { value: "primary", label: "Primary only" },
+  { value: "all", label: "All categories" },
 ];
 
 export function GmailSettings() {
@@ -49,34 +49,34 @@ export function GmailSettings() {
           <FieldSet>
             <FieldLegend>Appearance</FieldLegend>
             <ConfigSwitchField
-              label="Hide Gmail Logo"
+              label="Hide Gmail logo"
               description="Hide the Gmail logo in the top left corner."
               configKey="gmail.hideGmailLogo"
               restartRequired
             />
             <ConfigSwitchField
-              label="Hide Out-of-Office Banner"
+              label="Hide out-of-office banner"
               description="Hide the out-of-office banner at the top of the window."
               configKey="gmail.hideOutOfOfficeBanner"
               restartRequired
               licenseKeyRequired
             />
             <ConfigSwitchField
-              label="Hide Promotional Banner"
+              label="Hide promotional banner"
               description="Hide the promotional banners at the top of the message list, such as the Google Workspace upgrade offer."
               configKey="gmail.hidePromoBanner"
               restartRequired
               licenseKeyRequired
             />
             <ConfigSwitchField
-              label="Hide Upgrade Button"
+              label="Hide upgrade button"
               description="Hide the Upgrade button in Gmail."
               configKey="gmail.hideUpgradeButton"
               restartRequired
               licenseKeyRequired
             />
             <ConfigSwitchField
-              label="Extend Dark Theme"
+              label="Extend dark theme"
               description="Extend Gmail's own dark theme to emails and the compose window. Gmail's theme has to be set to dark. The feature is in beta, so report anything it gets wrong."
               configKey="gmail.extendDarkTheme"
               restartRequired
@@ -88,14 +88,14 @@ export function GmailSettings() {
           <FieldSet>
             <FieldLegend>Compose</FieldLegend>
             <ConfigSwitchField
-              label="Always Compose New Emails in New Window"
+              label="Always compose new emails in new window"
               description="Open a new window to compose an email, instead of composing inside Gmail."
               configKey="gmail.openComposeInNewWindow"
               restartRequired
               licenseKeyRequired
             />
             <ConfigSwitchField
-              label="Close Compose Window After Send"
+              label="Close compose window after send"
               description="Close the compose window after you send."
               configKey="gmail.closeComposeWindowAfterSend"
               restartRequired
@@ -106,21 +106,21 @@ export function GmailSettings() {
           <FieldSet>
             <FieldLegend>Conversation</FieldLegend>
             <ConfigSwitchField
-              label="Reverse Conversation"
+              label="Reverse conversation"
               description="Show email conversations in reverse order, with the latest message at the top."
               configKey="gmail.reverseConversation"
               restartRequired
               licenseKeyRequired
             />
             <ConfigSwitchField
-              label="Move Attachments to Top"
+              label="Move attachments to top"
               description="Move email attachments to the top of the email."
               configKey="gmail.moveAttachmentsToTop"
               restartRequired
               licenseKeyRequired
             />
             <ConfigSwitchField
-              label="Always Reply and Forward in a Pop-Out"
+              label="Always reply and forward in a pop-out"
               description="Open replies and forwards in a pop-out instead of below the message."
               configKey="gmail.replyForwardInPopOut"
               restartRequired
@@ -131,13 +131,13 @@ export function GmailSettings() {
           <FieldSet>
             <FieldLegend>Inbox</FieldLegend>
             <ConfigSwitchField
-              label="Hide Inbox Footer"
+              label="Hide inbox footer"
               description="Hide the footer at the bottom of the inbox."
               configKey="gmail.hideInboxFooter"
               restartRequired
             />
             <ConfigSwitchField
-              label="Show Sender Icons"
+              label="Show sender icons"
               description="Show sender icons next to the senders in your inbox."
               configKey="gmail.showSenderIcons"
               restartRequired
@@ -145,7 +145,7 @@ export function GmailSettings() {
             />
             <ConfigSelectField
               configKey="gmail.unreadCountPreference"
-              label="Unread Count Preference"
+              label="Unread count preference"
               description="With multiple inboxes, choose which sections count toward the unread count shown in the app. The default combines every section."
               items={unreadCountPreferenceItems}
               placeholder="Select preference"
@@ -154,7 +154,7 @@ export function GmailSettings() {
             />
             <ConfigSelectField
               configKey="gmail.inboxCategoriesToMonitor"
-              label="Categories to Monitor"
+              label="Categories to monitor"
               description="With a categorized inbox, choose which categories are watched for new email notifications and included in the unified inbox."
               items={inboxCategoriesToMonitorItems}
               placeholder="Select categories"
@@ -165,7 +165,7 @@ export function GmailSettings() {
           <FieldSeparator />
           <FieldSet>
             <FieldLegend className="flex items-center gap-2">
-              Label Colors
+              Label colors
               <LicenseKeyRequiredFieldBadge />
             </FieldLegend>
             <GmailLabelColors />
@@ -176,7 +176,7 @@ export function GmailSettings() {
             <Field>
               <FieldContent>
                 <FieldLabel className="flex items-center gap-2">
-                  User Styles
+                  User styles
                   <LicenseKeyRequiredFieldBadge />
                 </FieldLabel>
                 <FieldDescription>
@@ -192,7 +192,7 @@ export function GmailSettings() {
                   }}
                   disabled={!isLicenseKeyValid}
                 >
-                  Open in Editor
+                  Open in editor
                 </Button>
                 <Button
                   variant="outline"
@@ -201,7 +201,7 @@ export function GmailSettings() {
                   }}
                   disabled={!isLicenseKeyValid}
                 >
-                  Open in Folder
+                  Open in folder
                 </Button>
               </div>
             </Field>

--- a/packages/renderer/routes/settings/gmail/label-colors.tsx
+++ b/packages/renderer/routes/settings/gmail/label-colors.tsx
@@ -110,7 +110,7 @@ function LabelColorForm({
       <form.Field name="textColor">
         {(field) => (
           <Field>
-            <FieldLabel htmlFor={field.name}>Text Color</FieldLabel>
+            <FieldLabel htmlFor={field.name}>Text color</FieldLabel>
             <Select
               items={textColorItems}
               value={field.state.value}
@@ -151,13 +151,13 @@ function AddLabelColorButton({ onAdd }: { onAdd: (labelColor: GmailLabelColorInp
       <DialogTrigger
         render={
           <Button variant="outline" disabled={!isLicenseKeyValid}>
-            Add Label Color
+            Add label color
           </Button>
         }
       />
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Add Label Color</DialogTitle>
+          <DialogTitle>Add label color</DialogTitle>
         </DialogHeader>
         <LabelColorForm
           type="add"
@@ -192,7 +192,7 @@ function EditLabelColorButton({
       />
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Edit Label Color</DialogTitle>
+          <DialogTitle>Edit label color</DialogTitle>
         </DialogHeader>
         <LabelColorForm
           labelColor={labelColor}

--- a/packages/renderer/routes/settings/languages.tsx
+++ b/packages/renderer/routes/settings/languages.tsx
@@ -82,7 +82,7 @@ export function LanguagesSettings() {
           <FieldSet>
             <FieldLabel className="flex items-center gap-2">
               Spellchecker
-              {!isLicenseKeyValid && <Badge variant="secondary">Meru Pro Required</Badge>}
+              {!isLicenseKeyValid && <Badge variant="secondary">Meru Pro required</Badge>}
             </FieldLabel>
             <FieldDescription>
               Select additional languages for spellchecking alongside the system language.

--- a/packages/renderer/routes/settings/license.tsx
+++ b/packages/renderer/routes/settings/license.tsx
@@ -64,7 +64,7 @@ function LicenseKeyForm({
           {(field) => {
             return (
               <Field>
-                <FieldLabel>License Key</FieldLabel>
+                <FieldLabel>License key</FieldLabel>
                 <Input
                   id={field.name}
                   name={field.name}
@@ -100,7 +100,9 @@ function ActivateLicenseDialog({
       {children}
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{variant === "activate" ? "Activate" : "Change"} License Key</DialogTitle>
+          <DialogTitle>
+            {variant === "activate" ? "Activate license key" : "Change license key"}
+          </DialogTitle>
         </DialogHeader>
         <DialogDescription>
           Enter the license key sent to your email address after your purchase.
@@ -182,7 +184,7 @@ export function LicenseSettings() {
           <div>
             <FieldGroup>
               <Field>
-                <FieldLabel>License Key</FieldLabel>
+                <FieldLabel>License key</FieldLabel>
                 <div className="flex gap-2">
                   <Input
                     placeholder="Click to reveal the license key"
@@ -245,7 +247,7 @@ export function LicenseSettings() {
 
                     return (
                       <Field data-invalid={isInvalid}>
-                        <FieldLabel htmlFor={field.name}>Device Label</FieldLabel>
+                        <FieldLabel htmlFor={field.name}>Device label</FieldLabel>
                         <div className="flex items-end gap-2">
                           <InputGroup>
                             <InputGroupInput

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -146,31 +146,31 @@ export function NotificationsSettings() {
             <FieldLegend>Emails</FieldLegend>
             <FieldGroup>
               <ConfigSwitchField
-                label="New Emails"
+                label="New emails"
                 description="Show notifications for new emails."
                 configKey="notifications.enabled"
               />
               {config["notifications.enabled"] && (
                 <>
                   <ConfigSwitchField
-                    label="Show Sender"
+                    label="Show sender"
                     description="Display the email sender's name in notifications."
                     configKey="notifications.showSender"
                   />
                   <ConfigSwitchField
-                    label="Show Subject"
+                    label="Show subject"
                     description="Display the email subject in notifications."
                     configKey="notifications.showSubject"
                   />
                   <ConfigSwitchField
-                    label="Show Summary"
+                    label="Show summary"
                     description="Display the email summary in notifications."
                     configKey="notifications.showSummary"
                   />
                   <Field>
                     <FieldLabel className="flex items-center gap-2">
-                      Notification Times
-                      {!isLicenseKeyValid && <Badge variant="secondary">Meru Pro Required</Badge>}
+                      Notification times
+                      {!isLicenseKeyValid && <Badge variant="secondary">Meru Pro required</Badge>}
                     </FieldLabel>
                     <FieldDescription>
                       Set the time windows when notifications are active. Outside them,
@@ -232,12 +232,12 @@ export function NotificationsSettings() {
                     ))}
                     <div>
                       <Button variant="outline" onClick={addTime} disabled={!isLicenseKeyValid}>
-                        <Plus /> Add Time Window
+                        <Plus /> Add time window
                       </Button>
                     </div>
                   </Field>
                   <Field>
-                    <FieldLabel>Test Notification</FieldLabel>
+                    <FieldLabel>Test notification</FieldLabel>
                     <FieldDescription>
                       Show a test notification to see how notifications appear.
                     </FieldDescription>
@@ -254,7 +254,7 @@ export function NotificationsSettings() {
                           ipc.main.send("notifications.showTestNotification");
                         }}
                       >
-                        Show Test Notification
+                        Show test notification
                       </Button>
                     </div>
                   </Field>
@@ -267,19 +267,19 @@ export function NotificationsSettings() {
             <FieldLegend>Downloads</FieldLegend>
             <FieldGroup>
               <ConfigSwitchField
-                label="Show Notification"
+                label="Show notification"
                 description="Show a notification when a download finishes."
                 configKey="notifications.downloadCompleted"
               />
               {config["notifications.downloadCompleted"] && (
                 <ConfigSelectField
-                  label="On Click"
+                  label="On click"
                   description="Choose what happens when clicking the download notification."
                   configKey="notifications.onClickDownloadCompleted"
                   placeholder="Select action"
                   items={[
-                    { value: "showInFolder", label: "Show in Folder" },
-                    { value: "openFile", label: "Open File" },
+                    { value: "showInFolder", label: "Show in folder" },
+                    { value: "openFile", label: "Open file" },
                   ]}
                 />
               )}
@@ -287,11 +287,11 @@ export function NotificationsSettings() {
           </FieldSet>
           <FieldSeparator />
           <FieldSet>
-            <FieldLegend>Workspace Apps</FieldLegend>
+            <FieldLegend>Workspace apps</FieldLegend>
             <FieldGroup>
               <ConfigSwitchField
-                label="Show Notifications"
-                description="Show notifications from Workspace Apps such as Calendar, Meet, and Chat."
+                label="Show notifications"
+                description="Show notifications from Workspace apps such as Calendar, Meet, and Chat."
                 configKey="notifications.allowFromWorkspaceApps"
                 licenseKeyRequired
               />
@@ -302,7 +302,7 @@ export function NotificationsSettings() {
             <FieldLegend>Sound</FieldLegend>
             <FieldGroup>
               <ConfigSwitchField
-                label="Play Sound"
+                label="Play sound"
                 description="Play a sound when showing a notification."
                 configKey="notifications.playSound"
               />
@@ -311,7 +311,7 @@ export function NotificationsSettings() {
                   <Field>
                     <FieldLabel className="flex items-center gap-2">
                       Sound
-                      {!isLicenseKeyValid && <Badge variant="secondary">Meru Pro Required</Badge>}
+                      {!isLicenseKeyValid && <Badge variant="secondary">Meru Pro required</Badge>}
                     </FieldLabel>
                     <FieldDescription>Select the sound to play for notifications.</FieldDescription>
                     <Select

--- a/packages/renderer/routes/settings/phishing-protection.tsx
+++ b/packages/renderer/routes/settings/phishing-protection.tsx
@@ -27,13 +27,13 @@ export function PhishingProtectionSettings() {
   return (
     <Settings>
       <SettingsHeader>
-        <SettingsTitle>Phishing Protection</SettingsTitle>
+        <SettingsTitle>Phishing protection</SettingsTitle>
       </SettingsHeader>
       <SettingsContent>
         <LicenseKeyRequiredBanner />
         <FieldGroup>
           <ConfigSwitchField
-            label="Confirm External Links Before Opening"
+            label="Confirm external links before opening"
             description="Prompt for confirmation before opening links from untrusted hosts in your browser."
             configKey="externalLinks.confirm"
             licenseKeyRequired
@@ -43,10 +43,11 @@ export function PhishingProtectionSettings() {
               <FieldSeparator />
               <Field>
                 <FieldContent>
-                  <FieldLabel>Trusted Hosts</FieldLabel>
+                  <FieldLabel>Trusted hosts</FieldLabel>
                   {config["externalLinks.trustedHosts"].length === 0 && (
                     <FieldDescription>
-                      No trusted hosts yet. Choosing “Trust all links” in the link prompt adds one.
+                      No trusted hosts yet. Selecting Trust all links on a host in the link prompt
+                      adds it here.
                     </FieldDescription>
                   )}
                 </FieldContent>

--- a/packages/renderer/routes/settings/saved-searches.tsx
+++ b/packages/renderer/routes/settings/saved-searches.tsx
@@ -139,7 +139,7 @@ export function AddSavedSearchButton({
       />
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Add Saved Search</DialogTitle>
+          <DialogTitle>Add saved search</DialogTitle>
         </DialogHeader>
         <SavedSearchForm
           type="add"
@@ -174,7 +174,7 @@ function EditSavedSearchButton({
       />
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Edit Saved Search</DialogTitle>
+          <DialogTitle>Edit saved search</DialogTitle>
         </DialogHeader>
         <SavedSearchForm
           savedSearch={savedSearch}
@@ -260,7 +260,7 @@ export function SavedSearchesSettings() {
   return (
     <>
       <SettingsHeader>
-        <SettingsTitle>Saved Searches</SettingsTitle>
+        <SettingsTitle>Saved searches</SettingsTitle>
         <AddSavedSearchButton
           onAdd={(savedSearch) => {
             configMutation.mutate({

--- a/packages/renderer/routes/settings/unified-inbox.tsx
+++ b/packages/renderer/routes/settings/unified-inbox.tsx
@@ -14,13 +14,13 @@ export function UnifiedInboxSettings() {
   return (
     <Settings>
       <SettingsHeader>
-        <SettingsTitle>Unified Inbox</SettingsTitle>
+        <SettingsTitle>Unified inbox</SettingsTitle>
       </SettingsHeader>
       <SettingsContent>
         <LicenseKeyRequiredBanner />
         <FieldGroup>
           <ConfigSwitchField
-            label="Enable Unified Inbox"
+            label="Enable unified inbox"
             description="Show all unread messages from every account in a single unified inbox."
             configKey="unifiedInbox.enabled"
             licenseKeyRequired
@@ -28,7 +28,7 @@ export function UnifiedInboxSettings() {
           />
           {config["unifiedInbox.enabled"] && (
             <ConfigSwitchField
-              label="Show Sender Icons"
+              label="Show sender icons"
               description="Show sender icons next to the senders in the unified inbox."
               configKey="unifiedInbox.showSenderIcons"
               licenseKeyRequired

--- a/packages/renderer/routes/settings/updates.tsx
+++ b/packages/renderer/routes/settings/updates.tsx
@@ -17,28 +17,28 @@ export function UpdatesSettings() {
       <SettingsContent>
         <FieldGroup>
           <ConfigSwitchField
-            label="Check for Updates Automatically"
+            label="Check for updates automatically"
             description="Check for updates in the background."
             configKey="updates.autoCheck"
             restartRequired
           />
           <ConfigSwitchField
-            label="Notify When Updates Are Available"
+            label="Notify when updates are available"
             description="Receive notifications when updates are available."
             configKey="updates.showNotifications"
           />
           <ConfigSelectField
-            label="Release Channel"
+            label="Release channel"
             description="Choose which releases to receive. The beta channel gets upcoming features early."
             configKey="updates.channel"
             items={releaseChannelItems}
             placeholder="Select channel"
             confirmation={{
               when: (value) => value === "beta",
-              title: "Switch to the Beta Channel?",
+              title: "Switch to the beta channel?",
               description:
                 "Beta releases are pre-release builds of upcoming versions. They might contain bugs or unfinished features. You can switch back to the stable channel at any time.",
-              confirmLabel: "Switch to Beta",
+              confirmLabel: "Switch to beta",
             }}
           />
         </FieldGroup>

--- a/packages/renderer/routes/settings/verification-codes.tsx
+++ b/packages/renderer/routes/settings/verification-codes.tsx
@@ -20,33 +20,33 @@ export function VerificationCodesSettings() {
   return (
     <Settings>
       <SettingsHeader>
-        <SettingsTitle>Verification Codes</SettingsTitle>
+        <SettingsTitle>Verification codes</SettingsTitle>
       </SettingsHeader>
       <SettingsContent>
         <LicenseKeyRequiredBanner />
         <FieldGroup>
           <ConfigSwitchField
-            label="Copy Codes to Clipboard"
+            label="Copy codes to clipboard"
             description="Copy a verification code to your clipboard as soon as it arrives by email."
             configKey="verificationCodes.autoCopy"
             licenseKeyRequired
           />
           <ConfigSelectField
             configKey="verificationCodes.confidence"
-            label="Detection Confidence"
+            label="Detection confidence"
             description="Choose how certain Meru has to be before it treats something as a verification code. Medium can pick up codes that aren't there. High looks for explicit keywords and can miss some."
             items={verificationCodeConfidenceItems}
             placeholder="Select confidence"
             licenseKeyRequired
           />
           <ConfigSwitchField
-            label="Mark Email as Read After Copying"
+            label="Mark email as read after copying"
             description="Mark the email as read once its verification code has been copied."
             configKey="verificationCodes.autoMarkAsRead"
             licenseKeyRequired
           />
           <ConfigSwitchField
-            label="Delete Email After Copying"
+            label="Delete email after copying"
             description="Delete the email once its verification code has been copied."
             configKey="verificationCodes.autoDelete"
             licenseKeyRequired

--- a/packages/renderer/routes/settings/version-history.tsx
+++ b/packages/renderer/routes/settings/version-history.tsx
@@ -67,7 +67,7 @@ export function VersionHistorySettings() {
                 refetch();
               }}
             >
-              Try Again
+              Try again
             </Button>
           </EmptyContent>
         </Empty>
@@ -84,7 +84,7 @@ export function VersionHistorySettings() {
         <ItemContent>
           <div className="flex items-center justify-between gap-2">
             <ItemTitle className="text-2xl font-semibold">{release.tag_name}</ItemTitle>
-            {release.tag_name === currentTagName ? <Badge>Current Version</Badge> : null}
+            {release.tag_name === currentTagName ? <Badge>Current version</Badge> : null}
           </div>
           <ItemDescription>{dayjs(release.published_at).fromNow()}</ItemDescription>
           <div className="prose dark:prose-invert prose-h3:text-lg prose-li:marker:text-white prose-li:pl-0 mt-6 text-sm">
@@ -106,7 +106,7 @@ export function VersionHistorySettings() {
   return (
     <>
       <SettingsHeader className="flex-col items-start justify-start gap-1">
-        <SettingsTitle>What's New</SettingsTitle>
+        <SettingsTitle>What's new</SettingsTitle>
         {info ? <SettingsDescription>Current version: v{info.version}</SettingsDescription> : null}
       </SettingsHeader>
       <div className="space-y-8">{renderContent()}</div>

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -132,14 +132,14 @@ export function WorkspaceAppsSettings() {
   return (
     <Settings>
       <SettingsHeader>
-        <SettingsTitle>Workspace Apps</SettingsTitle>
+        <SettingsTitle>Workspace apps</SettingsTitle>
       </SettingsHeader>
       <SettingsContent>
         <LicenseKeyRequiredBanner />
         <FieldGroup>
           <ConfigSwitchField
-            label="Open in App"
-            description="Open Workspace Apps in the app instead of the external browser."
+            label="Open in app"
+            description="Open Workspace apps in the app instead of the external browser."
             configKey="workspaceApps.openInApp"
             licenseKeyRequired
             restartRequired
@@ -150,8 +150,8 @@ export function WorkspaceAppsSettings() {
                 label="Mode"
                 description={
                   <>
-                    How Workspace Apps open. Tabs, the default, opens them in the main window. New
-                    Windows gives each one its own window with no tab strip. In Tabs, hold{" "}
+                    How Workspace apps open. Tabs, the default, opens them in the main window. New
+                    windows gives each one its own window with no tab strip. In Tabs, hold{" "}
                     <Kbd>{platform.isMacOS ? "Cmd" : "Ctrl"}</Kbd> to open a background tab or{" "}
                     <Kbd>Shift</Kbd> to open a new window.
                   </>
@@ -166,27 +166,27 @@ export function WorkspaceAppsSettings() {
                 confirmation={{
                   when: (mode) =>
                     mode === "windows" && (hasOpenWorkspaceAppTabs || hasLoadOnLaunchWorkspaceApps),
-                  title: "Switch to New Windows?",
+                  title: "Switch to New windows?",
                   description: (
                     <>
-                      Workspace Apps open in their own window from now on.
+                      Workspace apps open in their own window from now on.
                       {hasOpenWorkspaceAppTabs &&
                         " The tabs you already have open stay as they are, and the tab strip hides after you close them, or after a restart."}
                       {hasLoadOnLaunchWorkspaceApps &&
                         " Pinned apps set to load on launch open as windows the next time you start Meru."}
                     </>
                   ),
-                  confirmLabel: "Switch to New Windows",
+                  confirmLabel: "Switch to New windows",
                 }}
               />
               <Field>
                 <FieldContent>
                   <FieldLabel className="flex items-center gap-2">
-                    Excluded Apps
+                    Excluded apps
                     {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
                   </FieldLabel>
                   <FieldDescription>
-                    Select the Workspace Apps that open in the external browser instead of the app.
+                    Select the Workspace apps that open in the external browser instead of the app.
                   </FieldDescription>
                 </FieldContent>
                 <DropdownMenu>
@@ -229,10 +229,10 @@ export function WorkspaceAppsSettings() {
             <>
               <FieldSeparator />
               <FieldSet>
-                <FieldLegend>Vertical Tabs</FieldLegend>
+                <FieldLegend>Vertical tabs</FieldLegend>
                 <ConfigSwitchField
-                  label="Show Windows"
-                  description="List Workspace Apps that are open in their own window alongside the tabs, so the sidebar is an overview of everything open. Click one to bring its window forward."
+                  label="Show windows"
+                  description="List Workspace apps that are open in their own window alongside the tabs, so the sidebar is an overview of everything open. Click one to bring its window forward."
                   configKey="verticalTabs.showWindows"
                   licenseKeyRequired
                 />
@@ -248,19 +248,19 @@ export function WorkspaceAppsSettings() {
                   }))}
                 />
                 <ConfigSwitchField
-                  label="Show Width Button"
+                  label="Show width button"
                   description="Show the button at the bottom of the sidebar that switches between narrow and wide. With this off, use Reset Width from the sidebar's context menu or the Width setting above."
                   configKey="verticalTabs.showWidthToggle"
                   licenseKeyRequired
                 />
                 <ConfigSwitchField
-                  label="Hide Gmail Unread Badge When Active"
+                  label="Hide Gmail unread badge when active"
                   description="Hide the unread badge on the Gmail tab while it is the active tab, because the inbox is already in front. Accounts that need attention are still flagged."
                   configKey="verticalTabs.hideUnreadBadgeWhenActive"
                   licenseKeyRequired
                 />
                 <ConfigSwitchField
-                  label="Show App Links Badge"
+                  label="Show app links badge"
                   description="Mark the tab that opens all of an app's links, set from the tab's context menu. With this off, the tab still takes the links, and its tooltip still says so."
                   configKey="verticalTabs.showAppLinksBadge"
                   licenseKeyRequired
@@ -272,29 +272,29 @@ export function WorkspaceAppsSettings() {
           <FieldSet>
             <FieldLegend>Windows</FieldLegend>
             <ConfigSwitchField
-              label="Show Account Label"
-              description="Show the account label in the titlebar of Workspace Apps windows, with more than one account."
+              label="Show account label"
+              description="Show the account label in the titlebar of Workspace apps windows, with more than one account."
               configKey="workspaceApps.showAccountLabel"
               licenseKeyRequired
             />
             <ConfigSwitchField
-              label="Show Account Color"
-              description="Show a colored indicator on top of a Workspace Apps window, naming the account in use. It appears only for accounts that have a color."
+              label="Show account color"
+              description="Show a colored indicator on top of a Workspace apps window, naming the account in use. It appears only for accounts that have a color."
               configKey="workspaceApps.showAccountColor"
               licenseKeyRequired
             />
           </FieldSet>
           <FieldSeparator />
           <ConfigSwitchField
-            label="Persist Zoom"
-            description="Remember the zoom level of Workspace Apps across restarts. Each app keeps its own zoom level, shared by all its tabs and windows."
+            label="Persist zoom"
+            description="Remember the zoom level of Workspace apps across restarts. Each app keeps its own zoom level, shared by all its tabs and windows."
             configKey="workspaceApps.persistZoom"
             licenseKeyRequired
           />
           <FieldSeparator />
           <ConfigSelectField
-            label="Hibernate Idle Tabs"
-            description="Unload tabs that have been sitting unused, giving back the memory they hold. A hibernated tab keeps its place in the sidebar and loads again when you click it, on the page you left. Selected Tabs only hibernates the tabs you mark with Hibernate When Idle in the tab's context menu."
+            label="Hibernate idle tabs"
+            description="Unload tabs that have been sitting unused, giving back the memory they hold. A hibernated tab keeps its place in the sidebar and loads again when you click it, on the page you left. Selected tabs only hibernates the tabs you mark with Hibernate When Idle in the tab's context menu."
             configKey="workspaceApps.hibernation"
             placeholder="Select which tabs"
             licenseKeyRequired
@@ -304,7 +304,7 @@ export function WorkspaceAppsSettings() {
             }))}
           />
           <ConfigSelectField
-            label="Hibernate After"
+            label="Hibernate after"
             description="How long a tab has to go unused before it hibernates. The active tab, tabs in their own window, and tabs playing audio are left alone."
             configKey="workspaceApps.hibernationTimeout"
             placeholder="Select timeout"
@@ -316,20 +316,20 @@ export function WorkspaceAppsSettings() {
           />
           <FieldSeparator />
           <FieldSet>
-            <FieldLegend>Launcher and Bookmarks</FieldLegend>
+            <FieldLegend>Launcher and bookmarks</FieldLegend>
             <Field>
               <FieldContent>
                 <FieldLabel className="flex items-center gap-2">
-                  Launcher Apps
+                  Launcher apps
                   {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
                 </FieldLabel>
                 <FieldDescription>
-                  Add Workspace Apps to the launcher on the right of the titlebar.
+                  Add Workspace apps to the launcher on the right of the titlebar.
                 </FieldDescription>
               </FieldContent>
               <div className="flex flex-col gap-4">
                 <div className="flex flex-col gap-2">
-                  <div className="text-xs font-medium text-muted-foreground">In Launcher</div>
+                  <div className="text-xs font-medium text-muted-foreground">In launcher</div>
                   {launcherApps.length === 0 ? (
                     <p className="rounded-lg border border-dashed px-3 py-4 text-center text-sm text-muted-foreground">
                       No apps in the launcher yet. Add one from Available.
@@ -394,7 +394,7 @@ export function WorkspaceAppsSettings() {
               </div>
             </Field>
             <ConfigSelectField
-              label="Launcher Display"
+              label="Launcher display"
               description="How launcher apps are shown in the titlebar. Auto expands up to three apps into individual buttons and collapses beyond that. Collapsed always keeps them behind a single button, and Expanded always shows them as individual buttons."
               configKey="workspaceApps.launcherDisplay"
               placeholder="Select display"

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -80,7 +80,7 @@ export type LauncherAndBookmarksPlacement = keyof typeof launcherAndBookmarksPla
 
 export const workspaceAppsModes = {
   tabs: "Tabs",
-  windows: "New Windows",
+  windows: "New windows",
 } as const;
 
 export type WorkspaceAppsMode = keyof typeof workspaceAppsModes;
@@ -90,18 +90,18 @@ export type WorkspaceAppsMode = keyof typeof workspaceAppsModes;
  * with no tab marked hibernates nothing.
  */
 export const workspaceAppsHibernations = {
-  selected: "Selected Tabs",
-  all: "All Tabs",
+  selected: "Selected tabs",
+  all: "All tabs",
 } as const;
 
 export type WorkspaceAppsHibernation = keyof typeof workspaceAppsHibernations;
 
 /** Keys double as durations for `ms`. */
 export const workspaceAppsHibernationTimeouts = {
-  "30m": "30 Minutes",
-  "1h": "1 Hour",
-  "3h": "3 Hours",
-  "6h": "6 Hours",
+  "30m": "30 minutes",
+  "1h": "1 hour",
+  "3h": "3 hours",
+  "6h": "6 hours",
 } as const;
 
 export type WorkspaceAppsHibernationTimeout = keyof typeof workspaceAppsHibernationTimeouts;


### PR DESCRIPTION
Meru's settings screens were written in title case, which is the convention for native menus but not for the HTML the renderer draws. This puts every user-facing string on the settings pages into sentence case: page titles, section legends, field labels, select options, dialog titles, badges, and buttons. Hide Gmail Logo becomes Hide Gmail logo, Hibernate After becomes Hibernate after, 30 Minutes becomes 30 minutes. Product names keep their capitals — Meru Pro, Gmail, the Google app names, 1Password, Touch ID, Do Not Disturb, and the Save As dialog.

The descriptions that name a control were respelled to match it, so Selected Tabs and Workspace Apps now read Selected tabs and Workspace apps. The two that point at native context menu items, Reset Width and Hibernate When Idle, keep the menus' own casing, because the native menus stay in title case.

The empty state under Trusted hosts named the wrong control. It said choosing "Trust all links" adds a host, in quotes; the real control is a checkbox labeled Trust all links on the site's origin. It now names it accurately and without quotes.

The Pro badge is written out three times, twice by hand on the settings pages and once in LicenseKeyRequiredFieldBadge, so all three are recased together and main never shows two spellings. Collapsing them into the one component is left for later.

The shared option label maps in workspace-apps.ts and tabs.ts changed too. Every one of them is rendered only by the Workspace apps settings page, so no native menu picks up the new casing.

Not verified by running the app — the change is copy only. `bun run types`, `bun run lint`, `bun run fmt:check`, and `bun test` pass.
