### PR TITLE
rewrite the window chrome text in sentence case

### DIFF
--- a/packages/renderer/bookmarks.tsx
+++ b/packages/renderer/bookmarks.tsx
@@ -129,7 +129,6 @@ function BookmarkList() {
             <BookOpenIcon />
           </EmptyMedia>
           <EmptyTitle>No bookmarks yet</EmptyTitle>
-          <EmptyDescription>Bookmarked pages appear here.</EmptyDescription>
           <EmptyDescription>
             Bookmark a page with the star on its tab or window titlebar, or from a tab's context
             menu.

--- a/packages/renderer/components/app-main.tsx
+++ b/packages/renderer/components/app-main.tsx
@@ -27,7 +27,7 @@ function CloseButton() {
       >
         <XIcon />
       </Button>
-      <div className="text-xs font-semibold text-muted-foreground">ESC</div>
+      <div className="text-xs font-semibold text-muted-foreground">Esc</div>
     </div>
   );
 }

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -54,7 +54,7 @@ function BookmarksButton() {
       onMouseLeave={() => {
         ipc.main.send("bookmarks.setPopupCloseOnBlurEnabled", true);
       }}
-      title="Bookmarks"
+      title="Show bookmarks"
     >
       <BookOpenIcon />
     </TitlebarIconButton>
@@ -73,7 +73,7 @@ function RecentDownloadHistoryButton() {
       onMouseLeave={() => {
         ipc.main.send("downloads.setDownloadHistoryPopupOnBlurEnabled", true);
       }}
-      title="Recent download history"
+      title="Show recent download history"
     >
       <DownloadIcon />
     </TitlebarIconButton>
@@ -173,7 +173,7 @@ function DoNotDisturb() {
 
         ipc.main.send("doNotDisturb.showOptions");
       }}
-      title="Do Not Disturb"
+      title={config["doNotDisturb.enabled"] ? "Turn Do Not Disturb off" : "Turn Do Not Disturb on"}
     >
       <MoonIcon
         className={cn({
@@ -293,7 +293,7 @@ export function AppTitlebar() {
                 ipc.main.send("appUpdater.quitAndInstall");
               }}
             >
-              Restart Now
+              Restart now
             </Button>
             <Button
               variant="outline"
@@ -314,7 +314,7 @@ export function AppTitlebar() {
                 ipc.main.send("appUpdater.openVersionHistory");
               }}
             >
-              What's New
+              What's new
             </Button>
           </div>
         </div>
@@ -355,7 +355,7 @@ export function AppTitlebar() {
                 onClick={() => {
                   navigate("/unified-inbox");
                 }}
-                title="Unified Inbox"
+                title="Open unified inbox"
               >
                 <InboxIcon />
               </Button>
@@ -368,7 +368,7 @@ export function AppTitlebar() {
                   variant="ghost"
                   size="icon-sm"
                   className="draggable-none"
-                  title="Out of office"
+                  title="Open Gmail settings to turn off out of office"
                   onClick={() => {
                     ipc.main.send("gmail.navigateTo", "settings");
                   }}
@@ -402,7 +402,7 @@ export function AppTitlebar() {
             <ExtensionActions />
             {shouldShowSavedSearchesButton && (
               <TitlebarDropdownMenu
-                title="Saved Searches"
+                title="Show saved searches"
                 icon={<MailSearchIcon />}
                 side="left"
                 disabled={isUnifiedInboxLocation || isWorkspaceAppTabActive}
@@ -432,7 +432,7 @@ export function AppTitlebar() {
                 setIsAppUpdateDetailsOpen(true);
               }}
             >
-              <SparklesIcon /> Update Available
+              <SparklesIcon /> Update available
             </Button>
           )}
           <AppMenuButton />

--- a/packages/renderer/components/download-history.tsx
+++ b/packages/renderer/components/download-history.tsx
@@ -38,10 +38,7 @@ export function DownloadHistoryList({ limit }: { limit?: number }) {
             <DownloadIcon />
           </EmptyMedia>
           <EmptyTitle>No downloads yet</EmptyTitle>
-          <EmptyDescription>Downloaded files appear here.</EmptyDescription>
-          <EmptyDescription>
-            Downloads older than 30 days are removed from the history automatically.
-          </EmptyDescription>
+          <EmptyDescription>Files you download appear here for 30 days.</EmptyDescription>
         </EmptyHeader>
       </Empty>
     );
@@ -85,7 +82,7 @@ export function DownloadHistoryList({ limit }: { limit?: number }) {
                 {fileName}
               </ItemTitle>
               <ItemDescription className="first-letter:capitalize">
-                {exists ? <DateFromNow timestamp={createdAt} /> : "File not found"}
+                {exists ? <DateFromNow timestamp={createdAt} /> : "File moved or deleted"}
               </ItemDescription>
             </ItemContent>
             <ItemActions>

--- a/packages/renderer/components/extension-actions.tsx
+++ b/packages/renderer/components/extension-actions.tsx
@@ -20,7 +20,7 @@ export function ExtensionActions() {
 
   return (
     <TitlebarIconButton
-      title="Extensions"
+      title="Show extensions"
       onClick={(event) => {
         const { x, y, width, height } = event.currentTarget.getBoundingClientRect();
 

--- a/packages/renderer/components/titlebar.tsx
+++ b/packages/renderer/components/titlebar.tsx
@@ -147,18 +147,18 @@ export function TitlebarNavigationControls({
 
   return (
     <>
-      <TitlebarIconButton title="Back" disabled={disabled || !canGoBack} onClick={onGoBack}>
+      <TitlebarIconButton title="Go back" disabled={disabled || !canGoBack} onClick={onGoBack}>
         <ArrowLeftIcon />
       </TitlebarIconButton>
       <TitlebarIconButton
-        title="Forward"
+        title="Go forward"
         disabled={disabled || !canGoForward}
         onClick={onGoForward}
       >
         <ArrowRightIcon />
       </TitlebarIconButton>
       <TitlebarIconButton
-        title={isLoading ? "Stop" : "Reload"}
+        title={isLoading ? "Stop loading" : "Reload page"}
         disabled={disabled}
         onMouseEnter={() => setIsReloadHovered(true)}
         onMouseLeave={() => setIsReloadHovered(false)}

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -314,7 +314,7 @@ function VerticalTabsBookmarks({ isWide }: { isWide: boolean }) {
       size={isWide ? "sm" : "icon"}
       // Colours transition, the box never does, as in `VerticalTab`
       className={cn("text-muted-foreground transition-colors", isWide && "w-full justify-start")}
-      title="Bookmarks"
+      title="Show bookmarks"
       onClick={() => {
         ipc.main.send("bookmarks.togglePopup", "verticalTabs");
       }}
@@ -360,7 +360,7 @@ function VerticalTabsWidthToggle({
         "mt-auto text-muted-foreground transition-[color,background-color]",
         isWide && "self-end",
       )}
-      title={isWide ? "Narrow tabs" : "Wide tabs"}
+      title={isWide ? "Narrow the tab strip" : "Widen the tab strip"}
       onClick={() => {
         ipc.main.send("tabs.setVerticalTabsWidth", accountId, isWide ? "narrow" : "wide");
       }}

--- a/packages/renderer/components/workspace-apps-launcher.tsx
+++ b/packages/renderer/components/workspace-apps-launcher.tsx
@@ -72,7 +72,7 @@ export function WorkspaceAppsLauncher({
 
   return (
     <TitlebarDropdownMenu
-      title="Workspace Apps"
+      title="Open workspace app"
       icon={<LayoutGridIcon />}
       side="left"
       disabled={disabled}
@@ -119,7 +119,7 @@ export function VerticalTabsWorkspaceAppsLauncher({
             title="Open app"
           >
             <LayoutGridIcon />
-            {isWide && "Open App"}
+            {isWide && "Open app"}
           </Button>
         }
       />

--- a/packages/renderer/recent-download-history.tsx
+++ b/packages/renderer/recent-download-history.tsx
@@ -10,7 +10,7 @@ import { renderApp } from "@/lib/react";
 function RecentDownloadHistory() {
   return (
     <>
-      <div className="p-4 font-semibold">Recent Download History</div>
+      <div className="p-4 font-semibold">Recent download history</div>
       <Button
         size="icon"
         variant="ghost"
@@ -35,7 +35,7 @@ function RecentDownloadHistory() {
             ipc.main.send("downloads.openDownloadHistory");
           }}
         >
-          <SquareArrowOutUpRightIcon /> Full Download History
+          <SquareArrowOutUpRightIcon /> Full download history
         </Button>
       </div>
     </>

--- a/packages/renderer/routes/download-history.tsx
+++ b/packages/renderer/routes/download-history.tsx
@@ -22,7 +22,7 @@ function DownloadHistoryClearAllButton() {
       }}
       disabled={config["downloads.history"].length === 0}
     >
-      Clear All
+      Clear all
     </Button>
   );
 }
@@ -31,7 +31,7 @@ export function DownloadHistory() {
   return (
     <>
       <SettingsHeader>
-        <SettingsTitle>Download History</SettingsTitle>
+        <SettingsTitle>Download history</SettingsTitle>
         <DownloadHistoryClearAllButton />
       </SettingsHeader>
       <DownloadHistoryList />

--- a/packages/renderer/routes/unified-inbox.tsx
+++ b/packages/renderer/routes/unified-inbox.tsx
@@ -449,7 +449,7 @@ export function UnifiedInbox() {
   return (
     <>
       <SettingsHeader className="flex-col">
-        <SettingsTitle>Unified Inbox</SettingsTitle>
+        <SettingsTitle>Unified inbox</SettingsTitle>
       </SettingsHeader>
       {renderContent()}
     </>

--- a/packages/renderer/workspace-app.tsx
+++ b/packages/renderer/workspace-app.tsx
@@ -31,7 +31,7 @@ function RecentDownloadHistoryButton() {
       onMouseLeave={() => {
         ipc.main.send("downloads.setDownloadHistoryPopupOnBlurEnabled", true);
       }}
-      title="Recent download history"
+      title="Show recent download history"
     >
       <DownloadIcon />
     </TitlebarIconButton>


### PR DESCRIPTION
The window chrome follows the settings pages into sentence case, and the tooltips get the same pass. The native OS menus keep title case and are not touched here.

Half the icon-only tooltips named a place rather than an action. Bookmarks, Extensions, Workspace Apps, Saved Searches, Unified Inbox, Do Not Disturb, Out of office, and Recent download history were all bare nouns, which say where a control leads but not what pressing it does. Each now leads with a verb: Show bookmarks, Show extensions, Open workspace app, Open unified inbox, and so on. Out of office navigates to Gmail's settings root, so it says Open Gmail settings to turn off out of office rather than implying the click flips the switch. Back and forward become Go back and Go forward, which is one word each and keeps the navigation group consistent with Reload page beside it.

Two toggles read equally well as a description of the current state. The vertical tabs width control said Narrow tabs and Wide tabs, which could be either the result of pressing or a label for what you are looking at; it now says Narrow the tab strip and Widen the tab strip, keeping the article because dropping it restores the ambiguity. Stop and Reload never said what stops, and now read Stop loading and Reload page. Do Not Disturb is a toggle too, so its tooltip flips with the state the component already reads for the icon color.

Both empty states restated their own titles. No bookmarks yet was followed by "Bookmarked pages appear here", and No downloads yet by "Downloaded files appear here" — a line each that says nothing the title hasn't. Bookmarks now keeps only the sentence naming the action that fills it, the star on a tab or window titlebar and the tab's context menu. Downloads has no in-app action to offer, so it says what lands there and for how long, which also absorbs the separate sentence about the 30 day retention.

A missing download showed a bare verdict. Where the timestamp goes, a file that is gone from disk read File not found; it now reads File moved or deleted, which says what happened rather than what the lookup returned.

The rest is capitalization, and the settings close hint follows the key name convention with Esc rather than ESC.

Not verified by running the app — the change is copy only. `bun run types`, `bun run lint`, `bun run fmt:check`, and `bun test` pass.

Left for a separate call: App menu and More options on the two ellipsis buttons, the tab and popup Close buttons, and the four unified inbox pagination tooltips are bare nouns or bare verbs by the same test, but they are conventional names for those controls and rewording them is a wider decision than this pass.
