### PR TITLE
apply the writing guide to the native dialogs and tray

### DIFF
--- a/packages/app/dialogs.ts
+++ b/packages/app/dialogs.ts
@@ -8,7 +8,7 @@ export async function showRestartDialog() {
   const { response } = await dialog.showMessageBox({
     type: "info",
     buttons: ["Restart", "Later"],
-    message: "Restart Meru to apply the changes?",
+    message: "Restart Meru to apply the changes.",
     defaultId: 0,
     cancelId: 1,
   });
@@ -27,7 +27,7 @@ export async function confirmAppLinksTabHandover(
 
   const { response } = await dialog.showMessageBox(main.window, {
     type: "info",
-    buttons: ["Open Links Here", "Cancel"],
+    buttons: ["Open links here", "Cancel"],
     message: `Open ${appLabel} links in this tab?`,
     detail: `“${appLinksTabTitle}” opens all ${appLabel} links right now, and gives them up to this tab.`,
     defaultId: 0,

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -1047,7 +1047,9 @@ class Ipc {
 
     ipc.main.handle("extensions.install", async (_event, extensionId) => {
       if (!licenseKey.isValid) {
-        return { error: "Meru Pro is required to install extensions" };
+        return {
+          error: "Meru Pro is required to install extensions. Upgrade to Meru Pro to continue.",
+        };
       }
 
       if (!isCuratedExtensionId(extensionId)) {
@@ -1085,7 +1087,9 @@ class Ipc {
 
     ipc.main.handle("extensions.update", async () => {
       if (!licenseKey.isValid) {
-        return { error: "Meru Pro is required to update extensions" };
+        return {
+          error: "Meru Pro is required to update extensions. Upgrade to Meru Pro to continue.",
+        };
       }
 
       return { results: await extensionUpdater.checkForUpdates() };

--- a/packages/app/license-key.ts
+++ b/packages/app/license-key.ts
@@ -131,8 +131,8 @@ class LicenseKey {
         };
 
         const { response } = await this.showValidationError({
-          detail: `${errorMessages[error.code]}, and Meru removes it from this device. Contact support if you need help.`,
-          buttons: ["Remove and Restart", "Quit"],
+          detail: `${errorMessages[error.code]}. Contact support if you need help.`,
+          buttons: ["Remove and restart", "Quit"],
           defaultId: 0,
           cancelId: 1,
         });

--- a/packages/app/tray.ts
+++ b/packages/app/tray.ts
@@ -147,7 +147,7 @@ export class AppTray {
         type: "separator",
       },
       {
-        label: mainWindowIsVisible ? "Hide" : "Show",
+        label: mainWindowIsVisible ? "Hide Meru" : "Show Meru",
         click: () => {
           main.window[mainWindowIsVisible ? "hide" : "show"]();
         },

--- a/packages/app/trial.ts
+++ b/packages/app/trial.ts
@@ -66,7 +66,7 @@ class Trial {
         type: "info",
         message: "Your Meru Pro trial has ended.",
         detail: "Upgrade to Meru Pro to keep every feature, or continue with the free version.",
-        buttons: ["Upgrade to Meru Pro", "Continue with Free", "Quit"],
+        buttons: ["Upgrade to Meru Pro", "Continue with the free version", "Quit"],
         defaultId: 0,
         cancelId: 2,
       });

--- a/packages/app/url.ts
+++ b/packages/app/url.ts
@@ -25,7 +25,7 @@ export async function openExternalUrl(
     if (!options?.skipTrustedHostCheck && !trustedHosts.includes(origin)) {
       const { response, checkboxChecked } = await dialog.showMessageBox({
         type: "info",
-        buttons: ["Open Link", "Copy Link", "Cancel"],
+        buttons: ["Open link", "Copy link", "Cancel"],
         message: "Open this link in your default browser?",
         checkboxLabel: `Trust all links on ${origin}`,
         detail:


### PR DESCRIPTION
The guide keeps title-style capitalization for native menus but not for alerts: the HIG puts alert body text, helper text, tooltips and alert buttons in sentence case. So Open Links Here becomes Open links here, Open Link and Copy Link become Open link and Copy link, and Remove and Restart becomes Remove and restart, while the tray menu is left in title case and Upgrade to Meru Pro and Open Meru Portal keep every capital they have — those are all proper nouns.

Continue with Free was not English. The trial dialog's own detail calls the tier "the free version", so the button now reads Continue with the free version and matches the sentence above it.

Three different sentences said restart. The restart dialog asked Restart Meru to apply the changes? while license activation stated Restart Meru to apply the changes. in a detail, and the renderer has a third with a Restart Now action. Both in the main process now read Restart Meru to apply the changes. with Restart and Later. The period wins over the question mark because the sentence is an imperative rather than a real question, and because the license path renders it as body text where a question mark would be wrong. The renderer toast is not in this PR; aligning it, including renaming Restart Now to Restart, is a follow-up.

Two errors stated a verdict and stopped. Meru Pro is required to install extensions and the same for update had no period and no next step, while the same sentence in protocol.ts had both. All four now end in a period, and the two extension ones, which reach the reader as toasts with no button to press, carry the remedy.

The license validation detail claimed something that hadn't happened. It appended ", and Meru removes it from this device" to a per-code clause, in the present tense, when removal only happens if the reader chooses Remove and restart. On the DEVICE_NOT_ACTIVATED branch it also said "this device" twice in one sentence. The clause is gone; each of the four codes now reads as This license key has expired. Contact support if you need help. and the buttons carry the action, as the guide prefers.

The tray said Hide without saying what. A toggling control names where it leads, so it is now Hide Meru and Show Meru, in title case because a tray menu is a native menu.

Not verified by running the app — every change is a user-facing string, checked by reading. `bun run types`, `bun run lint`, `bun run fmt:check`, and `bun test` pass.

Two things found and left alone. The passkey alerts in settings/extensions.tsx disagree with each other, Meru can sign you in with a Touch ID passkey against Meru can sign you in with your Windows passkeys, article against possessive and singular against plural; that file belongs to a later change in this stack. And the app links handover detail, which says a tab "gives them up to this tab", is hard to parse, but fixing it means deciding what the handover should say, which is more than a casing pass.
