### PR TITLE
align the native menus with the macOS menu bar canon

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -89,7 +89,7 @@ export class AppMenu {
   }
 
   createMenu() {
-    const macOSWindowItems: MenuItemConstructorOptions[] = [
+    const macOSAppHideItems: MenuItemConstructorOptions[] = [
       {
         label: `Hide ${app.name}`,
         role: "hide",
@@ -104,6 +104,20 @@ export class AppMenu {
       },
       {
         type: "separator",
+      },
+    ];
+
+    // Zoom and Bring All to Front are macOS-only roles, and the Window menu
+    // itself is a macOS convention.
+    const macOSWindowArrangementItems: MenuItemConstructorOptions[] = [
+      {
+        role: "zoom",
+      },
+      {
+        type: "separator",
+      },
+      {
+        role: "front",
       },
     ];
 
@@ -253,14 +267,14 @@ export class AppMenu {
             type: "separator",
           },
           {
-            label: "Settings…",
+            label: "Settings",
             accelerator: "CommandOrControl+,",
             click: () => {
               main.navigate("/settings/general");
             },
           },
           {
-            label: "Gmail Settings…",
+            label: "Gmail Settings",
             accelerator: "CommandOrControl+Shift+,",
             click: () => {
               ipc.renderer.send(
@@ -275,7 +289,7 @@ export class AppMenu {
           {
             type: "separator",
           },
-          ...(platform.isMacOS ? macOSWindowItems : []),
+          ...(platform.isMacOS ? macOSAppHideItems : []),
           {
             label: `Quit ${app.name}`,
             accelerator: "CommandOrControl+Q",
@@ -374,34 +388,6 @@ export class AppMenu {
         ],
       },
       {
-        label: "Message",
-        visible: licenseKey.isValid,
-        submenu: [
-          {
-            label: "Copy Message Link",
-            enabled: Boolean(copyOrShareMessageLink),
-            accelerator: "CommandOrControl+Shift+C",
-            click: () => {
-              if (copyOrShareMessageLink) {
-                clipboard.writeText(copyOrShareMessageLink);
-              }
-            },
-          },
-          copyOrShareMessageLink
-            ? {
-                role: "shareMenu",
-                sharingItem: {
-                  urls: [copyOrShareMessageLink],
-                },
-              }
-            : {
-                label: "Share",
-                enabled: false,
-                submenu: [],
-              },
-        ],
-      },
-      {
         label: "View",
         submenu: [
           {
@@ -428,7 +414,7 @@ export class AppMenu {
             type: "separator",
           },
           {
-            label: "Reset Zoom",
+            label: "Actual Size",
             accelerator: "CommandOrControl+0",
             click: () => {
               getActiveZoomTarget()?.resetZoom();
@@ -498,6 +484,34 @@ export class AppMenu {
               getActiveViewWebContents().openDevTools();
             },
           },
+        ],
+      },
+      {
+        label: "Message",
+        visible: licenseKey.isValid,
+        submenu: [
+          {
+            label: "Copy Message Link",
+            enabled: Boolean(copyOrShareMessageLink),
+            accelerator: "CommandOrControl+Shift+C",
+            click: () => {
+              if (copyOrShareMessageLink) {
+                clipboard.writeText(copyOrShareMessageLink);
+              }
+            },
+          },
+          copyOrShareMessageLink
+            ? {
+                role: "shareMenu",
+                sharingItem: {
+                  urls: [copyOrShareMessageLink],
+                },
+              }
+            : {
+                label: "Share",
+                enabled: false,
+                submenu: [],
+              },
         ],
       },
       {
@@ -632,7 +646,7 @@ export class AppMenu {
             type: "separator",
           },
           {
-            label: "Manage Accounts…",
+            label: "Manage Accounts",
             click: () => {
               main.navigate("/settings/accounts");
             },
@@ -648,11 +662,7 @@ export class AppMenu {
             accelerator: "CommandOrControl+M",
             role: "minimize",
           },
-          {
-            label: "Close",
-            accelerator: "CommandOrControl+W",
-            role: "close",
-          },
+          ...(platform.isMacOS ? macOSWindowArrangementItems : []),
         ],
       },
       {
@@ -693,13 +703,13 @@ export class AppMenu {
             type: "separator",
           },
           {
-            label: "Ask Question",
+            label: "Ask Question…",
             click: () => {
               selectedAccount.instance.gmail.createComposeWindow("mailto:tim@meru.so");
             },
           },
           {
-            label: "Request Feature",
+            label: "Request Feature…",
             click: () => {
               selectedAccount.instance.gmail.createComposeWindow(
                 "mailto:tim@meru.so?subject=Feature%20Request:%20",
@@ -707,7 +717,7 @@ export class AppMenu {
             },
           },
           {
-            label: "Report Issue",
+            label: "Report Issue…",
             click: () => {
               selectedAccount.instance.gmail.createComposeWindow(
                 "mailto:tim@meru.so?subject=Report Issue:%20",
@@ -727,6 +737,12 @@ export class AppMenu {
                 },
               },
               {
+                label: "View Logs",
+                click: () => {
+                  shell.openPath(log.transports.file.getFile().path);
+                },
+              },
+              {
                 type: "separator",
               },
               {
@@ -740,7 +756,10 @@ export class AppMenu {
                 },
               },
               {
-                label: "Reset App…",
+                type: "separator",
+              },
+              {
+                label: "Reset App",
                 click: async () => {
                   const { response } = await dialog.showMessageBox({
                     type: "warning",
@@ -760,15 +779,6 @@ export class AppMenu {
                   app.relaunch();
 
                   app.quit();
-                },
-              },
-              {
-                type: "separator",
-              },
-              {
-                label: "View Logs",
-                click: () => {
-                  shell.openPath(log.transports.file.getFile().path);
                 },
               },
             ],


### PR DESCRIPTION
The native OS menus measured against the guide's macOS menu bar canon. Title-style capitalization stays — the canon is explicit that macOS controls take it.

The ellipsis marked the wrong items in both directions. The guide reserves it for an action that needs more input before it completes, and navigation never takes one. Four items had one without asking for anything: Settings, Gmail Settings and Manage Accounts all call main.navigate on the window that's already open, and Reset App opens a confirmation, which isn't input. The canon does list Settings… with an ellipsis, but that's Apple's architecture showing through — on stock macOS, Settings opens its own window. The proof is one line up in the same menu: About Meru navigates to /settings/about exactly as Settings navigates to /settings/general, and the canon gives About no ellipsis. Only the separate window explains the difference, and Meru doesn't have one.

Three items were missing one. Ask Question, Request Feature and Report Issue each open a pre-addressed compose window, and none of them completes on click — no question is asked and no issue reported until you write the mail and send it.

Reset Zoom is Actual Size, the canon name for Command-0, as in Safari and Preview.

The Window menu had Minimize and Close. The canon is Minimize, Zoom, Bring All to Front. Zoom and front are built-in Electron roles, both macOS-only, so they are guarded with the platform helper the file already uses. Close was a duplicate of the File menu's role: "close", which is unconditional, so Command/Ctrl-W is unaffected — the canon puts Close in File. On Windows and Linux this leaves Minimize as the only Window item.

The Message menu sat between Edit and View. The canon order is AppName, File, Edit, Format, View, app-specific menus, Window, Help, so it moves after View, which is also where Apple Mail puts its own Message menu.

Reset App wasn't last. Destructive items go at the end, so Troubleshooting now reads Edit Config, View Logs, then Clear Cache, then Reset App, grouping the two inspection items and escalating through the two destructive ones.

One considered exception: the File menu's Compose. The canon wants a noun naming what gets created, but Compose is Gmail's own term and matching the product people are actually in beats matching the canon here. It also stays without an ellipsis, unlike the three Help items above: Compose names opening the composer, which the click completes, and it is this app's File > New Item, bare in the canon as Mail's New Message is. The Help items name an outcome the click doesn't reach.

context-menu.ts needed no change — no item sets an accelerator, so the rule about showing shortcuts in menu bar menus only already held, and the labels are correct title style.

Not verified by running the app — every change is a label, an ordering, or a built-in Electron role, checked by reading. `bun run types`, `bun run lint`, `bun run fmt:check`, and `bun test` pass.

Left for a decision rather than changed:

- The Help menu opens with What's New where the canon wants Meru Help first. Adding one needs a destination, and that's a product call.
- Compose is hidden when Gmail isn't visible, and the whole Message menu is hidden without a license, where the canon says disable rather than hide. Both change what's on screen for a class of users, and the second is a licensing decision.
- role: "services" in the App menu and role: "togglefullscreen" in View are both free and both canon, but each adds a surface rather than fixing text.
- Find is a single item where the canon wants a submenu. That is feature work, not copy.
