### PR TITLE
replace the window.confirm prompts with alert dialogs

### DIFF
--- a/packages/renderer/routes/settings/accounts.tsx
+++ b/packages/renderer/routes/settings/accounts.tsx
@@ -5,6 +5,17 @@ import { accountColorsMap } from "@meru/shared/accounts";
 import { ipc } from "@meru/shared/renderer/ipc";
 import type { AccountConfig } from "@meru/shared/schemas";
 import { type AccountConfigInput, accountConfigInputSchema } from "@meru/shared/schemas";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@meru/ui/components/alert-dialog";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import {
@@ -335,21 +346,34 @@ function SortableAccountItem({
       <ItemActions>
         <EditAccountButton account={account} />
         {removable && (
-          <Button
-            size="icon"
-            className="size-8 p-0"
-            variant="outline"
-            title="Remove account"
-            onClick={() => {
-              const confirmed = window.confirm(`Remove ${account.label}?`);
-
-              if (confirmed) {
-                ipc.main.send("accounts.removeAccount", account.id);
+          <AlertDialog>
+            <AlertDialogTrigger
+              render={
+                <Button size="icon" className="size-8 p-0" variant="outline" title="Remove account">
+                  <TrashIcon />
+                </Button>
               }
-            }}
-          >
-            <TrashIcon />
-          </Button>
+            />
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Remove {account.label}?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Meru signs out of this account and clears its data from this computer, including
+                  saved tabs and bookmarks. Your Gmail account isn't affected.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel />
+                <AlertDialogAction
+                  onClick={() => {
+                    ipc.main.send("accounts.removeAccount", account.id);
+                  }}
+                >
+                  Remove account
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         )}
       </ItemActions>
     </Item>

--- a/packages/renderer/routes/settings/gmail/label-colors.tsx
+++ b/packages/renderer/routes/settings/gmail/label-colors.tsx
@@ -5,17 +5,6 @@ import {
   type GmailLabelTextColor,
   gmailLabelColorInputSchema,
 } from "@meru/shared/schemas";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@meru/ui/components/alert-dialog";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import {
@@ -264,42 +253,21 @@ export function GmailLabelColors() {
                     });
                   }}
                 />
-                <AlertDialog>
-                  <AlertDialogTrigger
-                    render={
-                      <Button
-                        size="icon"
-                        className="size-8 p-0"
-                        variant="outline"
-                        title="Delete label color"
-                      >
-                        <TrashIcon />
-                      </Button>
-                    }
-                  />
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>Delete the color for {labelColor.label}?</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        The label goes back to its color in Gmail.
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel />
-                      <AlertDialogAction
-                        onClick={() => {
-                          configMutation.mutate({
-                            "gmail.labelColors": config["gmail.labelColors"].filter(
-                              (existingLabelColor) => existingLabelColor.id !== labelColor.id,
-                            ),
-                          });
-                        }}
-                      >
-                        Delete color
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
+                <Button
+                  size="icon"
+                  className="size-8 p-0"
+                  variant="outline"
+                  title="Delete label color"
+                  onClick={() => {
+                    configMutation.mutate({
+                      "gmail.labelColors": config["gmail.labelColors"].filter(
+                        (existingLabelColor) => existingLabelColor.id !== labelColor.id,
+                      ),
+                    });
+                  }}
+                >
+                  <TrashIcon />
+                </Button>
               </ItemActions>
             </Item>
           ))}

--- a/packages/renderer/routes/settings/gmail/label-colors.tsx
+++ b/packages/renderer/routes/settings/gmail/label-colors.tsx
@@ -5,6 +5,17 @@ import {
   type GmailLabelTextColor,
   gmailLabelColorInputSchema,
 } from "@meru/shared/schemas";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@meru/ui/components/alert-dialog";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import {
@@ -253,25 +264,42 @@ export function GmailLabelColors() {
                     });
                   }}
                 />
-                <Button
-                  size="icon"
-                  className="size-8 p-0"
-                  variant="outline"
-                  title="Delete label color"
-                  onClick={() => {
-                    const confirmed = window.confirm(`Delete the color for ${labelColor.label}?`);
-
-                    if (confirmed) {
-                      configMutation.mutate({
-                        "gmail.labelColors": config["gmail.labelColors"].filter(
-                          (existingLabelColor) => existingLabelColor.id !== labelColor.id,
-                        ),
-                      });
+                <AlertDialog>
+                  <AlertDialogTrigger
+                    render={
+                      <Button
+                        size="icon"
+                        className="size-8 p-0"
+                        variant="outline"
+                        title="Delete label color"
+                      >
+                        <TrashIcon />
+                      </Button>
                     }
-                  }}
-                >
-                  <TrashIcon />
-                </Button>
+                  />
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Delete the color for {labelColor.label}?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        The label goes back to its color in Gmail.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel />
+                      <AlertDialogAction
+                        onClick={() => {
+                          configMutation.mutate({
+                            "gmail.labelColors": config["gmail.labelColors"].filter(
+                              (existingLabelColor) => existingLabelColor.id !== labelColor.id,
+                            ),
+                          });
+                        }}
+                      >
+                        Delete color
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
               </ItemActions>
             </Item>
           ))}

--- a/packages/renderer/routes/settings/saved-searches.tsx
+++ b/packages/renderer/routes/settings/saved-searches.tsx
@@ -6,6 +6,17 @@ import {
   type GmailSavedSearchInput,
   gmailSavedSearchInputSchema,
 } from "@meru/shared/schemas";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@meru/ui/components/alert-dialog";
 import { Button } from "@meru/ui/components/button";
 import {
   Dialog,
@@ -226,21 +237,32 @@ function SortableSavedSearchItem({
       </ItemContent>
       <ItemActions>
         <EditSavedSearchButton savedSearch={savedSearch} onEdit={onEdit} />
-        <Button
-          size="icon"
-          className="size-8 p-0"
-          variant="outline"
-          title="Delete saved search"
-          onClick={() => {
-            const confirmed = window.confirm(`Delete ${savedSearch.label}?`);
-
-            if (confirmed) {
-              onDelete();
+        <AlertDialog>
+          <AlertDialogTrigger
+            render={
+              <Button
+                size="icon"
+                className="size-8 p-0"
+                variant="outline"
+                title="Delete saved search"
+              >
+                <TrashIcon />
+              </Button>
             }
-          }}
-        >
-          <TrashIcon />
-        </Button>
+          />
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete {savedSearch.label}?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This deletes the saved search, not the mail it finds.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel />
+              <AlertDialogAction onClick={onDelete}>Delete saved search</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </ItemActions>
     </Item>
   );

--- a/packages/ui/components/alert-dialog.tsx
+++ b/packages/ui/components/alert-dialog.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
+import type * as React from "react";
+import { cn } from "../lib/utils";
+import { Button } from "./button";
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />;
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
+}
+
+function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({ className, ...props }: AlertDialogPrimitive.Popup.Props) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className,
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({ className, ...props }: AlertDialogPrimitive.Title.Props) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("cn-font-heading text-base leading-none font-medium", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({ className, ...props }: AlertDialogPrimitive.Description.Props) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogAction({ children, ...props }: React.ComponentProps<typeof Button>) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-action"
+      render={<Button {...props}>{children}</Button>}
+    />
+  );
+}
+
+function AlertDialogCancel({
+  children = "Cancel",
+  variant = "outline",
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      render={
+        <Button variant={variant} {...props}>
+          {children}
+        </Button>
+      }
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};


### PR DESCRIPTION
Three destructive actions in settings confirmed through window.confirm: removing an account, deleting a saved search, and deleting a label color. That gives OK and Cancel, and OK only acknowledges information — it never confirms an action — so the button never named what pressing it would do. It also drops out of the app's own visual language into a Chromium dialog. All three now use an alert dialog.

packages/ui had no alert dialog, so this adds one. It is Base UI's AlertDialog primitive, the same library dialog.tsx already builds on, and it mirrors that file part for part: the same backdrop, popup, header, footer, title, and description styling, minus the corner close button, which an alert dialog shouldn't offer. AlertDialogCancel and AlertDialogAction are the two conveniences on top, rendering the project's Button through Base UI's Close part so either choice dismisses.

Each dialog puts the message in the title and reserves the body for what the title doesn't say. Removing an account asks Remove Work?, and the body says Meru signs out of the account and clears its data from this computer, including saved tabs and bookmarks, and that the Gmail account isn't affected — removeAccount really does clear the session and drop the account's stored tabs and bookmarks, and Remove reads as if it could reach into Gmail. Deleting a saved search asks Delete Friends? and the body says this deletes the saved search, not the mail it finds, since the item is named after a mail query. Deleting a label color asks Delete the color for Friends? and the body says the label goes back to its color in Gmail. The buttons are Remove account, Delete saved search, and Delete color; Cancel is on all three and is never the emphasized one.

None of the confirm buttons is styled destructive. That styling is for dangerous choices a person didn't initiate; all three of these start with a deliberate press of a trash button, and the button label already names what goes.

The label color confirmation is dropped rather than converted. A confirmation is for unexpected, irreversible loss, and deleting a label color loses only a name, a hex value, and a text color choice — all recreated by adding it again, with the label reverting to its Gmail color in the meantime. Its trash button now deletes straight away; removing an account and deleting a saved search keep their dialogs.

Not verified by running the app. `bun run types`, `bun run lint`, `bun run fmt:check`, and `bun test` pass.

