### PR TITLE
give the renderer errors a surface and a next step

### DIFF
--- a/packages/renderer/lib/stores.ts
+++ b/packages/renderer/lib/stores.ts
@@ -26,8 +26,8 @@ ipc.renderer.on("accounts.openAddAccountDialog", async (_event) => {
   const config = await getConfig();
 
   if (!config.licenseKey && !useTrialStore.getState().daysLeft) {
-    toast.error("Meru Pro required", {
-      description: "Upgrade to Meru Pro to add more accounts.",
+    toast.error("Meru Pro is required to add more accounts.", {
+      description: "Upgrade to Meru Pro to continue.",
     });
 
     return;

--- a/packages/renderer/lib/toast.ts
+++ b/packages/renderer/lib/toast.ts
@@ -6,7 +6,7 @@ export function restartRequiredToast() {
     id: "restart-required",
     duration: Number.POSITIVE_INFINITY,
     action: {
-      label: "Restart Now",
+      label: "Restart",
       onClick: () => {
         ipc.main.send("app.relaunch");
       },

--- a/packages/renderer/routes/settings/about.tsx
+++ b/packages/renderer/routes/settings/about.tsx
@@ -64,11 +64,6 @@ function DiagnosticInfo() {
 function ExportLogsField() {
   const exportLogsMutation = useMutation({
     mutationFn: () => ipc.main.invoke("about.exportLogs"),
-    onSuccess: ({ canceled }) => {
-      if (!canceled) {
-        toast("Logs exported");
-      }
-    },
     onError: () => {
       toast.error("Couldn't export the logs.");
     },

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -120,8 +120,42 @@ function OnePasswordSetupDialog({
               ipc.main.send("app.relaunch");
             }}
           >
-            Restart now
+            Restart
           </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+type ExtensionError = {
+  title: string;
+  description: string;
+};
+
+function ExtensionErrorDialog({
+  error,
+  onDismiss,
+}: {
+  error: ExtensionError | null;
+  onDismiss: () => void;
+}) {
+  return (
+    <Dialog
+      open={Boolean(error)}
+      onOpenChange={(open) => {
+        if (!open) {
+          onDismiss();
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{error?.title}</DialogTitle>
+        </DialogHeader>
+        <DialogDescription className="whitespace-pre-line">{error?.description}</DialogDescription>
+        <DialogFooter>
+          <DialogClose render={<Button>OK</Button>} />
         </DialogFooter>
       </DialogContent>
     </Dialog>
@@ -143,6 +177,8 @@ function ExtensionItem({
 
   const [isSetupDialogOpen, setIsSetupDialogOpen] = useState(false);
 
+  const [extensionError, setExtensionError] = useState<ExtensionError | null>(null);
+
   const extensionMutation = useMutation({
     mutationFn: (install: boolean) =>
       install
@@ -150,7 +186,12 @@ function ExtensionItem({
         : ipc.main.invoke("extensions.uninstall", extension.id),
     onSuccess: ({ error }, install) => {
       if (error) {
-        toast.error(error);
+        setExtensionError({
+          title: install
+            ? `Couldn't install ${extension.name}`
+            : `Couldn't uninstall ${extension.name}`,
+          description: error,
+        });
 
         return;
       }
@@ -217,6 +258,12 @@ function ExtensionItem({
       {isOnePassword && (
         <OnePasswordSetupDialog open={isSetupDialogOpen} onOpenChange={setIsSetupDialogOpen} />
       )}
+      <ExtensionErrorDialog
+        error={extensionError}
+        onDismiss={() => {
+          setExtensionError(null);
+        }}
+      />
     </>
   );
 }
@@ -226,7 +273,7 @@ function PasskeysAlert() {
     return (
       <Alert>
         <KeyRoundIcon />
-        <AlertTitle>Meru can sign you in with a Touch ID passkey</AlertTitle>
+        <AlertTitle>Passkeys work with Touch ID</AlertTitle>
         <AlertDescription>
           Add a passkey to your Google account from its security settings inside Meru and sign in
           with Touch ID — lighter than running an extension. iCloud passkeys don't work here, and
@@ -240,7 +287,7 @@ function PasskeysAlert() {
     return (
       <Alert>
         <KeyRoundIcon />
-        <AlertTitle>Meru can sign you in with your Windows passkeys</AlertTitle>
+        <AlertTitle>Passkeys work with Windows Hello</AlertTitle>
         <AlertDescription>
           Google sign-in uses Windows' own passkey dialog, so Windows Hello and synced passkeys work
           with no extension. Filling passwords still needs a password manager.
@@ -252,7 +299,7 @@ function PasskeysAlert() {
   return (
     <Alert>
       <KeyRoundIcon />
-      <AlertTitle>Passkeys need a password manager on Linux</AlertTitle>
+      <AlertTitle>Passkeys need a password manager</AlertTitle>
       <AlertDescription>
         Linux has no system passkey support, so a password manager extension is the only way to sign
         in to Google with a passkey in Meru.
@@ -262,16 +309,20 @@ function PasskeysAlert() {
 }
 
 function UpdateExtensionsButton() {
+  const [extensionError, setExtensionError] = useState<ExtensionError | null>(null);
+
   const updateExtensionsMutation = useMutation({
     mutationFn: () => ipc.main.invoke("extensions.update"),
     onSuccess: ({ error, results }) => {
       if (error) {
-        toast.error(error);
+        setExtensionError({ title: "Couldn't update extensions", description: error });
 
         return;
       }
 
       let updatedAny = false;
+
+      const failedUpdates: { name: string; reason: string }[] = [];
 
       for (const result of results ?? []) {
         const name = curatedExtensions.find(({ id }) => id === result.id)?.name ?? result.id;
@@ -290,11 +341,25 @@ function UpdateExtensionsButton() {
             break;
           }
           case "failed": {
-            toast.error(`Couldn't update ${name}: ${result.error}`);
+            failedUpdates.push({ name, reason: result.error });
 
             break;
           }
         }
+      }
+
+      const [firstFailedUpdate] = failedUpdates;
+
+      if (firstFailedUpdate) {
+        setExtensionError({
+          title:
+            failedUpdates.length === 1
+              ? `Couldn't update ${firstFailedUpdate.name}`
+              : `Couldn't update ${failedUpdates.length} extensions`,
+          description: `${failedUpdates
+            .map(({ name, reason }) => `${name}: ${reason}`)
+            .join("\n")}\n\nTry updating again.`,
+        });
       }
 
       if (updatedAny) {
@@ -308,16 +373,24 @@ function UpdateExtensionsButton() {
   });
 
   return (
-    <Button
-      variant="outline"
-      disabled={updateExtensionsMutation.isPending}
-      onClick={() => {
-        updateExtensionsMutation.mutate();
-      }}
-    >
-      {updateExtensionsMutation.isPending && <Spinner />}
-      Update extensions
-    </Button>
+    <>
+      <Button
+        variant="outline"
+        disabled={updateExtensionsMutation.isPending}
+        onClick={() => {
+          updateExtensionsMutation.mutate();
+        }}
+      >
+        {updateExtensionsMutation.isPending && <Spinner />}
+        Update extensions
+      </Button>
+      <ExtensionErrorDialog
+        error={extensionError}
+        onDismiss={() => {
+          setExtensionError(null);
+        }}
+      />
+    </>
   );
 }
 

--- a/packages/renderer/routes/settings/license.tsx
+++ b/packages/renderer/routes/settings/license.tsx
@@ -15,7 +15,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@meru/ui/components/dropdown-menu";
-import { Field, FieldError, FieldGroup, FieldLabel } from "@meru/ui/components/field";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@meru/ui/components/field";
 import { Input } from "@meru/ui/components/input";
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@meru/ui/components/input-group";
 import { Spinner } from "@meru/ui/components/spinner";
@@ -23,7 +29,6 @@ import { useForm, useForm as useTanStackForm } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
 import { MoreHorizontalIcon } from "lucide-react";
 import { type ComponentProps, type ReactNode, useState } from "react";
-import { toast } from "sonner";
 import { z } from "zod";
 import { SettingsHeader, SettingsTitle } from "@/components/settings";
 import { useConfig } from "@/lib/react-query";
@@ -164,8 +169,6 @@ export function LicenseSettings() {
       await refetchDeviceInfo();
 
       formApi.reset();
-
-      toast("Device label updated");
     },
   });
 
@@ -185,9 +188,9 @@ export function LicenseSettings() {
             <FieldGroup>
               <Field>
                 <FieldLabel>License key</FieldLabel>
+                <FieldDescription>Select the field to show the key.</FieldDescription>
                 <div className="flex gap-2">
                   <Input
-                    placeholder="Click to reveal the license key"
                     value={isLicenseKeyRevealed ? config.licenseKey : ""}
                     onFocus={() => {
                       setIsLicenseKeyRevealed(true);
@@ -210,8 +213,6 @@ export function LicenseSettings() {
                         onClick={() => {
                           if (config.licenseKey) {
                             navigator.clipboard.writeText(config.licenseKey);
-
-                            toast("License key copied to clipboard");
                           }
                         }}
                       >

--- a/packages/renderer/routes/settings/version-history.tsx
+++ b/packages/renderer/routes/settings/version-history.tsx
@@ -1,7 +1,13 @@
 import { ipc } from "@meru/shared/renderer/ipc";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
-import { Empty, EmptyContent, EmptyHeader, EmptyTitle } from "@meru/ui/components/empty";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@meru/ui/components/empty";
 import { Item, ItemContent, ItemDescription, ItemTitle } from "@meru/ui/components/item";
 import { Kbd } from "@meru/ui/components/kbd";
 import { Skeleton } from "@meru/ui/components/skeleton";
@@ -60,6 +66,9 @@ export function VersionHistorySettings() {
         <Empty>
           <EmptyHeader>
             <EmptyTitle>Couldn't load what's new</EmptyTitle>
+            <EmptyDescription>
+              The release notes come from GitHub. Check your connection, then try again.
+            </EmptyDescription>
           </EmptyHeader>
           <EmptyContent>
             <Button


### PR DESCRIPTION
Meru's renderer sent several errors through toasts, which is the one surface an error shouldn't use: a toast passes, carries no decision, and can stack when more than one thing fails at once. The extensions settings page had three such call sites, and the update loop could raise one error toast per failed extension. All three now open a dialog on the page instead. The dialog's title says what happened in context, Couldn't install 1Password or Couldn't update extensions, and the body carries the reason the main process reported, which for the licensing cases already ends in the next step. Failed updates collect into a single dialog listing each extension and its reason, followed by Try updating again. Successful and up-to-date results stay as toasts, which is what a toast is for.

The Pro gate on adding an account stays a toast. It fires from a menu item rather than a page, so there is no renderer-owned region reliably on screen to put a dialog in, and child WebContentsViews paint over anything drawn elsewhere. Its wording was brought in line with the rest, from the bare verdict Meru Pro required to Meru Pro is required to add more accounts. with Upgrade to Meru Pro to continue. beneath. Gating the menu item itself is the real fix and is left for later.

Three success toasts came out. Logs exported, Device label updated, and License key copied to clipboard all confirm things nobody doubts: the log file lands where the reader chose it in the save dialog, the Save button re-disables when the label is saved, and a paste verifies a copy. The export's failure toast stays, because that one is a real failure.

On the license page, the read-only key input used Click to reveal the license key as its placeholder. A placeholder shows format or scope, never an instruction, and it disappeared at the moment it worked. The sentence moves to a field description that names the outcome rather than the input device, and it stays visible. Making the reveal an explicit control would be better still, but it changes behavior.

The passkey alerts said three different things three ways: Meru can sign you in with a Touch ID passkey, Meru can sign you in with your Windows passkeys, and Passkeys need a password manager on Linux. They now read as one set, Passkeys work with Touch ID, Passkeys work with Windows Hello, and Passkeys need a password manager, with the platform detail left to the bodies that already carried it. The 1Password setup steps were checked against the guide and against 1Password's own support page and needed no change.

The what's-new error state said only Couldn't load what's new. It now adds the reason and the fix, that the release notes come from GitHub and to check the connection before trying again, without claiming a failure mode the query can't distinguish. The restart toast's action label changes from Restart Now to Restart, and the 1Password dialog's Restart now with it, so all the restart prompts match the main process.

Not verified by running the app. `bun run types`, `bun run lint`, `bun run fmt:check`, and `bun test` pass.
