### PR TITLE
settle on upgrade for Meru Pro and drop the dead select placeholders

### DIFF
--- a/packages/renderer/components/config-select-field.tsx
+++ b/packages/renderer/components/config-select-field.tsx
@@ -28,7 +28,6 @@ export function ConfigSelectField({
   label,
   description,
   items,
-  placeholder,
   licenseKeyRequired,
   disabled,
   restartRequired,
@@ -38,7 +37,6 @@ export function ConfigSelectField({
   label: string;
   description: ReactNode;
   items: { value: string; label: string }[];
-  placeholder: string;
   licenseKeyRequired?: boolean;
   disabled?: boolean;
   restartRequired?: boolean;
@@ -114,7 +112,7 @@ export function ConfigSelectField({
         disabled={isDisabled}
       >
         <SelectTrigger>
-          <SelectValue placeholder={placeholder} />
+          <SelectValue />
         </SelectTrigger>
         <SelectContent>
           {items.map(({ value, label }) => (

--- a/packages/renderer/components/license-key-required-banner.tsx
+++ b/packages/renderer/components/license-key-required-banner.tsx
@@ -23,7 +23,7 @@ export function LicenseKeyRequiredBanner({ children, ...props }: ComponentProps<
           rel="noreferrer"
           className={buttonVariants({ size: "sm" })}
         >
-          Purchase
+          Upgrade
         </a>
       </ItemActions>
     </Item>

--- a/packages/renderer/routes/settings/appearance.tsx
+++ b/packages/renderer/routes/settings/appearance.tsx
@@ -110,7 +110,6 @@ export function AppearanceSettings() {
           label="Color"
           description="Choose the color of the system tray icon."
           items={systemTrayIconColorItems}
-          placeholder="Select color"
           restartRequired
         />
         {selectAccountWithUnreadField}
@@ -146,7 +145,7 @@ export function AppearanceSettings() {
                 }}
               >
                 <SelectTrigger>
-                  <SelectValue placeholder="Select theme" />
+                  <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
                   {themeItems.map(({ value, label }) => (

--- a/packages/renderer/routes/settings/gmail/index.tsx
+++ b/packages/renderer/routes/settings/gmail/index.tsx
@@ -148,7 +148,6 @@ export function GmailSettings() {
               label="Unread count preference"
               description="With multiple inboxes, choose which sections count toward the unread count shown in the app. The default combines every section."
               items={unreadCountPreferenceItems}
-              placeholder="Select preference"
               licenseKeyRequired
               restartRequired
             />
@@ -157,7 +156,6 @@ export function GmailSettings() {
               label="Categories to monitor"
               description="With a categorized inbox, choose which categories are watched for new email notifications and included in the unified inbox."
               items={inboxCategoriesToMonitorItems}
-              placeholder="Select categories"
               licenseKeyRequired
               restartRequired
             />

--- a/packages/renderer/routes/settings/languages.tsx
+++ b/packages/renderer/routes/settings/languages.tsx
@@ -1,5 +1,4 @@
 import { ipc } from "@meru/shared/renderer/ipc";
-import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import {
   DropdownMenu,
@@ -13,6 +12,7 @@ import { cn } from "@meru/ui/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { ChevronDownIcon } from "lucide-react";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
+import { LicenseKeyRequiredFieldBadge } from "@/components/license-key-required-field-badge";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useConfig, useConfigMutation } from "@/lib/react-query";
@@ -82,7 +82,7 @@ export function LanguagesSettings() {
           <FieldSet>
             <FieldLabel className="flex items-center gap-2">
               Spellchecker
-              {!isLicenseKeyValid && <Badge variant="secondary">Meru Pro required</Badge>}
+              <LicenseKeyRequiredFieldBadge />
             </FieldLabel>
             <FieldDescription>
               Select additional languages for spellchecking alongside the system language.

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -1,7 +1,6 @@
 import { ipc } from "@meru/shared/renderer/ipc";
 import { minutesToTime, timeToMinutes } from "@meru/shared/time";
 import type { NotificationTime } from "@meru/shared/types";
-import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import {
   Field,
@@ -29,6 +28,7 @@ import { toast } from "sonner";
 import { ConfigSelectField } from "@/components/config-select-field";
 import { ConfigSwitchField } from "@/components/config-switch-field";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
+import { LicenseKeyRequiredFieldBadge } from "@/components/license-key-required-field-badge";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { NOTIFICATION_SOUNDS, playNotificationSound } from "@/lib/notifications";
@@ -170,7 +170,7 @@ export function NotificationsSettings() {
                   <Field>
                     <FieldLabel className="flex items-center gap-2">
                       Notification times
-                      {!isLicenseKeyValid && <Badge variant="secondary">Meru Pro required</Badge>}
+                      <LicenseKeyRequiredFieldBadge />
                     </FieldLabel>
                     <FieldDescription>
                       Set the time windows when notifications are active. Outside them,
@@ -276,7 +276,6 @@ export function NotificationsSettings() {
                   label="On click"
                   description="Choose what happens when clicking the download notification."
                   configKey="notifications.onClickDownloadCompleted"
-                  placeholder="Select action"
                   items={[
                     { value: "showInFolder", label: "Show in folder" },
                     { value: "openFile", label: "Open file" },
@@ -311,7 +310,7 @@ export function NotificationsSettings() {
                   <Field>
                     <FieldLabel className="flex items-center gap-2">
                       Sound
-                      {!isLicenseKeyValid && <Badge variant="secondary">Meru Pro required</Badge>}
+                      <LicenseKeyRequiredFieldBadge />
                     </FieldLabel>
                     <FieldDescription>Select the sound to play for notifications.</FieldDescription>
                     <Select
@@ -337,7 +336,7 @@ export function NotificationsSettings() {
                       disabled={!isLicenseKeyValid}
                     >
                       <SelectTrigger>
-                        <SelectValue placeholder="Select sound" />
+                        <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
                         {Object.entries(NOTIFICATION_SOUNDS).map(([sound, { label }]) => (

--- a/packages/renderer/routes/settings/updates.tsx
+++ b/packages/renderer/routes/settings/updates.tsx
@@ -32,7 +32,6 @@ export function UpdatesSettings() {
             description="Choose which releases to receive. The beta channel gets upcoming features early."
             configKey="updates.channel"
             items={releaseChannelItems}
-            placeholder="Select channel"
             confirmation={{
               when: (value) => value === "beta",
               title: "Switch to the beta channel?",

--- a/packages/renderer/routes/settings/verification-codes.tsx
+++ b/packages/renderer/routes/settings/verification-codes.tsx
@@ -36,7 +36,6 @@ export function VerificationCodesSettings() {
             label="Detection confidence"
             description="Choose how certain Meru has to be before it treats something as a verification code. Medium can pick up codes that aren't there. High looks for explicit keywords and can miss some."
             items={verificationCodeConfidenceItems}
-            placeholder="Select confidence"
             licenseKeyRequired
           />
           <ConfigSwitchField

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -157,7 +157,6 @@ export function WorkspaceAppsSettings() {
                   </>
                 }
                 configKey="workspaceApps.mode"
-                placeholder="Select mode"
                 licenseKeyRequired
                 items={Object.entries(workspaceAppsModes).map(([value, label]) => ({
                   value,
@@ -183,7 +182,7 @@ export function WorkspaceAppsSettings() {
                 <FieldContent>
                   <FieldLabel className="flex items-center gap-2">
                     Excluded apps
-                    {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
+                    <LicenseKeyRequiredFieldBadge />
                   </FieldLabel>
                   <FieldDescription>
                     Select the Workspace apps that open in the external browser instead of the app.
@@ -240,7 +239,6 @@ export function WorkspaceAppsSettings() {
                   label="Width"
                   description="How wide the vertical tabs sidebar is. Auto switches between narrow and wide based on the open tabs. The button at the bottom of the sidebar switches between narrow and wide for that account until Meru quits, leaving this setting as it is. Right-click the sidebar and choose Reset Width to hand it back."
                   configKey="verticalTabs.width"
-                  placeholder="Select width"
                   licenseKeyRequired
                   items={Object.entries(verticalTabsWidths).map(([value, label]) => ({
                     value,
@@ -296,7 +294,6 @@ export function WorkspaceAppsSettings() {
             label="Hibernate idle tabs"
             description="Unload tabs that have been sitting unused, giving back the memory they hold. A hibernated tab keeps its place in the sidebar and loads again when you click it, on the page you left. Selected tabs only hibernates the tabs you mark with Hibernate When Idle in the tab's context menu."
             configKey="workspaceApps.hibernation"
-            placeholder="Select which tabs"
             licenseKeyRequired
             items={Object.entries(workspaceAppsHibernations).map(([value, label]) => ({
               value,
@@ -307,7 +304,6 @@ export function WorkspaceAppsSettings() {
             label="Hibernate after"
             description="How long a tab has to go unused before it hibernates. The active tab, tabs in their own window, and tabs playing audio are left alone."
             configKey="workspaceApps.hibernationTimeout"
-            placeholder="Select timeout"
             licenseKeyRequired
             items={Object.entries(workspaceAppsHibernationTimeouts).map(([value, label]) => ({
               value,
@@ -321,7 +317,7 @@ export function WorkspaceAppsSettings() {
               <FieldContent>
                 <FieldLabel className="flex items-center gap-2">
                   Launcher apps
-                  {!isLicenseKeyValid && <LicenseKeyRequiredFieldBadge />}
+                  <LicenseKeyRequiredFieldBadge />
                 </FieldLabel>
                 <FieldDescription>
                   Add Workspace apps to the launcher on the right of the titlebar.
@@ -397,7 +393,6 @@ export function WorkspaceAppsSettings() {
               label="Launcher display"
               description="How launcher apps are shown in the titlebar. Auto expands up to three apps into individual buttons and collapses beyond that. Collapsed always keeps them behind a single button, and Expanded always shows them as individual buttons."
               configKey="workspaceApps.launcherDisplay"
-              placeholder="Select display"
               licenseKeyRequired
               items={Object.entries(workspaceAppsLauncherDisplays).map(([value, label]) => ({
                 value,
@@ -409,7 +404,6 @@ export function WorkspaceAppsSettings() {
                 label="Placement"
                 description="Where the launcher and the bookmarks button sit. Auto moves them to the bottom of the vertical tabs sidebar while it is shown. Sidebar keeps them there and holds the sidebar open even with a single tab, and Titlebar keeps them in the titlebar at all times."
                 configKey="workspaceApps.launcherAndBookmarksPlacement"
-                placeholder="Select placement"
                 licenseKeyRequired
                 items={Object.entries(launcherAndBookmarksPlacements).map(([value, label]) => ({
                   value,


### PR DESCRIPTION
Meru asked people to upgrade and to purchase in the same breath. The Pro banner's title says Upgrade to Meru Pro to unlock all options while its button said Purchase, so one component used two words for one action, and the native trial dialog, the Pro upgrade dialog, the accounts toast, and the titlebar trial badge all say upgrade. The button now says Upgrade. It is a link to the pricing page on the website, the same destination the titlebar badge opens, and the banner title already carries "to Meru Pro" in all three of its wordings, so the button says the action and nothing more. Purchase also promised a transaction the button does not perform.

The Meru Pro required badge was written out four times. LicenseKeyRequiredFieldBadge renders it, and notifications.tsx hand-rolled the same markup twice while languages.tsx did it once, each behind a !isLicenseKeyValid guard. The component reads the license state itself and renders nothing when the license is valid, so the guard was a duplicate of what the component already does and the rendered output is unchanged. The three copies are now the component, and the same redundant guard came off the two existing call sites in workspace-apps.tsx. The next wording change lands in one place.

Every ConfigSelectField was passed a placeholder — Select action, Select theme, Select which tabs, Select confidence — that can never appear. SelectValue shows its placeholder only when there is no value, and each of these fields is backed by a config key that is a required string union in Config with a non-empty default in the store, so a value is always present. ConfigSelectField throws before rendering if a key ever resolves to something that is not a string. The twelve call-site props are gone along with the prop on the component, as are the two placeholders on the Selects that bind config.theme and notifications.sound directly, on the same evidence. The input placeholders elsewhere in settings are real and untouched.

Not verified by running the app — the change is copy and dead-prop removal only. `bun run types`, `bun run lint`, `bun run fmt:check`, and `bun test` pass.
