### PR TITLE
ship the Window menu on macOS only and disable rather than hide

### DIFF
--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -107,19 +107,40 @@ export class AppMenu {
       },
     ];
 
+    const minimizeItem: MenuItemConstructorOptions = {
+      label: "Minimize",
+      accelerator: "CommandOrControl+M",
+      role: "minimize",
+    };
+
     // Zoom and Bring All to Front are macOS-only roles, and the Window menu
-    // itself is a macOS convention.
-    const macOSWindowArrangementItems: MenuItemConstructorOptions[] = [
+    // itself is a macOS convention, so the whole menu ships on macOS alone.
+    const macOSWindowMenuItems: MenuItemConstructorOptions[] = [
       {
-        role: "zoom",
-      },
-      {
-        type: "separator",
-      },
-      {
-        role: "front",
+        label: "Window",
+        role: "window",
+        submenu: [
+          minimizeItem,
+          {
+            role: "zoom",
+          },
+          {
+            type: "separator",
+          },
+          {
+            role: "front",
+          },
+        ],
       },
     ];
+
+    // Windows and Linux minimize from the titlebar window controls, and nothing
+    // else binds Ctrl+M there, so the File menu carries Minimize as a shortcut
+    // with no visible entry.
+    const nonMacOSMinimizeItem: MenuItemConstructorOptions = {
+      ...minimizeItem,
+      visible: false,
+    };
 
     const focusedWindow = BrowserWindow.getFocusedWindow();
 
@@ -238,8 +259,15 @@ export class AppMenu {
     const userEmail = selectedAccount.instance.gmail.userEmail;
     const messageId = selectedAccount.instance.gmail.messageId;
 
+    // The Message menu carries the license check, but a disabled parent leaves
+    // its children live — their accelerators still fire on Windows and Linux —
+    // so the license gates the link itself as well.
     const copyOrShareMessageLink =
-      isGmailVisible && userEmail && messageId && createMeruMessageUrl(userEmail, messageId);
+      licenseKey.isValid &&
+      isGmailVisible &&
+      userEmail &&
+      messageId &&
+      createMeruMessageUrl(userEmail, messageId);
 
     const isFindInPageEnabled =
       Boolean(focusedWindow && WorkspaceApp.tryFromWebContents(focusedWindow.webContents)) ||
@@ -304,7 +332,7 @@ export class AppMenu {
         submenu: [
           {
             label: "Compose",
-            visible: isGmailVisible,
+            enabled: isGmailVisible,
             click: () => {
               ipc.renderer.send(
                 selectedAccount.instance.gmail.view.webContents,
@@ -317,11 +345,11 @@ export class AppMenu {
           },
           {
             type: "separator",
-            visible: isGmailVisible,
           },
           {
             role: "close",
           },
+          ...(platform.isMacOS ? [] : [nonMacOSMinimizeItem]),
         ],
       },
       {
@@ -488,7 +516,7 @@ export class AppMenu {
       },
       {
         label: "Message",
-        visible: licenseKey.isValid,
+        enabled: licenseKey.isValid,
         submenu: [
           {
             label: "Copy Message Link",
@@ -653,18 +681,7 @@ export class AppMenu {
           },
         ],
       },
-      {
-        label: "Window",
-        role: "window",
-        submenu: [
-          {
-            label: "Minimize",
-            accelerator: "CommandOrControl+M",
-            role: "minimize",
-          },
-          ...(platform.isMacOS ? macOSWindowArrangementItems : []),
-        ],
-      },
+      ...(platform.isMacOS ? macOSWindowMenuItems : []),
       {
         label: "Help",
         role: "help",


### PR DESCRIPTION
The two deviations #917 left for a decision, now decided. This is behavior rather than copy, which is why it was split out.

The Window menu is a macOS convention, and the canon shape #917 gave it left Windows and Linux with Minimize as its only item. It ships on macOS alone now, guarded the way the App menu's Hide items already are, keeping Minimize, Zoom and Bring All to Front. Zoom and front were guarded individually before; the guard moves up a level and their const becomes the whole menu.

Dropping the menu takes Ctrl+M with it, and nothing else binds it — no globalShortcut, no before-input-event handler, and neither Windows nor the common Linux window managers minimize on Ctrl+M of their own accord. Both platforms minimize by clicking the titlebar control, so the button isn't the loss, but the shortcut would be a regression rather than a decision. The File menu carries the item there instead, invisible, purely as the keybinding, next to role: "close" — the other window command the canon puts in File. Electron documents that accelerators always work when items are hidden on Windows and Linux, which is what makes that work.

Compose and the Message menu disable instead of hiding, as the canon asks: an app menu shows every command it has so people can learn what the app can do. Compose's separator carried the same visible: isGmailVisible so the File menu wouldn't open with a stray rule above Close. With Compose always present the separator always earns its place, so the condition goes. The Message menu greying out rather than vanishing for people without Meru Pro is the intended consequence.

Disabling a parent doesn't disable its children. On Windows and Linux the accelerator table is generated by recursing through every submenu without consulting the parent, and dispatch checks only the leaf item's enabled state, so Command/Ctrl-Shift-C would still have copied a message link with no license. The license check therefore moves to the front of copyOrShareMessageLink, which leaves both items in the menu inert without one — Copy Message Link is already enabled off that value, and Share falls back to its disabled placeholder. That covers the macOS side of the same question too: Electron has a long-standing limitation where a top-level menu bar item's enabled state may not reach the rendered title, so the worst case there is a menu that opens with everything inside greyed out, which is still disabled rather than hidden.

Not verified by running the app. The two behaviors this turns on — whether a hidden item keeps its accelerator on Windows and Linux, and whether disabling a menu reaches its children — were checked against Electron 43's source and documentation rather than in the app, and the greying of the Message menu title on macOS is the one point that source leaves open. `bun run types`, `bun run lint`, `bun run fmt:check` and `bun test` pass.
