### PR TITLE
say plainly which tab loses an app's links and which one takes them

### DIFF
--- a/packages/app/dialogs.ts
+++ b/packages/app/dialogs.ts
@@ -29,7 +29,7 @@ export async function confirmAppLinksTabHandover(
     type: "info",
     buttons: ["Open links here", "Cancel"],
     message: `Open ${appLabel} links in this tab?`,
-    detail: `“${appLinksTabTitle}” opens all ${appLabel} links right now, and gives them up to this tab.`,
+    detail: `“${appLinksTabTitle}” currently opens all ${appLabel} links. This tab will open them instead.`,
     defaultId: 0,
     cancelId: 1,
   });


### PR DESCRIPTION
The app links handover dialog used a metaphor where it needed a fact. Its detail read "Q3 planning" opens all Calendar links right now, and gives them up to this tab — "gives them up" reads as though the other tab surrenders something of its own, and nothing in the sentence says what the reader ends up with.

It now states the before and the after and nothing else: "Q3 planning" currently opens all Calendar links. This tab will open them instead. That is what the code does. setTabOpensLinksForApp clears the designation on the previous tab and sets it on the new one, saves it, and leaves the old tab open with its page untouched, so the only thing that moves is where future links land — which is also why the second sentence is in the future tense.

The quotation marks around the tab title stay. The guide's rule against quoting a control's name is about fixed UI labels, and this is a live page title that could be any string, so it needs the marks to hold together inside the sentence. The sentence also no longer ends on the title, which keeps the period out of someone else's quotes.

The message and the buttons are unchanged. Open Calendar links in this tab? already carries the decision and the detail adds only what the title cannot know, and Open links here names the result while Cancel abandons — both already in the sentence case the HIG wants from alert buttons.

One thing found and left alone. The context menu item that opens this dialog says "in This Window" for a windowed tab while the dialog's message always says "this tab". Fixing it means passing the windowed-ness into confirmAppLinksTabHandover, which is a signature change rather than a wording one. It is also why the button keeps "here", which is true in both cases.

Not verified by running the app — the change is a single user-facing string, checked by reading. `bun run types`, `bun run lint`, `bun run fmt:check`, and `bun test` pass.
