### PR TITLE
reveal the license key with an explicit toggle

### DIFF
--- a/packages/renderer/routes/settings/license.tsx
+++ b/packages/renderer/routes/settings/license.tsx
@@ -15,19 +15,18 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@meru/ui/components/dropdown-menu";
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldGroup,
-  FieldLabel,
-} from "@meru/ui/components/field";
+import { Field, FieldError, FieldGroup, FieldLabel } from "@meru/ui/components/field";
 import { Input } from "@meru/ui/components/input";
-import { InputGroup, InputGroupAddon, InputGroupInput } from "@meru/ui/components/input-group";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@meru/ui/components/input-group";
 import { Spinner } from "@meru/ui/components/spinner";
 import { useForm, useForm as useTanStackForm } from "@tanstack/react-form";
 import { useQuery } from "@tanstack/react-query";
-import { MoreHorizontalIcon } from "lucide-react";
+import { EyeIcon, EyeOffIcon, MoreHorizontalIcon } from "lucide-react";
 import { type ComponentProps, type ReactNode, useState } from "react";
 import { z } from "zod";
 import { SettingsHeader, SettingsTitle } from "@/components/settings";
@@ -188,18 +187,25 @@ export function LicenseSettings() {
             <FieldGroup>
               <Field>
                 <FieldLabel>License key</FieldLabel>
-                <FieldDescription>Select the field to show the key.</FieldDescription>
                 <div className="flex gap-2">
-                  <Input
-                    value={isLicenseKeyRevealed ? config.licenseKey : ""}
-                    onFocus={() => {
-                      setIsLicenseKeyRevealed(true);
-                    }}
-                    onBlur={() => {
-                      setIsLicenseKeyRevealed(false);
-                    }}
-                    readOnly
-                  />
+                  <InputGroup>
+                    <InputGroupInput
+                      value={config.licenseKey}
+                      type={isLicenseKeyRevealed ? "text" : "password"}
+                      readOnly
+                    />
+                    <InputGroupAddon align="inline-end">
+                      <InputGroupButton
+                        size="icon-xs"
+                        title={isLicenseKeyRevealed ? "Hide license key" : "Show license key"}
+                        onClick={() => {
+                          setIsLicenseKeyRevealed((isRevealed) => !isRevealed);
+                        }}
+                      >
+                        {isLicenseKeyRevealed ? <EyeOffIcon /> : <EyeIcon />}
+                      </InputGroupButton>
+                    </InputGroupAddon>
+                  </InputGroup>
                   <DropdownMenu>
                     <DropdownMenuTrigger
                       render={


### PR DESCRIPTION
The license key field revealed itself on focus and hid itself on blur, which is an interaction nobody can discover without a sentence telling them about it — and that sentence had to name the input device to make sense. #920 moved it out of the placeholder into a field description as the smaller fix; this replaces the interaction itself with an eye button inside the field. Press it to show the key, press it again to hide it, and the tooltip flips between Show license key and Hide license key so the label always names where it leads.

The field is now an InputGroup with the button in an inline-end addon, matching the device label field on the same page. InputGroupButton already existed in packages/ui and had never been used in the renderer. Masking moved from blanking the value to a password-type input, so the masked state shows dots at the key's length rather than an empty box that reads as a field with nothing in it.

The description under the label is gone. It described the focus behavior, which no longer exists, and the button names its own action.

Revealing does not survive leaving the page. The state lives in the settings component and wouter unmounts it when you navigate away, so the key is masked again on the next visit. Within a visit it stays where you put it — blurring the input to select the key, copy it, or open the menu beside it should not snap it shut.

Copy and Change in the dropdown are unchanged.

Not verified by running the app. `bun run types`, `bun run lint`, `bun run fmt:check`, and `bun test` pass.
