### PR TITLE
style the confirm buttons in the destructive alert dialogs

### DIFF
--- a/packages/renderer/routes/settings/accounts.tsx
+++ b/packages/renderer/routes/settings/accounts.tsx
@@ -9,6 +9,7 @@ import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
+  AlertDialogClose,
   AlertDialogContent,
   AlertDialogDescription,
   AlertDialogFooter,
@@ -363,15 +364,15 @@ function SortableAccountItem({
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
-                <AlertDialogCancel />
-                <AlertDialogAction
-                  variant="destructive"
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogClose
+                  render={<AlertDialogAction variant="destructive" />}
                   onClick={() => {
                     ipc.main.send("accounts.removeAccount", account.id);
                   }}
                 >
                   Remove account
-                </AlertDialogAction>
+                </AlertDialogClose>
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>

--- a/packages/renderer/routes/settings/accounts.tsx
+++ b/packages/renderer/routes/settings/accounts.tsx
@@ -365,6 +365,7 @@ function SortableAccountItem({
               <AlertDialogFooter>
                 <AlertDialogCancel />
                 <AlertDialogAction
+                  variant="destructive"
                   onClick={() => {
                     ipc.main.send("accounts.removeAccount", account.id);
                   }}

--- a/packages/renderer/routes/settings/saved-searches.tsx
+++ b/packages/renderer/routes/settings/saved-searches.tsx
@@ -10,6 +10,7 @@ import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
+  AlertDialogClose,
   AlertDialogContent,
   AlertDialogDescription,
   AlertDialogFooter,
@@ -258,10 +259,13 @@ function SortableSavedSearchItem({
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel />
-              <AlertDialogAction variant="destructive" onClick={onDelete}>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogClose
+                render={<AlertDialogAction variant="destructive" />}
+                onClick={onDelete}
+              >
                 Delete saved search
-              </AlertDialogAction>
+              </AlertDialogClose>
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>

--- a/packages/renderer/routes/settings/saved-searches.tsx
+++ b/packages/renderer/routes/settings/saved-searches.tsx
@@ -259,7 +259,9 @@ function SortableSavedSearchItem({
             </AlertDialogHeader>
             <AlertDialogFooter>
               <AlertDialogCancel />
-              <AlertDialogAction onClick={onDelete}>Delete saved search</AlertDialogAction>
+              <AlertDialogAction variant="destructive" onClick={onDelete}>
+                Delete saved search
+              </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>

--- a/packages/ui/components/alert-dialog.tsx
+++ b/packages/ui/components/alert-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
-import type * as React from "react";
+import * as React from "react";
 import { cn } from "../lib/utils";
 import { Button } from "./button";
 
@@ -17,6 +17,10 @@ function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
   return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
 }
 
+function AlertDialogClose({ ...props }: AlertDialogPrimitive.Close.Props) {
+  return <AlertDialogPrimitive.Close data-slot="alert-dialog-close" {...props} />;
+}
+
 function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdrop.Props) {
   return (
     <AlertDialogPrimitive.Backdrop
@@ -30,14 +34,21 @@ function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdr
   );
 }
 
-function AlertDialogContent({ className, ...props }: AlertDialogPrimitive.Popup.Props) {
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Popup.Props & {
+  size?: "default" | "sm";
+}) {
   return (
     <AlertDialogPortal>
       <AlertDialogOverlay />
       <AlertDialogPrimitive.Popup
         data-slot="alert-dialog-content"
+        data-size={size}
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}
@@ -50,7 +61,10 @@ function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">)
   return (
     <div
       data-slot="alert-dialog-header"
-      className={cn("flex flex-col gap-2", className)}
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className,
+      )}
       {...props}
     />
   );
@@ -61,7 +75,7 @@ function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">)
     <div
       data-slot="alert-dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
         className,
       )}
       {...props}
@@ -69,48 +83,68 @@ function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">)
   );
 }
 
-function AlertDialogTitle({ className, ...props }: AlertDialogPrimitive.Title.Props) {
+function AlertDialogMedia({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-10 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
   return (
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
-      className={cn("cn-font-heading text-base leading-none font-medium", className)}
+      className={cn(
+        "cn-font-heading text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className,
+      )}
       {...props}
     />
   );
 }
 
-function AlertDialogDescription({ className, ...props }: AlertDialogPrimitive.Description.Props) {
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
-      className={cn("text-sm text-muted-foreground", className)}
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className,
+      )}
       {...props}
     />
   );
 }
 
-function AlertDialogAction({ children, ...props }: React.ComponentProps<typeof Button>) {
-  return (
-    <AlertDialogPrimitive.Close
-      data-slot="alert-dialog-action"
-      render={<Button {...props}>{children}</Button>}
-    />
-  );
+function AlertDialogAction({ className, ...props }: React.ComponentProps<typeof Button>) {
+  return <Button data-slot="alert-dialog-action" className={cn(className)} {...props} />;
 }
 
 function AlertDialogCancel({
-  children = "Cancel",
+  className,
   variant = "outline",
+  size = "default",
   ...props
-}: React.ComponentProps<typeof Button>) {
+}: AlertDialogPrimitive.Close.Props &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
   return (
     <AlertDialogPrimitive.Close
       data-slot="alert-dialog-cancel"
-      render={
-        <Button variant={variant} {...props}>
-          {children}
-        </Button>
-      }
+      className={cn(className)}
+      render={<Button variant={variant} size={size} />}
+      {...props}
     />
   );
 }
@@ -119,10 +153,12 @@ export {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
+  AlertDialogClose,
   AlertDialogContent,
   AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogHeader,
+  AlertDialogMedia,
   AlertDialogOverlay,
   AlertDialogPortal,
   AlertDialogTitle,


### PR DESCRIPTION
#919 needed an alert dialog, found none in `packages/ui`, and hand-wrote one by mirroring `dialog.tsx` part for part. This PR fixes the confirm buttons in the two dialogs that use it, then replaces the hand-written component with shadcn's own alert dialog for Base UI so we stop maintaining a local approximation of it.

#919 left the confirm buttons unstyled, reasoning that confirming an action a person deliberately chose isn't a dangerous choice and so doesn't get destructive styling. That reading was right about the semantics and wrong about the result. `AlertDialogAction` renders a `Button` with no variant, which resolves to `default`, so leaving it alone doesn't leave the button neutral — it makes it `bg-primary`, a solid filled button and the loudest control in the dialog. The rule that destructive styling is for choices a person didn't initiate sits next to the rule that the primary button in a view is the safe, expected action and never a destructive one, because people press prominent buttons without reading them. Following the first rule broke the second.

Meru's `destructive` variant is `bg-destructive/10 text-destructive`, a tinted low-emphasis treatment rather than a loud red fill. Switching to it lowers the button's visual pull while adding the semantic, so this reads as correcting a miscue rather than raising an alarm. Removing an account and deleting a saved search both get it, and the labels are unchanged: Remove account and Delete saved search already name what goes.

The variant is passed at the two call sites rather than defaulted in `AlertDialogAction`. An alert dialog's action is by convention the consequential choice, but consequential isn't the same as destructive, and a future alert that confirms something harmless should get the default button, not a red-tinted one. Both current callers are destructive, so the two dialogs look the same either way.

The component itself is now the upstream file from `ui.shadcn.com/docs/components/base/alert-dialog`, which in the shadcn repository is `apps/v4/registry/bases/base/ui/alert-dialog.tsx`. That registry entry names the same docs URL, and it imports `@base-ui/react/alert-dialog` rather than `@radix-ui/react-alert-dialog`, which is how the Base UI version is told apart from the Radix one under `apps/v4/registry/bases/radix/`. The only edits are local: the imports use relative paths, and `cn-font-heading` stays on the title because six other components here already carry it and the shadcn CLI keeps it as a marker class. No dependency changed — `@base-ui/react` was already here.

Upstream differs from the hand-written version in ways the call sites had to absorb. `AlertDialogCancel` has no default `children`, so both footers now pass `Cancel` explicitly; its `variant="outline"` default survives. `AlertDialogAction` renders a bare `Button` with no `Close` wrapper, so on its own it no longer dismisses the dialog. Both dialogs are uncontrolled, and both would have appeared to close anyway once the removed account or saved search unmounted the surrounding item, but that is an accident of rendering rather than a design. Both actions are now wrapped in `AlertDialogClose` so the dismissal is explicit and doesn't depend on what the click happens to unmount. `AlertDialogClose` is added alongside upstream's exports, mirroring the `DialogClose` that `dialog.tsx` already exports. Upstream's `AlertDialogMedia` and the `size` prop on `AlertDialogContent` come along unused.

On focus order, nothing needed changing. Base UI's dialog popup defaults `initialFocus` to the first tabbable element in the popup, upstream's footer still puts `AlertDialogCancel` ahead of the action in the DOM, and the header holds nothing tabbable, so Cancel takes focus on open and a stray Return abandons rather than removes. Cancel is still `variant="outline"`, so it holds the focus ring without being the emphasized default.

Worth knowing before this merges: the app now has two dialog styles. Upstream's alert dialog uses `bg-popover` where `dialog.tsx` uses `bg-background`. Those are the same color in light mode and different in dark, where `--popover` is `oklch(0.205 0 0)` against `--background` at `oklch(0.145 0 0)`, so a dark-mode alert dialog sits on a lighter surface than a regular dialog. Upstream also caps the popup at `max-w-xs` below the `sm` breakpoint and centers the header there, and drops the `leading-none` the local title had. Bringing `dialog.tsx` up to the same upstream generation would settle this, and belongs in its own change.

Not verified by running the app. `bun run types`, `bun run lint`, `bun run fmt:check`, and `bun test` pass.
