### PR TITLE
put the dialog on the same surface as the alert dialog

### DIFF
--- a/packages/renderer/routes/settings/accounts.tsx
+++ b/packages/renderer/routes/settings/accounts.tsx
@@ -9,6 +9,7 @@ import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
+  AlertDialogClose,
   AlertDialogContent,
   AlertDialogDescription,
   AlertDialogFooter,
@@ -363,15 +364,15 @@ function SortableAccountItem({
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
-                <AlertDialogCancel />
-                <AlertDialogAction
-                  variant="destructive"
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogClose
+                  render={<AlertDialogAction variant="destructive" />}
                   onClick={() => {
                     ipc.main.send("accounts.removeAccount", account.id);
                   }}
                 >
                   Remove account
-                </AlertDialogAction>
+                </AlertDialogClose>
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>

--- a/packages/renderer/routes/settings/accounts.tsx
+++ b/packages/renderer/routes/settings/accounts.tsx
@@ -365,6 +365,7 @@ function SortableAccountItem({
               <AlertDialogFooter>
                 <AlertDialogCancel />
                 <AlertDialogAction
+                  variant="destructive"
                   onClick={() => {
                     ipc.main.send("accounts.removeAccount", account.id);
                   }}

--- a/packages/renderer/routes/settings/saved-searches.tsx
+++ b/packages/renderer/routes/settings/saved-searches.tsx
@@ -10,6 +10,7 @@ import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
+  AlertDialogClose,
   AlertDialogContent,
   AlertDialogDescription,
   AlertDialogFooter,
@@ -258,10 +259,13 @@ function SortableSavedSearchItem({
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel />
-              <AlertDialogAction variant="destructive" onClick={onDelete}>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogClose
+                render={<AlertDialogAction variant="destructive" />}
+                onClick={onDelete}
+              >
                 Delete saved search
-              </AlertDialogAction>
+              </AlertDialogClose>
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>

--- a/packages/renderer/routes/settings/saved-searches.tsx
+++ b/packages/renderer/routes/settings/saved-searches.tsx
@@ -259,7 +259,9 @@ function SortableSavedSearchItem({
             </AlertDialogHeader>
             <AlertDialogFooter>
               <AlertDialogCancel />
-              <AlertDialogAction onClick={onDelete}>Delete saved search</AlertDialogAction>
+              <AlertDialogAction variant="destructive" onClick={onDelete}>
+                Delete saved search
+              </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>

--- a/packages/ui/components/alert-dialog.tsx
+++ b/packages/ui/components/alert-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
-import type * as React from "react";
+import * as React from "react";
 import { cn } from "../lib/utils";
 import { Button } from "./button";
 
@@ -17,6 +17,10 @@ function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
   return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
 }
 
+function AlertDialogClose({ ...props }: AlertDialogPrimitive.Close.Props) {
+  return <AlertDialogPrimitive.Close data-slot="alert-dialog-close" {...props} />;
+}
+
 function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdrop.Props) {
   return (
     <AlertDialogPrimitive.Backdrop
@@ -30,14 +34,21 @@ function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdr
   );
 }
 
-function AlertDialogContent({ className, ...props }: AlertDialogPrimitive.Popup.Props) {
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Popup.Props & {
+  size?: "default" | "sm";
+}) {
   return (
     <AlertDialogPortal>
       <AlertDialogOverlay />
       <AlertDialogPrimitive.Popup
         data-slot="alert-dialog-content"
+        data-size={size}
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}
@@ -50,7 +61,10 @@ function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">)
   return (
     <div
       data-slot="alert-dialog-header"
-      className={cn("flex flex-col gap-2", className)}
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className,
+      )}
       {...props}
     />
   );
@@ -61,7 +75,7 @@ function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">)
     <div
       data-slot="alert-dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
         className,
       )}
       {...props}
@@ -69,48 +83,68 @@ function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">)
   );
 }
 
-function AlertDialogTitle({ className, ...props }: AlertDialogPrimitive.Title.Props) {
+function AlertDialogMedia({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-10 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
   return (
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
-      className={cn("cn-font-heading text-base leading-none font-medium", className)}
+      className={cn(
+        "cn-font-heading text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className,
+      )}
       {...props}
     />
   );
 }
 
-function AlertDialogDescription({ className, ...props }: AlertDialogPrimitive.Description.Props) {
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
-      className={cn("text-sm text-muted-foreground", className)}
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className,
+      )}
       {...props}
     />
   );
 }
 
-function AlertDialogAction({ children, ...props }: React.ComponentProps<typeof Button>) {
-  return (
-    <AlertDialogPrimitive.Close
-      data-slot="alert-dialog-action"
-      render={<Button {...props}>{children}</Button>}
-    />
-  );
+function AlertDialogAction({ className, ...props }: React.ComponentProps<typeof Button>) {
+  return <Button data-slot="alert-dialog-action" className={cn(className)} {...props} />;
 }
 
 function AlertDialogCancel({
-  children = "Cancel",
+  className,
   variant = "outline",
+  size = "default",
   ...props
-}: React.ComponentProps<typeof Button>) {
+}: AlertDialogPrimitive.Close.Props &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
   return (
     <AlertDialogPrimitive.Close
       data-slot="alert-dialog-cancel"
-      render={
-        <Button variant={variant} {...props}>
-          {children}
-        </Button>
-      }
+      className={cn(className)}
+      render={<Button variant={variant} size={size} />}
+      {...props}
     />
   );
 }
@@ -119,10 +153,12 @@ export {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
+  AlertDialogClose,
   AlertDialogContent,
   AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogHeader,
+  AlertDialogMedia,
   AlertDialogOverlay,
   AlertDialogPortal,
   AlertDialogTitle,

--- a/packages/ui/components/dialog.tsx
+++ b/packages/ui/components/dialog.tsx
@@ -49,7 +49,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}


### PR DESCRIPTION
#926 closed with a note that the app now carries two dialog styles, because upstream's alert dialog draws on `bg-popover` while `dialog.tsx` drew on `bg-background`. Those are the same color in light mode and different in dark, where `--popover` is `oklch(0.205 0 0)` against `--background` at `oklch(0.145 0 0)`, so a dark-mode alert dialog sat on a lighter surface than a regular dialog. This closes that gap.

The gap turned out to be one class pair, not a generation. `dialog.tsx` was already the current upstream file: the shadcn update in #599 brought over the Base UI dialog with the ghost icon Close button at `absolute top-2 right-2`, the `showCloseButton` prop on both `DialogContent` and `DialogFooter`, the `-mx-4 -mb-4 border-t bg-muted/50` footer, `DialogHeader` as `flex flex-col gap-2`, and `sm:max-w-sm` sizing. Diffing today's `ui.shadcn.com/docs/components/base/dialog` against it, with the imports rewritten to relative paths, leaves exactly one line: the popup's `bg-background` where upstream has `bg-popover text-popover-foreground`. That line is what changed, and the file is now byte-identical to upstream apart from the two import paths. `cn-font-heading` stays on the title, as in the alert dialog.

`text-popover-foreground` is not a visible change on its own — `--popover-foreground` and `--foreground` hold the same value in both themes — but it keeps the surface and its text token paired, so the popup stays readable if the two ever diverge.

No call site needed changing. All six importers use `DialogContent` with no `className`, so nothing was relying on a width the component no longer gives, and nothing gets narrower here since `sm:max-w-sm` was already in force. Three of them hand-roll a button in `DialogFooter` — Cancel in the select confirmation, Later in the 1Password setup dialog, OK in the extension error dialog — and all three keep it. `showCloseButton` renders a button labeled Close, and those three labels were settled by earlier PRs: Later reads as a deferral rather than a dismissal, OK acknowledges an error, and Cancel pairs with a confirm. Adopting the built-in button would rewrite user-facing wording to do it.

The two surfaces agree now on background, ring, radius and footer. The differences that remain are the alert dialog's own: it takes a `size` prop and drives its width from `data-size` rather than a fixed `sm:max-w-sm`, its header centers below the `sm` breakpoint, it has an `AlertDialogMedia` slot, its footer becomes a two-column grid at `size="sm"`, and its title drops the `leading-none` the dialog title keeps. Those are all upstream's own choices for the two components, not leftovers. Nested popups inside a dialog still read as separate surfaces in dark mode: select and popover content carry `shadow-md ring-1 ring-foreground/10`, which was already doing that work inside alert dialogs.

Not verified by running the app. `bun run types`, `bun run lint`, `bun run fmt:check`, and `bun test` pass.
