### PR TITLE
show the download notification whatever the folder setting says

### DIFF
--- a/packages/app/downloads.ts
+++ b/packages/app/downloads.ts
@@ -63,8 +63,6 @@ class Downloads {
   }
 
   init() {
-    const openFolderWhenDone = config.get("downloads.openFolderWhenDone");
-
     const handleStarted = (item: Electron.DownloadItem) => {
       item.once("done", (_, state) => {
         const filePath = item.getSavePath();
@@ -77,7 +75,15 @@ class Downloads {
           exists: true,
         });
 
-        if (state === "completed" && config.get("notifications.downloadCompleted")) {
+        if (state !== "completed") {
+          return;
+        }
+
+        if (config.get("downloads.openFolderWhenDone")) {
+          shell.showItemInFolder(filePath);
+        }
+
+        if (config.get("notifications.downloadCompleted")) {
           const shouldOpenFile =
             config.get("notifications.onClickDownloadCompleted") === "openFile";
 
@@ -98,12 +104,13 @@ class Downloads {
       });
     };
 
+    // `openFolderWhenDone` is handled above rather than by electron-dl, which
+    // reads the option once when the listener is registered.
     electronDl({
       saveAs: config.get("downloads.saveAs"),
-      openFolderWhenDone,
       directory: config.get("downloads.location"),
       showBadge: false,
-      onStarted: openFolderWhenDone ? undefined : handleStarted,
+      onStarted: handleStarted,
     });
 
     const cleanupDownloadsHistory = () => {

--- a/packages/renderer/routes/settings/downloads.tsx
+++ b/packages/renderer/routes/settings/downloads.tsx
@@ -39,7 +39,6 @@ export function DownloadsSettings() {
             label="Open folder when done"
             description="Open the folder containing the file when a download finishes."
             configKey="downloads.openFolderWhenDone"
-            restartRequired
           />
           <Field>
             <FieldLabel>Default download location</FieldLabel>


### PR DESCRIPTION
`Downloads.init` passed `onStarted` to electron-dl only when `downloads.openFolderWhenDone` was off, so the download notification setting did nothing at all while the folder setting was on — and the history item never got recorded either. Both settings were also read once at startup, so either one took a restart to take effect.

The `onStarted` handler is now always wired, and it opens the folder itself on a completed download, reading `downloads.openFolderWhenDone` per download rather than handing the option to electron-dl, which reads it once when it registers its `will-download` listener. The notification path is unchanged apart from no longer being gated on the folder setting.

With the folder setting live, its switch on the Downloads page drops the restart-required flag. `downloads.saveAs` and `downloads.location` stay captured by electron-dl and keep theirs — making those live means taking over `will-download`, which is a bigger change than this row.

Removes the todo row.

Not verified by running the app: I have not exercised a real download in either setting combination.

https://claude.ai/code/session_01LeYUfyAx126SQizkyDTmdg