### PR TITLE
put the form dialogs' buttons in a dialog footer

### DIFF
--- a/packages/renderer/routes/settings/accounts.tsx
+++ b/packages/renderer/routes/settings/accounts.tsx
@@ -21,7 +21,9 @@ import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -215,9 +217,10 @@ function AccountForm({
           </form.Field>
         </FieldSet>
       </FieldGroup>
-      <div className="flex items-center justify-end">
+      <DialogFooter>
+        <DialogClose render={<Button variant="outline">Cancel</Button>} />
         <Button type="submit">{type === "add" ? "Add" : "Save"}</Button>
-      </div>
+      </DialogFooter>
     </form>
   );
 }

--- a/packages/renderer/routes/settings/gmail/label-colors.tsx
+++ b/packages/renderer/routes/settings/gmail/label-colors.tsx
@@ -9,7 +9,9 @@ import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -134,9 +136,10 @@ function LabelColorForm({
           </Field>
         )}
       </form.Field>
-      <div className="flex justify-end">
+      <DialogFooter>
+        <DialogClose render={<Button variant="outline">Cancel</Button>} />
         <Button type="submit">{type === "add" ? "Add" : "Save"}</Button>
-      </div>
+      </DialogFooter>
     </form>
   );
 }

--- a/packages/renderer/routes/settings/license.tsx
+++ b/packages/renderer/routes/settings/license.tsx
@@ -3,8 +3,10 @@ import { ipc } from "@meru/shared/renderer/ipc";
 import { Button, buttonVariants } from "@meru/ui/components/button";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -83,9 +85,10 @@ function LicenseKeyForm({
           }}
         </form.Field>
       </FieldGroup>
-      <div className="flex items-center justify-end">
+      <DialogFooter>
+        <DialogClose render={<Button variant="outline">Cancel</Button>} />
         <Button type="submit">Activate</Button>
-      </div>
+      </DialogFooter>
     </form>
   );
 }

--- a/packages/renderer/routes/settings/saved-searches.tsx
+++ b/packages/renderer/routes/settings/saved-searches.tsx
@@ -21,7 +21,9 @@ import {
 import { Button } from "@meru/ui/components/button";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -119,9 +121,10 @@ export function SavedSearchForm({
           )}
         </form.Field>
       </FieldGroup>
-      <div className="flex justify-end">
+      <DialogFooter>
+        <DialogClose render={<Button variant="outline">Cancel</Button>} />
         <Button type="submit">{type === "add" ? "Add" : "Save"}</Button>
-      </div>
+      </DialogFooter>
     </form>
   );
 }


### PR DESCRIPTION
The accounts, saved searches, label colors and license dialogs each closed their form with a bare `flex justify-end` div, so none of them showed the muted footer bar that the select confirmation, 1Password and extension error dialogs get. It predates the interface text work and was left alone in #927 because moving those buttons changes layout the copy changes had settled around.

Each submit button now sits in a `DialogFooter`, paired with a Cancel button rendered through `DialogClose` — the same shape the 1Password and select confirmation dialogs already use. Base UI's `DialogClose` renders with `type="button"`, so Cancel dismisses without submitting the form.

The footer's `-mx-4 -mb-4` bleed resolves against the dialog's padding in all four cases, because each form is the last direct child of `DialogContent` and the footer is the last child of the form. The `space-y-4` on the form gives the footer the same 16px gap above it that `DialogContent`'s `gap-4` gives the footers that sit directly inside it.

`bun run types`, `bun run lint`, `bun run fmt:check` and `bun test` pass. The four dialogs were not opened in the running app, so the rendered footer bar is unverified.