### PR TITLE
delete the dead accounts.openAddAccountDialog channel

### DIFF
--- a/packages/renderer/lib/react-query.ts
+++ b/packages/renderer/lib/react-query.ts
@@ -22,10 +22,6 @@ export function useConfig() {
   };
 }
 
-export function getConfig() {
-  return queryClient.fetchQuery(configOptions);
-}
-
 ipc.renderer.on("bookmarks.changed", (_event, bookmarks) => {
   queryClient.setQueryData(["bookmarks"], bookmarks);
 });

--- a/packages/renderer/lib/stores.ts
+++ b/packages/renderer/lib/stores.ts
@@ -1,9 +1,7 @@
 import { ipc } from "@meru/shared/renderer/ipc";
 import type { AccountInstances } from "@meru/shared/schemas";
 import type { AccountTabsState } from "@meru/shared/tabs";
-import { toast } from "sonner";
 import { create } from "zustand";
-import { getConfig } from "./react-query";
 import { accountsSearchParam, trialDaysLeftSearchParam } from "./search-params";
 
 export const useAccountsStore = create<{
@@ -20,20 +18,6 @@ export const useAccountsStore = create<{
 
 ipc.renderer.on("accounts.changed", (_event, accounts) => {
   useAccountsStore.setState({ accounts });
-});
-
-ipc.renderer.on("accounts.openAddAccountDialog", async (_event) => {
-  const config = await getConfig();
-
-  if (!config.licenseKey && !useTrialStore.getState().daysLeft) {
-    toast.error("Meru Pro is required to add more accounts.", {
-      description: "Upgrade to Meru Pro to continue.",
-    });
-
-    return;
-  }
-
-  useAccountsStore.setState({ isAddAccountDialogOpen: true });
 });
 
 export const useTabsStore = create<{

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -304,7 +304,6 @@ export type IpcRendererEvent = {
   "tabs.changed": [accountsTabs: AccountTabsState[]];
   "bookmarks.changed": [bookmarks: BookmarkState[]];
   "extensions.actionsChanged": [actions: ExtensionActionState[]];
-  "accounts.openAddAccountDialog": [];
   "findInPage.activate": [];
   "findInPage.result": [result: { activeMatch: number; totalMatches: number }];
   "trial.daysLeftChanged": [daysLeft: number];


### PR DESCRIPTION
`accounts.openAddAccountDialog` was declared in `packages/shared/types.ts` and listened for in `packages/renderer/lib/stores.ts`, but nothing in `packages/app` sent it, so the listener and the Meru Pro toast inside it were unreachable — #920 had already reworded a toast nobody could see.

The channel was not stillborn. It had a sender until d35c66e ("open version changelog in app", 30 October 2025), which collapsed the Gmail `AddSession` branch from four calls — open settings, hide accounts, navigate to `/accounts`, send the channel — down to a single navigation, dropping the send along with them. That commit was about routing the changelog in-app, so the dialog auto-open reads as collateral of the routing refactor rather than a decision. The branch now lives at `packages/app/workspace-app.ts:258` as `main.navigate("/settings/accounts")`.

Given the choice between rewiring a sender and deleting the channel, this deletes it. Clicking **Add another account** in Gmail still lands on the settings accounts page, where the **Add** button runs its own licensing check — so the toast's job is already covered, by a disabled button rather than an error after the fact.

Removing the listener left `getConfig` in `packages/renderer/lib/react-query.ts` without a caller anywhere in the workspace, so that goes too.

`bun run types`, `bun run lint`, `bun run fmt:check` and `bun test` pass. The Gmail **Add another account** path was not exercised in the running app.