### PR TITLE
find the native messaging host on localized Windows

### DIFF
--- a/packages/electron-extensions/native-messaging/windows-registry.test.ts
+++ b/packages/electron-extensions/native-messaging/windows-registry.test.ts
@@ -38,8 +38,41 @@ describe("parseRegistryQueryOutput", () => {
     ).toBe("C:\\Program Files\\1Password\\h.json");
   });
 
+  test("reads the manifest path when Windows localizes the value name", () => {
+    expect(
+      parseRegistryQueryOutput(
+        [
+          "",
+          "HKEY_CURRENT_USER\\Software\\Google\\Chrome\\NativeMessagingHosts\\com.1password.1password",
+          "    (Standard)    REG_SZ    C:\\Users\\Tim\\AppData\\Local\\1Password\\com.1password.1password.json",
+          "",
+        ].join("\r\n"),
+      ),
+    ).toBe("C:\\Users\\Tim\\AppData\\Local\\1Password\\com.1password.1password.json");
+  });
+
+  test("reads the manifest path when the localized value name has a space in it", () => {
+    expect(
+      parseRegistryQueryOutput(
+        "    (par défaut)    REG_SZ    C:\\Program Files\\1Password\\host.json\r\n",
+      ),
+    ).toBe("C:\\Program Files\\1Password\\host.json");
+  });
+
+  test("expands an expandable string value under a localized value name", () => {
+    expect(
+      parseRegistryQueryOutput("    (Standard)    REG_EXPAND_SZ    %LOCALAPPDATA%\\host.json", {
+        LOCALAPPDATA: "C:\\Users\\Tim\\AppData\\Local",
+      }),
+    ).toBe("C:\\Users\\Tim\\AppData\\Local\\host.json");
+  });
+
   test("ignores a value that is not a string", () => {
     expect(parseRegistryQueryOutput("    (Default)    REG_DWORD    0x1")).toBeUndefined();
+  });
+
+  test("ignores a value that is not a string under a localized value name", () => {
+    expect(parseRegistryQueryOutput("    (Standard)    REG_DWORD    0x1")).toBeUndefined();
   });
 
   test("answers with nothing when the key has no default value", () => {

--- a/packages/electron-extensions/native-messaging/windows-registry.ts
+++ b/packages/electron-extensions/native-messaging/windows-registry.ts
@@ -1,7 +1,19 @@
 import { execFile } from "node:child_process";
+import path from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * `reg` is resolved out of the system directory rather than off the search
+ * path, so that whatever else is named `reg.exe` on this machine can't stand in
+ * for it.
+ */
+const REG_EXECUTABLE_PATH = path.join(
+  process.env.SystemRoot ?? "C:\\Windows",
+  "System32",
+  "reg.exe",
+);
 
 /**
  * What Windows does to a `REG_EXPAND_SZ` value when it is read: every
@@ -27,8 +39,11 @@ export function expandEnvironmentVariables(
 /**
  * The manifest path out of `reg query <key> /ve`, which prints the key it read
  * and then the default value as name, type and data separated by runs of
- * spaces. Only a string value is a path; anything else is a registration this
- * code has no business following.
+ * spaces. `reg` localizes the name of that value — German Windows prints
+ * `(Standard)`, French `(par défaut)` with a space in it — so the line is
+ * recognized by its type column instead, which is unambiguous because `/ve`
+ * prints exactly one value. Only a string value is a path; anything else is a
+ * registration this code has no business following.
  *
  *     HKEY_CURRENT_USER\Software\Google\Chrome\NativeMessagingHosts\com.1password.1password
  *         (Default)    REG_SZ    C:\Users\me\AppData\Local\1Password\com.1password.1password.json
@@ -38,7 +53,7 @@ export function parseRegistryQueryOutput(
   environment?: Record<string, string | undefined>,
 ) {
   for (const line of output.split(/\r?\n/)) {
-    const value = /^\s+\(Default\)\s+(REG_SZ|REG_EXPAND_SZ)\s+(.+?)\s*$/.exec(line);
+    const value = /^\s+.+?\s+(REG_SZ|REG_EXPAND_SZ)\s+(.+?)\s*$/.exec(line);
 
     if (value?.[2]) {
       return value[1] === "REG_EXPAND_SZ"
@@ -52,7 +67,7 @@ export function parseRegistryQueryOutput(
 
 async function queryRegistryValue(key: string) {
   try {
-    const { stdout } = await execFileAsync("reg.exe", ["query", key, "/ve"], {
+    const { stdout } = await execFileAsync(REG_EXECUTABLE_PATH, ["query", key, "/ve"], {
       windowsHide: true,
     });
 


### PR DESCRIPTION
`parseRegistryQueryOutput` matched the literal `(Default)` in `reg query <key> /ve` output, but `reg` localizes the default value's name: German Windows prints `(Standard)`, French `(par défaut)`. On any non-English Windows the manifest path was never parsed, so `findHostManifest` found nothing and 1Password's desktop-app integration reported "Specified native messaging host not found".

`/ve` prints exactly one value, so the line is identified by its type column (`REG_SZ` or `REG_EXPAND_SZ`) and the value name isn't matched at all — a localized name with a space in it, like `(par défaut)`, parses the same as `(Default)`. Tests cover `(Standard)`, `(par défaut)`, the expandable variant, and a localized non-string value still being ignored.

Also in the same file: `reg` is resolved out of `%SystemRoot%\System32` instead of off the search path.

Verified by `bun test`, `bun run types`, `bun run lint` and `bun run fmt:check`. Not verified on a real Windows machine, localized or otherwise — this came out of a static read, and Windows stays unexercised at runtime.

https://claude.ai/code/session_019dYbChnfMpnQNG22vG7txT