### PR TITLE
harden the extensions layer against four edge cases

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -5,6 +5,7 @@ import {
   findExtensionDirs,
   getInstalledExtension,
   installLatestExtension,
+  type LatestExtensionInstall,
   pruneDerivedExtensions,
   registerExtensionBridgeScheme,
   uninstallExtension,
@@ -145,13 +146,35 @@ export async function getInstalledExtensions() {
   return installedExtensions;
 }
 
+/**
+ * The install in flight per extension, which a second call joins rather than
+ * starting its own. Two installs of one extension — the user toggling it on
+ * while the updater is checking it — unpack into the same staging directory,
+ * where their writes tread on each other and one of the two renames fails.
+ */
+const runningInstalls = new Map<string, Promise<LatestExtensionInstall>>();
+
+function installLatestCuratedExtension(extensionId: string) {
+  let runningInstall = runningInstalls.get(extensionId);
+
+  if (!runningInstall) {
+    runningInstall = installLatestExtension({
+      extensionId,
+      installDir: INSTALL_DIR,
+      chromeVersion: process.versions.chrome,
+    }).finally(() => {
+      runningInstalls.delete(extensionId);
+    });
+
+    runningInstalls.set(extensionId, runningInstall);
+  }
+
+  return runningInstall;
+}
+
 /** Installs the latest version and records the opt-in, which is what loads it. */
 export async function installCuratedExtension(extensionId: string) {
-  const { version } = await installLatestExtension({
-    extensionId,
-    installDir: INSTALL_DIR,
-    chromeVersion: process.versions.chrome,
-  });
+  const { version } = await installLatestCuratedExtension(extensionId);
 
   const installedExtensionIds = config.get("extensions.installed");
 
@@ -233,11 +256,7 @@ class ExtensionUpdater {
 
     for (const extensionId of getOptedInExtensionIds()) {
       try {
-        const { updated, version } = await installLatestExtension({
-          extensionId,
-          installDir: INSTALL_DIR,
-          chromeVersion: process.versions.chrome,
-        });
+        const { updated, version } = await installLatestCuratedExtension(extensionId);
 
         log.info(updated ? "Updated extension" : "Extension is up to date", {
           extensionId,

--- a/packages/electron-extensions/action.test.ts
+++ b/packages/electron-extensions/action.test.ts
@@ -155,4 +155,20 @@ describe("readExtensionActionIcon", () => {
       readExtensionActionIcon(createExtension({ icons: { "48": "missing.png" } })),
     ).rejects.toThrow();
   });
+
+  test("refuses an icon the manifest points outside the extension at", async () => {
+    await writeFile(path.join(path.dirname(extensionDir), "outside.png"), "outside");
+
+    expect(
+      readExtensionActionIcon(createExtension({ icons: { "48": "../outside.png" } })),
+    ).rejects.toThrow(/outside the extension/);
+  });
+
+  test("reads an icon declared from the extension root", async () => {
+    await writeFile(path.join(extensionDir, "icon-48.png"), "icon");
+
+    expect(
+      await readExtensionActionIcon(createExtension({ icons: { "48": "/icon-48.png" } })),
+    ).toBe(`data:image/png;base64,${Buffer.from("icon").toString("base64")}`);
+  });
 });

--- a/packages/electron-extensions/action.ts
+++ b/packages/electron-extensions/action.ts
@@ -140,7 +140,17 @@ export async function readExtensionActionIcon(extension: ActionExtension) {
     return null;
   }
 
-  const icon = await readFile(path.join(extension.path, iconPath));
+  const extensionDir = path.resolve(extension.path);
+
+  const iconFilePath = path.join(extensionDir, iconPath);
+
+  // Chrome resolves an icon against the extension root and never outside it, so
+  // a manifest reaching out with `..` names a file the extension never shipped
+  if (!iconFilePath.startsWith(`${extensionDir}${path.sep}`)) {
+    throw new Error(`Manifest declares "${iconPath}", which is outside the extension`);
+  }
+
+  const icon = await readFile(iconFilePath);
 
   return `data:${mimeType};base64,${icon.toString("base64")}`;
 }

--- a/packages/electron-extensions/native-messaging/framing.ts
+++ b/packages/electron-extensions/native-messaging/framing.ts
@@ -1,6 +1,6 @@
 /**
- * Chrome's native messaging wire format: a 4-byte little-endian byte length in
- * the platform's native byte order, then that many bytes of UTF-8 JSON.
+ * Chrome's native messaging wire format: a 4-byte little-endian byte length,
+ * then that many bytes of UTF-8 JSON.
  *
  * The same framing carries messages twice — between Meru and the host over the
  * host's stdio, and between Meru and the extension over the bridge stream — so

--- a/packages/electron-extensions/native-messaging/native-messaging.test.ts
+++ b/packages/electron-extensions/native-messaging/native-messaging.test.ts
@@ -222,6 +222,26 @@ describe("NativeMessaging", () => {
     });
   });
 
+  test("disconnects when the embedder's policy throws", async () => {
+    await writeHostManifest();
+
+    createNativeMessaging({
+      isHostAllowed: () => {
+        throw new Error("Policy is unavailable");
+      },
+    });
+
+    const response = await connect();
+
+    expect(await readFrame(response)).toEqual({
+      type: "disconnect",
+      error: "Access to the specified native messaging host is forbidden.",
+    });
+
+    // The port is gone with it, which a second connect on the same id proves
+    expect((await connect()).status).toBe(200);
+  });
+
   test("kills the host when the extension side cancels the stream", async () => {
     await writeHostManifest();
 

--- a/packages/electron-extensions/native-messaging/native-messaging.ts
+++ b/packages/electron-extensions/native-messaging/native-messaging.ts
@@ -161,7 +161,20 @@ export class NativeMessaging {
     });
 
     if (port) {
-      await this.startHost(port);
+      try {
+        await this.startHost(port);
+      } catch (error) {
+        // Nothing here throws of its own accord, so this is an embedder policy
+        // that did. The port has to go with it: it is already in `this.ports`
+        // and would sit there for the life of the process
+        this.options.logger?.error("Failed to start native messaging host", {
+          hostName: port.hostName,
+          extensionId: port.extensionId,
+          error,
+        });
+
+        this.closePort(port, HOST_FORBIDDEN_ERROR);
+      }
     }
 
     return new Response(body, {


### PR DESCRIPTION
Four independent hardenings in the Chrome extensions layer, from a static reading of the code. None depends on another, and each is a few lines.

## A port that outlived its connect

`NativeMessaging.handleConnect` puts the port in `this.ports` from the stream's `start` callback, before it awaits `startHost`. A throw out of that await — only an embedder `isHostAllowed` policy can raise one today, since `findHostManifest` catches its own errors and Meru passes no policy — left the entry behind for the life of the process, and every later `connect` on that port id was answered 400. The connect path now closes the port on a throw, which disconnects the extension with the error Chrome uses for a host it may not reach and logs what actually went wrong.

## Two installs over one staging directory

`installLatestExtension` unpacks into `<version>.staging` and renames it into place. `ExtensionUpdater` single-flights its own runs, but an IPC install went around that, so a user toggling an extension on while a scheduled check was fetching the same one had both runs writing the same directory and one rename failing. A module-level map from extension id to the install in flight now covers both call sites, so the second caller joins the first.

## An icon path that could leave the extension

`readExtensionActionIcon` joined a manifest-supplied path onto the extension directory without confining it, so `../` read a file outside. The input is curated and signature-verified today, but Chrome forbids escaping the extension root either way. It now carries the same containment check the installer uses on unpacked zip entries, and a leading `/` still resolves against the extension root the way Chrome reads it.

## A comment that said two things

`framing.ts` described the length prefix as "4-byte little-endian … in the platform's native byte order". The code writes and reads it little-endian unconditionally; the comment now says that.

## Tests

`bun test packages/electron-extensions` covers the areas touched: a new test asserts a throwing policy disconnects the port and frees its id, and two cover the icon path — one refusing a `..` escape, one keeping root-relative `/icon.png` working. Both fail against the code before this change. The full suite, `bun run types`, `bun run lint`, and `bun run fmt:check` pass.

The install single-flight has no test — `packages/app` imports `electron` and carries no test setup — and none of the four was exercised in a running app.

https://claude.ai/code/session_01NeTdjTun4EEgv1jvDuwj6s