### PR TITLE
validate the extension id before it becomes a path

### DIFF
--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { IpcEmitter, IpcListener } from "@electron-toolkit/typed-ipc/main";
 import { platform } from "@electron-toolkit/utils";
+import { isExtensionId } from "@meru/electron-extensions";
 import { MAX_RECENT_DOWNLOAD_HISTORY_ITEMS } from "@meru/shared/constants";
 import { isCuratedExtensionId } from "@meru/shared/extensions";
 import { getWorkspaceAppUrl } from "@meru/shared/google";
@@ -1072,6 +1073,10 @@ class Ipc {
     // Opting out is never gated, so an extension can be taken off a device that
     // has lost its license
     ipc.main.handle("extensions.uninstall", async (_event, extensionId) => {
+      if (!isExtensionId(extensionId)) {
+        return { error: "Meru doesn't know this extension." };
+      }
+
       try {
         await uninstallCuratedExtension(extensionId);
 

--- a/packages/electron-extensions/derive/extension-id.test.ts
+++ b/packages/electron-extensions/derive/extension-id.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getExtensionIdFromManifestKey } from "./extension-id";
+import { getExtensionIdFromManifestKey, isExtensionId } from "./extension-id";
 
 /** 1Password 8.12.32.33, whose Chrome Web Store id this key has to derive. */
 const ONE_PASSWORD_KEY =
@@ -18,5 +18,29 @@ describe("getExtensionIdFromManifestKey", () => {
 
   test("has no id for a manifest without a key", () => {
     expect(getExtensionIdFromManifestKey(undefined)).toBeUndefined();
+  });
+});
+
+describe("isExtensionId", () => {
+  test("accepts an id Chromium would write", () => {
+    expect(isExtensionId("aeblfdkhhhdcdjpifhhbdiojplfjncoa")).toBe(true);
+  });
+
+  test("refuses a string outside the a-p alphabet", () => {
+    expect(isExtensionId("zeblfdkhhhdcdjpifhhbdiojplfjncoa")).toBe(false);
+    expect(isExtensionId("AEBLFDKHHHDCDJPIFHHBDIOJPLFJNCOA")).toBe(false);
+    expect(isExtensionId("aeblfdkhhhdcdjpifhhbdiojplfjnco1")).toBe(false);
+  });
+
+  test("refuses a string that is not 32 characters", () => {
+    expect(isExtensionId("")).toBe(false);
+    expect(isExtensionId("aeblfdkhhhdcdjpifhhbdiojplfjnco")).toBe(false);
+    expect(isExtensionId("aeblfdkhhhdcdjpifhhbdiojplfjncoaa")).toBe(false);
+  });
+
+  test("refuses a path rather than an id", () => {
+    expect(isExtensionId("../..")).toBe(false);
+    expect(isExtensionId("aeblfdkhhhdcdjpifhhbdiojplfjnco/")).toBe(false);
+    expect(isExtensionId("aeblfdkhhhdcdjpifhhbdiojplfjncoa\n")).toBe(false);
   });
 });

--- a/packages/electron-extensions/derive/extension-id.ts
+++ b/packages/electron-extensions/derive/extension-id.ts
@@ -43,3 +43,15 @@ export function getExtensionIdFromManifestKey(key: string | undefined) {
 
   return getExtensionIdFromPublicKey(Buffer.from(key, "base64"));
 }
+
+/** The a-p alphabet over the 16 bytes an id is made of, two characters a byte. */
+const EXTENSION_ID_PATTERN = new RegExp(`^[a-p]{${EXTENSION_ID_BYTE_LENGTH * 2}}$`);
+
+/**
+ * Whether a string is shaped like an extension id, which is what makes it safe
+ * to build a path from: an id names a directory under the install directory and
+ * can never climb out of it.
+ */
+export function isExtensionId(value: string) {
+  return EXTENSION_ID_PATTERN.test(value);
+}

--- a/packages/electron-extensions/index.ts
+++ b/packages/electron-extensions/index.ts
@@ -4,6 +4,7 @@ export { compareExtensionVersions, verifyCrx } from "./crx";
 export type { VerifiedCrx } from "./crx";
 export { pruneDerivedExtensions } from "./derive";
 export type { PruneDerivedExtensionsOptions } from "./derive";
+export { isExtensionId } from "./derive/extension-id";
 export { Extensions } from "./extensions";
 export type { ActionsChangedListener, ExtensionDirs, ExtensionsOptions } from "./extensions";
 export {

--- a/packages/electron-extensions/install/installer.test.ts
+++ b/packages/electron-extensions/install/installer.test.ts
@@ -140,6 +140,16 @@ describe("installExtension", () => {
 
     expect(await readEntryNames(extensionInstallDir)).toEqual([]);
   });
+
+  test("refuses an id that is not one, before it reads the package", async () => {
+    await expect(
+      installExtension({
+        crx: createExtensionCrx("1.2.3"),
+        extensionId: "../elsewhere",
+        installDir,
+      }),
+    ).rejects.toThrow("Not an extension id: ../elsewhere");
+  });
 });
 
 describe("getInstalledExtension", () => {
@@ -177,6 +187,12 @@ describe("getInstalledExtension", () => {
       version: "1.0.0",
       extensionDir: path.join(extensionInstallDir, "1.0.0"),
     });
+  });
+
+  test("refuses an id that is not one", async () => {
+    await expect(
+      getInstalledExtension({ installDir, extensionId: "../elsewhere" }),
+    ).rejects.toThrow("Not an extension id: ../elsewhere");
   });
 });
 
@@ -300,5 +316,22 @@ describe("uninstallExtension", () => {
 
     expect(await readEntryNames(extensionInstallDir)).toEqual([]);
     expect(await getInstalledExtension({ installDir, extensionId })).toBeUndefined();
+  });
+
+  test("refuses an id that is not one, rather than deleting what it climbs to", async () => {
+    const outsideDir = path.join(installDir, "outside");
+
+    await mkdir(outsideDir);
+
+    await writeFile(path.join(outsideDir, "kept"), "kept");
+
+    await expect(
+      uninstallExtension({
+        installDir: path.join(installDir, "extensions"),
+        extensionId: "../outside",
+      }),
+    ).rejects.toThrow("Not an extension id: ../outside");
+
+    expect(await readFile(path.join(outsideDir, "kept"), "utf8")).toBe("kept");
   });
 });

--- a/packages/electron-extensions/install/installer.ts
+++ b/packages/electron-extensions/install/installer.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { unzipSync } from "fflate";
 import { verifyCrx } from "../crx/crx";
 import { compareExtensionVersions } from "../crx/version";
+import { isExtensionId } from "../derive/extension-id";
 import { type FetchImplementation, fetchCrx, fetchCrxUpdate } from "./omaha";
 
 const MANIFEST_FILE_NAME = "manifest.json";
@@ -32,6 +33,16 @@ type ExtensionPackage = {
   files: Record<string, Uint8Array>;
   manifest: ExtensionManifest;
 };
+
+/**
+ * Refuses an id that isn't shaped like one before it is joined onto the install
+ * directory, so a caller can't reach outside it with a traversal.
+ */
+function assertExtensionId(extensionId: string) {
+  if (!isExtensionId(extensionId)) {
+    throw new Error(`Not an extension id: ${extensionId}`);
+  }
+}
 
 /**
  * Turns CRX bytes into the files an install writes, refusing everything a
@@ -133,6 +144,8 @@ export type InstallExtensionOptions = {
  * the directory so an update check can read what is installed off the disk.
  */
 export async function installExtension({ crx, extensionId, installDir }: InstallExtensionOptions) {
+  assertExtensionId(extensionId);
+
   return installExtensionPackage(readCrxPackage(crx, extensionId), { extensionId, installDir });
 }
 
@@ -189,6 +202,8 @@ export async function getInstalledExtension({
   installDir,
   extensionId,
 }: InstalledExtensionOptions): Promise<InstalledExtension | undefined> {
+  assertExtensionId(extensionId);
+
   const extensionInstallDir = path.join(installDir, extensionId);
 
   const [version] = (await readInstalledVersions(extensionInstallDir)).sort(
@@ -291,5 +306,7 @@ export async function installLatestExtension({
  * extension wrote lives in the session rather than here.
  */
 export async function uninstallExtension({ installDir, extensionId }: InstalledExtensionOptions) {
+  assertExtensionId(extensionId);
+
   await rm(path.join(installDir, extensionId), { recursive: true, force: true });
 }


### PR DESCRIPTION
`extensions.uninstall` fed whatever the renderer sent straight into a recursive delete. The install handler checks `isCuratedExtensionId`; the uninstall handler checked nothing, so the id reached `rm(path.join(installDir, extensionId), { recursive: true, force: true })` unexamined, and an id of `../..` would have deleted userData's parent directory.

It was only ever reachable from Meru's own context-isolated renderer — the Gmail and workspace-app preloads expose no generic invoke to page content — so this is defense in depth rather than a live hole. Found by static reading, not from a report.

## What changed

`isExtensionId` joins `derive/extension-id.ts`, which already owns the a-p alphabet and the 16-byte length an id is made of. Every exported function in `install/` that joins an id onto the install directory — `installExtension`, `getInstalledExtension`, `uninstallExtension` — now throws on an id that isn't shaped like one, so the contract is that the package refuses a malformed id wherever it enters, not just in the one function that deletes. `installLatestExtension` inherits the check through `getInstalledExtension`.

The uninstall handler guards at the IPC boundary too, with shape rather than catalog membership. Catalog membership would match install exactly, but it would also mean that an extension dropped from the curated list can no longer be removed by the users who still have it — the files stay on disk with no UI to delete them. Shape blocks every traversal payload without that. Uninstall stays ungated by license, which is orthogonal and deliberate: an extension has to be removable from a device that lost its license.

## Tests

`isExtensionId` is covered in `extension-id.test.ts` — alphabet, length, and paths. Each of the three guarded functions has a case in `installer.test.ts`; the uninstall one builds a directory outside the install directory, points the id at it, and asserts the file inside survives. All three fail with the guard removed.

Type checking, lint, formatting, and `bun test` pass. Nothing here was exercised in a running app: the guarded paths are unreachable from the real UI, which is the point, so there's no behavior to click through.

https://claude.ai/code/session_01QWpaSHj2fneV8FPCEacRsK