### PR TITLE
delete extension directories at launch, never mid-session

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -6,6 +6,7 @@ import {
   getInstalledExtension,
   installLatestExtension,
   pruneDerivedExtensions,
+  pruneExtensionVersions,
   registerExtensionBridgeScheme,
   uninstallExtension,
 } from "@meru/electron-extensions";
@@ -176,10 +177,23 @@ export async function uninstallCuratedExtension(extensionId: string) {
 }
 
 /**
+ * The version directories an update replaced, and the staging directories a
+ * crashed install left behind. Runs before the first session is set up, since
+ * that is where deriving reads an install directory from.
+ */
+export async function pruneInstalledExtensionVersions() {
+  try {
+    await pruneExtensionVersions({ installDir: INSTALL_DIR });
+  } catch (error) {
+    log.error("Failed to prune installed extension versions", { error: serializeError(error) });
+  }
+}
+
+/**
  * The copies the loader derived from extensions that are no longer loaded — an
  * extension the user opted out of, a version an update replaced — are the
- * embedder's to collect. Once per launch: every session derives from the same
- * list.
+ * embedder's to collect. Once per launch, before the sessions derive: a copy is
+ * unaccounted for the moment a derive drops its stamp to write it again.
  */
 export async function pruneDerivedExtensionCopies() {
   try {

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -7,7 +7,12 @@ import { bookmarks } from "@/bookmarks";
 import { config } from "@/config";
 import { downloads } from "@/downloads";
 import { extensionActions } from "@/extension-actions";
-import { extensions, extensionUpdater, pruneDerivedExtensionCopies } from "@/extensions";
+import {
+  extensions,
+  extensionUpdater,
+  pruneDerivedExtensionCopies,
+  pruneInstalledExtensionVersions,
+} from "@/extensions";
 import { ipc } from "@/ipc";
 import { initLinuxWindowControls } from "@/lib/linux";
 import { licenseKey } from "@/license-key";
@@ -113,6 +118,12 @@ async function init() {
 
   spellchecker.init();
 
+  // Both prunes delete what the sessions are about to read from, so they run
+  // before the first session derives its copies rather than alongside
+  await pruneInstalledExtensionVersions();
+
+  await pruneDerivedExtensionCopies();
+
   accounts.init();
 
   await initLinuxWindowControls();
@@ -136,8 +147,6 @@ async function init() {
   appUpdater.init();
 
   extensionUpdater.init();
-
-  pruneDerivedExtensionCopies();
 
   doNotDisturb.init();
 

--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -184,6 +184,21 @@ describe("deriveExtension", () => {
     );
   });
 
+  test("copies again when the copy is gone and its stamp still matches", async () => {
+    const derivedDir = await derive();
+
+    await rm(derivedDir, { recursive: true, force: true });
+
+    await derive();
+
+    expect(await readFile(path.join(derivedDir, "background", "background.js"), "utf8")).toBe(
+      "// background\n",
+    );
+    expect(await readFile(path.join(derivedDir, "chrome-facade.js"), "utf8")).toEndWith(
+      "// facade\n",
+    );
+  });
+
   test("copies again when a file other than the manifest changed", async () => {
     const derivedDir = await derive();
 

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -74,6 +74,14 @@ async function readStamp(stampPath: string) {
   }
 }
 
+async function directoryExists(dirPath: string) {
+  try {
+    return (await stat(dirPath)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 /** Chromium serves `Popup.HTM` as a page just as well, so the net is this wide. */
 const PAGE_FILE_EXTENSIONS = new Set([".html", ".htm"]);
 
@@ -139,7 +147,10 @@ export async function deriveExtension({
     contentScriptMatches,
   });
 
-  if ((await readStamp(stampPath)) !== stamp) {
+  // A stamp that matches while its copy is gone would otherwise skip the copy
+  // and go on writing the facade into nothing, on this launch and every one
+  // after it, since nothing but a copy moves the stamp back off a match
+  if ((await readStamp(stampPath)) !== stamp || !(await directoryExists(derivedDir))) {
     await rm(derivedDir, { recursive: true, force: true });
 
     await rm(stampPath, { force: true });

--- a/packages/electron-extensions/index.ts
+++ b/packages/electron-extensions/index.ts
@@ -14,6 +14,7 @@ export {
   getInstalledExtension,
   installExtension,
   installLatestExtension,
+  pruneExtensionVersions,
   uninstallExtension,
 } from "./install";
 export type {
@@ -27,6 +28,7 @@ export type {
   InstallExtensionOptions,
   InstallLatestExtensionOptions,
   LatestExtensionInstall,
+  PruneExtensionVersionsOptions,
   UpdateCheckOptions,
 } from "./install";
 export type { ExtensionsLogger } from "./logger";

--- a/packages/electron-extensions/install/index.ts
+++ b/packages/electron-extensions/install/index.ts
@@ -2,6 +2,7 @@ export {
   getInstalledExtension,
   installExtension,
   installLatestExtension,
+  pruneExtensionVersions,
   uninstallExtension,
 } from "./installer";
 export type {
@@ -10,6 +11,7 @@ export type {
   InstallExtensionOptions,
   InstallLatestExtensionOptions,
   LatestExtensionInstall,
+  PruneExtensionVersionsOptions,
 } from "./installer";
 export { buildCrxDownloadUrl, buildUpdateCheckUrl, fetchCrx, fetchCrxUpdate } from "./omaha";
 export type {

--- a/packages/electron-extensions/install/installer.test.ts
+++ b/packages/electron-extensions/install/installer.test.ts
@@ -9,6 +9,7 @@ import {
   getInstalledExtension,
   installExtension,
   installLatestExtension,
+  pruneExtensionVersions,
   uninstallExtension,
 } from "./index";
 import type { FetchImplementation } from "./omaha";
@@ -239,7 +240,7 @@ describe("installLatestExtension", () => {
     expect(downloadedUrls).toEqual([]);
   });
 
-  test("installs a newer version and drops the one it replaces", async () => {
+  test("installs a newer version and leaves the one it replaces on disk", async () => {
     await installExtension({ crx: createExtensionCrx("1.0.0"), extensionId, installDir });
 
     const { fetch } = createFetch({ crx: createExtensionCrx("2.0.0"), servedVersion: "2.0.0" });
@@ -253,7 +254,10 @@ describe("installLatestExtension", () => {
 
     expect(latestExtension.updated).toBe(true);
     expect(latestExtension.version).toBe("2.0.0");
-    expect(await readdir(extensionInstallDir)).toEqual(["2.0.0"]);
+
+    // A session can still be deriving its copy from the version that was
+    // replaced, so the launch-time prune is what drops it
+    expect((await readdir(extensionInstallDir)).sort()).toEqual(["1.0.0", "2.0.0"]);
   });
 
   test("writes nothing when the package turns out to carry the installed version", async () => {
@@ -287,6 +291,49 @@ describe("installLatestExtension", () => {
         fetch: async () => new Response("<html><body>Try again later</body></html>"),
       }),
     ).rejects.toThrow(`Update endpoint answered an unreadable update check for ${extensionId}`);
+  });
+});
+
+describe("pruneExtensionVersions", () => {
+  async function writeVersionDir(id: string, dirName: string) {
+    await mkdir(path.join(installDir, id, dirName), { recursive: true });
+
+    await writeFile(path.join(installDir, id, dirName, "manifest.json"), "{}");
+  }
+
+  test("keeps the newest version of every extension and drops what it replaced", async () => {
+    const otherExtensionId = "otherextensionidwithnoversions";
+
+    await writeVersionDir(extensionId, "1.0.0");
+
+    await writeVersionDir(extensionId, "2.0.0");
+
+    await writeVersionDir(otherExtensionId, "3.0.0");
+
+    await pruneExtensionVersions({ installDir });
+
+    expect(await readdir(extensionInstallDir)).toEqual(["2.0.0"]);
+    expect(await readdir(path.join(installDir, otherExtensionId))).toEqual(["3.0.0"]);
+  });
+
+  test("drops what a crashed install left behind", async () => {
+    await writeVersionDir(extensionId, "1.0.0");
+
+    await writeVersionDir(extensionId, "2.0.0.staging");
+
+    await mkdir(path.join(extensionInstallDir, "3.0.0"));
+
+    await pruneExtensionVersions({ installDir });
+
+    expect(await readdir(extensionInstallDir)).toEqual(["1.0.0"]);
+  });
+
+  test("does nothing when nothing is installed", async () => {
+    await rm(installDir, { recursive: true, force: true });
+
+    await pruneExtensionVersions({ installDir });
+
+    expect(await readEntryNames(installDir)).toEqual([]);
   });
 });
 

--- a/packages/electron-extensions/install/installer.ts
+++ b/packages/electron-extensions/install/installer.ts
@@ -1,3 +1,4 @@
+import type { Dirent } from "node:fs";
 import { access, mkdir, readdir, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { unzipSync } from "fflate";
@@ -202,19 +203,48 @@ export async function getInstalledExtension({
   return { version, extensionDir: path.join(extensionInstallDir, version) };
 }
 
-/**
- * Everything under the id except the version just installed: older versions,
- * and staging directories a crashed install left behind.
- *
- * Dropping an older version out from under a running session is safe because
- * sessions load a derived copy of an extension, never the install itself.
- */
-async function pruneOtherVersions(extensionInstallDir: string, keptVersion: string) {
-  const entryNames = await readdir(extensionInstallDir);
+export type PruneExtensionVersionsOptions = {
+  /** The directory installs live under, `<installDir>/<extensionId>/<version>`. */
+  installDir: string;
+};
 
-  for (const entryName of entryNames) {
-    if (entryName !== keptVersion) {
-      await rm(path.join(extensionInstallDir, entryName), { recursive: true, force: true });
+/**
+ * Drops everything an install superseded: the version directories an update
+ * replaced, and staging directories a crashed install left behind. What is kept
+ * for every extension is the newest version installed, which is the one an
+ * embedder loads.
+ *
+ * A launch-time sweep rather than part of the install, because a session reads
+ * an install directory while deriving its copy of the extension, and an update
+ * that dropped the version being read would fail that load. Nothing reads an
+ * install before the first session is set up, so that is where deletion belongs
+ * — an extension updated mid-session keeps its old version until the next
+ * launch, which is one directory per updated extension.
+ */
+export async function pruneExtensionVersions({ installDir }: PruneExtensionVersionsOptions) {
+  let installEntries: Dirent[];
+
+  try {
+    installEntries = await readdir(installDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const installEntry of installEntries) {
+    if (!installEntry.isDirectory()) {
+      continue;
+    }
+
+    const extensionId = installEntry.name;
+
+    const extensionInstallDir = path.join(installDir, extensionId);
+
+    const installedExtension = await getInstalledExtension({ installDir, extensionId });
+
+    for (const entryName of await readdir(extensionInstallDir)) {
+      if (entryName !== installedExtension?.version) {
+        await rm(path.join(extensionInstallDir, entryName), { recursive: true, force: true });
+      }
     }
   }
 }
@@ -279,8 +309,6 @@ export async function installLatestExtension({
     extensionId,
     installDir,
   });
-
-  await pruneOtherVersions(path.join(installDir, extensionId), latestExtension.version);
 
   return { ...latestExtension, updated: true };
 }


### PR DESCRIPTION
A code review of the extensions layer on 21 August 2026 turned up three startup-ordering bugs of one family: something deletes a directory a session is reading while it derives its copy of an extension. All three are static findings — none is verified at runtime, and none of it has been run in the app.

## Finding 1: derived-copy pruning raced the derives

`pruneDerivedExtensionCopies()` ran after `accounts.init()`, so it swept while the per-account `extensions.setupSession` derives were still in flight. A derive deletes its stamp and then copies for the whole `cp` plus inject window, and `pruneDerivedExtensions` treats a derived directory without a stamp as unaccounted for. Depending on timing the extension failed to load for that launch, or — when the prune classified the directory before the stamp landed and deleted it after `loadExtension` — the session ran an extension whose files went missing mid-session.

The window opens on exactly the launches that re-derive: the restart right after an install or update, every user's first launch after a `DERIVE_VERSION` bump, and development source edits. It self-healed the following launch.

Fixed by awaiting the prune before `accounts.init()`. It is a `readdir` plus one stamp read per copy, so the startup cost is trivial, and no derive can have started yet.

## Finding 2: the updater's first check could delete a version being copied

`extensionUpdater.init()` fires an immediate `checkForUpdates()`, and `installLatestExtension` removed the version directory an update replaced — possibly while a session derive was still copying from it.

Fixed the way Chromium handles it: an install never deletes what may be in use, and a separate launch-time sweep collects what installs superseded. `pruneOtherVersions` moves out of the install path and becomes an exported `pruneExtensionVersions`, awaited in `init()` next to the derived-copy prune. The cost is one stale version directory per extension updated mid-session, cleared on the next launch — the same trade Chromium makes.

## Finding 3: a stamp without its copy never healed

When the stamp matched but the derived directory was gone — the prune's window between removing a directory and removing its stamp, or a manual deletion — `deriveExtension` skipped the copy and writing the facade threw `ENOENT`. On every launch, forever, because the stamp kept matching. A missing derived directory now counts as a stamp mismatch.

## Tests

- `derive/index.test.ts` covers finding 3: with the fix reverted, the new test fails with the exact `ENOENT` from `writeFile`.
- `installer.test.ts` covers the new `pruneExtensionVersions`, and the update test now asserts that the replaced version stays on disk.
- `bun test`, `bun run types`, `bun run lint`, and `bun run fmt:check` all pass.

Docs: the startup-order section of `architecture/overview.md` and a new "Deleting on disk happens at launch, never during a session" section in `features/chrome-extensions.md`.

https://claude.ai/code/session_01RmoPUJu3sN7rMAoZAjQoia