### PR TITLE
rename the prerelease update channel to Experimental

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -7,7 +7,11 @@ description: Write release notes for Meru. Use when drafting or updating GitHub 
 
 ## Gather the changes
 
-- The release being written is the one the version commit at `HEAD` bumps to — a commit whose subject is the bare version number, matching `version` in `package.json`, such as `3.58.0`, tagged `v3.58.0`. The range runs from the previous release's tag to that commit, and `gh release list -L 2` gives both tags.
+- The release being written is the one the version commit at `HEAD` bumps to — a commit whose subject is the bare version number, matching `version` in `package.json`, such as `3.58.0` or `3.60.0-alpha.1`, tagged `v3.58.0` or `v3.60.0-alpha.1`.
+- The range runs from the previous release's tag to that commit, and which tag counts as previous depends on the channel:
+  - **Stable** — the last stable tag, from `gh release list --exclude-pre-releases -L 1`. Never `gh release list -L 2`, which picks up an interleaved `-alpha.N` tag and truncates the notes to the tail of the cycle.
+  - **Experimental** — the last release of any kind, from `gh release list -L 1`, so each prerelease covers only what's new since the previous one.
+- Every release gets its own notes, prereleases included, written exactly the same way. A stable that promotes a cycle of experimental releases therefore restates the changes those already carried, because its range runs back to the last stable. That repetition is intended: the stable notes have to be complete for the users who never saw a prerelease.
 - Triage the log before opening a single diff. Drop on the commit subject alone: comment and docs edits, refactors and extractions, `TODO.md` notes, tests, CI, and dependency bumps other than Electron. A release of 40 commits usually has around 10 user-facing ones.
 - For the commits that survive, `gh pr view <number>` is the fastest read — the PR body states what changed for the user, and the commit subject often doesn't. Fall back to `git show` when there's no PR.
 - Don't trust a commit message's scope — verify the actual fix from the diff. Messages often name a single platform or quote a GitHub issue title, such as "fix window position resetting after Windows reboot", when the underlying bug affects every platform. Only scope a note to a platform with `**macOS:**` or `**Windows:**` when the code confirms the fix is platform-specific.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: release
 description: Cut a Meru release. Use when asked to release, cut a release, ship a version, or bump the version.
-argument-hint: [major|minor|patch|beta]
+argument-hint: [major|minor|patch|experimental]
 ---
 
 # Release
@@ -16,7 +16,7 @@ Check all of these first. If one fails, report it and stop — never work around
 - The last `main` workflow run is for the current `HEAD` and passed: `gh run list --workflow=main.yml --branch=main -L 1 --json headSha,status,conclusion,url`.
   - `headSha` must equal `git rev-parse HEAD`. A `HEAD` with no run yet, or a run still `in_progress`, means waiting — say which and ask whether to wait for it.
   - Any `conclusion` other than `success` means `main` is broken. Report the run URL and stop.
-- There is something to release: the range from the last release's tag to `HEAD` is non-empty. For a stable release that's the last stable tag, from `gh release list --exclude-pre-releases -L 1`. For a beta it's the last release of any kind, from `gh release list -L 1`.
+- There is something to release: the range from the last release's tag to `HEAD` is non-empty. For a stable release that's the last stable tag, from `gh release list --exclude-pre-releases -L 1`. For an experimental release it's the last release of any kind, from `gh release list -L 1`.
 
 ## Choose the bump
 
@@ -28,13 +28,15 @@ Read `git log --oneline <lastTag>..HEAD` — a release usually runs to a few doz
 
 Arguments naming a level or an explicit version override this triage — take them, and still confirm.
 
-## Beta releases
+## Experimental releases
 
-A `beta` argument, or an explicit `-beta.N` version, cuts a pre-release for the beta update channel instead of a stable release. Only cut one when asked — never propose a beta unprompted.
+An `experimental` argument, or an explicit `-alpha.N` version, cuts a prerelease for the Experimental update channel instead of a stable release. Only cut one when asked — never propose one unprompted.
 
-- The version is the next stable version per the triage above with `-beta.N` appended: the first beta of a cycle is `X.Y.Z-beta.1`. Each further beta before that stable ships increments `N`.
+The channel is named Experimental in the app and versioned `alpha` on the wire, so the interface says Experimental everywhere the version string says `-alpha.N`. That seam is deliberate, and the version suffix is never `-experimental.N`. The reasoning is in `docs/decisions.md` under "The prerelease channel is named Experimental and versioned as `alpha`".
+
+- The version is the next stable version per the triage above with `-alpha.N` appended: the first experimental release of a cycle is `X.Y.Z-alpha.1`. Each further one before that stable ships increments `N`.
 - Everything else follows the stable flow, with two differences: `gh release create` gets `--prerelease`, and the triage range runs from the last release of any kind, not the last stable.
-- Promoting a beta to stable is the normal stable flow with the suffix dropped, as in `3.60.0-beta.2` → `3.60.0`. Beta users are moved onto the stable build automatically.
+- Promoting an experimental release to stable is the normal stable flow with the suffix dropped, as in `3.60.0-alpha.2` → `3.60.0`. Experimental users are moved onto the stable build automatically.
 
 ## Confirm the bump
 
@@ -54,7 +56,7 @@ Always confirm before editing `package.json`, even when the bump is obvious.
 
 - `gh release create v<version> --target "$(git rev-parse HEAD)" --notes ""`.
   - `--target` pins the tag to the version commit rather than wherever `main` has drifted to.
-  - For a beta, add `--prerelease`. It keeps the release off `/releases/latest`, so stable users never see it, and it makes `release.yml` publish `beta*.yml` update metadata instead of `latest*.yml`.
+  - For an experimental release, add `--prerelease`. It keeps the release off `/releases/latest`, so stable users never see it, and it makes `release.yml` publish `alpha*.yml` update metadata instead of `latest*.yml`.
   - Pass no `--title`. Every prior release leaves the title empty, so GitHub shows the tag.
   - Empty notes are deliberate — the next step writes them. Don't pass `--generate-notes`.
 - Never create it as a draft. `release.yml` triggers on `released` or `prereleased` only, so a draft never builds.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         # without it macOS refuses to launch the signed app.
         run: |
           echo "$APPLE_PROVISIONING_PROFILE" | base64 --decode > build/embedded.provisionprofile
-          bun run build:mac -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=beta' || '' }}
+          bun run build:mac -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=alpha' || '' }}
         env:
           APPLE_PROVISIONING_PROFILE: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
@@ -40,10 +40,10 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: startsWith(matrix.os, 'ubuntu')
-        run: bun run build:linux -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=beta' || '' }}
+        run: bun run build:linux -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=alpha' || '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: startsWith(matrix.os, 'windows')
-        run: bun run build:win -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=beta' || '' }}
+        run: bun run build:win -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=alpha' || '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/renderer/routes/settings/updates.tsx
+++ b/packages/renderer/routes/settings/updates.tsx
@@ -5,7 +5,7 @@ import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/comp
 
 const releaseChannelItems = [
   { value: "stable", label: "Stable" },
-  { value: "beta", label: "Beta" },
+  { value: "alpha", label: "Experimental" },
 ];
 
 export function UpdatesSettings() {
@@ -29,15 +29,15 @@ export function UpdatesSettings() {
           />
           <ConfigSelectField
             label="Release channel"
-            description="Choose which releases to receive. The beta channel gets upcoming features early."
+            description="Choose which releases to receive. The experimental channel gets upcoming features early."
             configKey="updates.channel"
             items={releaseChannelItems}
             confirmation={{
-              when: (value) => value === "beta",
-              title: "Switch to the beta channel?",
+              when: (value) => value === "alpha",
+              title: "Switch to the experimental channel?",
               description:
-                "Beta releases are pre-release builds of upcoming versions. They might contain bugs or unfinished features. You can switch back to the stable channel at any time.",
-              confirmLabel: "Switch to beta",
+                "Experimental releases are unfinished builds of upcoming versions. They can contain bugs and break in ways a stable release won't. You can switch back to the stable channel at any time.",
+              confirmLabel: "Switch to experimental",
             }}
           />
         </FieldGroup>

--- a/packages/renderer/routes/settings/version-history.tsx
+++ b/packages/renderer/routes/settings/version-history.tsx
@@ -84,7 +84,7 @@ export function VersionHistorySettings() {
     }
 
     const releases =
-      config?.["updates.channel"] === "beta"
+      config?.["updates.channel"] === "alpha"
         ? data
         : data.filter((release) => !release.prerelease || release.tag_name === currentTagName);
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -129,7 +129,7 @@ export type Config = {
   "notifications.times": NotificationTime[];
   "updates.autoCheck": boolean;
   "updates.showNotifications": boolean;
-  "updates.channel": "stable" | "beta";
+  "updates.channel": "stable" | "alpha";
   "blocker.enabled": boolean;
   "blocker.ads": boolean;
   "blocker.tracking": boolean;


### PR DESCRIPTION
The prerelease channel from #843 was `beta` everywhere. It now reads **Experimental** in the interface and is `alpha` everywhere else: the `updates.channel` value, the version suffix, and the `alpha*.yml` update metadata the release workflow publishes.

The value has to be `alpha` or `beta` rather than anything friendlier. `GitHubProvider.getLatestVersion` gates picking a stable entry on `["alpha", "beta"].includes(currentChannel)`, and a stable entry has a null channel so it can never match the `isNextPreRelease` branch either. Any other value walks past a promoted stable and resolves the older prerelease, stranding users on the channel. The name and the constraint are settled in the docs repository under "The prerelease channel is named Experimental and versioned as `alpha`".

No prerelease has ever shipped, so nothing is installed on the channel and no `beta*.yml` exists on any release. There is nothing to migrate.

## What changed

- `packages/shared/types.ts` — `"updates.channel"` becomes `"stable" | "alpha"`.
- `packages/renderer/routes/settings/updates.tsx` — the option is `{ value: "alpha", label: "Experimental" }`, with the field description and the confirmation dialog rewritten in the new terms.
- `packages/renderer/routes/settings/version-history.tsx` — the prerelease filter tests `=== "alpha"`.
- `.github/workflows/release.yml` — all three builds pass `--config.publish.channel=alpha` on prerelease events.
- `.claude/skills/release/SKILL.md` — the argument becomes `experimental`, the section becomes Experimental releases, and versions are `X.Y.Z-alpha.N` publishing `alpha*.yml`.
- `.claude/skills/release-notes/SKILL.md` — the range rules now name the channel. A stable's range comes from `gh release list --exclude-pre-releases -L 1`, matching what the release skill already does; the old `gh release list -L 2` would pick up an interleaved prerelease tag and truncate a stable's notes to the tail of the cycle. Every release gets its own notes, prereleases included, and a stable restates what the prereleases before it carried.

`packages/app/updater.ts` needs no change — it reads the config value generically and only compares against `"stable"`. `packages/app/config.ts` still defaults to `"stable"`.

Left alone deliberately: `BetaFieldBadge` and its callers, the Extensions settings badge, and the Gmail dark theme description. Those are maturity badges, not the release channel.

Docs landed separately on the docs repository's `main`: `features/release-channels.md` rewritten in the new name and value including the mermaid diagram, and the release-notes policy recorded as its own decision entry.

## Not verified

`bun run types`, `bun run lint`, `bun run fmt:check` and `bun test` all pass. Nothing here is runnable in this sandbox — no display server — so the settings select, the confirmation dialog and the publish path were not exercised. The first `-alpha.N` release is what proves the workflow flag end to end.

One pre-existing failure in `bun test`, unrelated to this change and present on `main`: `pruneExtensionVersions > keeps the newest version of every extension and drops what it replaced`, where a fixture id trips the `assertExtensionId` guard from #934. Recorded as a todo row rather than fixed here.

https://claude.ai/code/session_01QqDJF4FurXLN9QzbSyKVHg