### PR TITLE
prune past a directory that isn't an extension

### DIFF
--- a/packages/electron-extensions/install/installer.test.ts
+++ b/packages/electron-extensions/install/installer.test.ts
@@ -318,7 +318,7 @@ describe("pruneExtensionVersions", () => {
   }
 
   test("keeps the newest version of every extension and drops what it replaced", async () => {
-    const otherExtensionId = "otherextensionidwithnoversions";
+    const otherExtensionId = "abcdefghijklmnopabcdefghijklmnop";
 
     await writeVersionDir(extensionId, "1.0.0");
 
@@ -330,6 +330,23 @@ describe("pruneExtensionVersions", () => {
 
     expect(await readdir(extensionInstallDir)).toEqual(["2.0.0"]);
     expect(await readdir(path.join(installDir, otherExtensionId))).toEqual(["3.0.0"]);
+  });
+
+  test("keeps pruning past a directory that isn't an extension", async () => {
+    const strayDir = path.join(installDir, "not-an-extension");
+
+    await mkdir(strayDir);
+
+    await writeFile(path.join(strayDir, "kept"), "kept");
+
+    await writeVersionDir(extensionId, "1.0.0");
+
+    await writeVersionDir(extensionId, "2.0.0");
+
+    await pruneExtensionVersions({ installDir });
+
+    expect(await readdir(extensionInstallDir)).toEqual(["2.0.0"]);
+    expect(await readFile(path.join(strayDir, "kept"), "utf8")).toBe("kept");
   });
 
   test("drops what a crashed install left behind", async () => {

--- a/packages/electron-extensions/install/installer.ts
+++ b/packages/electron-extensions/install/installer.ts
@@ -252,6 +252,12 @@ export async function pruneExtensionVersions({ installDir }: PruneExtensionVersi
 
     const extensionId = installEntry.name;
 
+    // The names come off disk, so a directory that isn't an extension at all is
+    // left alone rather than aborting the prune for every extension after it.
+    if (!isExtensionId(extensionId)) {
+      continue;
+    }
+
     const extensionInstallDir = path.join(installDir, extensionId);
 
     const installedExtension = await getInstalledExtension({ installDir, extensionId });


### PR DESCRIPTION
`bun test` is red on `main` and has been since #935 merged — `pruneExtensionVersions > keeps the newest version of every extension and drops what it replaced` fails. #934 and #935 were each green against their own base; the squashed combination is not.

## What was broken

`pruneExtensionVersions` reads the install directory and takes every directory entry's name as an extension id, handing it to `getInstalledExtension` — which opens with the `assertExtensionId` guard #934 added. A single entry that isn't a well-formed id throws out of the whole loop, so every extension after it goes unpruned.

The fixture's `otherExtensionId` was `"otherextensionidwithnoversions"`, 30 characters and not a valid id, so the test tripped that guard.

## The fix

- `pruneExtensionVersions` skips a directory entry whose name isn't an extension id and carries on with the rest. The names come off disk, so one stray directory must not abort the prune for every other extension. The check uses the existing `isExtensionId` predicate rather than catching the throw — a guard that throws isn't a control-flow mechanism. `assertExtensionId` stays exactly where it is in `getInstalledExtension`; it is what stops a traversal reaching outside the install directory.
- The fixture takes a well-formed 32-character id. Half one alone would turn the test green while silently exercising the new skip path instead of the prune its name claims, which is why both halves are here.
- The skip gets its own test, `keeps pruning past a directory that isn't an extension`: a stray directory survives untouched and the extension beside it is still pruned. Verified failing against the unfixed `pruneExtensionVersions`.

## Checks

`bun run types`, `bun run lint`, `bun run fmt:check` and the full `bun test` (370 pass, 1 skip, 0 fail) are green in the worktree. Nothing here needs a display server, so nothing was left unverified.

The `docs/todo.md` row stays in place; it comes out at merge. The dead `main.yml` reference in the release skill is a separate item in another session and is untouched here.

https://claude.ai/code/session_017X43a8Q7ZChkokrTUywdnf