### PR TITLE
check the workflows the release actually depends on

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -13,9 +13,13 @@ The version commit goes straight onto `main` — no branch, no PR. Publishing th
 Check all of these first. If one fails, report it and stop — never work around it.
 
 - On `main`, clean and up to date: `git status --porcelain` empty, then `git checkout main && git pull --ff-only`.
-- The last `main` workflow run is for the current `HEAD` and passed: `gh run list --workflow=main.yml --branch=main -L 1 --json headSha,status,conclusion,url`.
+- The workflow names below are real: `.github/workflows/` holds `ci.yml` and `build.yml`. Check that before running either command — GitHub answers a renamed workflow with its pre-rename runs instead of an error, so a stale name here reads as "no run yet" on every release and never verifies anything.
+- The last `ci.yml` run is for the current `HEAD` and passed: `gh run list --workflow=ci.yml --branch=main -L 1 --json headSha,status,conclusion,url`.
   - `headSha` must equal `git rev-parse HEAD`. A `HEAD` with no run yet, or a run still `in_progress`, means waiting — say which and ask whether to wait for it.
   - Any `conclusion` other than `success` means `main` is broken. Report the run URL and stop.
+- The newest `build.yml` run on `main` is not a failure: `gh run list --workflow=build.yml --branch=main -L 1 --json headSha,status,conclusion,url`. A green `ci.yml` says nothing about whether the app compiles, and `release.yml` builds all three platforms — a broken build fails the release where it costs the most.
+  - A `conclusion` of `failure` means the release build will fail too. Report the run URL and stop. A run still `in_progress` means waiting — ask whether to wait for it.
+  - Its `headSha` may lag `HEAD`, because `build.yml` ignores commits that only touch Markdown. Don't require a match, and don't wait for a run that will never start.
 - There is something to release: the range from the last release's tag to `HEAD` is non-empty. For a stable release that's the last stable tag, from `gh release list --exclude-pre-releases -L 1`. For an experimental release it's the last release of any kind, from `gh release list -L 1`.
 
 ## Choose the bump


### PR DESCRIPTION
The `release` skill's precondition ran `gh run list --workflow=main.yml --branch=main -L 1`, and there is no `main.yml` — it was renamed to `ci.yml` some releases ago, alongside `build.yml` and `release.yml`. `gh` doesn't error on a renamed workflow; it answers with the pre-rename runs, the newest from #799. So the skill compared that run's `headSha` against `HEAD`, never matched, and reported "no run yet — wait for it" on every release. The check has never actually verified that `main` is green, and its failure mode was the friendly one, which is why it went unnoticed.

## What changed

- The CI check points at `ci.yml`. It keeps the `headSha` equality against `HEAD` — `ci.yml` runs on every push to `main`, so a matching run always exists.
- A second check on `build.yml`. `release.yml` reruns CI and then builds and uploads macOS, Windows, and Linux artifacts, and a green `ci.yml` covers formatting, linting, types, and tests without saying anything about whether the app compiles. Cutting a release on a green `ci.yml` with a broken `build.yml` fails at the point where it is most expensive to fail.
- `build.yml` is checked for failure, not for matching `HEAD`. It carries `paths-ignore: "**.md"`, so a docs-only commit legitimately has no run at that SHA; requiring equality there would block those releases forever, which is the same class of bug this fixes.
- Both checks are preceded by confirming the two files are still in `.github/workflows/`. That is what makes the next rename loud — a stale `--workflow` name returns stale rows rather than an error, so nothing else in the flow would catch it.

The decision to check both workflows, and to check them differently, is recorded in `docs/decisions.md` under "The release precondition checks builds as well as CI".

## Checks

`bun run types`, `bun run lint`, `bun run fmt:check`, and `bun test` all pass. The branch is rebased onto `main` at #937, which fixed the `pruneExtensionVersions` failure that was red when this PR opened.

The precondition itself was not exercised by actually cutting a release. The `gh run list` invocations were run by hand against this repo and return current, correct data for both workflows; the surrounding skill flow was not.
