### PR TITLE
serve the deprecated privacy.services.autofillEnabled setting

### DIFF
--- a/packages/electron-extensions/facade/api/privacy.ts
+++ b/packages/electron-extensions/facade/api/privacy.ts
@@ -37,6 +37,7 @@ export function createPrivacy(): ChromeNamespace {
       alternateErrorPagesEnabled: false,
       autofillAddressEnabled: false,
       autofillCreditCardEnabled: false,
+      autofillEnabled: false,
       passwordSavingEnabled: false,
       safeBrowsingEnabled: false,
       safeBrowsingExtendedReportingEnabled: false,

--- a/packages/electron-extensions/facade/install.test.ts
+++ b/packages/electron-extensions/facade/install.test.ts
@@ -151,6 +151,22 @@ describe("installChromeFacade", () => {
     });
   });
 
+  test("serves the deprecated privacy settings Chrome still ships", async () => {
+    const services = namespaceOf(namespaceOf(install(), "privacy"), "services");
+
+    // Deprecated since Chrome 70 and still in the API, so an extension reaching
+    // for the old key must find a setting rather than dereference `undefined`
+    const autofillEnabled = namespaceOf(services, "autofillEnabled");
+
+    expect(await methodOf(autofillEnabled, "get")({})).toEqual({
+      value: false,
+      levelOfControl: "not_controllable",
+    });
+    expect(await methodOf(autofillEnabled, "set")({ value: true })).toBeUndefined();
+    expect(await methodOf(autofillEnabled, "clear")({})).toBeUndefined();
+    expect(eventOf(autofillEnabled, "onChange").addListener).toBeFunction();
+  });
+
   test("shares one facade between the chrome and browser globals", () => {
     const facade = createChromeFacade();
 


### PR DESCRIPTION
Chrome still ships `privacy.services.autofillEnabled` — deprecated since Chrome 70, but present in the API — and `createPrivacy()`'s placeholder map omitted it. An extension toggling built-in autofill through the old key dereferenced `undefined` and threw, in a namespace whose entire point is not crashing. 1Password touches `privacy.services.*` in its service worker bundle and nothing exercised the namespace at boot, so this could have bitten live during the 1Password release. Which key 1Password reaches for is unmeasured; covering the deprecated one closes the gap either way.

One entry, `autofillEnabled: false`. `false` matches the convention the neighboring `autofillAddressEnabled` and `autofillCreditCardEnabled` entries set: a typed placeholder describing what Meru actually does, which is no built-in autofill.

The new `install.test.ts` case asserts the key is served in Chrome's `ChromeSetting` shape — `get` answers the placeholder with `levelOfControl: "not_controllable"`, `set` and `clear` resolve without effect, and `onChange` accepts listeners.

Checked against the official Chrome privacy reference on August 21, 2026: every other documented key was already covered, so the scope stops here.

The `privacy` row of `docs/architecture/chrome-api-conformance.md` named this key as a divergence; it's reworded to read as fixed, and that edit lands in the docs repo alongside this merge.

`bun test`, `bun run types`, `bun run lint`, and `bun run fmt:check` all pass. Not verified in a running app against a real extension calling the key.

https://claude.ai/code/session_013UUWGwo1Cz3WJD4fMiwKJJ