### PR TITLE
add the two missing chrome.tabs constants to the facade

### DIFF
--- a/packages/electron-extensions/facade/api/tabs.ts
+++ b/packages/electron-extensions/facade/api/tabs.ts
@@ -1,11 +1,13 @@
 import type { ChromeNamespace } from "../lib/chrome";
 
 /**
- * Electron implements the tabs namespace itself, minus the two constants
- * extensions compare ids against.
+ * Electron implements the tabs namespace itself, minus the constants
+ * extensions compare ids and call rates against.
  */
 export function createTabs(): ChromeNamespace {
   return {
+    MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND: 2,
+    SPLIT_VIEW_ID_NONE: -1,
     TAB_ID_NONE: -1,
     TAB_INDEX_NONE: -1,
   };

--- a/packages/electron-extensions/facade/install.test.ts
+++ b/packages/electron-extensions/facade/install.test.ts
@@ -67,10 +67,13 @@ describe("installChromeFacade", () => {
     }
   });
 
-  test("adds the constants extensions compare ids against", () => {
+  test("adds the constants Electron leaves off the namespaces", () => {
     const chrome = install();
 
     expect(namespaceOf(chrome, "tabs").TAB_ID_NONE).toBe(-1);
+    expect(namespaceOf(chrome, "tabs").TAB_INDEX_NONE).toBe(-1);
+    expect(namespaceOf(chrome, "tabs").SPLIT_VIEW_ID_NONE).toBe(-1);
+    expect(namespaceOf(chrome, "tabs").MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND).toBe(2);
     expect(namespaceOf(chrome, "windows").WINDOW_ID_NONE).toBe(-1);
     expect(namespaceOf(chrome, "windows").WINDOW_ID_CURRENT).toBe(-2);
   });


### PR DESCRIPTION
Electron implements `chrome.tabs` natively but ships none of its constants, and the facade filled in only `TAB_ID_NONE` and `TAB_INDEX_NONE`. A conformance pass against the official Chrome MV3 tabs reference found two more documented under Properties, so an extension reading either was comparing against `undefined` and silently taking the wrong branch.

Both values come from developer.chrome.com/docs/extensions/reference/api/tabs, fetched today rather than recalled:

- `SPLIT_VIEW_ID_NONE`: `-1` (Chrome 140). Recent, but included so extensions built against new Chrome can read it.
- `MAX_CAPTURE_VISIBLE_TAB_CALLS_PER_SECOND`: `2` (Chrome 92).

The existing facade test that asserts the id constants now covers all four, and its name widened to match — one of the two isn't an id. Nothing else about the namespace changes: the missing `tabs` methods and events still throw rather than noop, which stays the documented state, and promoting `tabs.create` is separate work.

The `tabs` row of `docs/architecture/chrome-api-conformance.md` moves both constants out of the gap list, pushed separately to the docs repo.

Verified with `bun test`, `bun run types`, `bun run lint`, and `bun run fmt:check`. Not verified against a real extension reading the constants at runtime.

https://claude.ai/code/session_01TGG7yjjaCtjjBtJHHWFLjE