### PR TITLE
add a script that clones the private docs repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ bun test           # tests across every package
 ## Docs
 
 - `docs/` is a separately cloned private docs repo, gitignored here, and it might be absent on fresh checkouts. When it's present, read `docs/README.md` for what lives where.
+- When `docs/` is missing, run `bun run docs:clone` to clone it. If you keep repositories in a shared directory, clone it there instead and symlink `docs/` to it, so several worktrees share one clone — set `MERU_DOCS_PATH` to that directory and the script does both.
 - Check `docs/decisions.md` before reopening a settled design decision.
 - Keep `docs/architecture/` current when changing the app's structure. Larger features start as a design doc in `docs/features/` before implementation.
 - When renaming a main-process class or file, grep `docs/` for the old name and fix every reference — the docs repo has no other mechanism to catch renames.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build:mac:x64": "bun run build:mac -- --x64",
     "build:win": "bun run build:js && bun run build:clean-dist && electron-builder --win",
     "dev": "bun run scripts/build.ts --dev",
+    "docs:clone": "scripts/clone-docs.sh",
     "extensions:download": "bun run scripts/download-extensions.ts",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",

--- a/scripts/clone-docs.sh
+++ b/scripts/clone-docs.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Clones the private docs repository into `docs/` at the repository root, which
+# is gitignored here and absent on a fresh checkout.
+#
+# Set MERU_DOCS_PATH to keep the clone outside the checkout — several worktrees
+# of this repository can then share one clone instead of cloning it each time.
+# `docs/` becomes a symlink to that path.
+
+set -euo pipefail
+
+DOCS_REPO=zoidsh/meru-docs
+
+repo_root=$(git rev-parse --show-toplevel)
+
+link="$repo_root/docs"
+
+if [ -e "$link" ] || [ -L "$link" ]; then
+  echo "docs: $link already exists, nothing to do"
+
+  exit 0
+fi
+
+clone_path="${MERU_DOCS_PATH:-$link}"
+
+if [ ! -d "$clone_path" ]; then
+  if ! GIT_TERMINAL_PROMPT=0 gh repo clone "$DOCS_REPO" "$clone_path" -- --quiet; then
+    echo "docs: could not clone $DOCS_REPO — is gh authenticated for it?" >&2
+
+    exit 1
+  fi
+fi
+
+if [ "$clone_path" != "$link" ]; then
+  ln -s "$clone_path" "$link"
+fi
+
+echo "docs: $DOCS_REPO is at $link — read docs/README.md for what lives where"


### PR DESCRIPTION
`docs/` is gitignored here and absent on a fresh checkout, so every session that needed it had to be told out of band where it comes from.

`scripts/clone-docs.sh`, run as `bun run docs:clone`, clones `zoidsh/meru-docs` into `docs/`. Setting `MERU_DOCS_PATH` clones it there instead and symlinks `docs/` to it, so several worktrees of this repository share one clone rather than cloning a private repo into each. It exits cleanly when `docs/` already exists, and fails with a message pointing at `gh` auth when the clone doesn't work.

`CLAUDE.md`'s `## Docs` section now names the command and the shared-clone flow.

This replaces a machine-wide Claude Code `SessionStart` hook that did the same linking for every checkout whose origin was `zoidsh/meru`; the logic belongs in this repo, invoked deliberately.

Verified by running the script three ways: against a checkout that already has `docs/`, against a fresh repo with `MERU_DOCS_PATH` set (symlink created, rerun idempotent), and against a fresh repo without it (real clone into `docs/`). `bun run types`, `bun run lint` and `bun run fmt:check` pass. The failure path — an unauthenticated `gh` — was not exercised.

https://claude.ai/code/session_014m6YQyeGzNPBUL9sUYttjX