### PR TITLE
Rewrite the verification code extractor with multilingual scoring

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -105,11 +105,15 @@
       "name": "@meru/ui",
       "version": "0.0.0",
     },
+    "packages/verification-code": {
+      "name": "@meru/verification-code",
+      "version": "0.0.0",
+    },
   },
   "patchedDependencies": {
+    "conf@14.0.0": "patches/conf@14.0.0.patch",
     "electron-context-menu@4.1.0": "patches/electron-context-menu@4.1.0.patch",
     "sonner@2.0.7": "patches/sonner@2.0.7.patch",
-    "conf@14.0.0": "patches/conf@14.0.0.patch",
   },
   "packages": {
     "7zip-bin": ["7zip-bin@5.2.0", "", {}, "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A=="],
@@ -297,6 +301,8 @@
     "@meru/shared": ["@meru/shared@workspace:packages/shared"],
 
     "@meru/ui": ["@meru/ui@workspace:packages/ui"],
+
+    "@meru/verification-code": ["@meru/verification-code@workspace:packages/verification-code"],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -116,7 +116,6 @@ export const config = new Store<Config>({
     "verificationCodes.autoCopy": false,
     "verificationCodes.autoDelete": false,
     "verificationCodes.autoMarkAsRead": false,
-    "verificationCodes.confidence": "high",
     "doNotDisturb.enabled": false,
     "doNotDisturb.duration": null,
     "doNotDisturb.until": null,
@@ -460,6 +459,13 @@ export const config = new Store<Config>({
         }
 
         store.set("accounts", accounts);
+      }
+    },
+    ">=3.60.0": (store) => {
+      // @ts-expect-error: `verificationCodes.confidence` has been removed
+      if (store.has("verificationCodes.confidence")) {
+        // @ts-expect-error
+        store.delete("verificationCodes.confidence");
       }
     },
   },

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -15,6 +15,7 @@ import {
 import { ms } from "@meru/shared/ms";
 import { clamp, wait } from "@meru/shared/utils";
 import type { SupportedWorkspaceApp } from "@meru/shared/workspace-apps";
+import { extractVerificationCode } from "@meru/verification-code";
 import {
   app,
   BrowserWindow,
@@ -89,126 +90,6 @@ const inboxFeedSchema = z.object({
 });
 
 const inboxTypeSchema = z.string();
-
-function extractVerificationCode(texts: string[]) {
-  const confidence = config.get("verificationCodes.confidence");
-
-  let textIncludesHighConfidencePattern = false;
-  let textIncludesMediumConfidencePattern = false;
-  let textIncludesNegativePattern = false;
-
-  if (confidence === "high") {
-    for (const text of texts) {
-      if (
-        /\b(verification|sign[-\s]in|sign[-\s]up|single[-\s]use|one[-\s]time|security|authentication)\b/i.test(
-          text,
-        )
-      ) {
-        textIncludesHighConfidencePattern = true;
-
-        break;
-      }
-    }
-  }
-
-  for (const text of texts) {
-    if (/\bcode\b/i.test(text)) {
-      textIncludesMediumConfidencePattern = true;
-
-      break;
-    }
-  }
-
-  for (const text of texts) {
-    if (/\b(pick[-\s]up|delivery|collection)\b/i.test(text)) {
-      textIncludesNegativePattern = true;
-
-      break;
-    }
-  }
-
-  if (
-    (confidence === "high" && !textIncludesHighConfidencePattern) ||
-    !textIncludesMediumConfidencePattern ||
-    textIncludesNegativePattern
-  ) {
-    return null;
-  }
-
-  // 6-digit codes
-  for (const text of texts) {
-    const verificationCodeMatch = text.match(/\b([0-9]{6})\b/);
-
-    if (verificationCodeMatch?.[1]) {
-      return verificationCodeMatch[1];
-    }
-  }
-
-  for (const text of texts) {
-    const verificationCodeMatch = text.match(/\b([0-9]{3}[\s-][0-9]{3})\b/);
-
-    if (verificationCodeMatch?.[1]) {
-      return verificationCodeMatch[1].replace(/[\s-]/g, "");
-    }
-  }
-
-  for (const text of texts) {
-    const verificationCodeMatch = text.match(/\b([0-9]{2}[\s-][0-9]{2}[\s-][0-9]{2})\b/);
-
-    if (verificationCodeMatch?.[1]) {
-      return verificationCodeMatch[1].replace(/[\s-]/g, "");
-    }
-  }
-
-  // 8-digit codes
-  for (const text of texts) {
-    const verificationCodeMatch = text.match(/\b([0-9]{8})\b/);
-
-    if (verificationCodeMatch?.[1]) {
-      return verificationCodeMatch[1];
-    }
-  }
-
-  for (const text of texts) {
-    const verificationCodeMatch = text.match(/\b([0-9]{4}[\s-][0-9]{4})\b/);
-
-    if (verificationCodeMatch?.[1]) {
-      return verificationCodeMatch[1].replace(/[\s-]/g, "");
-    }
-  }
-
-  for (const text of texts) {
-    const verificationCodeMatch = text.match(
-      /\b([0-9]{2}[\s-][0-9]{2}[\s-][0-9]{2}[\s-][0-9]{2})\b/,
-    );
-
-    if (verificationCodeMatch?.[1]) {
-      return verificationCodeMatch[1].replace(/[\s-]/g, "");
-    }
-  }
-
-  // 4-digit codes
-  for (const text of texts) {
-    const verificationCodeMatch = text.match(/\b([0-9]{4})\b/);
-
-    if (
-      verificationCodeMatch?.[1] &&
-      verificationCodeMatch[1] !== new Date().getFullYear().toString()
-    ) {
-      return verificationCodeMatch[1];
-    }
-  }
-
-  for (const text of texts) {
-    const verificationCodeMatch = text.match(/\b([0-9]{2}[\s-][0-9]{2})\b/);
-
-    if (verificationCodeMatch?.[1]) {
-      return verificationCodeMatch[1].replace(/[\s-]/g, "");
-    }
-  }
-
-  return null;
-}
 
 export class Gmail {
   accountId: string;

--- a/packages/renderer/routes/settings/verification-codes.tsx
+++ b/packages/renderer/routes/settings/verification-codes.tsx
@@ -1,14 +1,8 @@
 import { FieldGroup } from "@meru/ui/components/field";
-import { ConfigSelectField } from "@/components/config-select-field";
 import { ConfigSwitchField } from "@/components/config-switch-field";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
 import { useConfig } from "@/lib/react-query";
-
-const verificationCodeConfidenceItems = [
-  { value: "high", label: "High" },
-  { value: "medium", label: "Medium" },
-];
 
 export function VerificationCodesSettings() {
   const { config } = useConfig();
@@ -29,13 +23,6 @@ export function VerificationCodesSettings() {
             label="Copy codes to clipboard"
             description="Copy a verification code to your clipboard as soon as it arrives by email."
             configKey="verificationCodes.autoCopy"
-            licenseKeyRequired
-          />
-          <ConfigSelectField
-            configKey="verificationCodes.confidence"
-            label="Detection confidence"
-            description="Choose how certain Meru has to be before it treats something as a verification code. Medium can pick up codes that aren't there. High looks for explicit keywords and can miss some."
-            items={verificationCodeConfidenceItems}
             licenseKeyRequired
           />
           <ConfigSwitchField

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -182,7 +182,6 @@ export type Config = {
   "verificationCodes.autoCopy": boolean;
   "verificationCodes.autoDelete": boolean;
   "verificationCodes.autoMarkAsRead": boolean;
-  "verificationCodes.confidence": "high" | "medium";
   "doNotDisturb.enabled": boolean;
   "doNotDisturb.duration": string | null;
   "doNotDisturb.until": number | null;

--- a/packages/verification-code/corpus.fixtures.ts
+++ b/packages/verification-code/corpus.fixtures.ts
@@ -1,0 +1,868 @@
+// Labeled corpus for the verification-code extractor.
+//
+// Every entry is a synthetic message modeled on a well-known sender template —
+// no real mail, no real people. The extractor sees exactly what the Gmail Atom
+// feed gives us: the `subject` and `summary`, a truncated body snippet that is
+// usually under ~180 characters and is often cut mid-sentence.
+//
+// `expected` is the code the extractor must return, digits only with separators
+// stripped, or `null` when it must return nothing. The extractor's actions are
+// destructive — it can copy, mark read, and delete — so precision beats recall:
+// every `null` entry is a guardrail, and the tuning target is zero false
+// positives across the negatives before maximizing extracted positives.
+
+export interface CorpusEntry {
+  subject: string;
+  summary: string;
+  expected: string | null;
+  language: string;
+  note?: string;
+}
+
+export const corpus: CorpusEntry[] = [
+  // ---------------------------------------------------------------------------
+  // Positives — English
+  // ---------------------------------------------------------------------------
+  {
+    subject: "123456 is your verification code",
+    summary:
+      "Someone requested a verification code for your account. If this wasn't you, don't share this code with anyone.",
+    expected: "123456",
+    language: "en",
+    note: "code in the subject only, the snippet repeats the keyword without digits",
+  },
+  {
+    subject: "Verification code for your account",
+    summary: "Your verification code is: 490321. Do not share it with anyone.",
+    expected: "490321",
+    language: "en",
+  },
+  {
+    subject: "Account security code",
+    summary:
+      "Please use this security code to finish signing in on your new device. Security code: 7482910",
+    expected: "7482910",
+    language: "en",
+    note: "7 solid digits — currently unextractable, licensed at a low format prior",
+  },
+  {
+    subject: "Please verify your device",
+    summary: "Verification code: 483921. This code expires in 15 minutes.",
+    expected: "483921",
+    language: "en",
+  },
+  {
+    subject: "Sign-in attempt from a new device",
+    summary: "To verify your identity, enter the one-time password: 940213",
+    expected: "940213",
+    language: "en",
+    note: "keyword is OTP-shaped, the word code never appears",
+  },
+  {
+    subject: "Your one-time passcode",
+    summary: "Use passcode 493 021 to authorize your transfer. Never share this code.",
+    expected: "493021",
+    language: "en",
+    note: "grouped 3-3 with a space separator",
+  },
+  {
+    subject: "Messenger code 402-136",
+    summary: "Your messenger code: 402-136. Don't share this code with others.",
+    expected: "402136",
+    language: "en",
+    note: "grouped 3-3 with a hyphen separator, present in both strings",
+  },
+  {
+    subject: "Login code",
+    summary:
+      "Your login code: 74102. Enter it in the app. Do not give this code to anyone, even if they say they are from support.",
+    expected: "74102",
+    language: "en",
+    note: "5 solid digits — currently unextractable",
+  },
+  {
+    subject: "Your verification code",
+    summary: "Enter the code 40391827 to finish setting up your account.",
+    expected: "40391827",
+    language: "en",
+    note: "8 solid digits, the length an order number usually has",
+  },
+  {
+    subject: "Delivery confirmation code",
+    summary: "Your delivery code is 4930. Share it with the courier when your parcel arrives.",
+    expected: "4930",
+    language: "en",
+    note: "delivery wording must stay a penalty, not a veto — a genuine delivery OTP survives on proximity",
+  },
+  {
+    subject: "Security code",
+    summary: "Your security code is 49 30 21. It expires in 10 minutes.",
+    expected: "493021",
+    language: "en",
+    note: "grouped 2-2-2",
+  },
+  {
+    subject: "Sign-in verification",
+    summary: "Verification code: 4930-2178",
+    expected: "49302178",
+    language: "en",
+    note: "grouped 4-4",
+  },
+  {
+    subject: "Your access code",
+    summary: "Access code: 49-30-21-78. Enter it to continue.",
+    expected: "49302178",
+    language: "en",
+    note: "grouped 2-2-2-2",
+  },
+  {
+    subject: "Your verification code for the store",
+    summary: "Welcome back. Enter 620418 to continue signing in.",
+    expected: "620418",
+    language: "en",
+    note: "the most common real shape — keyword in the subject, digits in the snippet",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Positives — German (compound forms)
+  // ---------------------------------------------------------------------------
+  {
+    subject: "Ihr Bestätigungscode",
+    summary: "Ihr Bestätigungscode lautet 493021. Geben Sie ihn niemals an Dritte weiter.",
+    expected: "493021",
+    language: "de",
+    note: "compound Bestätigungscode — the \\bcode\\b gate misses this",
+  },
+  {
+    subject: "Sicherheitscode für Ihr Konto",
+    summary: "Verwenden Sie den Sicherheitscode 7482, um Ihre Anmeldung abzuschließen.",
+    expected: "7482",
+    language: "de",
+    note: "compound Sicherheitscode with a 4-digit code",
+  },
+  {
+    subject: "839217 ist Ihr Verifizierungscode",
+    summary:
+      "Sie haben eine Anmeldung angefordert. Der Code ist 15 Minuten gültig und gilt nur einmal.",
+    expected: "839217",
+    language: "de",
+    note: "compound Verifizierungscode, digits in the subject",
+  },
+  {
+    subject: "Anmeldung bestätigen",
+    summary: "Ihr Einmalcode lautet 40 21 36. Er gilt nur für diesen Auftrag.",
+    expected: "402136",
+    language: "de",
+    note: "compound Einmalcode, grouped 2-2-2",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Positives — French
+  // ---------------------------------------------------------------------------
+  {
+    subject: "Votre code de vérification",
+    summary: "Votre code de vérification est 493021. Ne le communiquez à personne.",
+    expected: "493021",
+    language: "fr",
+  },
+  {
+    subject: "306142 est votre code de connexion",
+    summary: "Utilisez ce code pour vous connecter à votre compte. Il expire dans 10 minutes.",
+    expected: "306142",
+    language: "fr",
+  },
+  {
+    subject: "Vérification en deux étapes",
+    summary: "Votre code à usage unique : 402 136",
+    expected: "402136",
+    language: "fr",
+    note: "grouped 3-3, very short snippet",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Positives — Spanish
+  // ---------------------------------------------------------------------------
+  {
+    subject: "Tu código de verificación",
+    summary: "Tu código de verificación es 493021. No lo compartas con nadie.",
+    expected: "493021",
+    language: "es",
+    note: "accented código must match on its own, not through \\bcode\\b",
+  },
+  {
+    subject: "620418 es tu código de acceso",
+    summary: "Introduce este código para iniciar sesión. Caduca en 10 minutos.",
+    expected: "620418",
+    language: "es",
+  },
+  {
+    subject: "Verificación en dos pasos",
+    summary: "Tu código de un solo uso: 40-21-36",
+    expected: "402136",
+    language: "es",
+    note: "grouped 2-2-2 with hyphens",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Positives — Portuguese
+  // ---------------------------------------------------------------------------
+  {
+    subject: "Seu código de verificação",
+    summary: "Seu código de verificação é 493021. Não compartilhe com ninguém.",
+    expected: "493021",
+    language: "pt",
+  },
+  {
+    subject: "839217 é o seu código de acesso",
+    summary: "Use este código para entrar na sua conta. Ele expira em 10 minutos.",
+    expected: "839217",
+    language: "pt",
+  },
+  {
+    subject: "Código de segurança",
+    summary: "Digite o código 5041 para confirmar o pagamento.",
+    expected: "5041",
+    language: "pt",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Positives — Italian
+  // ---------------------------------------------------------------------------
+  {
+    subject: "Il tuo codice di verifica",
+    summary: "Il tuo codice di verifica è 493021. Non condividerlo con nessuno.",
+    expected: "493021",
+    language: "it",
+  },
+  {
+    subject: "620418 è il tuo codice di accesso",
+    summary: "Inserisci il codice per accedere al tuo account. Scade tra 10 minuti.",
+    expected: "620418",
+    language: "it",
+  },
+  {
+    subject: "Codice di sicurezza",
+    summary: "Usa il codice 40 21 36 per autorizzare il pagamento.",
+    expected: "402136",
+    language: "it",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Positives — Polish
+  // ---------------------------------------------------------------------------
+  {
+    subject: "Twój kod weryfikacyjny",
+    summary: "Twój kod weryfikacyjny to 493021. Nie udostępniaj go nikomu.",
+    expected: "493021",
+    language: "pl",
+    note: "kod is prefix-anchored, the inflected kodu appears elsewhere in the language",
+  },
+  {
+    subject: "839217 to Twój kod logowania",
+    summary: "Użyj tego kodu, aby zalogować się na swoje konto.",
+    expected: "839217",
+    language: "pl",
+    note: "only the inflected kodu appears in the snippet",
+  },
+  {
+    subject: "Kod bezpieczeństwa",
+    summary: "Wpisz kod 7482, aby potwierdzić transakcję.",
+    expected: "7482",
+    language: "pl",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Positives — Turkish (suffixed forms)
+  // ---------------------------------------------------------------------------
+  {
+    subject: "Doğrulama kodunuz",
+    summary: "Doğrulama kodunuz: 493021. Bu kodu kimseyle paylaşmayın.",
+    expected: "493021",
+    language: "tr",
+    note: "suffixed kodunuz and kodu — only a prefix anchor on kod matches both",
+  },
+  {
+    subject: "620418 giriş kodunuz",
+    summary: "Hesabınıza giriş yapmak için bu kodu kullanın. Kod 10 dakika geçerlidir.",
+    expected: "620418",
+    language: "tr",
+  },
+  {
+    subject: "Güvenlik kodu",
+    summary: "İşlemi onaylamak için 7482 kodunu girin.",
+    expected: "7482",
+    language: "tr",
+    note: "the code word follows the digits instead of preceding them",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Positives — Russian
+  // ---------------------------------------------------------------------------
+  {
+    subject: "Ваш код подтверждения",
+    summary: "Ваш код подтверждения: 493021. Никому не сообщайте его.",
+    expected: "493021",
+    language: "ru",
+  },
+  {
+    subject: "839217 — код для входа",
+    summary: "Используйте этот код, чтобы войти в аккаунт. Он действует 10 минут.",
+    expected: "839217",
+    language: "ru",
+  },
+  {
+    subject: "Код безопасности",
+    summary: "Введите код 7482, чтобы подтвердить операцию.",
+    expected: "7482",
+    language: "ru",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Positives — Japanese (no word boundaries, full-width digits)
+  // ---------------------------------------------------------------------------
+  {
+    subject: "認証コードのお知らせ",
+    summary: "認証コードは 493021 です。他人には教えないでください。",
+    expected: "493021",
+    language: "ja",
+    note: "no word boundaries exist around 認証コード",
+  },
+  {
+    subject: "【重要】確認コード：４９３０２１",
+    summary: "ログインを完了するには、上記のコードを入力してください。",
+    expected: "493021",
+    language: "ja",
+    note: "full-width digits in the subject — NFKC normalization is required",
+  },
+  {
+    subject: "ワンタイムパスワード",
+    summary: "お客様の認証コードは ７４８２ です。有効期限は10分です。",
+    expected: "7482",
+    language: "ja",
+    note: "full-width 4-digit code next to a half-width 10 that must not win",
+  },
+  {
+    subject: "620418 はあなたの確認コードです",
+    summary: "心当たりがない場合は、このメールを無視してください。",
+    expected: "620418",
+    language: "ja",
+    note: "code word and digits in the subject, snippet has neither",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Positives — Chinese
+  // ---------------------------------------------------------------------------
+  {
+    subject: "您的验证码",
+    summary: "您的验证码是 493021，10分钟内有效，请勿泄露给他人。",
+    expected: "493021",
+    language: "zh-hans",
+  },
+  {
+    subject: "【安全提醒】620418 是您的登录验证码",
+    summary: "请在页面中输入该验证码完成登录。",
+    expected: "620418",
+    language: "zh-hans",
+  },
+  {
+    subject: "支付验证码",
+    summary: "验证码：７４８２，请勿转发。",
+    expected: "7482",
+    language: "zh-hans",
+    note: "full-width digits, no separating whitespace at all",
+  },
+  {
+    subject: "您的驗證碼",
+    summary: "您的驗證碼為 493021，請於 10 分鐘內完成驗證。",
+    expected: "493021",
+    language: "zh-hant",
+    note: "traditional 驗證碼 is a distinct lexicon entry from simplified 验证码",
+  },
+  {
+    subject: "登入驗證碼",
+    summary: "驗證碼：８３９２１７，請勿提供給他人。",
+    expected: "839217",
+    language: "zh-hant",
+    note: "full-width digits",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Positives — Korean
+  // ---------------------------------------------------------------------------
+  {
+    subject: "인증번호 안내",
+    summary: "인증번호는 493021 입니다. 타인에게 알려주지 마세요.",
+    expected: "493021",
+    language: "ko",
+    note: "인증번호 spells number, not code — it needs its own lexicon entry",
+  },
+  {
+    subject: "620418 인증 코드입니다",
+    summary: "본인 확인을 위해 인증 코드를 입력해 주세요.",
+    expected: "620418",
+    language: "ko",
+  },
+  {
+    subject: "보안 코드",
+    summary: "결제를 완료하려면 보안 코드 7482 를 입력하세요.",
+    expected: "7482",
+    language: "ko",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Positives — Arabic, Hebrew, Vietnamese, Hindi spot checks
+  // ---------------------------------------------------------------------------
+  {
+    subject: "رمز التحقق الخاص بك",
+    summary: "رمز التحقق الخاص بك هو ٤٩٣٠٢١. لا تشاركه مع أي شخص.",
+    expected: "493021",
+    language: "ar",
+    note: "Arabic-Indic digits — NFKC leaves these alone, they need an explicit mapping",
+  },
+  {
+    subject: "٦٢٠٤١٨ هو رمز تسجيل الدخول",
+    summary: "استخدم هذا الرمز لتسجيل الدخول إلى حسابك. تنتهي صلاحيته خلال ١٠ دقائق.",
+    expected: "620418",
+    language: "ar",
+    note: "Arabic-Indic digits in the subject, a 2-digit Arabic-Indic duration in the snippet",
+  },
+  {
+    subject: "קוד האימות שלך",
+    summary: "קוד האימות שלך הוא 493021. אין למסור אותו לאף אחד.",
+    expected: "493021",
+    language: "he",
+    note: "RTL text with ASCII digits",
+  },
+  {
+    subject: "Mã xác minh của bạn",
+    summary: "Mã xác minh của bạn là 493021. Không chia sẻ mã này với bất kỳ ai.",
+    expected: "493021",
+    language: "vi",
+    note: "mã is two characters — it must be word-bounded so it never fires inside other words",
+  },
+  {
+    subject: "620418 là mã đăng nhập của bạn",
+    summary: "Nhập mã này để tiếp tục đăng nhập. Mã có hiệu lực trong 10 phút.",
+    expected: "620418",
+    language: "vi",
+  },
+  {
+    subject: "आपका सत्यापन कोड",
+    summary: "आपका सत्यापन कोड ४९३०२१ है। इसे किसी के साथ साझा न करें।",
+    expected: "493021",
+    language: "hi",
+    note: "Devanagari digits need an explicit mapping alongside Arabic-Indic",
+  },
+  {
+    subject: "620418 आपका लॉगिन कोड है",
+    summary: "जारी रखने के लिए यह कोड दर्ज करें। यह 10 मिनट के लिए मान्य है।",
+    expected: "620418",
+    language: "hi",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Negatives — orders, shipping, invoices, prices
+  // ---------------------------------------------------------------------------
+  {
+    subject: "Your order 10025431 has shipped",
+    summary: "Track your package with tracking number 993412808394. Estimated delivery: Tuesday.",
+    expected: null,
+    language: "en",
+  },
+  {
+    subject: "Order confirmation 40391827",
+    summary: "Thanks for your order. Your order number is 40391827 and your total is $128.50.",
+    expected: null,
+    language: "en",
+    note: "an 8-digit order number is exactly the shape of an 8-digit code",
+  },
+  {
+    subject: "Invoice 2025-0417 is ready",
+    summary: "Invoice 20250417 for $1,240.00 is now available. Payment is due within 14 days.",
+    expected: null,
+    language: "en",
+  },
+  {
+    subject: "Your package is out for delivery",
+    summary: "Parcel 493021 will arrive today between 2 and 6 PM.",
+    expected: null,
+    language: "en",
+    note: "same digits as several positives, but no code word anywhere — the gate must hold",
+  },
+  {
+    subject: "Payment receipt",
+    summary: "We charged $49.30 to the card ending 2178 on 4 August 2025. Thank you.",
+    expected: null,
+    language: "en",
+    note: "a price, a card suffix and a year in one snippet",
+  },
+  {
+    subject: "Your statement is ready",
+    summary: "Your account ending 4021 has a closing balance of $1,384.22 for July 2025.",
+    expected: null,
+    language: "en",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Negatives — promotional and other harmless uses of the word code
+  // ---------------------------------------------------------------------------
+  {
+    subject: "20% off everything this weekend",
+    summary: "Use promo code SAVE20 at checkout. Offer ends Sunday, 31 August 2025.",
+    expected: null,
+    language: "en",
+    note: "the word code plus percent-off marketing digits",
+  },
+  {
+    subject: "Your discount code inside",
+    summary: "Take 15% off your next order with code 55555 — valid until 30 September.",
+    expected: null,
+    language: "en",
+    note: "a numeric promo code sitting right next to the keyword; needs a promo/discount veto",
+  },
+  {
+    subject: "Referral code for your friends",
+    summary: "Share your referral code 483921 and you both get $10 off.",
+    expected: null,
+    language: "en",
+    note: "shape-identical to a real code; only the word referral separates them",
+  },
+  {
+    subject: "Postal code required",
+    summary:
+      "We couldn't deliver your parcel. Confirm the postal code 10115 for the shipping address.",
+    expected: null,
+    language: "en",
+    note: "the word code with a 5-digit postal code and delivery wording",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Negatives — phone numbers, travel, tickets, calendar
+  // ---------------------------------------------------------------------------
+  {
+    subject: "Your appointment reminder",
+    summary: "Call us at +1 (415) 555-0134 if you need to reschedule your appointment on 12 March.",
+    expected: null,
+    language: "en",
+    note: "US-formatted phone number split into runs that look like grouped codes",
+  },
+  {
+    subject: "New voicemail from +49 30 12345678",
+    summary: "You have a new voicemail. Listen online or call back +49 30 12345678.",
+    expected: null,
+    language: "en",
+    note: "international phone number with space separators",
+  },
+  {
+    subject: "Flight booking confirmed",
+    summary: "Booking reference: KX7T2P. Flight LH 1074 departs 14 June at 09:35 from Terminal 2.",
+    expected: null,
+    language: "en",
+  },
+  {
+    subject: "Your boarding pass",
+    summary: "Flight AA 2841, seat 14C, gate B12. Boarding starts at 18:40.",
+    expected: null,
+    language: "en",
+  },
+  {
+    subject: "Support ticket 4930218 updated",
+    summary: "Our team replied to your ticket 4930218. View the conversation in the help center.",
+    expected: null,
+    language: "en",
+  },
+  {
+    subject: "Case number 20394812",
+    summary: "Your case has been assigned to an agent. Reference this number in future emails.",
+    expected: null,
+    language: "en",
+  },
+  {
+    subject: "Meeting tomorrow at 10:30",
+    summary: "Reminder: quarterly review, 21 October 2025, 10:30 to 11:30, room 4021.",
+    expected: null,
+    language: "en",
+  },
+  {
+    subject: "Invitation: design sync on 3 September 2025",
+    summary: "When: Wednesday 3 September 2025, 16:00 to 16:45 (CEST). Where: room 2178.",
+    expected: null,
+    language: "en",
+  },
+  {
+    subject: "Save 30% on your next 3 orders",
+    summary: "Spend $50, get 30% off. Ends 2025-09-30.",
+    expected: null,
+    language: "en",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Negatives — non-English
+  // ---------------------------------------------------------------------------
+  {
+    subject: "Ihre Bestellung 40391827 wurde versandt",
+    summary: "Ihr Paket ist unterwegs. Sendungsnummer: 003404346925101234.",
+    expected: null,
+    language: "de",
+  },
+  {
+    subject: "Rechnung Nr. 2025-0417",
+    summary: "Der Rechnungsbetrag von 128,50 € ist bis zum 15.09.2025 fällig.",
+    expected: null,
+    language: "de",
+    note: "German date format produces several short runs and one 4-digit year",
+  },
+  {
+    subject: "Confirmation de commande n° 4930218",
+    summary:
+      "Merci pour votre commande. Le montant total est de 128,50 €. Livraison prévue le 12 septembre.",
+    expected: null,
+    language: "fr",
+  },
+  {
+    subject: "Tu pedido 40391827 va en camino",
+    summary: "Puedes seguir tu envío con el número de seguimiento 8394812345.",
+    expected: null,
+    language: "es",
+  },
+  {
+    subject: "Fattura n. 4930218",
+    summary: "L'importo di 128,50 € è dovuto entro il 30 settembre 2025.",
+    expected: null,
+    language: "it",
+  },
+  {
+    subject: "Sua encomenda 20394812 foi enviada",
+    summary: "Acompanhe a entrega pelo código de rastreio 8394812345.",
+    expected: null,
+    language: "pt",
+    note: "código appears as tracking code — the gate opens and only scoring can reject it",
+  },
+  {
+    subject: "Potwierdzenie zamówienia 40391827",
+    summary:
+      "Dziękujemy za zakupy. Kwota do zapłaty: 128,50 zł. Przewidywana dostawa: 12 września.",
+    expected: null,
+    language: "pl",
+  },
+  {
+    subject: "Siparişiniz kargoya verildi",
+    summary: "Sipariş numaranız 40391827. Kargo takip numarası: 8394812345.",
+    expected: null,
+    language: "tr",
+  },
+  {
+    subject: "Заказ № 4930218 отправлен",
+    summary: "Отследить посылку можно по номеру 8394812345. Доставка ожидается 12 сентября.",
+    expected: null,
+    language: "ru",
+  },
+  {
+    subject: "ご注文 40391827 の発送のお知らせ",
+    summary: "お問い合わせ番号は 8394812345 です。お届け予定日は9月12日です。",
+    expected: null,
+    language: "ja",
+  },
+  {
+    subject: "您的订单 40391827 已发货",
+    summary: "快递单号：8394812345，预计9月12日送达。",
+    expected: null,
+    language: "zh-hans",
+  },
+  {
+    subject: "주문 40391827 배송 안내",
+    summary: "송장번호 8394812345 로 배송 조회가 가능합니다.",
+    expected: null,
+    language: "ko",
+  },
+  {
+    subject: "تم شحن طلبك رقم ٤٠٣٩١٨٢٧",
+    summary: "يمكنك تتبع شحنتك برقم التتبع ٨٣٩٤٨١٢٣٤٥.",
+    expected: null,
+    language: "ar",
+    note: "Arabic-Indic order and tracking numbers must normalize and still be rejected",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Adversarial pairs — a real code alongside a number that must not win
+  // ---------------------------------------------------------------------------
+  {
+    subject: "Your code for order 12345678",
+    summary: "Use code 4930 to confirm delivery of order 12345678.",
+    expected: "4930",
+    language: "en",
+    note: "measured failure: digit-length ranking returns the order number instead of the code",
+  },
+  {
+    subject: "Verification code for invoice 20394812",
+    summary: "Your verification code is 483921. The invoice total is $1,240.00.",
+    expected: "483921",
+    language: "en",
+    note: "an 8-digit invoice number competes with the 6-digit code",
+  },
+  {
+    subject: "Sign-in code",
+    summary: "Your code is 620418. Requested from a device in Berlin on 14 August 2025.",
+    expected: "620418",
+    language: "en",
+    note: "a plausible year in the same snippet as the code",
+  },
+  {
+    subject: "Confirm your payment",
+    summary: "Enter the security code 7482 to approve the payment of $1,299.00.",
+    expected: "7482",
+    language: "en",
+    note: "a price competes with a 4-digit code",
+  },
+  {
+    subject: "Your one-time code",
+    summary: "Code: 493021. Questions? Call support at +1 (415) 555-0134.",
+    expected: "493021",
+    language: "en",
+    note: "a phone number competes with the code",
+  },
+  {
+    subject: "Ticket 20394812 — verification required",
+    summary:
+      "Verification code 40 21 36 confirms your identity. Reference ticket 20394812 in your reply.",
+    expected: "402136",
+    language: "en",
+    note: "grouped code against a ticket number that appears twice",
+  },
+  {
+    subject: "Bestätigungscode für Ihre Bestellung 40391827",
+    summary: "Ihr Bestätigungscode lautet 5029. Bitte nennen Sie ihn dem Zusteller.",
+    expected: "5029",
+    language: "de",
+    note: "order number in the subject, delivery wording in the snippet, real code wins",
+  },
+  {
+    subject: "Sipariş 40391827 için doğrulama kodunuz",
+    summary: "Teslimat kodunuz: 839217. Kuryeye bu kodu iletin.",
+    expected: "839217",
+    language: "tr",
+  },
+  {
+    subject: "安全验证",
+    summary: "您的验证码是493021，请勿泄露给他人。",
+    expected: "493021",
+    language: "zh-hans",
+    note: "code glued to the keyword with no space — the common Chinese shape",
+  },
+  {
+    subject: "認証コードのお知らせ",
+    summary: "認証コードは830492です。10分以内に入力してください。",
+    expected: "830492",
+    language: "ja",
+    note: "code glued between kana with no spaces",
+  },
+  {
+    subject: "ご注文の認証コード",
+    summary: "認証コードは4930です。ご注文番号12345678。",
+    expected: "4930",
+    language: "ja",
+    note: "glued order number must lose to the glued code",
+  },
+  {
+    subject: "订单 40391827 的验证码",
+    summary: "您的验证码是 620418，请勿泄露。订单金额 128.50 元。",
+    expected: "620418",
+    language: "zh-hans",
+  },
+  {
+    subject: "Код подтверждения для заказа 4930218",
+    summary: "Ваш код: 748210. Никому его не сообщайте.",
+    expected: "748210",
+    language: "ru",
+  },
+  {
+    subject: "Code de vérification — commande n° 4930218",
+    summary: "Votre code est 8241. Montant : 128,50 €.",
+    expected: "8241",
+    language: "fr",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Truncation — the keyword survives the snippet cutoff but the digits don't.
+  // These document the recall ceiling; there is nothing to recover.
+  // ---------------------------------------------------------------------------
+  {
+    subject: "Your verification code",
+    summary:
+      "Thanks for signing up. To finish creating your account, enter the verification code below. Your code is…",
+    expected: null,
+    language: "en",
+    note: "truncation — digits fall past the snippet cutoff",
+  },
+  {
+    subject: "Ihr Sicherheitscode",
+    summary:
+      "Guten Tag, um Ihre Anmeldung abzuschließen, geben Sie bitte den folgenden Sicherheitscode ein. Ihr Code lautet…",
+    expected: null,
+    language: "de",
+    note: "truncation",
+  },
+  {
+    subject: "認証コードのご案内",
+    summary:
+      "いつもご利用いただきありがとうございます。ログインを完了するには、以下の認証コードを入力してください。認証コードは…",
+    expected: null,
+    language: "ja",
+    note: "truncation",
+  },
+  {
+    subject: "Tu código de verificación",
+    summary:
+      "Hola, hemos recibido una solicitud de inicio de sesión en tu cuenta. Para continuar, introduce el siguiente código de verificación:",
+    expected: null,
+    language: "es",
+    note: "truncation — the snippet ends on the colon",
+  },
+  {
+    subject: "Code de vérification",
+    summary:
+      "Bonjour, une connexion à votre compte a été demandée depuis un nouvel appareil. Votre code de vérification est le",
+    expected: null,
+    language: "fr",
+    note: "truncation — the snippet ends mid-sentence",
+  },
+
+  // ---------------------------------------------------------------------------
+  // Alphanumeric codes — genuine codes, but v1 is digits-only
+  // ---------------------------------------------------------------------------
+  {
+    subject: "Your verification code",
+    summary: "Your verification code is A3F9K2. It expires in 10 minutes.",
+    expected: null,
+    language: "en",
+    note: "alphanumeric — flip when supported",
+  },
+  {
+    subject: "Confirm your email address",
+    summary: "Enter this code to confirm your email: X7QM2B",
+    expected: null,
+    language: "en",
+    note: "alphanumeric — flip when supported",
+  },
+  {
+    subject: "Ihr Bestätigungscode",
+    summary: "Ihr Bestätigungscode lautet 4F9K2A. Er ist 15 Minuten gültig.",
+    expected: null,
+    language: "de",
+    note: "alphanumeric — flip when supported",
+  },
+  {
+    subject: "Code de sécurité",
+    summary: "Votre code de sécurité : K2P-9XR",
+    expected: null,
+    language: "fr",
+    note: "alphanumeric — flip when supported",
+  },
+  {
+    subject: "Two-factor authentication",
+    summary: "Your one-time code is 4A9-2K7. Do not share it.",
+    expected: null,
+    language: "en",
+    note: "alphanumeric — flip when supported; the digit groups must not be extracted on their own",
+  },
+];

--- a/packages/verification-code/corpus.fixtures.ts
+++ b/packages/verification-code/corpus.fixtures.ts
@@ -90,9 +90,16 @@ export const corpus: CorpusEntry[] = [
   {
     subject: "Delivery confirmation code",
     summary: "Your delivery code is 4930. Share it with the courier when your parcel arrives.",
-    expected: "4930",
+    expected: null,
     language: "en",
-    note: "delivery wording must stay a penalty, not a veto — a genuine delivery OTP survives on proximity",
+    note: "a pickup code is read aloud to the courier, never pasted — out of scope by decision",
+  },
+  {
+    subject: "Your package arrives today",
+    summary: "Your delivery OTP is 123456. Tell it to the delivery associate at the door.",
+    expected: null,
+    language: "en",
+    note: "delivery-named OTP — out of scope by decision",
   },
   {
     subject: "Security code",

--- a/packages/verification-code/index.test.ts
+++ b/packages/verification-code/index.test.ts
@@ -172,8 +172,9 @@ describe("extractVerificationCode", () => {
     expect(extractVerificationCode(["Your verification code is 493-021", ""])).toBe("493021");
   });
 
-  test("extracts a delivery one-time code despite the delivery penalty", () => {
-    expect(extractVerificationCode(["Your delivery code is 493021", ""])).toBe("493021");
+  test("ignores a delivery-named code", () => {
+    expect(extractVerificationCode(["Your delivery code is 493021", ""])).toBeNull();
+    expect(extractVerificationCode(["Your pickup code is 493021", ""])).toBeNull();
   });
 
   test("breaks a tie between equal scores in favor of the subject", () => {

--- a/packages/verification-code/index.test.ts
+++ b/packages/verification-code/index.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test } from "bun:test";
+import { corpus } from "./corpus.fixtures";
+import { collectCandidates, extractVerificationCode, normalizeText } from "./index";
+
+describe("normalizeText", () => {
+  test("folds full-width digits to ASCII", () => {
+    expect(normalizeText("４９３０２１")).toBe("493021");
+  });
+
+  test("maps Arabic-Indic digits to ASCII", () => {
+    expect(normalizeText("٤٩٣٠٢١")).toBe("493021");
+  });
+
+  test("maps Extended Arabic-Indic digits to ASCII", () => {
+    expect(normalizeText("۴۹۳۰۲۱")).toBe("493021");
+  });
+
+  test("maps Devanagari digits to ASCII", () => {
+    expect(normalizeText("४९३०२१")).toBe("493021");
+  });
+
+  test("leaves ASCII text untouched", () => {
+    expect(normalizeText("Your code is 493021")).toBe("Your code is 493021");
+  });
+});
+
+describe("collectCandidates", () => {
+  test("collects a solid run of four to eight digits", () => {
+    expect(collectCandidates("code 4930").map((candidate) => candidate.digits)).toEqual(["4930"]);
+    expect(collectCandidates("code 49302").map((candidate) => candidate.digits)).toEqual(["49302"]);
+    expect(collectCandidates("code 493021").map((candidate) => candidate.digits)).toEqual([
+      "493021",
+    ]);
+    expect(collectCandidates("code 4930217").map((candidate) => candidate.digits)).toEqual([
+      "4930217",
+    ]);
+    expect(collectCandidates("code 49302176").map((candidate) => candidate.digits)).toEqual([
+      "49302176",
+    ]);
+  });
+
+  test("collects plausible groupings and strips their separators", () => {
+    expect(collectCandidates("code 493 021").map((candidate) => candidate.digits)).toEqual([
+      "493021",
+    ]);
+    expect(collectCandidates("code 4930-2176").map((candidate) => candidate.digits)).toEqual([
+      "49302176",
+    ]);
+    expect(collectCandidates("code 49 30 21").map((candidate) => candidate.digits)).toEqual([
+      "493021",
+    ]);
+    expect(collectCandidates("code 49-30-21-76").map((candidate) => candidate.digits)).toEqual([
+      "49302176",
+    ]);
+  });
+
+  test("rejects implausible groupings", () => {
+    expect(collectCandidates("code 493 0217")).toEqual([]);
+    expect(collectCandidates("code 4 93021")).toEqual([]);
+  });
+
+  test("rejects runs shorter than four digits", () => {
+    expect(collectCandidates("code 493")).toEqual([]);
+    expect(collectCandidates("code 49 30")).toEqual([]);
+  });
+
+  test("yields nothing for an over-long run", () => {
+    expect(collectCandidates("call 5551234567 now")).toEqual([]);
+    expect(collectCandidates("tracking 1234 5678 9012")).toEqual([]);
+    expect(collectCandidates("tracking 123456789012")).toEqual([]);
+  });
+
+  test("rejects a run glued to letters", () => {
+    expect(collectCandidates("code AB493021")).toEqual([]);
+    expect(collectCandidates("code 493021px")).toEqual([]);
+  });
+
+  test("rejects a run that is part of a larger number", () => {
+    expect(collectCandidates("code 12.493021")).toEqual([]);
+    expect(collectCandidates("code 493021.75")).toEqual([]);
+  });
+
+  test("reports the position of every candidate", () => {
+    const [candidate] = collectCandidates("Your code is 493021");
+
+    expect(candidate?.start).toBe(13);
+    expect(candidate?.end).toBe(19);
+  });
+});
+
+describe("extractVerificationCode gate", () => {
+  test("returns null when no code word appears", () => {
+    expect(extractVerificationCode(["Your package 493021 is on its way", ""])).toBeNull();
+  });
+
+  test("matches a German compound", () => {
+    expect(extractVerificationCode(["Ihr Bestätigungscode", "Bestätigungscode: 493021"])).toBe(
+      "493021",
+    );
+  });
+
+  test("matches Turkish suffixed forms", () => {
+    expect(extractVerificationCode(["Doğrulama kodunuz: 493021", ""])).toBe("493021");
+    expect(extractVerificationCode(["Giriş kodu 493021", ""])).toBe("493021");
+  });
+
+  test("does not read a code word inside a longer word", () => {
+    expect(extractVerificationCode(["Shipping update 493021", ""])).toBeNull();
+  });
+
+  test("matches a bounded pin", () => {
+    expect(extractVerificationCode(["Your PIN is 4930", ""])).toBe("4930");
+  });
+});
+
+describe("extractVerificationCode vetoes", () => {
+  test("rejects a plausible year", () => {
+    expect(extractVerificationCode(["Your code expires in 2026", ""])).toBeNull();
+  });
+
+  test("accepts a four-digit run outside the year range", () => {
+    expect(extractVerificationCode(["Your code is 4930", ""])).toBe("4930");
+  });
+
+  test("rejects an amount of money", () => {
+    expect(extractVerificationCode(["Your code unlocks $4930 of credit", ""])).toBeNull();
+    expect(extractVerificationCode(["Your code unlocks 4930 EUR of credit", ""])).toBeNull();
+  });
+
+  test("rejects a percentage", () => {
+    expect(extractVerificationCode(["Your code gives 4930% back", ""])).toBeNull();
+  });
+
+  test("rejects a number behind an order term", () => {
+    expect(extractVerificationCode(["Your code, order 493021, is ready", ""])).toBeNull();
+    expect(extractVerificationCode(["Your code, invoice #493021, is ready", ""])).toBeNull();
+    expect(extractVerificationCode(["Your tracking code 493021 is ready", ""])).toBeNull();
+  });
+
+  test("rejects a phone number", () => {
+    expect(extractVerificationCode(["Your code was sent to +1234567", ""])).toBeNull();
+    expect(extractVerificationCode(["For your code call (030) 493021", ""])).toBeNull();
+  });
+});
+
+describe("extractVerificationCode", () => {
+  test("prefers the code over the order number in the same sentence", () => {
+    expect(extractVerificationCode(["Your code for order 12345678 is 4930", ""])).toBe("4930");
+  });
+
+  test("extracts a code from a message that also reports a shipment", () => {
+    expect(extractVerificationCode(["Order 987654 shipped. Your security code is 4930", ""])).toBe(
+      "4930",
+    );
+  });
+
+  test("extracts a full-width code", () => {
+    expect(extractVerificationCode(["認証コード: ４９３０２１", ""])).toBe("493021");
+  });
+
+  test("extracts an Arabic-Indic code", () => {
+    expect(extractVerificationCode(["رمز التحقق الخاص بك هو ٤٩٣٠٢١", ""])).toBe("493021");
+  });
+
+  test("extracts a code the subject announces and the snippet carries", () => {
+    expect(
+      extractVerificationCode(["Your verification code", "Use 493021 to finish signing in"]),
+    ).toBe("493021");
+  });
+
+  test("extracts a grouped code with its separators stripped", () => {
+    expect(extractVerificationCode(["Your verification code is 493-021", ""])).toBe("493021");
+  });
+
+  test("extracts a delivery one-time code despite the delivery penalty", () => {
+    expect(extractVerificationCode(["Your delivery code is 493021", ""])).toBe("493021");
+  });
+
+  test("breaks a tie between equal scores in favor of the subject", () => {
+    expect(extractVerificationCode(["Your code is 4930", "Your code is 5678"])).toBe("4930");
+  });
+
+  test("returns null for an order confirmation", () => {
+    expect(
+      extractVerificationCode([
+        "Your order has shipped",
+        "Order 12345678 is on its way and arrives on 24 August 2026",
+      ]),
+    ).toBeNull();
+  });
+
+  test("returns null when the snippet truncates before the code", () => {
+    expect(
+      extractVerificationCode(["Your verification code", "Hi Tim, here is the code you"]),
+    ).toBeNull();
+  });
+
+  test("returns null for empty input", () => {
+    expect(extractVerificationCode(["", ""])).toBeNull();
+  });
+});
+
+describe("corpus", () => {
+  for (const entry of corpus) {
+    const label = entry.note
+      ? `${entry.language}: ${entry.subject} (${entry.note})`
+      : `${entry.language}: ${entry.subject}`;
+
+    test(label, () => {
+      expect(extractVerificationCode([entry.subject, entry.summary])).toBe(entry.expected);
+    });
+  }
+});

--- a/packages/verification-code/index.ts
+++ b/packages/verification-code/index.ts
@@ -90,8 +90,10 @@ const contextWords: LexiconEntry[] = [
   { name: "imut (he)", pattern: unanchored("אימות") },
 ];
 
-// A delivery message can still carry a genuine one-time code, so these only cost
-// the message score — they are not the hard veto the previous extractor applied.
+// Delivery-named codes are excluded at the gate above: they are read aloud at a
+// handover, so a clipboard copy is useless and mark-read or delete would hide the
+// email while it is still needed. These terms catch the rest of the topic as a
+// score penalty, so a sign-in code in an email that mentions shipping survives.
 const deliveryTerms: LexiconEntry[] = [
   { name: "deliver (en)", pattern: prefixAnchored("deliver") },
   { name: "pick-up (en)", pattern: wordBounded("pick[-\\s]?up") },
@@ -113,9 +115,10 @@ const deliveryTerms: LexiconEntry[] = [
   { name: "baesong (ko)", pattern: unanchored("배송") },
 ];
 
-// A code word directly behind one of these names a different kind of code entirely —
-// a discount code, a postal code, a QR code — so the match doesn't open the gate.
-// The German entries cover compounds such as "Rabattcode" and "Gutscheincode".
+// A code word directly behind one of these names a code that is never pasted into
+// a website — a discount code, a postal code, a QR code, a delivery pickup code
+// read aloud to a courier — so the match doesn't open the gate. The German entries
+// cover compounds such as "Rabattcode", "Gutscheincode", and "Abholcode".
 const codeWordDisqualifierPrecedes = new RegExp(
   `(?:${[
     "discount",
@@ -134,6 +137,11 @@ const codeWordDisqualifierPrecedes = new RegExp(
     "country",
     "bar",
     "tracking",
+    "delivery",
+    "pick[\\s-]?up",
+    "collection",
+    "abhol",
+    "liefer",
     "rabatt",
     "gutschein",
     "werbe",

--- a/packages/verification-code/index.ts
+++ b/packages/verification-code/index.ts
@@ -1,0 +1,499 @@
+type LexiconEntry = {
+  name: string;
+  pattern: RegExp;
+};
+
+type TextRange = {
+  start: number;
+  end: number;
+};
+
+export type CodeCandidate = {
+  digits: string;
+  groups: string[];
+  start: number;
+  end: number;
+};
+
+// `\b` only knows ASCII word characters, so it cannot bound a word that ends in a
+// letter outside that set — `/\bmã\b/` never matches "mã xác minh". Every anchor
+// below is built from Unicode-property lookarounds instead.
+const letterOrDigit = "[\\p{L}\\p{N}]";
+
+// CJK scripts write without spaces, so an ideograph, kana, or hangul syllable
+// touching a digit run or a keyword is normal prose, not a glued identifier.
+const nonCjkLetter =
+  "(?![\\p{Script=Han}\\p{Script=Hiragana}\\p{Script=Katakana}\\p{Script=Hangul}])\\p{L}";
+
+function wordBounded(source: string): RegExp {
+  return new RegExp(`(?<!${letterOrDigit})(?:${source})(?!${letterOrDigit})`, "giu");
+}
+
+function prefixAnchored(source: string): RegExp {
+  return new RegExp(`(?<!${letterOrDigit})(?:${source})`, "giu");
+}
+
+function suffixAnchored(source: string): RegExp {
+  return new RegExp(`(?:${source})(?!${letterOrDigit})`, "giu");
+}
+
+// Case-insensitive despite targeting mostly caseless scripts: Cyrillic entries
+// still need to match capitalized forms like "Код".
+function unanchored(source: string): RegExp {
+  return new RegExp(source, "giu");
+}
+
+// One code word anywhere in the inputs is the only hard text gate.
+const codeWords: LexiconEntry[] = [
+  { name: "code (en, de compounds, fr, nl, da)", pattern: suffixAnchored("code") },
+  { name: "kod (tr suffixed, pl, sv, no, id)", pattern: prefixAnchored("kod") },
+  { name: "codigo (es, pt)", pattern: wordBounded("c[oó]digo") },
+  { name: "codice (it)", pattern: wordBounded("codice") },
+  { name: "koodi (fi)", pattern: wordBounded("koodi") },
+  { name: "ma (vi)", pattern: wordBounded("mã") },
+  { name: "otp (en)", pattern: wordBounded("otp") },
+  { name: "one-time password (en)", pattern: wordBounded("one[-\\s]?time\\s?password") },
+  { name: "passcode (en)", pattern: wordBounded("passcode") },
+  { name: "pin (en, de, fr)", pattern: wordBounded("pin") },
+  { name: "two-factor (en)", pattern: wordBounded("2fa") },
+  { name: "kod (ru, uk, bg)", pattern: unanchored("код") },
+  { name: "kod (hi)", pattern: unanchored("कोड") },
+  { name: "kodo (ja)", pattern: unanchored("コード") },
+  { name: "yanzhengma (zh-hans)", pattern: unanchored("验证码") },
+  { name: "yanzhengma (zh-hant)", pattern: unanchored("驗證碼") },
+  { name: "injeung beonho (ko)", pattern: unanchored("인증번호|인증\\s?코드|코드") },
+  { name: "ramz (ar)", pattern: unanchored("رمز") },
+  { name: "kod (he)", pattern: unanchored("קוד") },
+];
+
+// Not gating: a context word only raises a candidate's score.
+const contextWords: LexiconEntry[] = [
+  { name: "verify (en, es, fr, it, pt)", pattern: prefixAnchored("v[eé]rif") },
+  { name: "confirm (en, es, it, pt)", pattern: prefixAnchored("confirm") },
+  { name: "bestatigung (de)", pattern: prefixAnchored("best[äa]tigung") },
+  { name: "weryfikacja (pl)", pattern: prefixAnchored("weryfikacj") },
+  { name: "dogrulama (tr)", pattern: prefixAnchored("do[ğg]rulama") },
+  { name: "one-time (en)", pattern: wordBounded("one[-\\s]?time") },
+  { name: "single-use (en)", pattern: wordBounded("single[-\\s]?use") },
+  { name: "sign-in (en)", pattern: wordBounded("sign[-\\s]?(?:in|up)") },
+  { name: "log-in (en)", pattern: wordBounded("log[-\\s]?in") },
+  { name: "security (en)", pattern: wordBounded("security") },
+  { name: "authentication (en)", pattern: prefixAnchored("authentic") },
+  { name: "two-factor (en)", pattern: wordBounded("two[-\\s]?factor") },
+  { name: "xac minh (vi)", pattern: prefixAnchored("x[áa]c minh") },
+  { name: "podtverzhdenie (ru)", pattern: unanchored("подтвержд") },
+  { name: "ninsho (ja)", pattern: unanchored("認証") },
+  { name: "kakunin (ja, zh)", pattern: unanchored("確認") },
+  { name: "yanzheng (zh)", pattern: unanchored("验证|驗證") },
+  { name: "injeung (ko)", pattern: unanchored("인증") },
+  { name: "tahaqquq (ar)", pattern: unanchored("تحقق") },
+  { name: "imut (he)", pattern: unanchored("אימות") },
+];
+
+// A delivery message can still carry a genuine one-time code, so these only cost
+// the message score — they are not the hard veto the previous extractor applied.
+const deliveryTerms: LexiconEntry[] = [
+  { name: "deliver (en)", pattern: prefixAnchored("deliver") },
+  { name: "pick-up (en)", pattern: wordBounded("pick[-\\s]?up") },
+  { name: "collect (en)", pattern: prefixAnchored("collect") },
+  { name: "ship (en)", pattern: prefixAnchored("ship") },
+  { name: "track (en)", pattern: prefixAnchored("track") },
+  { name: "courier (en)", pattern: wordBounded("courier") },
+  { name: "dispatch (en)", pattern: prefixAnchored("dispatch") },
+  { name: "lieferung (de)", pattern: prefixAnchored("liefer") },
+  { name: "zustellung (de)", pattern: prefixAnchored("zustell") },
+  { name: "livraison (fr)", pattern: prefixAnchored("livrais") },
+  { name: "entrega (es, pt)", pattern: prefixAnchored("entrega") },
+  { name: "consegna (it)", pattern: prefixAnchored("consegna") },
+  { name: "dostawa (pl)", pattern: prefixAnchored("dostaw") },
+  { name: "teslimat (tr)", pattern: prefixAnchored("teslim") },
+  { name: "dostavka (ru)", pattern: unanchored("доставк") },
+  { name: "haiso (ja)", pattern: unanchored("配送|配達") },
+  { name: "kuaidi (zh)", pattern: unanchored("快递|快遞") },
+  { name: "baesong (ko)", pattern: unanchored("배송") },
+];
+
+// A code word directly behind one of these names a different kind of code entirely —
+// a discount code, a postal code, a QR code — so the match doesn't open the gate.
+// The German entries cover compounds such as "Rabattcode" and "Gutscheincode".
+const codeWordDisqualifierPrecedes = new RegExp(
+  `(?:${[
+    "discount",
+    "promo(?:tional)?",
+    "referral",
+    "coupon",
+    "voucher",
+    "gift",
+    "invite",
+    "postal",
+    "zip",
+    "area",
+    "dress",
+    "qr",
+    "error",
+    "country",
+    "bar",
+    "tracking",
+    "rabatt",
+    "gutschein",
+    "werbe",
+    "aktions",
+    "empfehlungs",
+    "geschenk",
+  ].join("|")})[\\s-]*$`,
+  "iu",
+);
+
+// Discount vocabulary anywhere in the message: a numeric promo code sitting right
+// next to the word "code" is indistinguishable by shape, so the topic has to pay.
+const promoTerms: LexiconEntry[] = [
+  { name: "percent off (en)", pattern: unanchored("\\d\\s?%\\s?off|percent\\s?off") },
+  { name: "discount (en)", pattern: prefixAnchored("discount") },
+  { name: "promo (en)", pattern: prefixAnchored("promo") },
+  { name: "referral (en)", pattern: prefixAnchored("referral") },
+  { name: "coupon (en)", pattern: prefixAnchored("coupon") },
+  { name: "voucher (en)", pattern: prefixAnchored("voucher") },
+  { name: "rabatt (de)", pattern: prefixAnchored("rabatt") },
+  { name: "gutschein (de)", pattern: prefixAnchored("gutschein") },
+  { name: "reduction (fr)", pattern: prefixAnchored("r[ée]duction") },
+  { name: "descuento (es)", pattern: prefixAnchored("descuento") },
+  { name: "desconto (pt)", pattern: prefixAnchored("desconto") },
+  { name: "sconto (it)", pattern: prefixAnchored("sconto") },
+  { name: "skidka (ru)", pattern: unanchored("скидк") },
+  { name: "zhekou (zh)", pattern: unanchored("折扣|优惠|優惠") },
+  { name: "waribiki (ja)", pattern: unanchored("割引|クーポン") },
+  { name: "harin (ko)", pattern: unanchored("할인|쿠폰") },
+];
+
+// Terms whose number follows them: a candidate directly behind one is never a code.
+const referenceTermSources = [
+  "order",
+  "invoice",
+  "receipt",
+  "tracking",
+  "shipment",
+  "ticket",
+  "reference",
+  "ref\\.?",
+  "transaction",
+  "confirmation\\s+number",
+  "bestell\\p{L}*",
+  "auftrag\\p{L}*",
+  "rechnung\\p{L}*",
+  "sendungs\\p{L}*",
+  "commande",
+  "facture",
+  "pedido",
+  "encomenda",
+  "factura",
+  "fatura",
+  "ordine",
+  "fattura",
+  "zam[oó]wieni\\p{L}*",
+  "sipari[şs]\\p{L}*",
+  "заказ\\p{L}*",
+  "注文",
+  "订单",
+  "訂單",
+  "주문",
+  "الطلب",
+  "הזמנה",
+];
+
+const referenceQualifierSources = [
+  "number",
+  "no\\.?",
+  "nr\\.?",
+  "num",
+  "id",
+  "code",
+  "#",
+  "番号",
+  "号",
+  "번호",
+];
+
+const referenceSeparator = "[\\s:#.-]{0,3}";
+
+const referencePrecedesCandidate = new RegExp(
+  `(?:#|(?<!${nonCjkLetter})(?:${referenceTermSources.join("|")})${referenceSeparator}(?:(?:${referenceQualifierSources.join("|")})${referenceSeparator})?)$`,
+  "iu",
+);
+
+const currencySymbolSource = "[$€£¥₹₽₺₩¢₪﷼]";
+
+const currencyCodeSource =
+  "usd|eur|gbp|jpy|chf|cad|aud|inr|rub|brl|krw|cny|pln|sek|nok|dkk|czk|huf";
+
+const currencyPrecedesCandidate = new RegExp(
+  `(?:${currencySymbolSource}|(?<!\\p{L})(?:${currencyCodeSource}))\\s?$`,
+  "iu",
+);
+
+const currencyOrPercentFollowsCandidate = new RegExp(
+  `^\\s?(?:%|${currencySymbolSource}|(?:${currencyCodeSource})(?!\\p{L}))`,
+  "iu",
+);
+
+const phonePunctuationPrecedesCandidate = /(?:\+[\d\s().-]{0,16}|\(\s?\d{1,5}\s?\)[\s-]{0,3})$/;
+
+const digitRunPattern = /\d+(?:[ -]\d+)*/g;
+
+const groupSeparatorPattern = /[ -]/;
+
+const alphanumericPrecedesRun = new RegExp(`(?:[\\p{N}_-]|${nonCjkLetter})$`, "u");
+
+const alphanumericFollowsRun = new RegExp(`^(?:[\\p{N}_-]|${nonCjkLetter})`, "u");
+
+const largerNumberPrecedesRun = /\d[.,:/]$/;
+
+const largerNumberFollowsRun = /^[.,:/]\d/;
+
+const plausibleGroupings = new Set(["3,3", "4,4", "2,2,2", "2,2,2,2"]);
+
+const minimumCodeLength = 4;
+
+const maximumCodeLength = 8;
+
+// NFKC folds full-width sentence punctuation to its ASCII shape, welding
+// "493021，10分钟" into "493021,10分钟" — which then reads as one decimal number.
+// These marks are never numeric separators, so they get a trailing space first.
+const fullWidthPunctuationPattern = /[，。、：；！？]/g;
+
+// NFKC folds full-width digits to ASCII but leaves these decimal scripts alone.
+const nonAsciiDigitPattern = /[٠-٩۰-۹०-९]/g;
+
+const nonAsciiDigitBlocks = [
+  0x0660, // Arabic-Indic
+  0x06f0, // Extended Arabic-Indic
+  0x0966, // Devanagari
+];
+
+// The year veto is a static range rather than the current year: the extractor must
+// stay a pure function of its inputs, with no reading of the clock.
+const earliestPlausibleYear = 2000;
+
+const latestPlausibleYear = 2099;
+
+const proximityCharacters = 30;
+
+const vetoWindowCharacters = 40;
+
+const scoreThreshold = 30;
+
+const scoreWeights = {
+  codeWordWithinProximity: 60,
+  codeWordInSameText: 25,
+  codeWordInOtherText: 20,
+  contextWordPresent: 10,
+  deliveryTermPresent: -25,
+  promoTermPresent: -40,
+  sixDigits: 24,
+  eightDigits: 16,
+  groupedDigits: 16,
+  fourDigits: 8,
+  fiveDigits: 4,
+  sevenDigits: 4,
+};
+
+export function normalizeText(text: string): string {
+  return text
+    .replace(fullWidthPunctuationPattern, "$& ")
+    .normalize("NFKC")
+    .replace(nonAsciiDigitPattern, (digit) => {
+      const codePoint = digit.codePointAt(0) ?? 0;
+
+      const blockStart = nonAsciiDigitBlocks.find(
+        (start) => codePoint >= start && codePoint <= start + 9,
+      );
+
+      return blockStart === undefined ? digit : String(codePoint - blockStart);
+    });
+}
+
+function hasPlausibleGrouping(groups: string[]): boolean {
+  if (groups.length === 1) {
+    return true;
+  }
+
+  return plausibleGroupings.has(groups.map((group) => group.length).join(","));
+}
+
+export function collectCandidates(text: string): CodeCandidate[] {
+  const candidates: CodeCandidate[] = [];
+
+  for (const match of text.matchAll(digitRunPattern)) {
+    const run = match[0];
+    const start = match.index;
+    const end = start + run.length;
+
+    const preceding = text.slice(Math.max(start - 2, 0), start);
+    const following = text.slice(end, end + 2);
+
+    if (alphanumericPrecedesRun.test(preceding) || alphanumericFollowsRun.test(following)) {
+      continue;
+    }
+
+    if (largerNumberPrecedesRun.test(preceding) || largerNumberFollowsRun.test(following)) {
+      continue;
+    }
+
+    const groups = run.split(groupSeparatorPattern);
+    const digits = groups.join("");
+
+    if (digits.length < minimumCodeLength || digits.length > maximumCodeLength) {
+      continue;
+    }
+
+    if (!hasPlausibleGrouping(groups)) {
+      continue;
+    }
+
+    candidates.push({ digits, groups, start, end });
+  }
+
+  return candidates;
+}
+
+function isPlausibleYear(candidate: CodeCandidate): boolean {
+  if (candidate.groups.length > 1 || candidate.digits.length !== 4) {
+    return false;
+  }
+
+  const year = Number(candidate.digits);
+
+  return year >= earliestPlausibleYear && year <= latestPlausibleYear;
+}
+
+function isVetoedCandidate(candidate: CodeCandidate, text: string): boolean {
+  if (isPlausibleYear(candidate)) {
+    return true;
+  }
+
+  const preceding = text.slice(
+    Math.max(candidate.start - vetoWindowCharacters, 0),
+    candidate.start,
+  );
+  const following = text.slice(candidate.end, candidate.end + 6);
+
+  if (
+    currencyPrecedesCandidate.test(preceding) ||
+    currencyOrPercentFollowsCandidate.test(following)
+  ) {
+    return true;
+  }
+
+  if (referencePrecedesCandidate.test(preceding)) {
+    return true;
+  }
+
+  return phonePunctuationPrecedesCandidate.test(preceding);
+}
+
+function getFormatScore(candidate: CodeCandidate): number {
+  if (candidate.groups.length > 1) {
+    return scoreWeights.groupedDigits;
+  }
+
+  switch (candidate.digits.length) {
+    case 6:
+      return scoreWeights.sixDigits;
+    case 8:
+      return scoreWeights.eightDigits;
+    case 4:
+      return scoreWeights.fourDigits;
+    case 5:
+      return scoreWeights.fiveDigits;
+    default:
+      return scoreWeights.sevenDigits;
+  }
+}
+
+function findLexiconRanges(text: string, lexicon: LexiconEntry[]): TextRange[] {
+  const ranges: TextRange[] = [];
+
+  for (const entry of lexicon) {
+    for (const match of text.matchAll(entry.pattern)) {
+      const start = match.index;
+
+      ranges.push({ start, end: start + match[0].length });
+    }
+  }
+
+  return ranges;
+}
+
+function matchesLexicon(texts: string[], lexicon: LexiconEntry[]): boolean {
+  return texts.some((text) => findLexiconRanges(text, lexicon).length > 0);
+}
+
+function findCodeWordRanges(text: string): TextRange[] {
+  return findLexiconRanges(text, codeWords).filter(
+    (range) => !codeWordDisqualifierPrecedes.test(text.slice(0, range.start)),
+  );
+}
+
+function getProximityScore(candidate: CodeCandidate, codeWordRanges: TextRange[]): number {
+  let nearestGap = Number.POSITIVE_INFINITY;
+
+  for (const range of codeWordRanges) {
+    const gap =
+      range.start >= candidate.end ? range.start - candidate.end : candidate.start - range.end;
+
+    nearestGap = Math.min(nearestGap, Math.max(gap, 0));
+  }
+
+  if (nearestGap <= proximityCharacters) {
+    return scoreWeights.codeWordWithinProximity;
+  }
+
+  if (codeWordRanges.length > 0) {
+    return scoreWeights.codeWordInSameText;
+  }
+
+  return scoreWeights.codeWordInOtherText;
+}
+
+export function extractVerificationCode(texts: string[]): string | null {
+  const normalizedTexts = texts.map(normalizeText);
+
+  const codeWordRangesByText = normalizedTexts.map(findCodeWordRanges);
+
+  if (codeWordRangesByText.every((ranges) => ranges.length === 0)) {
+    return null;
+  }
+
+  const hasContextWord = matchesLexicon(normalizedTexts, contextWords);
+  const hasDeliveryTerm = matchesLexicon(normalizedTexts, deliveryTerms);
+  const hasPromoTerm = matchesLexicon(normalizedTexts, promoTerms);
+
+  const messageScore =
+    (hasContextWord ? scoreWeights.contextWordPresent : 0) +
+    (hasDeliveryTerm ? scoreWeights.deliveryTermPresent : 0) +
+    (hasPromoTerm ? scoreWeights.promoTermPresent : 0);
+
+  let winner: { digits: string; score: number } | null = null;
+
+  for (const [textIndex, text] of normalizedTexts.entries()) {
+    for (const candidate of collectCandidates(text)) {
+      if (isVetoedCandidate(candidate, text)) {
+        continue;
+      }
+
+      const score =
+        messageScore +
+        getFormatScore(candidate) +
+        getProximityScore(candidate, codeWordRangesByText[textIndex] ?? []);
+
+      if (score < scoreThreshold) {
+        continue;
+      }
+
+      if (!winner || score > winner.score) {
+        winner = { digits: candidate.digits, score };
+      }
+    }
+  }
+
+  return winner?.digits ?? null;
+}

--- a/packages/verification-code/package.json
+++ b/packages/verification-code/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@meru/verification-code",
+  "version": "0.0.0",
+  "private": true,
+  "exports": {
+    ".": "./index.ts"
+  },
+  "scripts": {
+    "types": "tsc && tsc -p tsconfig.test.json"
+  }
+}

--- a/packages/verification-code/tsconfig.json
+++ b/packages/verification-code/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@total-typescript/tsconfig/bundler/dom",
+  "exclude": ["**/*.test.ts"]
+}

--- a/packages/verification-code/tsconfig.test.json
+++ b/packages/verification-code/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"]
+  },
+  "include": ["**/*.test.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## What this does

Rewrites `extractVerificationCode` from scratch — heuristics only, no model — as a pure function in a new `@meru/verification-code` package, tested against a labeled corpus of 115 subject/snippet pairs across 17 languages.

The old extractor had four verified failure modes:

1. **Effectively English-only** — the `\bcode\b` gate rejected `Bestätigungscode`, `código`, `verificación`, and every non-Latin script before extraction ever ran.
2. **Non-ASCII digits unmatched** — full-width `４９３０２１` and Arabic-Indic `٤٩٣٠٢١` failed `[0-9]`.
3. **The wrong number wins** — digit-length priority instead of keyword proximity: `Your code for order 12345678 is 4930` returned `12345678`. With auto-delete on, that deletes a real email over a wrong clipboard value.
4. **No alphanumeric coverage** — deferred to a follow-up (tracked in `docs/features/verification-codes.md`); the corpus already carries those samples marked to flip.

## The new pipeline

NFKC normalization plus folding of Arabic-Indic/Extended Arabic-Indic/Devanagari digits → a multilingual code-word lexicon with per-language regex anchoring (suffix-anchored `code` for German compounds, prefix-anchored `kod` for Turkish suffixes, Unicode-bounded Latin, substring CJK/Cyrillic/RTL) → candidate collection by maximal digit runs (4–8 digits, plausible groupings; phone and tracking numbers die structurally as over-long runs) → scoring by keyword proximity, format prior, and context words, with hard vetoes for years, currency, percentages, reference numbers (order/invoice/tracking, including CJK forms like `注文番号`), and phone shapes, plus message-level penalties for delivery and promo topics.

The scope is codes pasted to continue a flow on a screen — sign in, sign up, password reset, transaction confirmation. A code word behind a marker naming a different kind of code — *discount/referral/postal/QR/tracking/delivery/pickup*, compounds like `Rabattcode` and `Abholcode` included — doesn't open the gate at all: a delivery pickup code is read aloud to the courier, so a clipboard copy is useless and mark-read/delete would hide the email while it's still needed.

Weights are named constants tuned against the corpus. Tuning target: zero false positives on the corpus negatives — precision over recall, because auto-delete makes a false positive destructive.

## Behavior changes

- The `verificationCodes.confidence` (`high`/`medium`) setting is **removed** (settings UI field dropped, `>=3.60.0` migration deletes the stored key). Scoring replaces the two-value switch.
- Delivery wording as a *topic* is now a score penalty rather than a message-wide veto, so a sign-in code in an email that also mentions shipping still extracts; codes *named* delivery/pickup codes are excluded at the gate (see scope above).
- 5- and 7-digit codes are now extractable; space-less CJK shapes (`验证码493021`) now work; capitalized Cyrillic keywords match.

## Testing

- 150 tests in the package (115 corpus entries + unit tests for normalization, candidate collection, gating, and every veto class), 521 pass repo-wide; `bun run types`, `bun run lint`, `bun run fmt:check` clean.
- The corpus includes adversarial negatives where the word "code" legitimately appears (promo, referral, postal, tracking, delivery) and truncation cases documenting the recall ceiling of Gmail's snippet.
- Not verified: the live auto-copy path end-to-end (needs a real Gmail account receiving a code plus a valid license). The call site itself is unchanged — same inputs, same clipboard/notification/mark-read/delete flow.

## Follow-ups (tracked in docs/features/verification-codes.md)

- Alphanumeric codes (corpus samples in place, expectations marked to flip).
