### PR TITLE
Let the user choose when a verification code is copied

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -114,6 +114,7 @@ export const config = new Store<Config>({
     "workspaceApps.hibernation": "selected",
     "workspaceApps.hibernationTimeout": "1h",
     "verificationCodes.autoCopy": false,
+    "verificationCodes.copyMode": "immediately",
     "verificationCodes.autoDelete": false,
     "verificationCodes.autoMarkAsRead": false,
     "doNotDisturb.enabled": false,

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -684,25 +684,45 @@ export class Gmail {
           const verificationCode = extractVerificationCode([newMail.subject, newMail.summary]);
 
           if (verificationCode) {
-            clipboard.writeText(verificationCode);
+            const copyVerificationCode = () => {
+              clipboard.writeText(verificationCode);
+
+              if (config.get("verificationCodes.autoMarkAsRead")) {
+                ipc.renderer.send(
+                  this.view.webContents,
+                  "gmail.handleMessage",
+                  newMail.id,
+                  "markAsRead",
+                );
+              }
+
+              if (config.get("verificationCodes.autoDelete")) {
+                ipc.renderer.send(
+                  this.view.webContents,
+                  "gmail.handleMessage",
+                  newMail.id,
+                  "delete",
+                );
+              }
+            };
+
+            // Marking as read and deleting ride along with the copy rather than
+            // with the detection, so that nothing touches an email the user has
+            // not yet acted on.
+            const copiesOnNotificationClick =
+              config.get("verificationCodes.copyMode") === "notificationClick";
+
+            if (!copiesOnNotificationClick) {
+              copyVerificationCode();
+            }
 
             createNotification({
               title: notificationTitle,
-              body: `Copied verification code ${verificationCode}`,
+              body: copiesOnNotificationClick
+                ? `Click to copy verification code ${verificationCode}`
+                : `Copied verification code ${verificationCode}`,
+              click: copiesOnNotificationClick ? copyVerificationCode : undefined,
             });
-
-            if (config.get("verificationCodes.autoMarkAsRead")) {
-              ipc.renderer.send(
-                this.view.webContents,
-                "gmail.handleMessage",
-                newMail.id,
-                "markAsRead",
-              );
-            }
-
-            if (config.get("verificationCodes.autoDelete")) {
-              ipc.renderer.send(this.view.webContents, "gmail.handleMessage", newMail.id, "delete");
-            }
 
             continue;
           }

--- a/packages/renderer/routes/settings/verification-codes.tsx
+++ b/packages/renderer/routes/settings/verification-codes.tsx
@@ -1,4 +1,6 @@
+import { verificationCodeCopyModes } from "@meru/shared/verification-codes";
 import { FieldGroup } from "@meru/ui/components/field";
+import { ConfigSelectField } from "@/components/config-select-field";
 import { ConfigSwitchField } from "@/components/config-switch-field";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
@@ -21,8 +23,19 @@ export function VerificationCodesSettings() {
         <FieldGroup>
           <ConfigSwitchField
             label="Copy codes to clipboard"
-            description="Copy a verification code to your clipboard as soon as it arrives by email."
+            description="Detect a verification code in an incoming email and copy it to your clipboard."
             configKey="verificationCodes.autoCopy"
+            licenseKeyRequired
+          />
+          <ConfigSelectField
+            label="When to copy"
+            description="A notification shows the code either way. Copying on click leaves your clipboard untouched until you act."
+            configKey="verificationCodes.copyMode"
+            items={Object.entries(verificationCodeCopyModes).map(([value, label]) => ({
+              value,
+              label,
+            }))}
+            disabled={!config["verificationCodes.autoCopy"]}
             licenseKeyRequired
           />
           <ConfigSwitchField

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -12,6 +12,7 @@ import type {
   GmailSavedSearches,
 } from "./schemas";
 import type { AccountTabsState, VerticalTabsSessionWidth, VerticalTabsWidth } from "./tabs";
+import type { VerificationCodeCopyMode } from "./verification-codes";
 import type {
   LauncherAndBookmarksPlacement,
   LauncherWorkspaceApp,
@@ -180,6 +181,7 @@ export type Config = {
   "workspaceApps.hibernation": WorkspaceAppsHibernation;
   "workspaceApps.hibernationTimeout": WorkspaceAppsHibernationTimeout;
   "verificationCodes.autoCopy": boolean;
+  "verificationCodes.copyMode": VerificationCodeCopyMode;
   "verificationCodes.autoDelete": boolean;
   "verificationCodes.autoMarkAsRead": boolean;
   "doNotDisturb.enabled": boolean;

--- a/packages/shared/verification-codes.ts
+++ b/packages/shared/verification-codes.ts
@@ -1,0 +1,6 @@
+export const verificationCodeCopyModes = {
+  immediately: "As soon as it arrives",
+  notificationClick: "When you click the notification",
+} as const;
+
+export type VerificationCodeCopyMode = keyof typeof verificationCodeCopyModes;


### PR DESCRIPTION
Verification-code copying was a single boolean: on meant the code hit the clipboard the moment the mail arrived. This adds a mode so the user can hold the copy back until they click the notification.

## What changed

- **`verificationCodes.copyMode`** — a new string-union key, `immediately` (default) or `notificationClick`. `verificationCodes.autoCopy` stays the on/off switch; the mode select is disabled while it is off.
- **Notification copy** — `immediately` keeps `Copied verification code 123456`; `notificationClick` reads `Click to copy verification code 123456`, and clicking it writes the clipboard.
- **Mark as read and delete now follow the copy, not the detection.** In `notificationClick` mode nothing touches the mail until the user clicks. Firing them on arrival would delete the very email the notification points at, for a user who may never click — turning a false positive into silent loss with no copy to show for it.
- **No config migration.** The new key defaults to `immediately`, which reproduces the old behavior for everyone who had `autoCopy` on, and `autoCopy` itself is untouched.

## Settings

```
[x] Copy codes to clipboard
    Detect a verification code in an incoming email and copy it to your clipboard.

    When to copy                    [ As soon as it arrives          v ]
    A notification shows the code either way. Copying on click
    leaves your clipboard untouched until you act.

[ ] Mark email as read after copying
[ ] Delete email after copying
```

The two follow-up switches keep their labels — "after copying" stays accurate in both modes now that they fire with the copy.

## Design decisions

Modeling the off state as a third select value (`off | immediately | notificationClick`) was weighed and rejected: no other select in the app carries an off value, a switch states on/off more plainly than a dropdown entry, and it would have needed a migration. Both decisions are recorded in `docs/features/verification-codes.md`.

## Verification

`bun run types`, `bun run lint`, `bun run fmt:check` pass; `bun test` is 521 pass / 1 skip / 0 fail, including the 150 extractor tests. **Not verified by running the app** — the click path, the notification body on each platform, and the disabled state of the select were not exercised in a live build.