### PR TITLE
rename the auto-delete switch and warn about false positives

### DIFF
--- a/packages/renderer/routes/settings/verification-codes.tsx
+++ b/packages/renderer/routes/settings/verification-codes.tsx
@@ -32,8 +32,8 @@ export function VerificationCodesSettings() {
             licenseKeyRequired
           />
           <ConfigSwitchField
-            label="Delete email after copying"
-            description="Delete the email once its verification code has been copied."
+            label="Move email to Trash after copying"
+            description="Move the email to Trash once its verification code has been copied. Detection can misfire, and a real email can be moved too — Mark email as read is the safer choice."
             configKey="verificationCodes.autoDelete"
             licenseKeyRequired
           />


### PR DESCRIPTION
The verification codes setting read **Delete email after copying**, which overstates what it does: the delete action Meru sends is Gmail action code `9` (`packages/shared/gmail.ts:7`), which moves the message to Trash rather than erasing it. And because code detection is heuristics over the Atom feed's subject and truncated snippet, a false positive moves a real email — the extractor is tuned for precision precisely because of this switch, but it can't rule them out.

So the label is fixed at the source rather than walked back in the description:

- **Move email to Trash after copying** replaces **Delete email after copying**.
- The description gains the caution in one clause and points at the safer alternative: "Move the email to Trash once its verification code has been copied. Detection can misfire, and a real email can be moved too — Mark email as read is the safer choice."

Copy only. The `verificationCodes.autoDelete` config key is unchanged, so no migration and no stored settings move.

### What was considered and dropped

- **An `Alert` on the field.** The loss is recoverable, and the switch is off by default and license-gated, so a warning block would shout louder than the risk warrants. The description carries it, per the settings guidance in the ui-writing skill.
- **Renaming the new-mail notification's Delete button** (`packages/app/gmail/index.ts:734`). It mirrors Gmail's own button on a deliberate action the user takes, not an unattended one, so it keeps its name.
- **"Bin"** — Gmail's en-GB label. The app is American English throughout, so "Trash".
- **Naming Gmail's 30-day Trash retention.** That's Google's policy, not ours, and would go silently stale.

The decision and its reasoning are recorded in `docs/features/verification-codes.md` (pushed separately to the docs repo).

### Verification

`bun run types`, `bun run lint` and `bun run fmt:check` all pass. I have not launched the app to look at the rendered field.

### Merge order

Independent of `copy-mode-select`, which edits the `autoCopy` field in the same file. Either can merge first; the second may need a trivial rebase.