### PR TITLE
Add a setting for the extensions button in the titlebar

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -130,6 +130,7 @@ export const config = new Store<Config>({
     "verticalTabs.hideUnreadBadgeWhenActive": false,
     "verticalTabs.showAppLinksBadge": true,
     "extensions.installed": [],
+    "extensions.showTitlebarButton": false,
   },
   migrations: {
     ">=3.4.0": (store) => {

--- a/packages/renderer/components/extension-actions.tsx
+++ b/packages/renderer/components/extension-actions.tsx
@@ -2,19 +2,27 @@ import { ipc } from "@meru/shared/renderer/ipc";
 import { PuzzleIcon } from "lucide-react";
 import { TitlebarIconButton } from "@/components/titlebar";
 import { useExtensionActionsStore } from "@/lib/extension-actions";
+import { useConfig } from "@/lib/react-query";
 
 /**
  * The titlebar button listing the extensions loaded into the account this window
- * shows, drawing nothing at all while no extension is loaded — which is every
- * window until extensions can be installed.
+ * shows, drawing nothing at all unless the user has asked for it and an
+ * extension is loaded.
+ *
+ * It's off by default because 1Password, the only extension Meru curates, does
+ * its work in the page: the inline autofill menu and the WebAuthn override both
+ * run as content scripts on the Google sign-in pages, so the popup the button
+ * opens is a surface most users never need.
  *
  * The list itself is a native menu the main process pops up: a renderer-drawn
  * one would be covered wherever a workspace app view sits.
  */
 export function ExtensionActions() {
+  const { config } = useConfig();
+
   const actions = useExtensionActionsStore((state) => state.actions);
 
-  if (actions.length === 0) {
+  if (!config?.["extensions.showTitlebarButton"] || actions.length === 0) {
     return;
   }
 

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -16,7 +16,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@meru/ui/components/dialog";
-import { FieldDescription, FieldLegend, FieldSet } from "@meru/ui/components/field";
+import { FieldDescription, FieldLegend, FieldSeparator, FieldSet } from "@meru/ui/components/field";
 import {
   Item,
   ItemActions,
@@ -33,6 +33,7 @@ import { ExternalLinkIcon, KeyRoundIcon } from "lucide-react";
 import { type ComponentProps, useState } from "react";
 import { toast } from "sonner";
 import { BetaFieldBadge } from "@/components/beta-field-badge";
+import { ConfigSwitchField } from "@/components/config-switch-field";
 import { CopyButton } from "@/components/copy-button";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { LicenseKeyRequiredFieldBadge } from "@/components/license-key-required-field-badge";
@@ -439,6 +440,13 @@ export function ExtensionsSettings() {
               ))}
           </ItemGroup>
         </FieldSet>
+        <FieldSeparator />
+        <ConfigSwitchField
+          label="Show extensions button"
+          description="Show a titlebar button that lists the installed extensions and opens their popups."
+          configKey="extensions.showTitlebarButton"
+          licenseKeyRequired
+        />
       </SettingsContent>
     </Settings>
   );

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -197,6 +197,7 @@ export type Config = {
   "verticalTabs.hideUnreadBadgeWhenActive": boolean;
   "verticalTabs.showAppLinksBadge": boolean;
   "extensions.installed": string[];
+  "extensions.showTitlebarButton": boolean;
 };
 
 export type IpcMainEvents =


### PR DESCRIPTION
## Problem
The extensions menu button from #855 puts a puzzle icon in both the main and the Workspace app titlebar, and the titlebar is running out of room. It buys most users nothing: every 1Password flow Meru is there for runs in the page, not in the popup the button opens. The inline autofill menu and the MAIN-world WebAuthn override are content scripts on accounts.google.com, so passkey creation, passkey sign-in, autofill and password generation all happen inside the `WebContentsView`.

The [todo row](https://github.com/zoidsh/meru/blob/main/docs/todo.md) asked whether the button moves to the vertical tabs sidebar, moves to an overflow menu, or goes away. It does none of those: it stays where it is and stops being drawn unless asked for.

## Solution
- Adds the `extensions.showTitlebarButton` configuration key, defaulting to `false`
- Gates the button on it in `ExtensionActions` itself, so one key governs both titlebars and the config broadcast makes the toggle take effect without a restart
- Adds a **Show extensions button** switch below the curated list on the Extensions settings page, license-gated like the rest of that page

A setting rather than removing the button, because the popup is still load-bearing for extensions Meru doesn't curate yet — Bitwarden's UI is popup-primary, and the iCloud Passwords pairing code is entered there. Of the three reasons the [collapsed-actions decision](https://github.com/zoidsh/meru/blob/main/docs/decisions.md) gave for keeping the actions visible, only those two survive: 1Password standalone sign-in is out of scope since the desktop app became a requirement.

The field went on the Extensions settings page rather than Appearance, which has no titlebar section for it to join — only Dock, Menu bar and Window.

Extensions haven't shipped, so nothing carries the old default forward and there's no migration.

## Not verified
- ⚠️ Nothing was run in a real app: no display and no signed build here. The gate, the switch and the config round trip are covered by type checking only.
- ⚠️ The default gives up two things knowingly, both recoverable by turning the setting on. `content_scripts` is clamped to accounts.google.com and `host_permissions` was deliberately left unclamped so user-initiated fill through the action keeps working off that host — and the titlebar button is the action's only entry, since `commands` is a facade noop and `Cmd+Shift+X` does nothing. So filling on a Workspace app or on `myaccount.google.com/signinoptions/password` now needs the switch first. Unlock is the same shape: popup unlock is the only route recorded as verified, and whether the accounts.google.com inline menu can trigger a desktop-app unlock on its own is untested.