### PR TITLE
Fix the missing gap above the extensions button setting

### DIFF
--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -16,7 +16,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@meru/ui/components/dialog";
-import { FieldDescription, FieldLegend, FieldSeparator, FieldSet } from "@meru/ui/components/field";
+import {
+  FieldDescription,
+  FieldGroup,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+} from "@meru/ui/components/field";
 import {
   Item,
   ItemActions,
@@ -416,37 +422,39 @@ export function ExtensionsSettings() {
         </SettingsTitle>
         {config["extensions.installed"].length > 0 && <UpdateExtensionsButton />}
       </SettingsHeader>
-      <SettingsContent className="space-y-4">
+      <SettingsContent>
         <LicenseKeyRequiredBanner />
-        <FieldDescription>
-          Extensions are loaded into every account and take effect after a restart. Meru installs
-          the official extensions from the Chrome Web Store.
-        </FieldDescription>
-        <FieldSet>
-          <FieldLegend>Password managers</FieldLegend>
-          <PasskeysAlert />
-          <ItemGroup>
-            {curatedExtensions
-              .filter(({ category }) => category === "passwordManager")
-              .map((extension) => (
-                <ExtensionItem
-                  key={extension.id}
-                  extension={extension}
-                  installed={config["extensions.installed"].includes(extension.id)}
-                  installedVersion={
-                    installedExtensions?.find(({ id }) => id === extension.id)?.version
-                  }
-                />
-              ))}
-          </ItemGroup>
-        </FieldSet>
-        <FieldSeparator />
-        <ConfigSwitchField
-          label="Show extensions button"
-          description="Show a titlebar button that lists the installed extensions and opens their popups."
-          configKey="extensions.showTitlebarButton"
-          licenseKeyRequired
-        />
+        <FieldGroup>
+          <FieldDescription>
+            Extensions are loaded into every account and take effect after a restart. Meru installs
+            the official extensions from the Chrome Web Store.
+          </FieldDescription>
+          <FieldSet>
+            <FieldLegend>Password managers</FieldLegend>
+            <PasskeysAlert />
+            <ItemGroup>
+              {curatedExtensions
+                .filter(({ category }) => category === "passwordManager")
+                .map((extension) => (
+                  <ExtensionItem
+                    key={extension.id}
+                    extension={extension}
+                    installed={config["extensions.installed"].includes(extension.id)}
+                    installedVersion={
+                      installedExtensions?.find(({ id }) => id === extension.id)?.version
+                    }
+                  />
+                ))}
+            </ItemGroup>
+          </FieldSet>
+          <FieldSeparator />
+          <ConfigSwitchField
+            label="Show extensions button"
+            description="Show a titlebar button that lists the installed extensions and opens their popups."
+            configKey="extensions.showTitlebarButton"
+            licenseKeyRequired
+          />
+        </FieldGroup>
       </SettingsContent>
     </Settings>
   );


### PR DESCRIPTION
## Summary
The "Show extensions button" switch sat flush against the "Password managers" section above it, with no space around the separator. The Extensions page was the only settings page not using the shared `FieldGroup` layout; adopting it restores the spacing every other page has. Not seen rendered.

## Problem
`FieldSeparator` is a `-my-2 h-5` box that relies on its parent's gap for the space on either side of the rule. Extensions was the only settings page not wrapping its content in `FieldGroup` — it put an ad-hoc `space-y-4` on `SettingsContent` instead. That utility sets `margin-top` on siblings with higher specificity than `-my-2`, so it overrode the separator's negative top margin and collapsed the space around it.

## Solution
- Wraps the page content in `FieldGroup`, matching `general.tsx`, `appearance.tsx`, `notifications.tsx`, `advanced.tsx` and `workspace-apps.tsx`
- Drops the `space-y-4` from `SettingsContent`, and keeps `LicenseKeyRequiredBanner` outside the group where the other pages keep it — it carries its own `mb-8`
- Structural rather than a hand-tuned margin on the switch: the gap is wrong because the page opted out of the shared layout, so a margin would fix this one instance and leave the page still the odd one out
- The switch stays a bare `ConfigSwitchField` after the separator with no `FieldSet`/`FieldLegend` of its own — already the pattern for "Persist zoom" in `workspace-apps.tsx` and `DefaultMailClientField` in `general.tsx`

## Not verified
- Not seen rendered — `bun run types`, `bun run lint` and `bun run fmt:check` pass, but nothing here confirms the spacing visually