### PR TITLE
Extend the 1Password clamp to myaccount.google.com

### DIFF
--- a/packages/shared/extensions.ts
+++ b/packages/shared/extensions.ts
@@ -30,7 +30,11 @@ export const curatedExtensions: CuratedExtension[] = [
     description:
       "Password manager that fills logins and signs you in with passkeys stored in your vault.",
     category: "passwordManager",
-    contentScriptMatches: ["https://accounts.google.com/*"],
+    // Sign-in runs on accounts.google.com, and account settings — creating a
+    // passkey, changing a password — on myaccount.google.com. Both hosts, not
+    // the settings paths alone: Google reshuffles those and redirects between
+    // them, and a path that falls outside the clamp offers nothing, silently
+    contentScriptMatches: ["https://accounts.google.com/*", "https://myaccount.google.com/*"],
   },
 ];
 


### PR DESCRIPTION
## Summary
Adds `https://myaccount.google.com/*` to 1Password's `contentScriptMatches`, so its content scripts reach Google's account settings and it offers autofill, password generation and passkey creation on the My Account workspace app again. Not exercised in a running app; only type checks, lint and the test suite were run.

## Problem
The curated catalog clamps 1Password's content scripts to `https://accounts.google.com/*`, and the derive step writes that over every `content_scripts[].matches` entry. `myaccount.google.com` falls outside it, so 1Password sees nothing on the My Account workspace app: no autofill, no password generation, and no passkey creation, because the MAIN-world WebAuthn override never injects and `navigator.credentials.create()` falls through to native Electron WebAuthn.

This was already recorded as a known gap in `docs/features/chrome-extensions.md` on 18 August 2026, naming `signinoptions/passkeys`, `signinoptions/password` and `signinoptions/two-step-verification` as the three pages that matter.

## Solution
- Adds `https://myaccount.google.com/*` to the 1Password catalog entry in `packages/shared/extensions.ts`
- Clamps the whole host rather than the `signinoptions` paths alone, which was the narrower option considered: Google reshuffles those paths and redirects between them and accounts.google.com mid-flow, and a path outside the clamp injects nothing with no error and no warning — the exact failure mode being fixed here. My Account is one workspace app that is rarely open, so the always-on injection cost the clamp exists to control barely moves
- Widening to `https://*.google.com/*` was rejected for the reason the clamp exists at all
- `host_permissions` stays untouched, as before

## Not verified
- Not run in a real app. That 1Password now fills, generates a password and creates a passkey on `myaccount.google.com/signinoptions/*` is reasoned from the clamp, not observed
- On macOS, a passkey created from Google's security settings inside Meru is now expected to meet 1Password's override rather than native Touch ID whenever the extension is loaded. That interception is reasoned from the override's scope, and the per-platform passkey alert on the Extensions settings page still suggests the Touch ID path