### PR TITLE
Say window when the tab taking an app's links is windowed

### DIFF
--- a/packages/app/dialogs.ts
+++ b/packages/app/dialogs.ts
@@ -22,14 +22,19 @@ export async function showRestartDialog() {
 export async function confirmAppLinksTabHandover(
   workspaceApp: SupportedWorkspaceApp,
   appLinksTabTitle: string,
+  { isTargetWindowed }: { isTargetWindowed: boolean },
 ) {
   const appLabel = workspaceApps[workspaceApp].label;
+
+  // The tab taking the links can be living in its own window, and the context
+  // menu item that opens this dialog already says so.
+  const targetLabel = isTargetWindowed ? "window" : "tab";
 
   const { response } = await dialog.showMessageBox(main.window, {
     type: "info",
     buttons: ["Open links here", "Cancel"],
-    message: `Open ${appLabel} links in this tab?`,
-    detail: `“${appLinksTabTitle}” currently opens all ${appLabel} links. This tab will open them instead.`,
+    message: `Open ${appLabel} links in this ${targetLabel}?`,
+    detail: `“${appLinksTabTitle}” currently opens all ${appLabel} links. This ${targetLabel} will open them instead.`,
     defaultId: 0,
     cancelId: 1,
   });

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -32,7 +32,7 @@ import { config } from "@/config";
 import { licenseKey } from "@/license-key";
 import { main } from "@/main";
 import { appMenu } from "@/menu";
-import { DormantTab } from "@/tabs";
+import { DormantTab, isWindowedTab } from "@/tabs";
 import {
   canOpenWorkspaceAppInApp,
   resolveWorkspaceAppOpenBehavior,
@@ -380,6 +380,8 @@ class Ipc {
 
       const isWindowsMode = config.get("workspaceApps.mode") === "windows";
 
+      const isTabWindowed = isWindowedTab(tab);
+
       const openWorkspaceAppUrl = (url: string) => {
         account.instance.tabs.openUrl(url);
 
@@ -542,7 +544,7 @@ class Ipc {
               ...(tabApp ? [] : [{ type: "separator" as const }]),
               {
                 label: `Open ${workspaceApps[appLinksApp].label} Links in This ${
-                  tab instanceof WorkspaceApp && tab.isWindowed ? "Window" : "Tab"
+                  isTabWindowed ? "Window" : "Tab"
                 }`,
                 type: "checkbox" as const,
                 checked: Boolean(tab.opensLinksForApp),
@@ -557,7 +559,9 @@ class Ipc {
 
                   if (
                     appLinksTab &&
-                    !(await confirmAppLinksTabHandover(appLinksApp, appLinksTab.title))
+                    !(await confirmAppLinksTabHandover(appLinksApp, appLinksTab.title, {
+                      isTargetWindowed: isTabWindowed,
+                    }))
                   ) {
                     return;
                   }


### PR DESCRIPTION
## Summary
The tab context menu offers `Open Calendar Links in This Window` for a tab living in its own window, and then the confirmation asks `Open Calendar links in this tab?`. The dialog now takes the windowed state from the caller and says `window` in both of its lines, so it echoes the item that was just clicked. Not run in the app.

## Problem
`confirmAppLinksTabHandover` had no way to know whether the tab taking the designation is windowed, so its message and detail always said "tab". The context menu label a few lines above the caller already branched on `tab instanceof WorkspaceApp && tab.isWindowed`, which left the two texts disagreeing for exactly the case the label bothers to name. #924 rewrote this dialog and kept the button as `Open links here` precisely because "here" is true either way — that was the wording fix, and this is the signature change it deferred.

## Solution
- `confirmAppLinksTabHandover` takes `{ isTargetWindowed }` and derives one `targetLabel` used by both the message and the detail
- The caller hoists `isWindowedTab(tab)` into `isTabWindowed`, which now feeds the menu label and the dialog from one expression
- The detail's other reference, the tab losing the designation, is left alone: it is named by its page title and carries no tab/window noun, so it reads the same either way
- The boolean goes in an options object rather than a third positional argument, because the two strings before it describe the tab giving the links up while the boolean describes the one taking them, and a bare `true` at the call site would not say which
- The dialog stays attached to `main.window`. The context menu is opened from the vertical tab list in the main window, so that is where the interaction is; attaching it to the target window would pull a sheet onto another window, possibly another display, which is a behavior change this wording does not need

## Not verified
- Not run in the app — checked by reading. `bun run types`, `bun run lint`, `bun run fmt:check` and `bun test` pass