### PR TITLE
Add a component playground over a fake preload bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "fmt:check": "oxfmt --check",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix --fix-suggestions --fix-dangerously",
+    "playground": "bun run scripts/playground.ts",
     "postinstall": "electron-builder install-app-deps",
     "types": "tsc && bun run --filter='*' --elide-lines=0 types",
     "types:ci": "tsc && bun run --filter='*' types"

--- a/packages/renderer/playground/components.ts
+++ b/packages/renderer/playground/components.ts
@@ -1,0 +1,49 @@
+import { MAX_RECENT_DOWNLOAD_HISTORY_ITEMS } from "@meru/shared/constants";
+
+type PlaygroundComponent = {
+  name: string;
+  /** Where the component itself lives, so the file is one search away. */
+  source: string;
+  /** `fill` hands over the whole preview area, as the app's own layout does. */
+  layout: "padded" | "fill";
+};
+
+/**
+ * The catalog of what the playground can render. An entry is one call site
+ * rather than one component: props are code, so a component rendered with
+ * different props in different places earns an entry for each. A scenario picks
+ * an entry by id and supplies everything the component reads through IPC.
+ *
+ * This holds no React, because the shell renders the picker beside the preview
+ * and must not pull the renderer's modules into a page with no fake bridge
+ * under it. `render.tsx` is where an id becomes a component.
+ */
+export const playgroundComponents = {
+  downloadHistoryList: {
+    name: "DownloadHistoryList",
+    source: "components/download-history.tsx",
+    layout: "padded",
+  },
+  recentDownloadHistoryList: {
+    name: `DownloadHistoryList, limited to ${MAX_RECENT_DOWNLOAD_HISTORY_ITEMS}`,
+    source: "components/download-history.tsx",
+    layout: "padded",
+  },
+  findInPage: {
+    name: "FindInPage",
+    source: "components/find-in-page.tsx",
+    layout: "padded",
+  },
+  licenseKeyRequiredBanner: {
+    name: "LicenseKeyRequiredBanner",
+    source: "components/license-key-required-banner.tsx",
+    layout: "padded",
+  },
+  verticalTabs: {
+    name: "VerticalTabs",
+    source: "components/vertical-tabs.tsx",
+    layout: "fill",
+  },
+} satisfies Record<string, PlaygroundComponent>;
+
+export type PlaygroundComponentId = keyof typeof playgroundComponents;

--- a/packages/renderer/playground/constants.ts
+++ b/packages/renderer/playground/constants.ts
@@ -1,0 +1,32 @@
+export const playgroundPlatforms = {
+  linux: "Linux",
+  darwin: "macOS",
+  win32: "Windows",
+} as const;
+
+export type PlaygroundPlatform = keyof typeof playgroundPlatforms;
+
+function isPlaygroundPlatform(value: string | null): value is PlaygroundPlatform {
+  return value !== null && value in playgroundPlatforms;
+}
+
+/**
+ * The renderer's `platform` helper and the titlebar both read
+ * `process.platform` once as their module evaluates, so the platform travels in
+ * the URL and the preview reloads to change it.
+ */
+export function getPlaygroundPlatform(searchParams: URLSearchParams): PlaygroundPlatform {
+  const platform = searchParams.get("platform");
+
+  return isPlaygroundPlatform(platform) ? platform : "linux";
+}
+
+/** The account every scenario's fixtures belong to. */
+export const PLAYGROUND_ACCOUNT_ID = "playground-account";
+
+/** Names the preview reads out of its own URL, and the shell writes into it. */
+export const PLAYGROUND_SEARCH_PARAMS = {
+  scenario: "scenario",
+  platform: "platform",
+  darkMode: "darkMode",
+} as const;

--- a/packages/renderer/playground/fake-electron.ts
+++ b/packages/renderer/playground/fake-electron.ts
@@ -1,7 +1,13 @@
 import type { ElectronAPI, IpcRendererListener } from "@electron-toolkit/preload";
 import { createDefaultConfig } from "@meru/shared/config";
 import type { Config, IpcRendererEvent } from "@meru/shared/types";
-import { getPlaygroundPlatform, PLAYGROUND_ACCOUNT_ID, type PlaygroundPlatform } from "./constants";
+import {
+  getPlaygroundPlatform,
+  PLAYGROUND_ACCOUNT_ID,
+  PLAYGROUND_SEARCH_PARAMS,
+  type PlaygroundPlatform,
+} from "./constants";
+import { scenarios } from "./scenarios";
 import type { IpcCall, IpcCallChannel, IpcInvokeReplies, Scenario, ScenarioEvent } from "./types";
 
 /**
@@ -14,7 +20,9 @@ type FakeElectronApi = {
   process: Pick<ElectronAPI["process"], "platform">;
 };
 
-const platform = getPlaygroundPlatform(new URLSearchParams(window.location.search));
+const searchParams = new URLSearchParams(window.location.search);
+
+const platform = getPlaygroundPlatform(searchParams);
 
 const downloadsLocations: Record<PlaygroundPlatform, string> = {
   darwin: "/Users/you/Downloads",
@@ -33,9 +41,26 @@ function createPlaygroundConfig(overrides: Partial<Config> | undefined): Config 
   };
 }
 
-let config = createPlaygroundConfig(undefined);
+const scenarioId = searchParams.get(PLAYGROUND_SEARCH_PARAMS.scenario);
 
-let invokeReplies: IpcInvokeReplies = {};
+/**
+ * The scenario is resolved and applied here rather than in the entry point,
+ * because a renderer module is free to invoke as it evaluates — `lib/
+ * extension-actions.ts` asks for the loaded extensions that way — and every
+ * import in the entry point runs before its own first statement does. By the
+ * time anything can ask, the answers are already in place.
+ */
+const resolvedScenario = scenarios.find((scenario) => scenario.id === scenarioId) ?? scenarios[0];
+
+if (!resolvedScenario) {
+  throw new Error("The playground has no scenarios to render");
+}
+
+export const playgroundScenario: Scenario = resolvedScenario;
+
+let config = createPlaygroundConfig(playgroundScenario.config);
+
+const invokeReplies: IpcInvokeReplies = playgroundScenario.invoke ?? {};
 
 const rendererListeners = new Map<string, Set<IpcRendererListener>>();
 
@@ -91,17 +116,6 @@ export function onIpcCall(listener: (call: IpcCall) => void): () => void {
   return () => {
     callListeners.delete(listener);
   };
-}
-
-/**
- * Puts the fake back into a scenario's starting state. The config is rebuilt
- * from the app's real defaults every time, so a scenario that overrides a key
- * can't leak it into the next one.
- */
-export function applyScenario(scenario: Scenario): void {
-  config = createPlaygroundConfig(scenario.config);
-
-  invokeReplies = scenario.invoke ?? {};
 }
 
 const fakeElectron: FakeElectronApi = {

--- a/packages/renderer/playground/fake-electron.ts
+++ b/packages/renderer/playground/fake-electron.ts
@@ -1,0 +1,175 @@
+import type { ElectronAPI, IpcRendererListener } from "@electron-toolkit/preload";
+import { createDefaultConfig } from "@meru/shared/config";
+import type { Config, IpcRendererEvent } from "@meru/shared/types";
+import { getPlaygroundPlatform, PLAYGROUND_ACCOUNT_ID, type PlaygroundPlatform } from "./constants";
+import type { IpcCall, IpcCallChannel, IpcInvokeReplies, Scenario, ScenarioEvent } from "./types";
+
+/**
+ * The part of the preload's API the renderer actually reaches for.
+ * `window.electron` is typed as the whole exposed surface, so the fake names
+ * the subset it answers for rather than stubbing the rest of it.
+ */
+type FakeElectronApi = {
+  ipcRenderer: Pick<ElectronAPI["ipcRenderer"], "send" | "invoke" | "on" | "once">;
+  process: Pick<ElectronAPI["process"], "platform">;
+};
+
+const platform = getPlaygroundPlatform(new URLSearchParams(window.location.search));
+
+const downloadsLocations: Record<PlaygroundPlatform, string> = {
+  darwin: "/Users/you/Downloads",
+  linux: "/home/you/Downloads",
+  win32: "C:\\Users\\you\\Downloads",
+};
+
+function createPlaygroundConfig(overrides: Partial<Config> | undefined): Config {
+  return {
+    ...createDefaultConfig({
+      accountId: PLAYGROUND_ACCOUNT_ID,
+      downloadsLocation: downloadsLocations[platform],
+      trayEnabled: platform !== "darwin",
+    }),
+    ...overrides,
+  };
+}
+
+let config = createPlaygroundConfig(undefined);
+
+let invokeReplies: IpcInvokeReplies = {};
+
+const rendererListeners = new Map<string, Set<IpcRendererListener>>();
+
+const callListeners = new Set<(call: IpcCall) => void>();
+
+/** Every renderer listener ignores its event argument, so a bare object serves. */
+const rendererEvent = {} as Parameters<IpcRendererListener>[0];
+
+/**
+ * Pushes an event the way the main process does, through the listeners the
+ * stores, the query cache, and the theme registered as they were imported.
+ */
+function emit(channel: string, args: unknown[]): void {
+  const listeners = rendererListeners.get(channel);
+
+  if (!listeners) {
+    return;
+  }
+
+  // Over a copy: a `once` listener unsubscribes itself as it runs, and a
+  // listener is free to subscribe another to the same channel.
+  for (const listener of Array.from(listeners)) {
+    listener(rendererEvent, ...args);
+  }
+}
+
+export function emitRendererEvent<Channel extends keyof IpcRendererEvent>(
+  channel: Channel,
+  args: IpcRendererEvent[Channel],
+): void {
+  emit(channel, args);
+}
+
+/**
+ * A scenario's events arrive as a union of channel-and-arguments pairs, which
+ * only holds together while the two travel as one value — hence the object
+ * rather than two arguments.
+ */
+export function pushScenarioEvent(event: ScenarioEvent): void {
+  emit(event.channel, event.args);
+}
+
+function recordCall(call: IpcCall): void {
+  for (const listener of Array.from(callListeners)) {
+    listener(call);
+  }
+}
+
+/** Watches what the rendered component asks the main process for. */
+export function onIpcCall(listener: (call: IpcCall) => void): () => void {
+  callListeners.add(listener);
+
+  return () => {
+    callListeners.delete(listener);
+  };
+}
+
+/**
+ * Puts the fake back into a scenario's starting state. The config is rebuilt
+ * from the app's real defaults every time, so a scenario that overrides a key
+ * can't leak it into the next one.
+ */
+export function applyScenario(scenario: Scenario): void {
+  config = createPlaygroundConfig(scenario.config);
+
+  invokeReplies = scenario.invoke ?? {};
+}
+
+const fakeElectron: FakeElectronApi = {
+  ipcRenderer: {
+    send(channel, ...args) {
+      recordCall({ kind: "send", channel: channel as IpcCallChannel, args, unanswered: false });
+    },
+    invoke(channel, ...args) {
+      if (channel === "config.getConfig") {
+        recordCall({ kind: "invoke", channel, args, unanswered: false });
+
+        return Promise.resolve(config);
+      }
+
+      /**
+       * Stands in for the main process's config store, which answers
+       * `config.getConfig` and pushes `config.configChanged` on every write. A
+       * mutation in the playground therefore travels back through the real
+       * query cache rather than doing nothing.
+       */
+      if (channel === "config.setConfig") {
+        recordCall({ kind: "invoke", channel, args, unanswered: false });
+
+        config = { ...config, ...(args[0] as Partial<Config>) };
+
+        emitRendererEvent("config.configChanged", [config]);
+
+        return Promise.resolve(undefined);
+      }
+
+      const invokeChannel = channel as keyof IpcInvokeReplies;
+
+      recordCall({
+        kind: "invoke",
+        channel: invokeChannel,
+        args,
+        unanswered: !(invokeChannel in invokeReplies),
+      });
+
+      return Promise.resolve(invokeReplies[invokeChannel]);
+    },
+    on(channel, listener) {
+      const listeners = rendererListeners.get(channel) ?? new Set();
+
+      listeners.add(listener);
+
+      rendererListeners.set(channel, listeners);
+
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    once(channel, listener) {
+      const unsubscribe = fakeElectron.ipcRenderer.on(channel, (...listenerArgs) => {
+        unsubscribe();
+
+        listener(...listenerArgs);
+      });
+
+      return unsubscribe;
+    },
+  },
+  process: { platform },
+};
+
+// The renderer's stores, query cache, and theme all register `ipc.renderer.on`
+// handlers as they are imported, so the fake has to be in place before any of
+// them evaluates. `preview.html` loads this module in a script tag of its own,
+// ahead of the entry point's, because a comment on an import would not survive
+// the formatter's import sorting.
+window.electron = fakeElectron as ElectronAPI;

--- a/packages/renderer/playground/index.html
+++ b/packages/renderer/playground/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Meru component playground</title>
+    <link rel="stylesheet" href="../globals.css" />
+  </head>
+  <body class="bg-background text-foreground">
+    <div id="root"></div>
+    <script type="module" src="./shell.tsx"></script>
+  </body>
+</html>

--- a/packages/renderer/playground/messages.ts
+++ b/packages/renderer/playground/messages.ts
@@ -1,0 +1,26 @@
+import type { IpcCall } from "./types";
+
+/**
+ * The shell and the preview are separate documents on purpose: only the preview
+ * has a fake `window.electron` under it, so the shell's own controls can't
+ * reach the renderer's modules by accident, and dark mode and the platform
+ * apply to the component alone. What the two have to say to each other
+ * therefore travels by `postMessage`.
+ */
+export type PreviewMessage = {
+  type: "ipcCall";
+  call: IpcCall;
+};
+
+export type ShellMessage = {
+  type: "darkMode";
+  darkMode: boolean;
+};
+
+export function isPreviewMessage(data: unknown): data is PreviewMessage {
+  return typeof data === "object" && data !== null && "type" in data && data.type === "ipcCall";
+}
+
+export function isShellMessage(data: unknown): data is ShellMessage {
+  return typeof data === "object" && data !== null && "type" in data && data.type === "darkMode";
+}

--- a/packages/renderer/playground/preview.html
+++ b/packages/renderer/playground/preview.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="../globals.css" />
+  </head>
+  <body class="bg-background text-foreground">
+    <div id="root"></div>
+    <!--
+      The fake bridge installs `window.electron` as it evaluates, and the
+      renderer's stores, query cache and theme all register IPC listeners as
+      they are imported. Loading it in a script tag of its own puts it
+      unmistakably first: module scripts run in document order, whereas an
+      import inside the entry point would be at the mercy of import sorting.
+    -->
+    <script type="module" src="./fake-electron.ts"></script>
+    <script type="module" src="./preview.tsx"></script>
+  </body>
+</html>

--- a/packages/renderer/playground/preview.tsx
+++ b/packages/renderer/playground/preview.tsx
@@ -1,4 +1,12 @@
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@meru/ui/components/empty";
 import { cn } from "@meru/ui/lib/utils";
+import { EyeOffIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { renderApp } from "@/lib/react";
 import { playgroundComponents } from "./components";
@@ -59,9 +67,18 @@ function Preview({ scenario }: { scenario: Scenario }) {
         {playgroundComponentRenderers[scenario.component]()}
       </div>
       {rendersNothing && (
-        <div className="border-t px-6 py-3 text-sm text-muted-foreground">
-          This component renders nothing in this scenario.
-        </div>
+        <Empty className="flex-none border-t">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <EyeOffIcon />
+            </EmptyMedia>
+            <EmptyTitle>Nothing rendered</EmptyTitle>
+            <EmptyDescription>
+              This component draws nothing in this scenario, which is a state of its own rather than
+              a failure.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
       )}
     </div>
   );

--- a/packages/renderer/playground/preview.tsx
+++ b/packages/renderer/playground/preview.tsx
@@ -1,0 +1,80 @@
+import { cn } from "@meru/ui/lib/utils";
+import { useEffect, useRef, useState } from "react";
+import { renderApp } from "@/lib/react";
+import { playgroundComponents } from "./components";
+import { PLAYGROUND_SEARCH_PARAMS } from "./constants";
+import { applyScenario, emitRendererEvent, onIpcCall, pushScenarioEvent } from "./fake-electron";
+import { isShellMessage, type PreviewMessage } from "./messages";
+import { playgroundComponentRenderers } from "./render";
+import { scenarios } from "./scenarios";
+import type { Scenario } from "./types";
+
+const searchParams = new URLSearchParams(window.location.search);
+
+const scenarioId = searchParams.get(PLAYGROUND_SEARCH_PARAMS.scenario);
+
+const scenario = scenarios.find((candidate) => candidate.id === scenarioId) ?? scenarios[0];
+
+if (!scenario) {
+  throw new Error("The playground has no scenarios to render");
+}
+
+// Before anything reads the config or the stores, and so before `renderApp`.
+applyScenario(scenario);
+
+onIpcCall((call) => {
+  const message: PreviewMessage = { type: "ipcCall", call };
+
+  window.parent.postMessage(message, window.location.origin);
+});
+
+window.addEventListener("message", (event) => {
+  if (event.origin !== window.location.origin || !isShellMessage(event.data)) {
+    return;
+  }
+
+  emitRendererEvent("theme.darkModeChanged", [event.data.darkMode]);
+});
+
+function Preview({ scenario }: { scenario: Scenario }) {
+  const { layout } = playgroundComponents[scenario.component];
+
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const [rendersNothing, setRendersNothing] = useState(false);
+
+  useEffect(() => {
+    for (const event of scenario.events ?? []) {
+      pushScenarioEvent(event);
+    }
+  }, [scenario]);
+
+  // Whether the component drew anything is only knowable from the DOM, and it
+  // changes with every render rather than only on mount, so this has no
+  // dependencies on purpose. React bails out when the value is unchanged.
+  useEffect(() => {
+    const container = containerRef.current;
+
+    setRendersNothing(
+      container !== null && container.childElementCount === 0 && !container.textContent,
+    );
+  });
+
+  return (
+    <div className="flex h-screen flex-col">
+      <div
+        ref={containerRef}
+        className={cn("flex-1", layout === "padded" ? "overflow-auto p-6" : "flex overflow-hidden")}
+      >
+        {playgroundComponentRenderers[scenario.component]()}
+      </div>
+      {rendersNothing && (
+        <div className="border-t px-6 py-3 text-sm text-muted-foreground">
+          This component renders nothing in this scenario.
+        </div>
+      )}
+    </div>
+  );
+}
+
+renderApp(() => <Preview scenario={scenario} />);

--- a/packages/renderer/playground/preview.tsx
+++ b/packages/renderer/playground/preview.tsx
@@ -2,25 +2,15 @@ import { cn } from "@meru/ui/lib/utils";
 import { useEffect, useRef, useState } from "react";
 import { renderApp } from "@/lib/react";
 import { playgroundComponents } from "./components";
-import { PLAYGROUND_SEARCH_PARAMS } from "./constants";
-import { applyScenario, emitRendererEvent, onIpcCall, pushScenarioEvent } from "./fake-electron";
+import {
+  emitRendererEvent,
+  onIpcCall,
+  playgroundScenario,
+  pushScenarioEvent,
+} from "./fake-electron";
 import { isShellMessage, type PreviewMessage } from "./messages";
 import { playgroundComponentRenderers } from "./render";
-import { scenarios } from "./scenarios";
 import type { Scenario } from "./types";
-
-const searchParams = new URLSearchParams(window.location.search);
-
-const scenarioId = searchParams.get(PLAYGROUND_SEARCH_PARAMS.scenario);
-
-const scenario = scenarios.find((candidate) => candidate.id === scenarioId) ?? scenarios[0];
-
-if (!scenario) {
-  throw new Error("The playground has no scenarios to render");
-}
-
-// Before anything reads the config or the stores, and so before `renderApp`.
-applyScenario(scenario);
 
 onIpcCall((call) => {
   const message: PreviewMessage = { type: "ipcCall", call };
@@ -77,4 +67,4 @@ function Preview({ scenario }: { scenario: Scenario }) {
   );
 }
 
-renderApp(() => <Preview scenario={scenario} />);
+renderApp(() => <Preview scenario={playgroundScenario} />);

--- a/packages/renderer/playground/render.tsx
+++ b/packages/renderer/playground/render.tsx
@@ -1,0 +1,45 @@
+import { MAX_RECENT_DOWNLOAD_HISTORY_ITEMS } from "@meru/shared/constants";
+import { ipc } from "@meru/shared/renderer/ipc";
+import type { ReactNode } from "react";
+import { DownloadHistoryList } from "@/components/download-history";
+import { FindInPage } from "@/components/find-in-page";
+import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
+import { VerticalTabs } from "@/components/vertical-tabs";
+import { useFindInPageStore } from "@/lib/stores";
+import type { PlaygroundComponentId } from "./components";
+
+/**
+ * `FindInPage` takes its state as props, and in the app the titlebar is the
+ * composition root that reads the store and wires them up. The playground
+ * supplies the same root, so the store and the events driving it stay the real
+ * ones — see the matching container in `components/app-titlebar.tsx`.
+ */
+function FindInPageControls() {
+  const isActive = useFindInPageStore((state) => state.isActive);
+  const activeMatch = useFindInPageStore((state) => state.activeMatch);
+  const totalMatches = useFindInPageStore((state) => state.totalMatches);
+  const deactivate = useFindInPageStore((state) => state.deactivate);
+
+  return (
+    <FindInPage
+      isActive={isActive}
+      activeMatch={activeMatch}
+      totalMatches={totalMatches}
+      onFind={(text, options) => {
+        ipc.main.send("findInPage", text, options);
+      }}
+      onClose={deactivate}
+    />
+  );
+}
+
+/** One renderer per catalog entry, which the type here is what enforces. */
+export const playgroundComponentRenderers: Record<PlaygroundComponentId, () => ReactNode> = {
+  downloadHistoryList: () => <DownloadHistoryList />,
+  recentDownloadHistoryList: () => (
+    <DownloadHistoryList limit={MAX_RECENT_DOWNLOAD_HISTORY_ITEMS} />
+  ),
+  findInPage: () => <FindInPageControls />,
+  licenseKeyRequiredBanner: () => <LicenseKeyRequiredBanner />,
+  verticalTabs: () => <VerticalTabs />,
+};

--- a/packages/renderer/playground/scenarios.ts
+++ b/packages/renderer/playground/scenarios.ts
@@ -1,0 +1,271 @@
+import { ms } from "@meru/shared/ms";
+import type { AccountInstance } from "@meru/shared/schemas";
+import { GMAIL_TAB_ID, type TabState } from "@meru/shared/tabs";
+import type { DownloadItem } from "@meru/shared/types";
+import { PLAYGROUND_ACCOUNT_ID } from "./constants";
+import type { Scenario } from "./types";
+
+/**
+ * A download's `createdAt` is a unix timestamp in seconds, which is what
+ * Electron reports as a download's start time.
+ */
+function unixSecondsAgo(millisecondsAgo: number): number {
+  return Math.round((Date.now() - millisecondsAgo) / 1000);
+}
+
+function createDownload(
+  fileName: string,
+  { createdAt, exists = true }: { createdAt: number; exists?: boolean },
+): DownloadItem {
+  return {
+    id: fileName,
+    fileName,
+    filePath: `/home/you/Downloads/${fileName}`,
+    createdAt,
+    exists,
+  };
+}
+
+const downloadHistory: DownloadItem[] = [
+  createDownload("Q3 revenue.pdf", { createdAt: unixSecondsAgo(ms("40s")) }),
+  createDownload("team-offsite-photos.zip", { createdAt: unixSecondsAgo(ms("2h")) }),
+  createDownload("contract-countersigned.pdf", { createdAt: unixSecondsAgo(ms("3d")) }),
+  createDownload("logo-mark.svg", { createdAt: unixSecondsAgo(ms("3w")) }),
+];
+
+const playgroundAccount: AccountInstance = {
+  config: {
+    id: PLAYGROUND_ACCOUNT_ID,
+    label: "Work",
+    color: "blue",
+    selected: true,
+    notifications: true,
+    gmail: {
+      unreadBadge: true,
+      delegatedAccountId: null,
+      unifiedInbox: true,
+    },
+    workspaceApps: {
+      savedTabs: [],
+      bookmarks: [],
+    },
+  },
+  gmail: {
+    unreadCount: 12,
+    unreadInbox: [],
+    outOfOffice: false,
+    attentionRequired: false,
+  },
+  verticalTabsWidth: null,
+};
+
+function createTab(tab: Pick<TabState, "id" | "title"> & Partial<TabState>): TabState {
+  return {
+    app: undefined,
+    pinned: false,
+    dormant: false,
+    windowed: false,
+    bookmarked: false,
+    opensLinksForApp: null,
+    loadOnLaunch: false,
+    loading: false,
+    navigationHistory: { canGoBack: false, canGoForward: false },
+    active: false,
+    ...tab,
+  };
+}
+
+const gmailTab = createTab({
+  id: GMAIL_TAB_ID,
+  app: "gmail",
+  title: "Gmail",
+  pinned: true,
+  active: true,
+});
+
+/**
+ * Every state the playground can be put into, as data. A scenario names the
+ * call site it renders, what the config says while it renders, and the events
+ * pushed at it once it has mounted.
+ */
+export const scenarios: Scenario[] = [
+  {
+    id: "download-history-empty",
+    name: "Nothing downloaded yet",
+    description: "The empty state, which is what a fresh install shows.",
+    component: "downloadHistoryList",
+    config: { "downloads.history": [] },
+  },
+  {
+    id: "download-history-populated",
+    name: "Four downloads",
+    description:
+      "Ages spanning seconds to weeks, so the relative timestamps each read differently. Removing one goes through the real mutation and the config comes back changed.",
+    component: "downloadHistoryList",
+    config: { "downloads.history": downloadHistory },
+  },
+  {
+    id: "download-history-files-gone",
+    name: "Files moved or deleted",
+    description:
+      "Two of the four no longer exist on disk, so they lose their timestamp, their folder button and their click target.",
+    component: "downloadHistoryList",
+    config: {
+      "downloads.history": downloadHistory.map((download, index) =>
+        index % 2 === 1 ? { ...download, exists: false } : download,
+      ),
+    },
+  },
+  {
+    id: "download-history-limited",
+    name: "More downloads than the popup shows",
+    description:
+      "Fourteen downloads through the call site the recent-downloads popup uses, which cuts the list off at ten.",
+    component: "recentDownloadHistoryList",
+    config: {
+      "downloads.history": Array.from({ length: 14 }, (_unused, index) =>
+        createDownload(`attachment-${index + 1}.pdf`, {
+          createdAt: unixSecondsAgo(ms("1h") * (index + 1)),
+        }),
+      ),
+    },
+  },
+  {
+    id: "find-in-page-matches",
+    name: "Searching with matches",
+    description:
+      "Activated and sitting on the third of twelve matches. Typing sends `findInPage`, which the call log below records.",
+    component: "findInPage",
+    events: [
+      { channel: "findInPage.activate", args: [] },
+      { channel: "findInPage.result", args: [{ activeMatch: 3, totalMatches: 12 }] },
+    ],
+  },
+  {
+    id: "find-in-page-no-matches",
+    name: "Searching with no matches",
+    description: "Activated with nothing found, which is the zero-of-zero counter.",
+    component: "findInPage",
+    events: [
+      { channel: "findInPage.activate", args: [] },
+      { channel: "findInPage.result", args: [{ activeMatch: 0, totalMatches: 0 }] },
+    ],
+  },
+  {
+    id: "find-in-page-closed",
+    name: "Not searching",
+    description: "Never activated, so the component renders nothing at all.",
+    component: "findInPage",
+  },
+  {
+    id: "license-required-trial-over",
+    name: "Trial over, unlicensed",
+    description: "No trial days left and no license key, which is when the banner appears.",
+    component: "licenseKeyRequiredBanner",
+    config: { licenseKey: null },
+  },
+  {
+    id: "license-required-trial-running",
+    name: "Trial running",
+    description: "Seven days left pushed through `trial.daysLeftChanged`, which hides the banner.",
+    component: "licenseKeyRequiredBanner",
+    config: { licenseKey: null },
+    events: [{ channel: "trial.daysLeftChanged", args: [7] }],
+  },
+  {
+    id: "license-required-licensed",
+    name: "Licensed",
+    description: "A license key in the config, which hides the banner just as the trial does.",
+    component: "licenseKeyRequiredBanner",
+    config: { licenseKey: "MERU-PLAYGROUND-KEY" },
+  },
+  {
+    id: "vertical-tabs-gmail-only",
+    name: "Gmail alone",
+    description: "One account with nothing open but Gmail, carrying an unread count.",
+    component: "verticalTabs",
+    events: [
+      { channel: "accounts.changed", args: [[playgroundAccount]] },
+      {
+        channel: "tabs.changed",
+        args: [[{ accountId: PLAYGROUND_ACCOUNT_ID, tabs: [gmailTab] }]],
+      },
+    ],
+  },
+  {
+    id: "vertical-tabs-mixed",
+    name: "Pinned, open, windowed and dormant tabs",
+    description:
+      "Both sections filled, with a windowed app, a dormant pinned one, and a tab holding another app's links — every badge the strip can draw.",
+    component: "verticalTabs",
+    events: [
+      { channel: "accounts.changed", args: [[playgroundAccount]] },
+      {
+        channel: "tabs.changed",
+        args: [
+          [
+            {
+              accountId: PLAYGROUND_ACCOUNT_ID,
+              tabs: [
+                gmailTab,
+                createTab({
+                  id: "calendar",
+                  app: "calendar",
+                  title: "Calendar",
+                  pinned: true,
+                  opensLinksForApp: "calendar",
+                }),
+                createTab({
+                  id: "drive",
+                  app: "drive",
+                  title: "Drive",
+                  pinned: true,
+                  dormant: true,
+                }),
+                createTab({ id: "meet", app: "meet", title: "Meet", windowed: true }),
+                createTab({
+                  id: "docs",
+                  app: "docs",
+                  title: "Roadmap — Google Docs",
+                  bookmarked: true,
+                }),
+                createTab({ id: "sheets", app: "sheets", title: "Headcount", loading: true }),
+              ],
+            },
+          ],
+        ],
+      },
+    ],
+  },
+  {
+    id: "vertical-tabs-wide",
+    name: "Widened strip with the launcher",
+    description:
+      "The wide strip, which labels every tab and puts the Workspace Apps launcher above the bookmarks button. The launcher needs a license, so this scenario carries one.",
+    component: "verticalTabs",
+    config: {
+      licenseKey: "MERU-PLAYGROUND-KEY",
+      "verticalTabs.width": "wide",
+      "workspaceApps.launcherApps": ["calendar", "drive", "keep", "tasks"],
+    },
+    events: [
+      { channel: "accounts.changed", args: [[playgroundAccount]] },
+      {
+        channel: "tabs.changed",
+        args: [
+          [
+            {
+              accountId: PLAYGROUND_ACCOUNT_ID,
+              tabs: [
+                gmailTab,
+                createTab({ id: "calendar", app: "calendar", title: "Calendar", pinned: true }),
+                createTab({ id: "docs", app: "docs", title: "Roadmap — Google Docs" }),
+                createTab({ id: "sheets", app: "sheets", title: "Headcount" }),
+              ],
+            },
+          ],
+        ],
+      },
+    ],
+  },
+];

--- a/packages/renderer/playground/shell.tsx
+++ b/packages/renderer/playground/shell.tsx
@@ -1,0 +1,298 @@
+import { Button } from "@meru/ui/components/button";
+import { Label } from "@meru/ui/components/label";
+import { ScrollArea } from "@meru/ui/components/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@meru/ui/components/select";
+import { Switch } from "@meru/ui/components/switch";
+import { cn } from "@meru/ui/lib/utils";
+import { RotateCwIcon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { playgroundComponents } from "./components";
+import {
+  getPlaygroundPlatform,
+  PLAYGROUND_SEARCH_PARAMS,
+  type PlaygroundPlatform,
+  playgroundPlatforms,
+} from "./constants";
+import { isPreviewMessage, type ShellMessage } from "./messages";
+import { scenarios } from "./scenarios";
+import type { IpcCall } from "./types";
+
+/** How many calls the log keeps before the oldest fall off the top. */
+const MAX_LOGGED_CALLS = 100;
+
+const platformItems = Object.entries(playgroundPlatforms).map(([value, label]) => ({
+  value,
+  label,
+}));
+
+const shellSearchParams = new URLSearchParams(window.location.search);
+
+const initialScenarioId =
+  scenarios.find(
+    (scenario) => scenario.id === shellSearchParams.get(PLAYGROUND_SEARCH_PARAMS.scenario),
+  )?.id ??
+  scenarios[0]?.id ??
+  "";
+
+const initialPlatform = getPlaygroundPlatform(shellSearchParams);
+
+const initialDarkMode = shellSearchParams.get(PLAYGROUND_SEARCH_PARAMS.darkMode) === "true";
+
+function buildPreviewSource({
+  scenarioId,
+  platform,
+  darkMode,
+}: {
+  scenarioId: string;
+  platform: PlaygroundPlatform;
+  darkMode: boolean;
+}): string {
+  const previewSearchParams = new URLSearchParams({
+    [PLAYGROUND_SEARCH_PARAMS.scenario]: scenarioId,
+    [PLAYGROUND_SEARCH_PARAMS.platform]: platform,
+    [PLAYGROUND_SEARCH_PARAMS.darkMode]: String(darkMode),
+  });
+
+  return `./preview.html?${previewSearchParams}`;
+}
+
+type LoggedCall = IpcCall & { id: number };
+
+function ScenarioList({
+  scenarioId,
+  onSelect,
+}: {
+  scenarioId: string;
+  onSelect: (scenarioId: string) => void;
+}) {
+  return (
+    <ScrollArea className="flex-1">
+      <div className="space-y-6 p-4">
+        {Object.entries(playgroundComponents).map(([componentId, component]) => (
+          <div key={componentId} className="space-y-1">
+            <div className="px-2 text-xs font-semibold text-muted-foreground">{component.name}</div>
+            {scenarios
+              .filter((scenario) => scenario.component === componentId)
+              .map((scenario) => (
+                <button
+                  key={scenario.id}
+                  type="button"
+                  onClick={() => {
+                    onSelect(scenario.id);
+                  }}
+                  className={cn(
+                    "block w-full rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+                    scenario.id === scenarioId
+                      ? "bg-accent text-accent-foreground"
+                      : "hover:bg-muted/50",
+                  )}
+                >
+                  {scenario.name}
+                </button>
+              ))}
+          </div>
+        ))}
+      </div>
+    </ScrollArea>
+  );
+}
+
+function CallLog({ calls }: { calls: LoggedCall[] }) {
+  return (
+    <div className="flex h-56 flex-col border-t">
+      <div className="border-b px-4 py-2 text-xs font-semibold text-muted-foreground">
+        What the component asked the main process for
+      </div>
+      <ScrollArea className="flex-1">
+        {calls.length === 0 ? (
+          <div className="p-4 text-sm text-muted-foreground">Nothing yet.</div>
+        ) : (
+          <div className="space-y-1 p-4 font-mono text-xs">
+            {calls.map((call) => (
+              <div key={call.id} className="flex gap-2">
+                <span className="w-12 shrink-0 text-muted-foreground">{call.kind}</span>
+                <span
+                  className={cn("shrink-0", call.unanswered && "text-destructive")}
+                  title={call.unanswered ? "No scenario answers this channel" : undefined}
+                >
+                  {call.channel}
+                </span>
+                <span className="truncate text-muted-foreground">
+                  {call.args.map((argument) => JSON.stringify(argument)).join(", ")}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </ScrollArea>
+    </div>
+  );
+}
+
+function Shell() {
+  const [scenarioId, setScenarioId] = useState(initialScenarioId);
+
+  const [platform, setPlatform] = useState(initialPlatform);
+
+  const [darkMode, setDarkMode] = useState(initialDarkMode);
+
+  const [previewSource, setPreviewSource] = useState(() =>
+    buildPreviewSource({
+      scenarioId: initialScenarioId,
+      platform: initialPlatform,
+      darkMode: initialDarkMode,
+    }),
+  );
+
+  const [reloadCount, setReloadCount] = useState(0);
+
+  const [calls, setCalls] = useState<LoggedCall[]>([]);
+
+  const previewRef = useRef<HTMLIFrameElement>(null);
+
+  const previewKey = `${previewSource}#${reloadCount}`;
+
+  useEffect(() => {
+    setCalls([]);
+  }, [previewKey]);
+
+  useEffect(() => {
+    let nextCallId = 0;
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin || !isPreviewMessage(event.data)) {
+        return;
+      }
+
+      nextCallId += 1;
+
+      const loggedCall = { ...event.data.call, id: nextCallId };
+
+      setCalls((previousCalls) => [...previousCalls, loggedCall].slice(-MAX_LOGGED_CALLS));
+    };
+
+    window.addEventListener("message", handleMessage);
+
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, []);
+
+  useEffect(() => {
+    window.history.replaceState(
+      null,
+      "",
+      `?${new URLSearchParams({
+        [PLAYGROUND_SEARCH_PARAMS.scenario]: scenarioId,
+        [PLAYGROUND_SEARCH_PARAMS.platform]: platform,
+        [PLAYGROUND_SEARCH_PARAMS.darkMode]: String(darkMode),
+      })}`,
+    );
+  }, [scenarioId, platform, darkMode]);
+
+  const selectScenario = (nextScenarioId: string) => {
+    setScenarioId(nextScenarioId);
+
+    setPreviewSource(buildPreviewSource({ scenarioId: nextScenarioId, platform, darkMode }));
+  };
+
+  const selectPlatform = (nextPlatform: PlaygroundPlatform) => {
+    setPlatform(nextPlatform);
+
+    setPreviewSource(buildPreviewSource({ scenarioId, platform: nextPlatform, darkMode }));
+  };
+
+  /**
+   * Pushed rather than reloaded, because `theme.darkModeChanged` is a real
+   * event and the preview's theme module listens for it. The URL still carries
+   * the value, for the reload a scenario or platform change does cause.
+   */
+  const toggleDarkMode = (nextDarkMode: boolean) => {
+    setDarkMode(nextDarkMode);
+
+    const message: ShellMessage = { type: "darkMode", darkMode: nextDarkMode };
+
+    previewRef.current?.contentWindow?.postMessage(message, window.location.origin);
+  };
+
+  const scenario = scenarios.find((candidate) => candidate.id === scenarioId);
+
+  return (
+    <div className="flex h-screen">
+      <div className="flex w-72 flex-col border-r">
+        <div className="border-b px-4 py-3">
+          <div className="font-semibold">Component playground</div>
+          <div className="text-xs text-muted-foreground">
+            Meru's components over a fake preload bridge
+          </div>
+        </div>
+        <ScenarioList scenarioId={scenarioId} onSelect={selectScenario} />
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex items-center gap-6 border-b px-4 py-3">
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-semibold">{scenario?.name}</div>
+            <div className="truncate text-xs text-muted-foreground" title={scenario?.description}>
+              {scenario?.description}
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Label htmlFor="dark-mode">Dark mode</Label>
+            <Switch id="dark-mode" checked={darkMode} onCheckedChange={toggleDarkMode} />
+          </div>
+          <Select
+            items={platformItems}
+            value={platform}
+            onValueChange={(value) => {
+              if (value) {
+                selectPlatform(value as PlaygroundPlatform);
+              }
+            }}
+          >
+            <SelectTrigger className="w-36">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {platformItems.map(({ value, label }) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            variant="outline"
+            size="icon"
+            title="Reload the preview"
+            onClick={() => {
+              setReloadCount((count) => count + 1);
+            }}
+          >
+            <RotateCwIcon />
+          </Button>
+        </div>
+        <iframe
+          key={previewKey}
+          ref={previewRef}
+          src={previewSource}
+          title="Component preview"
+          className="min-h-0 flex-1 border-0"
+        />
+        <CallLog calls={calls} />
+      </div>
+    </div>
+  );
+}
+
+const rootElement = document.getElementById("root");
+
+if (rootElement) {
+  createRoot(rootElement).render(<Shell />);
+}

--- a/packages/renderer/playground/shell.tsx
+++ b/packages/renderer/playground/shell.tsx
@@ -1,5 +1,20 @@
+import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
-import { Label } from "@meru/ui/components/label";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@meru/ui/components/empty";
+import { Field, FieldLabel } from "@meru/ui/components/field";
+import {
+  Item,
+  ItemActions,
+  ItemContent,
+  ItemDescription,
+  ItemTitle,
+} from "@meru/ui/components/item";
 import { ScrollArea } from "@meru/ui/components/scroll-area";
 import {
   Select,
@@ -8,10 +23,19 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@meru/ui/components/select";
+import { Separator } from "@meru/ui/components/separator";
 import { Switch } from "@meru/ui/components/switch";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@meru/ui/components/table";
 import { cn } from "@meru/ui/lib/utils";
-import { RotateCwIcon } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { CableIcon, RotateCwIcon } from "lucide-react";
+import { Fragment, useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { playgroundComponents } from "./components";
 import {
@@ -65,6 +89,12 @@ function buildPreviewSource({
 
 type LoggedCall = IpcCall & { id: number };
 
+/**
+ * The scenarios grouped under the call site they render, in the catalog's
+ * order. It follows the app's own sidebar rather than a list of its own: the
+ * selected entry is a `secondary` button and the rest are `ghost`, which is
+ * where the hover, focus and selected states come from.
+ */
 function ScenarioList({
   scenarioId,
   onSelect,
@@ -72,32 +102,34 @@ function ScenarioList({
   scenarioId: string;
   onSelect: (scenarioId: string) => void;
 }) {
+  const componentIds = Object.keys(playgroundComponents) as (keyof typeof playgroundComponents)[];
+
   return (
     <ScrollArea className="flex-1">
-      <div className="space-y-6 p-4">
-        {Object.entries(playgroundComponents).map(([componentId, component]) => (
-          <div key={componentId} className="space-y-1">
-            <div className="px-2 text-xs font-semibold text-muted-foreground">{component.name}</div>
+      <div className="space-y-2 p-4">
+        {componentIds.map((componentId, componentIndex) => (
+          <Fragment key={componentId}>
+            {componentIndex > 0 && <Separator />}
+            <div className="px-2 pt-2 text-xs font-semibold text-muted-foreground">
+              {playgroundComponents[componentId].name}
+            </div>
             {scenarios
               .filter((scenario) => scenario.component === componentId)
               .map((scenario) => (
-                <button
+                <Button
                   key={scenario.id}
-                  type="button"
+                  variant={scenario.id === scenarioId ? "secondary" : "ghost"}
                   onClick={() => {
                     onSelect(scenario.id);
                   }}
-                  className={cn(
-                    "block w-full rounded-md px-2 py-1.5 text-left text-sm transition-colors",
-                    scenario.id === scenarioId
-                      ? "bg-accent text-accent-foreground"
-                      : "hover:bg-muted/50",
-                  )}
+                  className={cn("w-full justify-start font-normal", {
+                    "text-muted-foreground hover:text-muted-foreground": scenario.id !== scenarioId,
+                  })}
                 >
                   {scenario.name}
-                </button>
+                </Button>
               ))}
-          </div>
+          </Fragment>
         ))}
       </div>
     </ScrollArea>
@@ -112,24 +144,50 @@ function CallLog({ calls }: { calls: LoggedCall[] }) {
       </div>
       <ScrollArea className="flex-1">
         {calls.length === 0 ? (
-          <div className="p-4 text-sm text-muted-foreground">Nothing yet.</div>
+          <Empty>
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <CableIcon />
+              </EmptyMedia>
+              <EmptyTitle>Nothing asked for yet</EmptyTitle>
+              <EmptyDescription>
+                Every send and invoke the component makes shows up here.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
         ) : (
-          <div className="space-y-1 p-4 font-mono text-xs">
-            {calls.map((call) => (
-              <div key={call.id} className="flex gap-2">
-                <span className="w-12 shrink-0 text-muted-foreground">{call.kind}</span>
-                <span
-                  className={cn("shrink-0", call.unanswered && "text-destructive")}
-                  title={call.unanswered ? "No scenario answers this channel" : undefined}
-                >
-                  {call.channel}
-                </span>
-                <span className="truncate text-muted-foreground">
-                  {call.args.map((argument) => JSON.stringify(argument)).join(", ")}
-                </span>
-              </div>
-            ))}
-          </div>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-20 pl-4">Kind</TableHead>
+                <TableHead className="w-72">Channel</TableHead>
+                <TableHead className="pr-4">Arguments</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {calls.map((call) => (
+                <TableRow key={call.id}>
+                  <TableCell className="pl-4">
+                    <Badge variant={call.kind === "send" ? "secondary" : "outline"}>
+                      {call.kind}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="font-mono text-xs">
+                    {call.unanswered ? (
+                      <Badge variant="destructive" title="No scenario answers this channel">
+                        {call.channel}
+                      </Badge>
+                    ) : (
+                      call.channel
+                    )}
+                  </TableCell>
+                  <TableCell className="max-w-0 truncate pr-4 font-mono text-xs text-muted-foreground">
+                    {call.args.map((argument) => JSON.stringify(argument)).join(", ")}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
         )}
       </ScrollArea>
     </div>
@@ -226,57 +284,64 @@ function Shell() {
 
   return (
     <div className="flex h-screen">
-      <div className="flex w-72 flex-col border-r">
-        <div className="border-b px-4 py-3">
-          <div className="font-semibold">Component playground</div>
-          <div className="text-xs text-muted-foreground">
-            Meru's components over a fake preload bridge
-          </div>
+      <div className="flex w-72 flex-col border-r bg-sidebar">
+        <div className="border-b">
+          <Item>
+            <ItemContent>
+              <ItemTitle>Component playground</ItemTitle>
+              <ItemDescription>Meru's components over a fake preload bridge</ItemDescription>
+            </ItemContent>
+          </Item>
         </div>
         <ScenarioList scenarioId={scenarioId} onSelect={selectScenario} />
       </div>
       <div className="flex min-w-0 flex-1 flex-col">
-        <div className="flex items-center gap-6 border-b px-4 py-3">
-          <div className="min-w-0 flex-1">
-            <div className="truncate text-sm font-semibold">{scenario?.name}</div>
-            <div className="truncate text-xs text-muted-foreground" title={scenario?.description}>
-              {scenario?.description}
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
-            <Label htmlFor="dark-mode">Dark mode</Label>
-            <Switch id="dark-mode" checked={darkMode} onCheckedChange={toggleDarkMode} />
-          </div>
-          <Select
-            items={platformItems}
-            value={platform}
-            onValueChange={(value) => {
-              if (value) {
-                selectPlatform(value as PlaygroundPlatform);
-              }
-            }}
-          >
-            <SelectTrigger className="w-36">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {platformItems.map(({ value, label }) => (
-                <SelectItem key={value} value={value}>
-                  {label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Button
-            variant="outline"
-            size="icon"
-            title="Reload the preview"
-            onClick={() => {
-              setReloadCount((count) => count + 1);
-            }}
-          >
-            <RotateCwIcon />
-          </Button>
+        <div className="border-b">
+          <Item>
+            <ItemContent className="min-w-0">
+              <ItemTitle>{scenario?.name}</ItemTitle>
+              <ItemDescription>{scenario?.description}</ItemDescription>
+            </ItemContent>
+            <ItemActions className="gap-4">
+              <Field orientation="horizontal" className="w-fit">
+                <FieldLabel htmlFor="dark-mode">Dark mode</FieldLabel>
+                <Switch id="dark-mode" checked={darkMode} onCheckedChange={toggleDarkMode} />
+              </Field>
+              <Field orientation="horizontal" className="w-fit">
+                <FieldLabel htmlFor="platform">Platform</FieldLabel>
+                <Select
+                  items={platformItems}
+                  value={platform}
+                  onValueChange={(value) => {
+                    if (value) {
+                      selectPlatform(value as PlaygroundPlatform);
+                    }
+                  }}
+                >
+                  <SelectTrigger id="platform" className="w-32">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {platformItems.map(({ value, label }) => (
+                      <SelectItem key={value} value={value}>
+                        {label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Field>
+              <Button
+                variant="outline"
+                size="icon"
+                title="Reload the preview"
+                onClick={() => {
+                  setReloadCount((count) => count + 1);
+                }}
+              >
+                <RotateCwIcon />
+              </Button>
+            </ItemActions>
+          </Item>
         </div>
         <iframe
           key={previewKey}

--- a/packages/renderer/playground/shell.tsx
+++ b/packages/renderer/playground/shell.tsx
@@ -23,7 +23,21 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@meru/ui/components/select";
-import { Separator } from "@meru/ui/components/separator";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarTrigger,
+} from "@meru/ui/components/sidebar";
 import { Switch } from "@meru/ui/components/switch";
 import {
   Table,
@@ -33,9 +47,8 @@ import {
   TableHeader,
   TableRow,
 } from "@meru/ui/components/table";
-import { cn } from "@meru/ui/lib/utils";
 import { CableIcon, RotateCwIcon } from "lucide-react";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { playgroundComponents } from "./components";
 import {
@@ -90,10 +103,12 @@ function buildPreviewSource({
 type LoggedCall = IpcCall & { id: number };
 
 /**
- * The scenarios grouped under the call site they render, in the catalog's
- * order. It follows the app's own sidebar rather than a list of its own: the
- * selected entry is a `secondary` button and the rest are `ghost`, which is
- * where the hover, focus and selected states come from.
+ * One `SidebarGroup` per call site, its scenarios the menu under it. The active
+ * entry and the hover and focus rings come from the sidebar's own parts.
+ *
+ * It collapses off-canvas rather than to icons, which is the default: a
+ * scenario is named and has no icon, so icon mode would leave a column of blank
+ * squares. Collapsing it hands the whole window to the preview.
  */
 function ScenarioList({
   scenarioId,
@@ -105,34 +120,31 @@ function ScenarioList({
   const componentIds = Object.keys(playgroundComponents) as (keyof typeof playgroundComponents)[];
 
   return (
-    <ScrollArea className="flex-1">
-      <div className="space-y-2 p-4">
-        {componentIds.map((componentId, componentIndex) => (
-          <Fragment key={componentId}>
-            {componentIndex > 0 && <Separator />}
-            <div className="px-2 pt-2 text-xs font-semibold text-muted-foreground">
-              {playgroundComponents[componentId].name}
-            </div>
-            {scenarios
-              .filter((scenario) => scenario.component === componentId)
-              .map((scenario) => (
-                <Button
-                  key={scenario.id}
-                  variant={scenario.id === scenarioId ? "secondary" : "ghost"}
-                  onClick={() => {
-                    onSelect(scenario.id);
-                  }}
-                  className={cn("w-full justify-start font-normal", {
-                    "text-muted-foreground hover:text-muted-foreground": scenario.id !== scenarioId,
-                  })}
-                >
-                  {scenario.name}
-                </Button>
-              ))}
-          </Fragment>
-        ))}
-      </div>
-    </ScrollArea>
+    <SidebarContent>
+      {componentIds.map((componentId) => (
+        <SidebarGroup key={componentId}>
+          <SidebarGroupLabel>{playgroundComponents[componentId].name}</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {scenarios
+                .filter((scenario) => scenario.component === componentId)
+                .map((scenario) => (
+                  <SidebarMenuItem key={scenario.id}>
+                    <SidebarMenuButton
+                      isActive={scenario.id === scenarioId}
+                      onClick={() => {
+                        onSelect(scenario.id);
+                      }}
+                    >
+                      <span>{scenario.name}</span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      ))}
+    </SidebarContent>
   );
 }
 
@@ -283,21 +295,23 @@ function Shell() {
   const scenario = scenarios.find((candidate) => candidate.id === scenarioId);
 
   return (
-    <div className="flex h-screen">
-      <div className="flex w-72 flex-col border-r bg-sidebar">
-        <div className="border-b">
-          <Item>
+    <SidebarProvider className="h-screen min-h-0">
+      <Sidebar>
+        <SidebarHeader>
+          <Item size="xs">
             <ItemContent>
               <ItemTitle>Component playground</ItemTitle>
               <ItemDescription>Meru's components over a fake preload bridge</ItemDescription>
             </ItemContent>
           </Item>
-        </div>
+        </SidebarHeader>
         <ScenarioList scenarioId={scenarioId} onSelect={selectScenario} />
-      </div>
-      <div className="flex min-w-0 flex-1 flex-col">
+        <SidebarRail />
+      </Sidebar>
+      <SidebarInset className="min-w-0 overflow-hidden">
         <div className="border-b">
           <Item>
+            <SidebarTrigger />
             <ItemContent className="min-w-0">
               <ItemTitle>{scenario?.name}</ItemTitle>
               <ItemDescription>{scenario?.description}</ItemDescription>
@@ -351,8 +365,8 @@ function Shell() {
           className="min-h-0 flex-1 border-0"
         />
         <CallLog calls={calls} />
-      </div>
-    </div>
+      </SidebarInset>
+    </SidebarProvider>
   );
 }
 

--- a/packages/renderer/playground/types.ts
+++ b/packages/renderer/playground/types.ts
@@ -1,0 +1,58 @@
+import type { ExtractArgs, ExtractHandler } from "@electron-toolkit/typed-ipc/renderer";
+import type { Config, IpcMainEvents, IpcRendererEvent } from "@meru/shared/types";
+import type { PlaygroundComponentId } from "./components";
+
+/** Every channel the renderer can reach the main process on, either way. */
+export type IpcCallChannel = keyof ExtractArgs<IpcMainEvents> | keyof ExtractHandler<IpcMainEvents>;
+
+/**
+ * One call the renderer made, which is as far as it gets here: a send has
+ * nowhere to arrive, so the playground records it and shows it instead.
+ */
+export type IpcCall = {
+  kind: "send" | "invoke";
+  channel: IpcCallChannel;
+  args: unknown[];
+  /** Set on an invoke no scenario answers, which resolves with `undefined`. */
+  unanswered: boolean;
+};
+
+/**
+ * What each invoke channel answers with, so that a scenario can fixture any of
+ * them by name and have the reply checked against the real return type.
+ */
+export type IpcInvokeReplies = {
+  [Channel in keyof ExtractHandler<IpcMainEvents>]?: ReturnType<
+    ExtractHandler<IpcMainEvents>[Channel]
+  >;
+};
+
+/**
+ * One event to push, held as its channel and arguments rather than as a call.
+ * This is what keeps a scenario plain data: a runner could read the list out of
+ * a JSON file and drive the same components without the playground around them.
+ */
+export type ScenarioEvent = {
+  [Channel in keyof IpcRendererEvent]: {
+    channel: Channel;
+    args: IpcRendererEvent[Channel];
+  };
+}[keyof IpcRendererEvent];
+
+/**
+ * A state to render a component in. Everything here is data, for the reason
+ * given on `ScenarioEvent`.
+ */
+export type Scenario = {
+  id: string;
+  /** Names the state rather than the component: "Files moved or deleted". */
+  name: string;
+  description: string;
+  component: PlaygroundComponentId;
+  /** Merged over the app's real default config before anything reads it. */
+  config?: Partial<Config>;
+  /** Replies for invoke channels other than the config, which comes from `config`. */
+  invoke?: IpcInvokeReplies;
+  /** Pushed in order once the component has mounted. */
+  events?: ScenarioEvent[];
+};

--- a/scripts/playground.ts
+++ b/scripts/playground.ts
@@ -1,0 +1,30 @@
+import path from "node:path";
+import viteTailwindcss from "@tailwindcss/vite";
+import viteReact from "@vitejs/plugin-react";
+import * as vite from "vite";
+
+/**
+ * Serves the renderer package on its own, without building the main process or
+ * starting Electron: the playground is a browser page, and Electron is the
+ * thing it exists to do without. The port is one along from `bun run dev`, so
+ * the two can run side by side.
+ */
+const server = await vite.createServer({
+  configFile: false,
+  root: path.join(process.cwd(), "packages", "renderer"),
+  plugins: [viteReact(), viteTailwindcss()],
+  resolve: {
+    tsconfigPaths: true,
+  },
+  server: {
+    port: 3001,
+    strictPort: true,
+  },
+  clearScreen: false,
+});
+
+await server.listen();
+
+server.printUrls();
+
+console.info("\n  Playground:  http://localhost:3001/playground/\n");


### PR DESCRIPTION
## Summary
Adds a component playground: a browser page that renders Meru's shipped renderer components against a fake `window.electron`, with states picked from a scenario list instead of reproduced in a live account. `bun run playground` serves it without starting Electron. Five call sites across four components ship with it. Nothing renders in a browser yet in this sandbox — see **Not verified**.

## Problem
Meru's renderer components can only be seen inside a running, signed-in Electron app. An empty download history, a trial that has run out, a Windows titlebar from a Linux machine: each is either expensive to reach or unreachable, and every iteration on one costs a full app restart. There is nowhere to look at a component's states side by side, and no way to see the ones that only occur on another platform.

## Solution
The seam is `window.electron`. `@electron-toolkit/typed-ipc` bottoms out in four calls on `window.electron.ipcRenderer` — `send`, `invoke`, `on`, `once` — and its emitter and listener touch the global only when a method is called, never in their constructors. A fake installed before the renderer's modules evaluate is therefore enough: components, hooks, stores and the query cache are all the shipped ones, and no production code changes.

- `playground/fake-electron.ts` keeps the listener registry, so a scenario can push `accounts.changed`, `tabs.changed`, `findInPage.result`, `trial.daysLeftChanged`, `theme.darkModeChanged` and the rest through the real code path. It also stands in for the main process's config store, answering `config.getConfig` and pushing `config.configChanged` on every write — so a mutation in the playground travels back through the real query cache rather than doing nothing. It narrows `ElectronAPI` to the part the renderer actually reaches for rather than stubbing the whole preload surface.
- The scenario is resolved from the URL and applied in the fake's own module scope, not in the entry point. A renderer module is free to invoke as it evaluates — `lib/extension-actions.ts` asks for the loaded extensions that way — and every import in an entry point runs before its own first statement, so a scenario applied from there would arrive after such a call had already been answered with nothing.
- `preview.html` loads the fake in a script tag of its own, ahead of the entry point's. The stores, the query cache and the theme all register `ipc.renderer.on` handlers at import time, so the fake has to be first — and a comment on an import would not have held it there, because `sortImports` is on in the shared oxfmt config.
- The shell and the preview are two pages. Only the preview has a fake under it, so the tool's own controls cannot reach the renderer's modules by accident, dark mode and the platform apply to the component alone, and switching scenario reloads the component without disturbing the tool around it.
- A scenario is data — an event is its channel and its arguments, not a call — so the list survives `JSON.stringify`. The playground asserts nothing and runs nowhere in CI, but a headless runner reading the same list stays additive rather than a rewrite. Colocating scenarios with each component was the alternative; it would put playground-only files in the renderer's component directories.
- `playground/` sits under the renderer package rather than in a package of its own. The build globs `*.html` at the package root without recursing, so it stays out of shipped builds with no build-script change, while type checking, the `@/` alias, Tailwind and `globals.css` keep working. A package of its own would mean a second copy of all that configuration.
- The catalog entry is a call site rather than a component, because props are code and only IPC is data: `DownloadHistoryList` earns two entries, plain and capped at ten as the recent-downloads popup renders it.
- The platform travels in the URL and reloads the preview, because the `platform` helper reads `process.platform` once at module load. Dark mode is carried in the URL too, but toggling it pushes `theme.darkModeChanged` instead of reloading.
- The call log under the preview records every `send` and `invoke`, flagging an invoke no scenario answers. It is the only way to see a `send` do anything, since it has nowhere to arrive.
- The playground's own chrome is built from `packages/ui` rather than hand-rolled. The scenario list is a `SidebarGroup` per call site with its scenarios as the menu under it, collapsing off-canvas from a `SidebarTrigger` in the toolbar, which hands the whole window to the preview. Off-canvas rather than to icons: a scenario is named and has no icon, so icon mode would leave a column of blank squares. The toolbar is an `Item` with `ItemContent` and `ItemActions`, each control a `Field` with its `FieldLabel`. The call log is a `Table`, with a `Badge` for a call's kind and for a channel no scenario answers, and an `Empty` where it has nothing to show; the preview says it drew nothing with an `Empty` too.

Decisions are recorded in the private docs repo, and `docs/features/component-playground.md` moves to `in progress`.

## Try it
`bun run playground`, then http://localhost:3001/playground/. It is a local dev server by design — the page is deliberately excluded from shipped builds, so there is no preview deployment to link.

Start on **Four downloads** under `DownloadHistoryList`: removing a row goes through the real mutation and the config comes back changed. **Pinned, open, windowed and dormant tabs** under `VerticalTabs` is the widest one. The platform picker previews the macOS and Windows values from Linux.

## Not verified
- Nothing has been rendered in a browser. This sandbox has no Chromium, Electron or Playwright binary, and none could be installed, so every claim about how the playground *looks* is unverified — including whether the shell's layout holds, whether the iframe sizes correctly, and whether `VerticalTabs` fills its container.
- What was verified, headlessly against the real renderer modules: the fake installs and reports the URL's platform; a module invoking at import time gets the scenario's fixture rather than nothing; `config.getConfig` answers with the real defaults plus the scenario's overrides; `config.setConfig` merges and pushes `config.configChanged` into the real query cache; `accounts.changed`, `tabs.changed`, `findInPage.activate`, `findInPage.result` and `trial.daysLeftChanged` all move the real zustand stores; `once` fires once and `on` returns a working unsubscribe; an unfixtured invoke is flagged; every scenario survives `JSON.stringify`; and every catalog entry has a scenario and vice versa.
- `bun run types`, `bun run lint` and `bun run fmt:check` pass, and every playground module transforms cleanly through the dev server.
