### PR TITLE
Add the app titlebar to the component playground

### DIFF
--- a/packages/renderer/playground/components.ts
+++ b/packages/renderer/playground/components.ts
@@ -1,11 +1,16 @@
 import { MAX_RECENT_DOWNLOAD_HISTORY_ITEMS } from "@meru/shared/constants";
 
-type PlaygroundComponent = {
+export type PlaygroundComponent = {
   name: string;
   /** Where the component itself lives, so the file is one search away. */
   source: string;
-  /** `fill` hands over the whole preview area, as the app's own layout does. */
-  layout: "padded" | "fill";
+  /**
+   * How the preview frames the component:
+   * - `padded` leaves room around it, for something sitting inside a page
+   * - `fill` hands over the whole area as a row, as the tab strip needs
+   * - `flush` gives it the full width at the top edge, as the titlebar sits
+   */
+  layout: "padded" | "fill" | "flush";
 };
 
 /**
@@ -43,6 +48,11 @@ export const playgroundComponents = {
     name: "VerticalTabs",
     source: "components/vertical-tabs.tsx",
     layout: "fill",
+  },
+  appTitlebar: {
+    name: "AppTitlebar",
+    source: "components/app-titlebar.tsx",
+    layout: "flush",
   },
 } satisfies Record<string, PlaygroundComponent>;
 

--- a/packages/renderer/playground/preview.tsx
+++ b/packages/renderer/playground/preview.tsx
@@ -9,7 +9,7 @@ import { cn } from "@meru/ui/lib/utils";
 import { EyeOffIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { renderApp } from "@/lib/react";
-import { playgroundComponents } from "./components";
+import { type PlaygroundComponent, playgroundComponents } from "./components";
 import {
   emitRendererEvent,
   onIpcCall,
@@ -33,6 +33,13 @@ window.addEventListener("message", (event) => {
 
   emitRendererEvent("theme.darkModeChanged", [event.data.darkMode]);
 });
+
+/** How the preview frames each of the catalog's layouts. */
+const PREVIEW_LAYOUT_CLASS_NAMES = {
+  padded: "overflow-auto p-6",
+  fill: "flex overflow-hidden",
+  flush: "overflow-auto",
+} satisfies Record<PlaygroundComponent["layout"], string>;
 
 function Preview({ scenario }: { scenario: Scenario }) {
   const { layout } = playgroundComponents[scenario.component];
@@ -60,10 +67,7 @@ function Preview({ scenario }: { scenario: Scenario }) {
 
   return (
     <div className="flex h-screen flex-col">
-      <div
-        ref={containerRef}
-        className={cn("flex-1", layout === "padded" ? "overflow-auto p-6" : "flex overflow-hidden")}
-      >
+      <div ref={containerRef} className={cn("flex-1", PREVIEW_LAYOUT_CLASS_NAMES[layout])}>
         {playgroundComponentRenderers[scenario.component]()}
       </div>
       {rendersNothing && (

--- a/packages/renderer/playground/render.tsx
+++ b/packages/renderer/playground/render.tsx
@@ -1,6 +1,9 @@
 import { MAX_RECENT_DOWNLOAD_HISTORY_ITEMS } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
 import type { ReactNode } from "react";
+import { Router } from "wouter";
+import { useHashLocation } from "wouter/use-hash-location";
+import { AppTitlebar } from "@/components/app-titlebar";
 import { DownloadHistoryList } from "@/components/download-history";
 import { FindInPage } from "@/components/find-in-page";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
@@ -33,6 +36,20 @@ function FindInPageControls() {
   );
 }
 
+/**
+ * The titlebar reads the route — the settings pages get a different one, and
+ * the account buttons light up only on the account route. `main.tsx` is what
+ * puts a hash router around it in the app, so the playground does the same;
+ * with no hash the route is `/`, which is the account one.
+ */
+function AppTitlebarInRouter() {
+  return (
+    <Router hook={useHashLocation}>
+      <AppTitlebar />
+    </Router>
+  );
+}
+
 /** One renderer per catalog entry, which the type here is what enforces. */
 export const playgroundComponentRenderers: Record<PlaygroundComponentId, () => ReactNode> = {
   downloadHistoryList: () => <DownloadHistoryList />,
@@ -42,4 +59,5 @@ export const playgroundComponentRenderers: Record<PlaygroundComponentId, () => R
   findInPage: () => <FindInPageControls />,
   licenseKeyRequiredBanner: () => <LicenseKeyRequiredBanner />,
   verticalTabs: () => <VerticalTabs />,
+  appTitlebar: () => <AppTitlebarInRouter />,
 };

--- a/packages/renderer/playground/scenarios.ts
+++ b/packages/renderer/playground/scenarios.ts
@@ -1,5 +1,6 @@
+import type { GmailState } from "@meru/shared/gmail";
 import { ms } from "@meru/shared/ms";
-import type { AccountInstance } from "@meru/shared/schemas";
+import type { AccountConfig, AccountInstance } from "@meru/shared/schemas";
 import { GMAIL_TAB_ID, type TabState } from "@meru/shared/tabs";
 import type { DownloadItem } from "@meru/shared/types";
 import { PLAYGROUND_ACCOUNT_ID } from "./constants";
@@ -33,31 +34,68 @@ const downloadHistory: DownloadItem[] = [
   createDownload("logo-mark.svg", { createdAt: unixSecondsAgo(ms("3w")) }),
 ];
 
-const playgroundAccount: AccountInstance = {
-  config: {
-    id: PLAYGROUND_ACCOUNT_ID,
-    label: "Work",
-    color: "blue",
-    selected: true,
-    notifications: true,
+function createAccount({
+  id,
+  label,
+  color = null,
+  selected = false,
+  gmail,
+}: {
+  id: string;
+  label: string;
+  color?: AccountConfig["color"];
+  selected?: boolean;
+  gmail?: Partial<GmailState>;
+}): AccountInstance {
+  return {
+    config: {
+      id,
+      label,
+      color,
+      selected,
+      notifications: true,
+      gmail: {
+        unreadBadge: true,
+        delegatedAccountId: null,
+        unifiedInbox: true,
+      },
+      workspaceApps: {
+        savedTabs: [],
+        bookmarks: [],
+      },
+    },
     gmail: {
-      unreadBadge: true,
-      delegatedAccountId: null,
-      unifiedInbox: true,
+      unreadCount: null,
+      unreadInbox: [],
+      outOfOffice: false,
+      attentionRequired: false,
+      ...gmail,
     },
-    workspaceApps: {
-      savedTabs: [],
-      bookmarks: [],
-    },
-  },
-  gmail: {
-    unreadCount: 12,
-    unreadInbox: [],
-    outOfOffice: false,
-    attentionRequired: false,
-  },
-  verticalTabsWidth: null,
-};
+    verticalTabsWidth: null,
+  };
+}
+
+const playgroundAccount = createAccount({
+  id: PLAYGROUND_ACCOUNT_ID,
+  label: "Work",
+  color: "blue",
+  selected: true,
+  gmail: { unreadCount: 12 },
+});
+
+const personalAccount = createAccount({
+  id: "playground-account-personal",
+  label: "Personal",
+  color: "emerald",
+  gmail: { unreadCount: 3 },
+});
+
+const consultingAccount = createAccount({
+  id: "playground-account-consulting",
+  label: "Consulting",
+  color: "amber",
+  gmail: { attentionRequired: true, outOfOffice: true },
+});
 
 function createTab(tab: Pick<TabState, "id" | "title"> & Partial<TabState>): TabState {
   return {
@@ -81,7 +119,14 @@ const gmailTab = createTab({
   title: "Gmail",
   pinned: true,
   active: true,
+  navigationHistory: { canGoBack: true, canGoForward: false },
 });
+
+function accountTabs(tabs: TabState[]) {
+  return [{ accountId: PLAYGROUND_ACCOUNT_ID, tabs }];
+}
+
+const PLAYGROUND_LICENSE_KEY = "MERU-PLAYGROUND-KEY";
 
 /**
  * Every state the playground can be put into, as data. A scenario names the
@@ -177,7 +222,7 @@ export const scenarios: Scenario[] = [
     name: "Licensed",
     description: "A license key in the config, which hides the banner just as the trial does.",
     component: "licenseKeyRequiredBanner",
-    config: { licenseKey: "MERU-PLAYGROUND-KEY" },
+    config: { licenseKey: PLAYGROUND_LICENSE_KEY },
   },
   {
     id: "vertical-tabs-gmail-only",
@@ -244,7 +289,7 @@ export const scenarios: Scenario[] = [
       "The wide strip, which labels every tab and puts the Workspace Apps launcher above the bookmarks button. The launcher needs a license, so this scenario carries one.",
     component: "verticalTabs",
     config: {
-      licenseKey: "MERU-PLAYGROUND-KEY",
+      licenseKey: PLAYGROUND_LICENSE_KEY,
       "verticalTabs.width": "wide",
       "workspaceApps.launcherApps": ["calendar", "drive", "keep", "tasks"],
     },
@@ -266,6 +311,106 @@ export const scenarios: Scenario[] = [
           ],
         ],
       },
+    ],
+  },
+  {
+    id: "titlebar-gmail-only",
+    name: "One account, Gmail alone",
+    description:
+      "Nothing open but Gmail, so the tab strip is not there and the titlebar hosts the Workspace Apps launcher and the bookmarks button itself.",
+    component: "appTitlebar",
+    events: [
+      { channel: "accounts.changed", args: [[playgroundAccount]] },
+      { channel: "tabs.changed", args: [accountTabs([gmailTab])] },
+    ],
+  },
+  {
+    id: "titlebar-tabs-open",
+    name: "Tabs open, controls handed over",
+    description:
+      "With a tab strip beside it, the titlebar hands the launcher and the bookmarks button over to the strip and fades its own group out.",
+    component: "appTitlebar",
+    config: { "workspaceApps.launcherApps": ["calendar", "drive", "keep"] },
+    events: [
+      { channel: "accounts.changed", args: [[playgroundAccount]] },
+      {
+        channel: "tabs.changed",
+        args: [
+          accountTabs([
+            gmailTab,
+            createTab({ id: "docs", app: "docs", title: "Roadmap — Google Docs" }),
+            createTab({ id: "sheets", app: "sheets", title: "Headcount" }),
+          ]),
+        ],
+      },
+    ],
+  },
+  {
+    id: "titlebar-multiple-accounts",
+    name: "Three accounts",
+    description:
+      "Account buttons with their colors, unread counts, an account wanting attention and one out of office. The unified inbox button needs a license and more than one account, so both are here.",
+    component: "appTitlebar",
+    config: { licenseKey: PLAYGROUND_LICENSE_KEY },
+    events: [
+      {
+        channel: "accounts.changed",
+        args: [[playgroundAccount, personalAccount, consultingAccount]],
+      },
+      { channel: "tabs.changed", args: [accountTabs([gmailTab])] },
+    ],
+  },
+  {
+    id: "titlebar-trial-ending",
+    name: "Trial with two days left",
+    description:
+      "The trial badge, which turns red at three days or fewer. Do Not Disturb is missing because the trial is what stands in for a license, and it has not been pushed yet when the badge is read.",
+    component: "appTitlebar",
+    events: [
+      { channel: "accounts.changed", args: [[playgroundAccount]] },
+      { channel: "tabs.changed", args: [accountTabs([gmailTab])] },
+      { channel: "trial.daysLeftChanged", args: [2] },
+    ],
+  },
+  {
+    id: "titlebar-update-available",
+    name: "Update available",
+    description:
+      "An update pushed through `appUpdater.updateAvailable`. The button opens the detail row, which takes over the whole titlebar.",
+    component: "appTitlebar",
+    config: { licenseKey: PLAYGROUND_LICENSE_KEY },
+    events: [
+      { channel: "accounts.changed", args: [[playgroundAccount]] },
+      { channel: "tabs.changed", args: [accountTabs([gmailTab])] },
+      { channel: "appUpdater.updateAvailable", args: ["3.60.0"] },
+    ],
+  },
+  {
+    id: "titlebar-everything-on",
+    name: "Saved searches, launcher and extensions",
+    description:
+      "Every optional control at once, with the launcher pinned to the titlebar rather than left to the strip. The extensions button reads `extensions.getActions`, which is the one scenario here fixturing an invoke.",
+    component: "appTitlebar",
+    config: {
+      licenseKey: PLAYGROUND_LICENSE_KEY,
+      "workspaceApps.launcherAndBookmarksPlacement": "titlebar",
+      "workspaceApps.launcherApps": ["calendar", "drive", "keep", "tasks"],
+      "workspaceApps.launcherDisplay": "expanded",
+      "extensions.showTitlebarButton": true,
+      "gmail.savedSearches": [
+        { id: "unread", label: "Unread", query: "is:unread" },
+        { id: "attachments", label: "With attachments", query: "has:attachment" },
+      ],
+      "doNotDisturb.enabled": true,
+    },
+    invoke: {
+      "extensions.getActions": [
+        { extensionId: "1password", title: "1Password", iconDataUrl: null },
+      ],
+    },
+    events: [
+      { channel: "accounts.changed", args: [[playgroundAccount]] },
+      { channel: "tabs.changed", args: [accountTabs([gmailTab])] },
     ],
   },
 ];


### PR DESCRIPTION
## Summary
Adds `AppTitlebar` to the component playground with six scenarios, so the platform picker has something to show. Nothing has been rendered in a browser — see **Not verified**.

## Problem
The playground's platform picker previews macOS and Windows from Linux, and none of the five call sites it shipped with branches on the platform. The titlebar is where that difference lives, and it is also the app's densest composition root: account buttons, the trial badge, find in page, the Workspace Apps launcher, bookmarks, extensions, saved searches, downloads, Do Not Disturb and the updater all hang off one row, most of them behind a condition.

## Solution
- Adds an `appTitlebar` catalog entry and six scenarios: one account with Gmail alone, tabs open, three accounts, a trial with two days left, an update available, and everything on at once.
- **Tabs open** exists for the handover: with a tab strip beside it the titlebar gives the launcher and the bookmarks button up to the strip and fades its own group out. That is the pair of states `HOST_HANDOVER_FADE_CLASS_NAME` exists for, and neither is reachable without switching accounts in a real app.
- **Everything on** fixtures `extensions.getActions` — the first scenario to answer an invoke rather than only override config. It is what made the ordering bug in #950 visible.
- A third `flush` layout gives the titlebar the full width at the top edge. The three layouts now sit in one table in the preview keyed by the catalog's value, rather than a ternary that only had room for two.
- The playground supplies the hash router that `main.tsx` supplies in the app. Without it wouter falls back to the browser path, so the titlebar would read `/playground/preview.html` and the account buttons would never light up. Same reasoning as the `FindInPage` container already in `render.tsx`: the playground stands in for the composition root, and everything below it stays the shipped code.

### What the platform picker actually shows
Less than hoped, and worth saying plainly. The macOS traffic-light inset comes from `env(titlebar-area-x)` and `env(titlebar-area-width)`, which only resolve in a window with a custom titlebar — a browser leaves them at the `0` and `100%` fallbacks. So the visible difference between the three platforms here is the app-menu button, which macOS drops. The inset needs a real Electron window, and no fake bridge can conjure it.

## Try it
`bun run playground`, then http://localhost:3001/playground/ and the `AppTitlebar` group in the sidebar. Local by design — the page is excluded from shipped builds, so there is no preview deployment.

**Tabs open** next to **One account, Gmail alone** is the pair worth looking at first. Switch the platform picker to macOS on any of them and the app-menu button on the right should disappear.

## Not verified
- Nothing has been rendered in a browser. This sandbox has no Chromium, Electron or Playwright binary, and none could be installed, so every claim about how the titlebar *looks* — the flush layout, the fade on the handover, the trial badge turning red — is unverified.
- What was verified headlessly, against the real renderer modules: the titlebar's whole import graph evaluates against the fake; the scenario named in the URL is the one resolved; `extensions.getActions` reaches `lib/extension-actions.ts`, which invokes as it evaluates; the scenario's config and its `accounts.changed` and `appUpdater.updateAvailable` events land in the real stores; every catalog entry has a scenario and every scenario survives `JSON.stringify`. Every playground module and `app-titlebar.tsx` transform cleanly through the dev server.
- `bun run types`, `bun run lint` and `bun run fmt:check` pass.
