### PR TITLE
Switch the UI package to the base-nova shadcn style

### DIFF
--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://ui.shadcn.com/schema.json",
-  "style": "base-vega",
+  "style": "base-nova",
   "rsc": false,
   "tsx": true,
   "tailwind": {

--- a/packages/ui/components/sheet.tsx
+++ b/packages/ui/components/sheet.tsx
@@ -59,7 +59,7 @@ function SheetContent({
         {showCloseButton && (
           <SheetPrimitive.Close
             data-slot="sheet-close"
-            render={<Button variant="ghost" className="absolute top-4 right-4" size="icon-sm" />}
+            render={<Button variant="ghost" className="absolute top-3 right-3" size="icon-sm" />}
           >
             <XIcon />
             <span className="sr-only">Close</span>
@@ -74,7 +74,7 @@ function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="sheet-header"
-      className={cn("flex flex-col gap-1.5 p-4", className)}
+      className={cn("flex flex-col gap-0.5 p-4", className)}
       {...props}
     />
   );
@@ -94,7 +94,7 @@ function SheetTitle({ className, ...props }: SheetPrimitive.Title.Props) {
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn("font-heading font-medium text-foreground", className)}
+      className={cn("font-heading text-base font-medium text-foreground", className)}
       {...props}
     />
   );

--- a/packages/ui/components/sidebar.tsx
+++ b/packages/ui/components/sidebar.tsx
@@ -353,7 +353,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        "no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
         className,
       )}
       {...props}
@@ -436,7 +436,7 @@ function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
     <ul
       data-slot="sidebar-menu"
       data-sidebar="menu"
-      className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+      className={cn("flex w-full min-w-0 flex-col gap-0", className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
Switches `packages/ui/components.json` from `base-vega` to `base-nova`, and re-adds the sidebar and the sheet through the CLI under that style. Every component already in the package came from `base-nova`, so this makes the declared style match what is actually there. The only code change is spacing — six lines — and no component's API moves.

## Problem
`components.json` landed with `"style": "base-vega"`, but the components it sits next to were installed from `base-nova`. The next `shadcn add` would therefore have pulled a component from a different preset than everything beside it, and the mismatch is not cosmetic at the margins: `base-vega` runs a size up and rounds tighter, so a button added under it comes out `h-9` where the existing one is `h-8`, `icon` at `size-9` against `size-8`, `rounded-md` against `rounded-lg`, with `shadow-xs` added to `outline`.

Diffing each existing component against both registries is what shows which one they came from. Where the two presets differ, the package matches `base-nova` every time:

| Component | vs `base-nova` | vs `base-vega` |
|---|---|---|
| `button.tsx` | **0.951** | 0.797 |
| `empty.tsx` | **0.990** | 0.972 |
| `switch.tsx` | **0.947** | 0.912 |
| `item.tsx` | **0.918** | 0.909 |
| `badge`, `separator`, `skeleton` | identical in both | identical in both |

## Solution
- `components.json` moves to `"style": "base-nova"`. That is the whole config change: the two presets differ only in `font` — Geist against Inter — and `font` is not a `components.json` field, so `baseColor`, `theme`, `iconLibrary`, `menuColor`, `menuAccent` and `radius` are the same either way. The package's Inter setup is untouched.
- `sidebar.tsx` and `sheet.tsx` are re-added with `shadcn add sidebar`, answering no to every overwrite prompt so that only the three files belonging to the sidebar are rewritten and no existing component is touched. `hooks/use-mobile.ts` is byte-identical between the two presets and so does not appear in the diff.
- The result is a spacing change and nothing else. `SidebarContent` and `SidebarMenu` close their gaps (`gap-2` and `gap-1` to `gap-0`), and `SheetHeader` opens one (`gap-1.5` to `gap-0.5`), with the sheet's close button and title following. Exports and prop signatures are identical across the two presets, which is why nothing downstream has to change.
- Not done by hand: the files are the CLI's own output, and its transforms here match the ones already in the pushed versions — `IconPlaceholder` resolved to the Lucide icon, and `"use client"` kept on the sidebar and dropped from the sheet.

## Not verified
- Nothing has been rendered in a browser. This sandbox has no Chromium, Electron or Playwright binary, so the spacing change is unverified visually. `bun run types`, `bun run lint`, `bun run fmt:check` and `bun test` all pass.
- Whether `base-nova` is the preset you want, as opposed to the one the package happens to hold. This aligns the config with the code; it does not argue the code was right.
