### PR TITLE
Add a CI job that proves the app boots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,27 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile --ignore-scripts
       - run: bun test
+  boot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile --ignore-scripts
+      # Bun does not run a dependency's postinstall unless it is trusted, so the
+      # Electron binary is missing after any install, with or without
+      # --ignore-scripts. Fetching it explicitly is the only way to get one.
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/electron
+          key: electron-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+      - run: node install.js
+        working-directory: node_modules/electron
+      # Pulls the container image on first use, so allow for that.
+      - run: bun run test:boot
+        timeout-minutes: 20
+      - if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: boot-smoke-test
+          if-no-files-found: ignore
+          path: boot-smoke-test.png

--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ dist
 .DS_Store
 
 # Meru
+/boot-smoke-test.png
 build/embedded.provisionprofile
 build/entitlements.mac.plist
 build-js

--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
         "node-machine-id": "^1.1.12",
         "oxfmt": "^0.57.0",
         "oxlint": "^1.72.0",
+        "playwright-core": "^1.62.1",
         "postcss": "^8.5.8",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -1523,6 +1524,8 @@
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "pkijs": ["pkijs@3.4.0", "", { "dependencies": { "@noble/hashes": "1.4.0", "asn1js": "^3.0.6", "bytestreamjs": "^2.0.1", "pvtsutils": "^1.3.6", "pvutils": "^1.1.3", "tslib": "^2.8.1" } }, "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw=="],
+
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint": "oxlint",
     "lint:fix": "oxlint --fix --fix-suggestions --fix-dangerously",
     "postinstall": "electron-builder install-app-deps",
+    "test:boot": "bun run tests/boot-smoke-test.ts",
     "types": "tsc && bun run --filter='*' --elide-lines=0 types",
     "types:ci": "tsc && bun run --filter='*' types"
   },
@@ -71,6 +72,7 @@
     "node-machine-id": "^1.1.12",
     "oxfmt": "^0.57.0",
     "oxlint": "^1.72.0",
+    "playwright-core": "^1.62.1",
     "postcss": "^8.5.8",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/packages/renderer/components/settings.tsx
+++ b/packages/renderer/components/settings.tsx
@@ -6,7 +6,15 @@ export function SettingsHeader({ className, ...props }: ComponentProps<"div">) {
 }
 
 export function SettingsTitle({ className, ...props }: ComponentProps<"div">) {
-  return <div className={cn("text-2xl font-semibold", className)} {...props} />;
+  // The boot smoke test waits for this to identify the settings page it routed
+  // to, so it does not have to match against copy that is free to change.
+  return (
+    <div
+      data-testid="settings-title"
+      className={cn("text-2xl font-semibold", className)}
+      {...props}
+    />
+  );
 }
 
 export function SettingsDescription({ className, ...props }: ComponentProps<"div">) {

--- a/tests/boot-smoke-test.ts
+++ b/tests/boot-smoke-test.ts
@@ -1,0 +1,251 @@
+/*
+ * Proves the app still starts. Launches it through `bun run dev:headless`,
+ * attaches to it over the Chrome DevTools Protocol and checks the renderer
+ * actually painted, then shuts it down.
+ *
+ * Needs Docker and Linux, because that is what `dev:headless` needs. Running
+ * the app the same way developers do is the point: a separate CI-only launch
+ * path would let `scripts/headless` rot without anything noticing.
+ */
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { ms } from "@meru/shared/ms";
+import { type Subprocess, spawn } from "bun";
+import { type Browser, chromium, type Page } from "playwright-core";
+
+// Deliberately not the launcher's defaults, so a smoke test neither disturbs
+// nor is disturbed by a `bun run dev:headless` already running on the machine.
+const INSTANCE = "boot-smoke-test";
+const CDP_PORT = process.env.MERU_CDP_PORT ?? "9333";
+
+const CDP_URL = `http://127.0.0.1:${CDP_PORT}`;
+const CONTAINER_NAME = `meru-headless-${INSTANCE}`;
+
+const SCREENSHOT_PATH = path.join(process.cwd(), "boot-smoke-test.png");
+
+// Generous because the first run downloads a multi-gigabyte container image
+// before the app can start at all, so this covers the pull as well as the boot.
+const BOOT_TIMEOUT = ms("10m");
+const RENDER_TIMEOUT = ms("1m");
+const SHUTDOWN_TIMEOUT = ms("10s");
+const POLL_INTERVAL = ms("0.5s");
+
+function log(message: string) {
+  console.log(`[boot-smoke-test] ${message}`);
+}
+
+/**
+ * The dev server treats Electron exiting as the user closing the app and exits
+ * 0 itself, so its exit code says nothing about whether the app crashed. Only
+ * the fact that it exited before the checks finished is meaningful.
+ */
+function watchForEarlyExit(devServer: Subprocess) {
+  let hasExited = false;
+
+  devServer.exited.then(() => {
+    hasExited = true;
+  });
+
+  return () => hasExited;
+}
+
+async function waitForDebuggerPort(hasDevServerExited: () => boolean) {
+  const deadline = Date.now() + BOOT_TIMEOUT;
+
+  while (Date.now() < deadline) {
+    if (hasDevServerExited()) {
+      throw new Error("The dev server exited before the app exposed a debugging port.");
+    }
+
+    try {
+      const response = await fetch(`${CDP_URL}/json/version`);
+
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Nothing is listening yet, which is the normal case while the image is
+      // being pulled and the app is starting.
+    }
+
+    await Bun.sleep(POLL_INTERVAL);
+  }
+
+  throw new Error(`The app did not expose a debugging port within ${BOOT_TIMEOUT}ms.`);
+}
+
+/**
+ * Every Gmail account and workspace app is a debugging target of its own, so
+ * the app's own window has to be picked out by the page it loaded.
+ */
+async function waitForRendererPage(browser: Browser) {
+  const deadline = Date.now() + RENDER_TIMEOUT;
+
+  while (Date.now() < deadline) {
+    const pages = browser.contexts().flatMap((context) => context.pages());
+    const renderer = pages.find((page) => page.url().includes("main.html"));
+
+    if (renderer) {
+      return renderer;
+    }
+
+    await Bun.sleep(POLL_INTERVAL);
+  }
+
+  throw new Error(`No window loaded the renderer within ${RENDER_TIMEOUT}ms.`);
+}
+
+/**
+ * Appearance settings is reachable without signing in, and it renders nothing
+ * until the config arrives from the main process. Waiting for its title to
+ * appear therefore proves the renderer bundle loaded, React mounted, routing
+ * works and an IPC round trip completed — not merely that a window exists.
+ */
+async function assertRendererRendered(renderer: Page) {
+  // Routing is hash based, so changing the fragment is what navigates.
+  const appearanceUrl = new URL(renderer.url());
+  appearanceUrl.hash = "#/settings/appearance";
+
+  await renderer.goto(appearanceUrl.href);
+
+  const settingsTitle = renderer.getByTestId("settings-title");
+
+  await settingsTitle.waitFor({ state: "visible", timeout: RENDER_TIMEOUT });
+
+  const renderedTitle = (await settingsTitle.textContent())?.trim();
+
+  if (renderedTitle !== "Appearance") {
+    throw new Error(
+      `Expected appearance settings to render, but the page is titled "${renderedTitle}".`,
+    );
+  }
+}
+
+/**
+ * Captures the renderer's own HTML. Gmail and workspace apps are separate
+ * views painted above it by the compositor, so they come out as blank
+ * rectangles here — that is the protocol, not a broken app.
+ */
+async function captureFailureScreenshot(renderer: Page | undefined) {
+  if (!renderer) {
+    return;
+  }
+
+  try {
+    await renderer.screenshot({ path: SCREENSHOT_PATH });
+
+    log(`Wrote a screenshot of the failure to ${SCREENSHOT_PATH}`);
+  } catch (error) {
+    log(`Could not screenshot the renderer: ${error}`);
+  }
+}
+
+async function logDebuggerTargets() {
+  try {
+    const response = await fetch(`${CDP_URL}/json/list`);
+    const targets = (await response.json()) as { type: string; url: string }[];
+
+    log("Debugging targets the app exposed:");
+
+    for (const target of targets) {
+      log(`  ${target.type} ${target.url}`);
+    }
+  } catch (error) {
+    log(`Could not list debugging targets: ${error}`);
+  }
+}
+
+/**
+ * Removing the container is what actually stops the app. The dev server
+ * spawned the launcher rather than the app itself, so killing the dev server
+ * does not reliably reach the container the launcher started.
+ */
+async function stopApp(devServer: Subprocess) {
+  await spawn(["docker", "rm", "--force", CONTAINER_NAME], {
+    stdout: "ignore",
+    stderr: "ignore",
+  }).exited;
+
+  // With the app gone the dev server exits by itself, so it is only signalled
+  // when it does not. Killing it first would turn every clean shutdown into a
+  // reported signal, which reads like a failure in the CI log.
+  const hasStoppedOnItsOwn = await Promise.race([
+    devServer.exited.then(() => true),
+    Bun.sleep(SHUTDOWN_TIMEOUT).then(() => false),
+  ]);
+
+  if (hasStoppedOnItsOwn) {
+    return;
+  }
+
+  devServer.kill();
+
+  await devServer.exited;
+}
+
+const headlessHome = await mkdtemp(path.join(tmpdir(), "meru-boot-smoke-test-"));
+
+// A fresh home every run, so a local run starts from the same empty config CI
+// gets and cannot pass on state left behind by an earlier one.
+const devServer = spawn(["bun", "run", "dev:headless"], {
+  env: {
+    ...process.env,
+    MERU_INSTANCE: INSTANCE,
+    MERU_CDP_PORT: CDP_PORT,
+    MERU_HEADLESS_HOME: headlessHome,
+  },
+  stdout: "inherit",
+  stderr: "inherit",
+});
+
+const hasDevServerExited = watchForEarlyExit(devServer);
+
+let browser: Browser | undefined;
+let renderer: Page | undefined;
+
+try {
+  log("Waiting for the app to start…");
+
+  await waitForDebuggerPort(hasDevServerExited);
+
+  browser = await chromium.connectOverCDP(CDP_URL);
+
+  renderer = await waitForRendererPage(browser);
+
+  const rendererErrors: Error[] = [];
+
+  renderer.on("pageerror", (error) => {
+    rendererErrors.push(error);
+  });
+
+  await assertRendererRendered(renderer);
+
+  if (hasDevServerExited()) {
+    throw new Error("The app exited while the smoke test was running.");
+  }
+
+  if (rendererErrors.length > 0) {
+    for (const rendererError of rendererErrors) {
+      log(`Uncaught renderer error: ${rendererError.stack ?? rendererError.message}`);
+    }
+
+    throw new Error(`The renderer threw ${rendererErrors.length} uncaught error(s) while booting.`);
+  }
+
+  log("The app booted and the renderer rendered.");
+} catch (error) {
+  await captureFailureScreenshot(renderer);
+
+  await logDebuggerTargets();
+
+  log(`Failed: ${error instanceof Error ? error.message : error}`);
+
+  process.exitCode = 1;
+} finally {
+  await browser?.close();
+
+  await stopApp(devServer);
+
+  await rm(headlessHome, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
Adds `bun run test:boot`, which launches the app, attaches to it over the Chrome DevTools Protocol and checks the renderer actually painted, and a CI job that runs it on every pull request. Nothing caught "Meru doesn't start" before a release until now. The `boot` job passes on `ubuntu-latest` in 54 seconds, 27 of which are a cold container image pull.

## Problem
`ci.yml` runs fmt, lint, types and `bun test`, and none of them launch the app. A change that breaks startup gets as far as a release before anyone notices, and the failure a user sees is the app not opening at all.

The reason there was no such job is that Electron needs a display and a set of GTK, NSS and GBM libraries a runner does not necessarily have. #956 solved that for developers by running the app in the official Playwright image under Xvfb, driven through `bun run dev:headless`. This is the test that groundwork was for.

## Solution
`tests/boot-smoke-test.ts` spawns `bun run dev:headless`, polls for the debugging port, attaches with `playwright-core`, and asserts on the window it finds. The `boot` job in `ci.yml` runs it and uploads a screenshot when it fails.

The test goes through `dev:headless` rather than launching Electron itself, and the CI job runs that same launcher rather than installing Xvfb on the runner. A runner has passwordless sudo, so `sudo apt-get install xvfb` would be lighter, and a job-level `container:` would be more idiomatic for Actions — but both leave CI exercising a launch path nobody uses locally, which lets `scripts/headless` break unnoticed. The image pull was the expected cost of keeping one code path and turned out to be minor: 27 seconds cold, because the runners and `mcr.microsoft.com` are both on Azure. There is deliberately no separate `docker pull` step: naming the image in the workflow as well as in the launcher gives the two somewhere to drift apart, and the pull shows up in the log either way. Recorded in `decisions.md`, which had flagged browsers in CI as a decision of its own.

The assertion is that appearance settings renders, not merely that a window exists. That route needs no Gmail sign-in, and it renders nothing until the config arrives from the main process, so its title appearing proves the renderer bundle loaded, React mounted, hash routing works and an IPC round trip completed. A window that exists but paints nothing still fails. `SettingsTitle` grew a `data-testid` so the check does not match against copy that is free to change.

Two things about the environment are worth knowing, because both are silent traps:

- The dev server treats Electron exiting as the user closing the app and exits `0` itself, so its exit code says nothing about whether the app crashed. The test treats *exiting before the checks finish* as the failure, never the code.
- Bun does not run a dependency's postinstall unless it is trusted, so Electron's binary is absent after any install, with or without `--ignore-scripts`. The job fetches it explicitly and caches the ~124MB download.

Shutdown removes the container rather than signalling the dev server, which spawned the launcher rather than the app and so cannot reliably reach it; with the app gone the dev server exits on its own. Each run gets a fresh `MERU_HEADLESS_HOME`, so a local run starts from the same empty config CI gets. The instance name and CDP port differ from the launcher's defaults, so a smoke test neither disturbs nor is disturbed by a `dev:headless` already running on the machine.

## Try it
No preview deployment applies — this runs a desktop app. The `boot` job on this PR is the change running: https://github.com/zoidsh/meru/actions/runs/32721512979/job/97413741731

On a Linux machine with Docker:

```sh
bun install --frozen-lockfile
(cd node_modules/electron && node install.js)
bun run test:boot
```

It prints `The app booted and the renderer rendered.` and exits `0`. To see the failure path, change the expected title in `tests/boot-smoke-test.ts` to something else: it exits `1`, writes `boot-smoke-test.png`, and lists the debugging targets the app exposed.

## Not verified
- The failure path has only been exercised locally, by breaking the assertion on purpose. The `actions/upload-artifact` step has never actually run, so whether the screenshot arrives as a usable artifact is unconfirmed.
- The Electron cache has only ever missed. This PR's run populated it; nothing has yet restored from it, so the cache key is unproven.
- The 20 minute step timeout was sized for a cold pull before one had been measured. At 54 seconds observed it is now a wide margin rather than a considered number, and it has never been hit.
- The test assumes the runner has network. The app boots to Google's sign-in page in a child `WebContentsView`, and while the assertions only touch the renderer and should hold regardless, a fully offline runner has not been tried.
- An uncaught error in the renderer fails the test. That is our own code rather than Google's, so it should not be noisy, but only the clean case has been observed — no real renderer exception has been through it.
- The screenshot captures the renderer's HTML only. Gmail and workspace apps are separate views the compositor paints above it, so they appear as blank rectangles; that is the protocol, not a broken app.
- Only exercised on Linux, which is all `dev:headless` supports.