### PR TITLE
Fix the boot job's Electron install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,15 +42,12 @@ jobs:
       - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile --ignore-scripts
-      # Bun does not run a dependency's postinstall unless it is trusted, so the
-      # Electron binary is missing after any install, with or without
-      # --ignore-scripts. Fetching it explicitly is the only way to get one.
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/electron
-          key: electron-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-      - run: node install.js
-        working-directory: node_modules/electron
+      # electron/index.js downloads the binary lazily on first require, so a
+      # plain `bun run dev` heals itself. The ELECTRON_OVERRIDE_DIST_PATH branch
+      # dev:headless relies on returns before that check, and the launcher then
+      # execs node_modules/electron/dist/electron inside the container, so the
+      # headless path is the one that needs the binary fetched by hand.
+      - run: bunx install-electron
       # Pulls the container image on first use, so allow for that.
       - run: bun run test:boot
         timeout-minutes: 20


### PR DESCRIPTION
## Summary
The `boot` job's comment explains its Electron install step with Bun's trust rules, which have nothing to do with it — misleading enough that it prompted a proposed `trustedDependencies` entry that would have done nothing. This replaces the comment with the real reason, swaps the hand-rolled `node install.js` for the package's own `install-electron` bin, and drops a cache step that has missed on every run and would save about two seconds if it hit. CI-only; the `boot` job on this PR is the check that matters.

## Problem
The step reads:

```yaml
# Bun does not run a dependency's postinstall unless it is trusted, so the
# Electron binary is missing after any install, with or without
# --ignore-scripts. Fetching it explicitly is the only way to get one.
- uses: actions/cache@v4
  with:
    path: ~/.cache/electron
    key: electron-${{ runner.os }}-${{ hashFiles('bun.lock') }}
- run: node install.js
  working-directory: node_modules/electron
```

Every part of that comment is wrong. The `electron` package publishes no `scripts` field at all, so there is no postinstall to skip or trust: `--ignore-scripts` is not the cause, `trustedDependencies: ["electron"]` changes nothing with or without it, `bun pm untrusted` reports zero blocked packages, and `bun pm default-trusted` already lists `electron`.

The real reason is narrower. `electron/index.js` downloads the binary lazily on first `require`, so an ordinary `bun run dev` on a fresh checkout heals itself. But the `ELECTRON_OVERRIDE_DIST_PATH` branch returns before the existence check that triggers that download, and `dev:headless` sets that variable — so `scripts/headless/electron` execs `node_modules/electron/dist/electron` inside the container against a binary that has to be there already. The headless path is the one that never self-heals, which is why the explicit step exists at all.

The cache step is a separate problem: it missed on both runs so far, because a cache saved on a pull request branch is not visible to `main`.

## Solution
- Replaces the comment with the `ELECTRON_OVERRIDE_DIST_PATH` account above. `docs/decisions.md` already carries the same explanation under "The boot smoke test runs the container launcher CI shares with developers", so it needed no update.
- Runs `bunx install-electron` instead of `node install.js` with a `working-directory`. The `electron` package ships that bin (`node_modules/.bin/install-electron` → `../electron/install.js`), so this is the supported entry point for the same script rather than reaching into `node_modules` by path.
- Drops the `actions/cache@v4` step rather than fixing its scope. Warming the cache from `main` would make it hit, but the download is ~124MB and takes about two seconds on a runner, against the cost of a step and a cache save on every run.

## Not verified
- `bunx install-electron` resolving on a GitHub runner. It was verified locally — the bin exists, and running it fetched the binary into `node_modules/electron/dist` — but the runner is the untested part, and the `boot` job here is what proves it.
- `bun run test:boot` passes locally on this branch, but it does not exercise the CI install step at all; it runs against a binary that is already present.