### PR TITLE
Stop the headless launcher inventing an empty renderer URL

### DIFF
--- a/packages/app/lib/window.ts
+++ b/packages/app/lib/window.ts
@@ -151,7 +151,9 @@ export function loadRenderer(
   searchParams.set("darkMode", nativeTheme.shouldUseDarkColors ? "true" : "false");
 
   if (is.dev) {
-    const rendererUrl = process.env.MERU_RENDERER_URL ?? "http://localhost:3000/";
+    // `||`, not `??`: an empty value is as unusable as an unset one, and
+    // keeping it loads the page with no origin to resolve against.
+    const rendererUrl = process.env.MERU_RENDERER_URL || "http://localhost:3000/";
 
     loadUrl(window.webContents, `${rendererUrl}${pageFileName}?${searchParams.toString()}`);
 

--- a/scripts/headless/electron
+++ b/scripts/headless/electron
@@ -29,7 +29,7 @@ exec docker run --rm -i --init \
   --workdir "$PWD" \
   --user "$(id -u):$(id -g)" \
   --env HOME="$headless_home" \
-  --env MERU_RENDERER_URL="${MERU_RENDERER_URL:-}" \
+  --env MERU_RENDERER_URL \
   --env CDP_PORT="$cdp_port" \
   --env SCREEN="$screen" \
   --env USER_DATA_DIR="$headless_home/$instance" \


### PR DESCRIPTION
## Summary
`scripts/headless/electron` defined `MERU_RENDERER_URL` as an empty string whenever the host had not set it, and `loadRenderer` read it with `??`, which does not fall back on an empty string — so the app loaded `main.html?…` with no origin and the page could never load. `bun run dev:headless` masks it because the dev server always sets the variable, so the trap only fires when the launcher is run directly. That is what driving the app with Playwright's `_electron.launch` does, which is how this surfaced.

## Problem
The launcher forwards `--env MERU_RENDERER_URL="${MERU_RENDERER_URL:-}"`. The `:-` expansion turns "unset" into "set to empty", so the variable always reaches the container defined. `packages/app/lib/window.ts` then does `process.env.MERU_RENDERER_URL ?? "http://localhost:3000/"`, and `??` only falls back on `null` and `undefined`. The empty string wins, and the app calls `loadURL("main.html?accounts=…")` — a relative reference with nothing to resolve against.

Nothing supported reaches it today: `bun run dev:headless` goes through `scripts/build.ts`, which always sets the variable before spawning the launcher. It fires when `scripts/headless/electron` is invoked on its own, which is exactly what `_electron.launch({ executablePath: "scripts/headless/electron" })` does. That evaluation is written up as "Playwright's `_electron.launch` drives the boot smoke test, over the same container launcher" in the docs repo's `decisions.md`; this PR carries only the bug it turned up, so the test rewrite reviews on its own.

## Solution
- The launcher uses bare `--env MERU_RENDERER_URL`, which forwards the host's value when set and defines nothing when it is not. Verified inside the container: `process.env.MERU_RENDERER_URL` is now `undefined` rather than `""`.
- `loadRenderer` uses `||` rather than `??`, so an empty value is treated the same as an absent one.

Both halves are fixed rather than just the launcher. Fixing only the launcher would leave a fallback that silently accepts a value it cannot use, and the comment on the `||` exists so the next reader does not "correct" it back to `??`.

## Try it
No preview deployment for a desktop app, so it is a local run on Linux with Docker:

```sh
bun install --frozen-lockfile && bunx install-electron && bun run build:js
env -u MERU_RENDERER_URL scripts/headless/electron .
```

Before this change the app logs `Failed to load URL {url: main.html?accounts=…}`. After it, it logs `Failed to load URL: http://localhost:3000/main.html?…` — still a failure with no dev server running, but now against the intended default. `bun run dev:headless` behaves identically either way.

## Not verified
- Only Linux with Docker. `bun run dev` on macOS and Windows never sets the variable and never went through the launcher, so it takes the same `localhost:3000` fallback as before, but that was reasoned rather than run.
- The packaged `is.dev === false` branch is untouched and was not exercised.
