### PR TITLE
Drive the boot smoke test with Playwright's _electron.launch

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -9,31 +9,18 @@ import postcss from "postcss";
 import { rolldown, defineConfig as defineRolldownConfig } from "rolldown";
 import * as vite from "vite";
 
-const args = parseArgs({
-  args: Bun.argv,
-  options: {
-    dev: {
-      type: "boolean",
-    },
-    devtools: {
-      type: "boolean",
-      short: "d",
-    },
-  },
-  strict: true,
-  allowPositionals: true,
-});
-
-await rm("./build-js", { recursive: true, force: true });
-
 // Keep in sync with Electron
 const browserTarget = "chrome146";
 
-function buildAppFiles() {
+export function resetBuildDirectory() {
+  return rm("./build-js", { recursive: true, force: true });
+}
+
+export function buildAppFiles({ dev }: { dev: boolean }) {
   const rolldownOptions = defineRolldownConfig({
     external: ["electron"],
     transform: {
-      define: !args.values.dev
+      define: !dev
         ? {
             "process.env.NODE_ENV": JSON.stringify("production"),
             ...(process.env.MERU_API_URL
@@ -132,12 +119,12 @@ function buildAppFiles() {
   ]);
 }
 
-async function buildRenderer(rendererName: string, port: number) {
+function createRendererViteConfig(rendererName: string, port: number): vite.InlineConfig {
   const rendererRoot = path.join(process.cwd(), "packages", rendererName);
 
   const pageFileNames = Array.from(new Bun.Glob("*.html").scanSync(rendererRoot));
 
-  const viteConfig: vite.InlineConfig = {
+  return {
     configFile: false,
     root: rendererRoot,
     base: "./",
@@ -161,68 +148,105 @@ async function buildRenderer(rendererName: string, port: number) {
     },
     clearScreen: false,
   };
+}
 
-  if (args.values.dev) {
-    const viteServer = await vite.createServer(viteConfig);
+export function buildRenderer(rendererName: string, port: number) {
+  return vite.build(createRendererViteConfig(rendererName, port));
+}
 
-    await viteServer.listen();
+/**
+ * Resolves once the server is listening, so `resolvedUrls` carries the port it
+ * actually took rather than the one it was asked for.
+ */
+export async function startRendererDevServer(rendererName: string, port: number) {
+  const viteServer = await vite.createServer(createRendererViteConfig(rendererName, port));
+
+  await viteServer.listen();
+
+  return viteServer;
+}
+
+// Guarded so the boot smoke test can import the builders and run the dev server
+// in its own process. `_electron.launch` has to spawn the app itself, which the
+// branch below already does, so the two cannot both drive it.
+if (import.meta.main) {
+  const args = parseArgs({
+    args: Bun.argv,
+    options: {
+      dev: {
+        type: "boolean",
+      },
+      devtools: {
+        type: "boolean",
+        short: "d",
+      },
+    },
+    strict: true,
+    allowPositionals: true,
+  });
+
+  const isDev = args.values.dev === true;
+
+  await resetBuildDirectory();
+
+  if (!isDev) {
+    await Promise.all([buildAppFiles({ dev: false }), buildRenderer("renderer", 3000)]);
+  } else {
+    const [, viteServer] = await Promise.all([
+      buildAppFiles({ dev: true }),
+      startRendererDevServer("renderer", 3000),
+    ]);
 
     viteServer.printUrls();
 
-    return viteServer.resolvedUrls?.local[0];
-  }
+    const rendererUrl = viteServer.resolvedUrls?.local[0];
 
-  await vite.build(viteConfig);
-}
+    let electron: Subprocess;
+    let isRestartingElectron = false;
 
-const [, rendererUrl] = await Promise.all([buildAppFiles(), buildRenderer("renderer", 3000)]);
+    const startElectron = () => {
+      electron = spawn(["electron", ".", ...(args.values.devtools ? ["--devtools"] : [])], {
+        env: { ...process.env, MERU_RENDERER_URL: rendererUrl },
+        onExit: async () => {
+          if (isRestartingElectron) {
+            isRestartingElectron = false;
+          } else {
+            await electron.exited;
 
-if (args.values.dev) {
-  let electron: Subprocess;
-  let isRestartingElectron = false;
+            process.exit(0);
+          }
+        },
+      });
+    };
 
-  const startElectron = () => {
-    electron = spawn(["electron", ".", ...(args.values.devtools ? ["--devtools"] : [])], {
-      env: { ...process.env, MERU_RENDERER_URL: rendererUrl },
-      onExit: async () => {
-        if (isRestartingElectron) {
-          isRestartingElectron = false;
-        } else {
-          await electron.exited;
+    const stopElectron = () => {
+      electron.kill();
 
-          process.exit(0);
-        }
-      },
-    });
-  };
+      return electron.exited;
+    };
 
-  const stopElectron = () => {
-    electron.kill();
+    const restartElectron = async () => {
+      isRestartingElectron = true;
 
-    return electron.exited;
-  };
+      await stopElectron();
 
-  const restartElectron = async () => {
-    isRestartingElectron = true;
+      startElectron();
+    };
 
-    await stopElectron();
+    await startElectron();
 
-    startElectron();
-  };
+    const watcher = watch("./packages", { recursive: true });
 
-  await startElectron();
+    for await (const event of watcher) {
+      const rendererPathnames = ["renderer/", "shared/renderer/", "ui/"];
 
-  const watcher = watch("./packages", { recursive: true });
+      if (rendererPathnames.some((pathname) => event.filename?.startsWith(pathname))) {
+        continue;
+      }
 
-  for await (const event of watcher) {
-    const rendererPathnames = ["renderer/", "shared/renderer/", "ui/"];
+      await buildAppFiles({ dev: true });
 
-    if (rendererPathnames.some((pathname) => event.filename?.startsWith(pathname))) {
-      continue;
+      await restartElectron();
     }
-
-    await buildAppFiles();
-
-    await restartElectron();
   }
 }

--- a/scripts/headless/electron
+++ b/scripts/headless/electron
@@ -57,11 +57,23 @@ exec docker run --rm -i --init \
 
     export DISPLAY=":$(cat /tmp/display)"
 
+    # A caller driving the app rather than watching it brings its own port,
+    # and Playwright asks for 0 so the OS picks a free one. Chromium honors
+    # the last of two, so passing both works and reads as though the fixed
+    # port were in force when it is not.
+    debugging_port=("--remote-debugging-port=$CDP_PORT")
+
+    for arg in "$@"; do
+      case "$arg" in
+        --remote-debugging-port=*) debugging_port=() ;;
+      esac
+    done
+
     # Electron holds a single instance lock scoped to the user data directory,
     # so a directory per instance is what lets several run side by side.
     exec ./node_modules/electron/dist/electron \
       --no-sandbox \
       --user-data-dir="$USER_DATA_DIR" \
-      --remote-debugging-port="$CDP_PORT" \
+      ${debugging_port[@]+"${debugging_port[@]}"} \
       "$@"
   ' -- "$@"

--- a/tests/boot-smoke-test.ts
+++ b/tests/boot-smoke-test.ts
@@ -1,26 +1,27 @@
 /*
- * Proves the app still starts. Launches it through `bun run dev:headless`,
- * attaches to it over the Chrome DevTools Protocol and checks the renderer
- * actually painted, then shuts it down.
+ * Proves the app still starts. Builds the app, serves the renderer from a dev
+ * server in this process, launches the app through the container launcher and
+ * checks the renderer actually painted, then shuts it down.
  *
- * Needs Docker and Linux, because that is what `dev:headless` needs. Running
- * the app the same way developers do is the point: a separate CI-only launch
- * path would let `scripts/headless` rot without anything noticing.
+ * Needs Docker and Linux, because that is what `scripts/headless/electron`
+ * needs. Running the app the same way developers do is the point: a separate
+ * CI-only launch path would let `scripts/headless` rot without anything
+ * noticing.
  */
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { ms } from "@meru/shared/ms";
-import { type Subprocess, spawn } from "bun";
-import { type Browser, chromium, type Page } from "playwright-core";
+import { spawn } from "bun";
+import { _electron, type ElectronApplication, type Page } from "playwright-core";
+import { buildAppFiles, resetBuildDirectory, startRendererDevServer } from "../scripts/build";
 
-// Deliberately not the launcher's defaults, so a smoke test neither disturbs
+// Deliberately not the launcher's default, so a smoke test neither disturbs
 // nor is disturbed by a `bun run dev:headless` already running on the machine.
 const INSTANCE = "boot-smoke-test";
-const CDP_PORT = process.env.MERU_CDP_PORT ?? "9333";
 
-const CDP_URL = `http://127.0.0.1:${CDP_PORT}`;
 const CONTAINER_NAME = `meru-headless-${INSTANCE}`;
+const LAUNCHER_PATH = path.join(process.cwd(), "scripts", "headless", "electron");
 
 const SCREENSHOT_PATH = path.join(process.cwd(), "boot-smoke-test.png");
 
@@ -28,7 +29,6 @@ const SCREENSHOT_PATH = path.join(process.cwd(), "boot-smoke-test.png");
 // before the app can start at all, so this covers the pull as well as the boot.
 const BOOT_TIMEOUT = ms("10m");
 const RENDER_TIMEOUT = ms("1m");
-const SHUTDOWN_TIMEOUT = ms("10s");
 const POLL_INTERVAL = ms("0.5s");
 
 function log(message: string) {
@@ -36,55 +36,18 @@ function log(message: string) {
 }
 
 /**
- * The dev server treats Electron exiting as the user closing the app and exits
- * 0 itself, so its exit code says nothing about whether the app crashed. Only
- * the fact that it exited before the checks finished is meaningful.
+ * Every Gmail account and workspace app is a window of its own as far as
+ * Playwright is concerned, so the app's own window has to be picked out by the
+ * page it loaded. `firstWindow()` is not that window — it returns whichever
+ * one appeared first, which is usually an account. Nor does asking whether a
+ * page has a `BrowserWindow` separate them, because `BrowserWindow`
+ * `fromWebContents` resolves a `WebContentsView` to the window that owns it.
  */
-function watchForEarlyExit(devServer: Subprocess) {
-  let hasExited = false;
-
-  devServer.exited.then(() => {
-    hasExited = true;
-  });
-
-  return () => hasExited;
-}
-
-async function waitForDebuggerPort(hasDevServerExited: () => boolean) {
-  const deadline = Date.now() + BOOT_TIMEOUT;
-
-  while (Date.now() < deadline) {
-    if (hasDevServerExited()) {
-      throw new Error("The dev server exited before the app exposed a debugging port.");
-    }
-
-    try {
-      const response = await fetch(`${CDP_URL}/json/version`);
-
-      if (response.ok) {
-        return;
-      }
-    } catch {
-      // Nothing is listening yet, which is the normal case while the image is
-      // being pulled and the app is starting.
-    }
-
-    await Bun.sleep(POLL_INTERVAL);
-  }
-
-  throw new Error(`The app did not expose a debugging port within ${BOOT_TIMEOUT}ms.`);
-}
-
-/**
- * Every Gmail account and workspace app is a debugging target of its own, so
- * the app's own window has to be picked out by the page it loaded.
- */
-async function waitForRendererPage(browser: Browser) {
+async function waitForRendererWindow(app: ElectronApplication) {
   const deadline = Date.now() + RENDER_TIMEOUT;
 
   while (Date.now() < deadline) {
-    const pages = browser.contexts().flatMap((context) => context.pages());
-    const renderer = pages.find((page) => page.url().includes("main.html"));
+    const renderer = app.windows().find((window) => window.url().includes("main.html"));
 
     if (renderer) {
       return renderer;
@@ -123,6 +86,31 @@ async function assertRendererRendered(renderer: Page) {
 }
 
 /**
+ * Reaches the main process over its own Node inspector, which the debugging
+ * protocol alone cannot see. A window can be a debugging target while never
+ * being shown, so whether the app put something on screen is only answerable
+ * from here.
+ */
+async function assertWindowShown(app: ElectronApplication) {
+  const windows = await app.evaluate(({ BrowserWindow }) =>
+    BrowserWindow.getAllWindows().map((window) => ({
+      title: window.getTitle(),
+      isVisible: window.isVisible(),
+    })),
+  );
+
+  if (windows.length !== 1) {
+    throw new Error(
+      `Expected the app to own one window, but the main process reports ${windows.length}: ${JSON.stringify(windows)}.`,
+    );
+  }
+
+  if (!windows[0]?.isVisible) {
+    throw new Error("The app's window was never shown.");
+  }
+}
+
+/**
  * Captures the renderer's own HTML. Gmail and workspace apps are separate
  * views painted above it by the compositor, so they come out as blank
  * rectangles here — that is the protocol, not a broken app.
@@ -141,77 +129,86 @@ async function captureFailureScreenshot(renderer: Page | undefined) {
   }
 }
 
-async function logDebuggerTargets() {
-  try {
-    const response = await fetch(`${CDP_URL}/json/list`);
-    const targets = (await response.json()) as { type: string; url: string }[];
+function logWindows(app: ElectronApplication | undefined) {
+  if (!app) {
+    return;
+  }
 
-    log("Debugging targets the app exposed:");
+  log("Windows the app had open:");
 
-    for (const target of targets) {
-      log(`  ${target.type} ${target.url}`);
-    }
-  } catch (error) {
-    log(`Could not list debugging targets: ${error}`);
+  for (const window of app.windows()) {
+    log(`  ${window.url()}`);
   }
 }
 
 /**
- * Removing the container is what actually stops the app. The dev server
- * spawned the launcher rather than the app itself, so killing the dev server
- * does not reliably reach the container the launcher started.
+ * Closing quits the app through `app.quit()`, which lets the container exit and
+ * remove itself. The force-remove is the safety net for the paths that never
+ * reach the close, such as a failed assertion or a launch that timed out.
  */
-async function stopApp(devServer: Subprocess) {
+async function stopApp(app: ElectronApplication | undefined) {
+  try {
+    await app?.close();
+  } catch (error) {
+    log(`Could not close the app: ${error}`);
+  }
+
   await spawn(["docker", "rm", "--force", CONTAINER_NAME], {
     stdout: "ignore",
     stderr: "ignore",
   }).exited;
-
-  // With the app gone the dev server exits by itself, so it is only signalled
-  // when it does not. Killing it first would turn every clean shutdown into a
-  // reported signal, which reads like a failure in the CI log.
-  const hasStoppedOnItsOwn = await Promise.race([
-    devServer.exited.then(() => true),
-    Bun.sleep(SHUTDOWN_TIMEOUT).then(() => false),
-  ]);
-
-  if (hasStoppedOnItsOwn) {
-    return;
-  }
-
-  devServer.kill();
-
-  await devServer.exited;
 }
-
-const headlessHome = await mkdtemp(path.join(tmpdir(), "meru-boot-smoke-test-"));
 
 // A fresh home every run, so a local run starts from the same empty config CI
 // gets and cannot pass on state left behind by an earlier one.
-const devServer = spawn(["bun", "run", "dev:headless"], {
-  env: {
-    ...process.env,
-    MERU_INSTANCE: INSTANCE,
-    MERU_CDP_PORT: CDP_PORT,
-    MERU_HEADLESS_HOME: headlessHome,
-  },
-  stdout: "inherit",
-  stderr: "inherit",
-});
+const headlessHome = await mkdtemp(path.join(tmpdir(), "meru-boot-smoke-test-"));
 
-const hasDevServerExited = watchForEarlyExit(devServer);
+await resetBuildDirectory();
 
-let browser: Browser | undefined;
+const [, viteServer] = await Promise.all([
+  buildAppFiles({ dev: true }),
+  startRendererDevServer("renderer", 3000),
+]);
+
+const rendererUrl = viteServer.resolvedUrls?.local[0];
+
+let app: ElectronApplication | undefined;
 let renderer: Page | undefined;
 
 try {
+  if (!rendererUrl) {
+    throw new Error("The renderer dev server started without resolving a URL.");
+  }
+
   log("Waiting for the app to start…");
 
-  await waitForDebuggerPort(hasDevServerExited);
+  // The launcher is a stand-in for the Electron binary, so Playwright spawns it
+  // the same way it would spawn Electron itself and reads the app's debugging
+  // endpoints off its stderr. Those are ephemeral ports inside the container,
+  // reachable only because the launcher runs it with --network host.
+  app = await _electron.launch({
+    executablePath: LAUNCHER_PATH,
+    args: ["."],
+    cwd: process.cwd(),
+    timeout: BOOT_TIMEOUT,
+    env: {
+      ...process.env,
+      MERU_INSTANCE: INSTANCE,
+      MERU_HEADLESS_HOME: headlessHome,
+      MERU_RENDERER_URL: rendererUrl,
+    } as Record<string, string>,
+  });
 
-  browser = await chromium.connectOverCDP(CDP_URL);
+  // Launching proves nothing on its own: the debugging endpoint is announced
+  // before the app's own code runs, so a main process that throws immediately
+  // still launches successfully. The assertions below are what test the app.
+  let hasAppClosed = false;
 
-  renderer = await waitForRendererPage(browser);
+  app.on("close", () => {
+    hasAppClosed = true;
+  });
+
+  renderer = await waitForRendererWindow(app);
 
   const rendererErrors: Error[] = [];
 
@@ -221,7 +218,9 @@ try {
 
   await assertRendererRendered(renderer);
 
-  if (hasDevServerExited()) {
+  await assertWindowShown(app);
+
+  if (hasAppClosed) {
     throw new Error("The app exited while the smoke test was running.");
   }
 
@@ -237,15 +236,15 @@ try {
 } catch (error) {
   await captureFailureScreenshot(renderer);
 
-  await logDebuggerTargets();
+  logWindows(app);
 
   log(`Failed: ${error instanceof Error ? error.message : error}`);
 
   process.exitCode = 1;
 } finally {
-  await browser?.close();
+  await stopApp(app);
 
-  await stopApp(devServer);
+  await viteServer.close();
 
   await rm(headlessHome, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
Replaces the boot smoke test's hand-rolled CDP plumbing with Playwright's `_electron.launch`, the API [Electron's automated testing guide](https://www.electronjs.org/docs/latest/tutorial/automated-testing) documents. The container launcher stays exactly as it is — the two compose — and the test gains access to the main process, which raw CDP cannot reach at all. Local run drops from ~15s to ~5s. The evaluation behind this is recorded in the docs repo as "Playwright's `_electron.launch` drives the boot smoke test, over the same container launcher".

## Problem
`tests/boot-smoke-test.ts` started the app with `bun run dev:headless` and attached with `chromium.connectOverCDP`. That meant re-implementing what Playwright already does: polling `http://127.0.0.1:$MERU_CDP_PORT/json/version` until something answered, picking a fixed port that would not collide with a developer's running session, and force-removing the container at the end because the dev server it could signal had spawned the launcher rather than the app.

It also could not see the main process. `app`, `BrowserWindow`, `Menu` and `Tray` live behind the main process's own Node inspector, not the browser's debugging protocol, so the test could confirm a window was a debugging target but never that anything was actually put on screen.

## Solution
- `tests/boot-smoke-test.ts` launches through `_electron.launch({ executablePath: "scripts/headless/electron" })`. Playwright spawns the executable it is given and reads the app's two debugging endpoints off that process's stderr, so a bash script that `docker run`s a container satisfies the contract as well as the real binary. Both endpoints are ephemeral ports *inside* the container, reachable only because the launcher already passes `--network host` — that flag is now load-bearing for the harness too, not just the dev server, and there is a comment saying so.
- Adds `assertWindowShown`, which asks the main process how many windows exist and whether they are visible.
- `electronApp.close()` quits via `app.quit()`, so the container exits and removes itself. `docker rm --force` stays as a safety net for paths that never reach the close, such as a failed assertion.
- `scripts/build.ts` exports its builders and dev server and puts the command-line half behind `import.meta.main`. `_electron.launch` must spawn the app itself, which is exactly what the dev branch already did, so the two cannot both drive it; the test now serves the renderer in its own process and reads the port Vite actually took instead of parsing a subprocess's output.
- `scripts/headless/electron` stops passing `--remote-debugging-port` when the caller passes one.

Picking the window by matching `main.html` in its URL survives, and that is deliberate rather than left over. `firstWindow()` returns whichever window appeared first, which in practice is a Gmail account; and testing whether a page has a `BrowserWindow` does not separate them either, because `BrowserWindow.fromWebContents` resolves a `WebContentsView` to the window that owns it. Both were tried. Several `webContents` in one window is the app's architecture, so any driver has to pick by URL.

Two flags were left as they are on purpose. Chromium honors the last `--remote-debugging-port` of two, so passing both worked — but the fixed port read as though it were in force when Playwright's `=0` had already overridden it, which is why the launcher now drops its own. And `@playwright/test` is not adopted: `playwright-core` is already a dev dependency and carries the launch API, so a second test runner alongside `bun test` plus a browser download the app never uses is not worth it for one test.

## Try it
No preview deployment for a desktop app, so it is a local run on Linux with Docker:

```sh
bun install --frozen-lockfile && bunx install-electron
bun run test:boot
```

It should print `[boot-smoke-test] The app booted and the renderer rendered.` and exit 0 in about five seconds against a warm image. `bun run dev` and `bun run dev:headless` are unchanged.

## Not verified
- Only Linux with Docker for the test itself. `bun run dev`'s file-watch restart loop was not exercised; the production build and `bun run dev:headless` both were, and CI's `build (macos-latest)` and `build (windows-latest)` cover the refactored command-line branch's production path on those platforms.
- The failure path was checked by deliberately breaking the title assertion — it exits 1, writes `boot-smoke-test.png` and lists the app's windows — but not by breaking the app itself.
