### PR TITLE
Cover settings and the application menu end to end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,18 +59,10 @@ jobs:
       - run: bun install --frozen-lockfile
       # Only Linux needs a display server invented for it. -a takes a free
       # display rather than colliding on :99.
-      # pw:browser prints the command Playwright launched and every line it read
-      # back, which is the only view into a launch that never returns: the app is
-      # running by then, but no fixture has been handed to a test, so nothing the
-      # test itself logs will ever run.
       - if: runner.os == 'Linux'
         run: xvfb-run -a bun run test:e2e
-        env:
-          DEBUG: pw:browser
       - if: runner.os != 'Linux'
         run: bun run test:e2e
-        env:
-          DEBUG: pw:browser
       # always(), not failure(): a job killed for running long counts as
       # cancelled rather than failed, and that is the run whose trace is most
       # worth having.

--- a/packages/renderer/components/app-sidebar.tsx
+++ b/packages/renderer/components/app-sidebar.tsx
@@ -138,7 +138,7 @@ export function AppSidebar() {
   const [location, navigate] = useLocation();
 
   return (
-    <div className="bg-sidebar p-4 pr-0">
+    <div className="bg-sidebar p-4 pr-0" data-testid="settings-nav">
       <ScrollArea className="h-full w-56">
         <div className="space-y-2">
           {sidebarNavItems

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -242,6 +242,10 @@ function ExtensionItem({
               variant="outline"
               size="sm"
               className="mt-1 self-start"
+              // The dialog explains how to pair the extension with 1Password's
+              // desktop app, which there is nothing to pair until it is
+              // installed. Installing needs Meru Pro, so this locks with it.
+              disabled={!installed}
               onClick={() => {
                 setIsSetupDialogOpen(true);
               }}

--- a/packages/renderer/routes/settings/general.tsx
+++ b/packages/renderer/routes/settings/general.tsx
@@ -8,6 +8,7 @@ import {
   FieldLegend,
   FieldSeparator,
   FieldSet,
+  FieldTitle,
 } from "@meru/ui/components/field";
 import { Switch } from "@meru/ui/components/switch";
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -91,12 +92,26 @@ function DefaultMailClientField() {
     return;
   }
 
+  const heading = (
+    <>
+      Default mail client <LicenseKeyRequiredFieldBadge />
+    </>
+  );
+
   return (
     <Field orientation="horizontal">
       <FieldContent>
-        <FieldLabel htmlFor={fieldId}>
-          Default mail client <LicenseKeyRequiredFieldBadge />
-        </FieldLabel>
+        {/*
+         * A label only while there is a switch for it to label. Once Meru is the
+         * default there is nothing left to turn on, so the switch goes and the
+         * row states the fact instead — and a `label` naming an id that nothing
+         * on the page carries is read as unlabelled by assistive technology.
+         */}
+        {isDefaultMailtoClient ? (
+          <FieldTitle>{heading}</FieldTitle>
+        ) : (
+          <FieldLabel htmlFor={fieldId}>{heading}</FieldLabel>
+        )}
         <FieldDescription>
           {isDefaultMailtoClient
             ? "Meru is set as the default mail client."

--- a/packages/renderer/routes/settings/notifications.tsx
+++ b/packages/renderer/routes/settings/notifications.tsx
@@ -338,7 +338,7 @@ export function NotificationsSettings() {
                       }}
                       disabled={!isLicenseKeyValid}
                     >
-                      <SelectTrigger>
+                      <SelectTrigger id={soundFieldId}>
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>

--- a/tests/launch.e2e.ts
+++ b/tests/launch.e2e.ts
@@ -2,223 +2,18 @@
  * Proves the app still launches. Starts the built app, routes it to appearance
  * settings and checks the renderer actually painted.
  *
- * `bun run test:e2e` builds the app before running this, so there is nothing
- * to do first beyond having a display. On a machine without one, wrap the
- * command: `xvfb-run -a bun run test:e2e`. The -a matters, because it picks a
- * free display number rather than colliding on :99 with another run.
- *
- * That build is Linux only. Elsewhere, build the app for the platform and
- * point MERU_EXECUTABLE at what electron-builder leaves in dist.
+ * The harness that launches it, and the reasoning behind how, lives in
+ * `tests/lib/app.ts`.
  */
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import path from "node:path";
-import { test as base, expect } from "@playwright/test";
-import { _electron, type ElectronApplication, type Page } from "playwright";
+import { expect, test } from "@playwright/test";
+import { useApp } from "./lib/app";
 
-// Where electron-builder leaves the unpacked app, per platform. macOS and
-// Windows name it after productName, "Meru"; Linux lowercases it. Getting that
-// case wrong is invisible on a Mac and on Windows, whose filesystems match it
-// either way, and breaks nowhere until someone runs on a case-sensitive one.
-const UNPACKED_PATHS: Record<string, string[]> = {
-  darwin: ["mac-arm64", "Meru.app", "Contents", "MacOS", "Meru"],
-  linux: ["linux-unpacked", "meru"],
-  win32: ["win-unpacked", "Meru.exe"],
-};
+const meru = useApp();
 
-function resolveExecutablePath() {
-  if (process.env.MERU_EXECUTABLE) {
-    return process.env.MERU_EXECUTABLE;
-  }
-
-  const unpackedPath = UNPACKED_PATHS[process.platform];
-
-  if (!unpackedPath) {
-    throw new Error(
-      `No unpacked app path is known for ${process.platform}. Set MERU_EXECUTABLE to the built app.`,
-    );
-  }
-
-  return path.join(process.cwd(), "dist", ...unpackedPath);
-}
-
-const EXECUTABLE_PATH = resolveExecutablePath();
-
-const CLOSE_TIMEOUT = 15_000;
-
-function launchArguments(userDataDir: string) {
-  const args = [`--user-data-dir=${userDataDir}`];
-
-  // chrome-sandbox ships without its setuid bit outside an installed package,
-  // so an unpacked Linux build cannot use the sandbox. The packaged apps on the
-  // other platforms can, and are left alone.
-  if (process.platform === "linux") {
-    args.push("--no-sandbox");
-  }
-
-  // Hosted runners have no GPU worth using, and Chromium spends a while finding
-  // that out for itself.
-  if (process.env.CI) {
-    args.push("--disable-gpu");
-  }
-
-  return args;
-}
-
-/**
- * Quitting can hang, and Playwright's own close() takes no timeout until after
- * 1.62, so the process gets killed rather than left to stall the worker for its
- * whole teardown budget.
- */
-async function closeApp(app: ElectronApplication) {
-  const closed = await Promise.race([
-    app.close().then(() => true),
-    new Promise<boolean>((resolve) => {
-      setTimeout(() => resolve(false), CLOSE_TIMEOUT);
-    }),
-  ]).catch(() => false);
-
-  if (!closed) {
-    console.log(`[e2e] the app did not quit within ${CLOSE_TIMEOUT}ms; killing it`);
-
-    app.process().kill("SIGKILL");
-  }
-}
-
-const test = base.extend<{ app: ElectronApplication }>({
-  // Playwright resolves a fixture's dependencies from its destructuring
-  // pattern, so the empty one is the framework's contract for depending on
-  // nothing, and it rejects a plain parameter in its place.
-  // oxlint-disable-next-line no-empty-pattern
-  app: async ({}, use, testInfo) => {
-    /*
-     * A user data directory of its own, for two reasons. The app takes a single
-     * instance lock scoped to that directory and quits when it loses, so runs
-     * sharing one cannot overlap — and several agents do work on this
-     * repository at once. It is also where the config lives, so a fresh
-     * directory is what makes a local run start from the same empty config CI
-     * gets.
-     */
-    const userDataDir = await mkdtemp(path.join(tmpdir(), "meru-e2e-"));
-
-    /*
-     * Startup validates the Pro trial against Meru's API before it creates any
-     * window, and on failure waits on a native dialog that no one is here to
-     * dismiss: the app stays up with no window, and even the main process stops
-     * answering. `trial.validate` returns early on this key without calling
-     * anything, so seeding it keeps the test off the network entirely.
-     *
-     * Linux and Windows only pass without this because the call happens to
-     * succeed there, which makes a live third-party service part of the test on
-     * every platform. That is the reason to seed rather than to retry.
-     */
-    await writeFile(
-      path.join(userDataDir, "config.json"),
-      JSON.stringify({ "trial.expired": true }, null, "\t"),
-    );
-
-    // The built binary, not `electron .`: only a packaged app has isPackaged
-    // true, which is what sends loadRenderer down its production loadFile
-    // branch. Running the app the way it ships is the point.
-    const app = await _electron.launch({
-      executablePath: EXECUTABLE_PATH,
-      args: launchArguments(userDataDir),
-      cwd: process.cwd(),
-    });
-
-    // Started by hand rather than through the `trace` option, which only covers
-    // contexts the runner creates itself, and this one is launched here.
-    await app.context().tracing.start({ screenshots: true, snapshots: true, sources: true });
-
-    await use(app);
-
-    const hasFailed = testInfo.status !== testInfo.expectedStatus;
-
-    if (hasFailed) {
-      const tracePath = testInfo.outputPath("trace.zip");
-
-      await app.context().tracing.stop({ path: tracePath });
-
-      testInfo.attachments.push({
-        name: "trace",
-        path: tracePath,
-        contentType: "application/zip",
-      });
-    } else {
-      await app.context().tracing.stop();
-    }
-
-    if (hasFailed) {
-      /*
-       * The renderer's own HTML. Gmail and workspace apps are separate views
-       * painted above it by the compositor, so they come out as blank
-       * rectangles here — that is the protocol, not a broken app.
-       */
-      const renderer = app.windows().find((window) => window.url().includes("main.html"));
-
-      if (renderer) {
-        await testInfo.attach("renderer", {
-          body: await renderer.screenshot(),
-          contentType: "image/png",
-        });
-      }
-
-      await testInfo.attach("windows", {
-        body: app
-          .windows()
-          .map((window) => window.url())
-          .join("\n"),
-        contentType: "text/plain",
-      });
-
-      // Also to stdout, not only the attachments: a job that is killed for
-      // running long never uploads its artifacts, and that is exactly the run
-      // whose state is worth seeing.
-      console.log(`[e2e] windows: ${JSON.stringify(app.windows().map((window) => window.url()))}`);
-
-      const mainProcessWindows = await app
-        .evaluate(({ BrowserWindow }) =>
-          BrowserWindow.getAllWindows().map((window) => ({
-            title: window.getTitle(),
-            url: window.webContents.getURL(),
-            isVisible: window.isVisible(),
-            isLoading: window.webContents.isLoading(),
-            crashed: window.webContents.isCrashed(),
-          })),
-        )
-        .catch((error: Error) => `unreachable: ${error.message}`);
-
-      console.log(`[e2e] main process: ${JSON.stringify(mainProcessWindows)}`);
-    }
-
-    await closeApp(app);
-
-    await rm(userDataDir, { recursive: true, force: true });
-  },
-});
-
-/**
- * Every Gmail account and workspace app is a window of its own as far as
- * Playwright is concerned, so the app's own window has to be picked out by the
- * page it loaded. `firstWindow()` is not that window — it returns whichever one
- * appeared first, which is usually an account. Nor does asking whether a page
- * has a `BrowserWindow` separate them, because `BrowserWindow.fromWebContents`
- * resolves a `WebContentsView` to the window that owns it.
- */
-async function findRendererWindow(app: ElectronApplication) {
-  await expect
-    .poll(() => app.windows().some((window) => window.url().includes("main.html")))
-    .toBe(true);
-
-  return app.windows().find((window) => window.url().includes("main.html")) as Page;
-}
-
-test("launches and renders appearance settings", async ({ app }) => {
-  const renderer = await findRendererWindow(app);
-
+test("launches and renders appearance settings", async () => {
   const rendererErrors: Error[] = [];
 
-  renderer.on("pageerror", (error) => {
+  meru.renderer.on("pageerror", (error) => {
     rendererErrors.push(error);
   });
 
@@ -227,15 +22,10 @@ test("launches and renders appearance settings", async ({ app }) => {
    * until the config arrives from the main process. Waiting for its title to
    * appear therefore proves the renderer bundle loaded, React mounted, routing
    * works and an IPC round trip completed — not merely that a window exists.
-   *
-   * Routing is hash based, so changing the fragment is what navigates.
    */
-  const appearanceUrl = new URL(renderer.url());
-  appearanceUrl.hash = "#/settings/appearance";
+  await meru.goto("/settings/appearance");
 
-  await renderer.goto(appearanceUrl.href);
-
-  await expect(renderer.getByTestId("settings-title")).toHaveText("Appearance");
+  await expect(meru.renderer.getByTestId("settings-title")).toHaveText("Appearance");
 
   /*
    * Reaches the main process over its own Node inspector, which the debugging
@@ -243,7 +33,7 @@ test("launches and renders appearance settings", async ({ app }) => {
    * being shown, so whether the app put something on screen is only answerable
    * from here.
    */
-  const windows = await app.evaluate(({ BrowserWindow }) =>
+  const windows = await meru.app.evaluate(({ BrowserWindow }) =>
     BrowserWindow.getAllWindows().map((window) => ({
       title: window.getTitle(),
       isVisible: window.isVisible(),

--- a/tests/launch.e2e.ts
+++ b/tests/launch.e2e.ts
@@ -22,8 +22,14 @@ test("launches and renders appearance settings", async () => {
    * until the config arrives from the main process. Waiting for its title to
    * appear therefore proves the renderer bundle loaded, React mounted, routing
    * works and an IPC round trip completed — not merely that a window exists.
+   *
+   * Reached through the menu and then the sidebar, the way anyone would. Setting
+   * the fragment by hand arrives at the same page while proving nothing about
+   * whether the app offers a way to get there.
    */
-  await meru.goto("/settings/appearance");
+  const navigation = await meru.openSettings();
+
+  await navigation.getByRole("button", { name: "Appearance", exact: true }).click();
 
   await expect(meru.renderer.getByTestId("settings-title")).toHaveText("Appearance");
 

--- a/tests/lib/app.ts
+++ b/tests/lib/app.ts
@@ -243,13 +243,18 @@ export type MeruApp = {
 };
 
 /**
- * Launches the app once for the file that calls this, and hands every test in
- * it the same window.
+ * Launches the app for every test in the file that calls this, and hands each
+ * one a window of its own.
  *
- * A launch costs about a second, so this is not about wall clock. It is that a
- * file's tests are usually steps through one surface, and reading them as one
- * session beats relaunching between each. Anything that needs an app of its own
- * — a different seeded config, a restart — belongs in a file of its own.
+ * One app per test rather than per file, because Playwright asks that "each test
+ * should be completely isolated from another test and should run independently
+ * with its own local storage, session storage, data, cookies etc." A shared app
+ * gave that up for about a second a test: a test that wrote to the config left
+ * it written for everything after it, and a retry — which Playwright runs in a
+ * fresh worker — saw a freshly seeded app where the first attempt had seen a
+ * mutated one. Two runs of the same test that disagree about the state they
+ * started from is the thing the rule exists to prevent, and it is worth more
+ * than the ten seconds it costs across this suite.
  */
 export function useApp(seedConfig: Partial<Config> = {}): MeruApp {
   let launched: LaunchedApp | undefined;
@@ -264,8 +269,13 @@ export function useApp(seedConfig: Partial<Config> = {}): MeruApp {
     return launched;
   }
 
+  // Playwright resolves which fixtures to set up from the destructuring
+  // pattern, so the empty one is the framework's contract for depending on
+  // nothing.
   // oxlint-disable-next-line no-empty-pattern
-  test.beforeAll(async ({}, testInfo) => {
+  test.beforeEach(async ({}, testInfo) => {
+    hasFailed = false;
+
     launched = await launchApp(seedConfig);
 
     /*
@@ -274,9 +284,9 @@ export function useApp(seedConfig: Partial<Config> = {}): MeruApp {
      * that happens — makes this poll throw, and reporting on that failure and
      * cleaning up after it both need the handle to the app already running.
      *
-     * Reported from in here too, because a hook that throws takes its file's
-     * tests with it and `afterEach` never runs. That leaves this the only place
-     * the state of an app that never came up is still there to be read.
+     * Reported from in here too, because a hook that throws skips the test and
+     * `afterEach` with it, which leaves this the only place the state of an app
+     * that never came up is still there to be read.
      */
     try {
       launched.renderer = await findRendererWindow(launched.app);
@@ -289,27 +299,18 @@ export function useApp(seedConfig: Partial<Config> = {}): MeruApp {
     }
   });
 
-  // Playwright resolves which fixtures to set up from the destructuring
-  // pattern, so the empty one is the framework's contract for depending on
-  // nothing.
   // oxlint-disable-next-line no-empty-pattern
   test.afterEach(async ({}, testInfo) => {
-    if (testInfo.status === testInfo.expectedStatus) {
-      return;
+    if (testInfo.status !== testInfo.expectedStatus) {
+      hasFailed = true;
+
+      await collectDiagnostics(current(), testInfo);
     }
 
-    hasFailed = true;
-
-    await collectDiagnostics(current(), testInfo);
-  });
-
-  // oxlint-disable-next-line no-empty-pattern
-  test.afterAll(async ({}, testInfo) => {
     const { app, userDataDir } = current();
 
     try {
-      // One trace covers the whole file, because one launch does. It is written
-      // only when something in the file failed; a passing run has nothing worth
+      // Written only when the test failed; a passing run has nothing worth
       // uploading.
       if (hasFailed) {
         const tracePath = testInfo.outputPath("trace.zip");
@@ -321,12 +322,15 @@ export function useApp(seedConfig: Partial<Config> = {}): MeruApp {
         await app.context().tracing.stop();
       }
     } finally {
-      // Whatever the trace did. A file fails because the app is in a bad way,
+      // Whatever the trace did. A test fails because the app is in a bad way,
       // which is exactly when stopping the trace throws — and leaving the app
-      // running would take the next file's launch down with it.
+      // running would take the next test's launch down with it through the
+      // single instance lock.
       await closeApp(app);
 
       await rm(userDataDir, { recursive: true, force: true });
+
+      launched = undefined;
     }
   });
 

--- a/tests/lib/app.ts
+++ b/tests/lib/app.ts
@@ -1,0 +1,294 @@
+/*
+ * The harness every end-to-end test launches through.
+ *
+ * `bun run test:e2e` builds the app before running them, so there is nothing to
+ * do first beyond having a display. On a machine without one, wrap the command:
+ * `xvfb-run -a bun run test:e2e`. The -a matters, because it picks a free
+ * display number rather than colliding on :99 with another run.
+ *
+ * That build is Linux only. Elsewhere, build the app for the platform and point
+ * MERU_EXECUTABLE at what electron-builder leaves in dist.
+ */
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Config } from "@meru/shared/types";
+import { expect, test, type TestInfo } from "@playwright/test";
+import { _electron, type ElectronApplication, type Page } from "playwright";
+
+// Where electron-builder leaves the unpacked app, per platform. macOS and
+// Windows name it after productName, "Meru"; Linux lowercases it. Getting that
+// case wrong is invisible on a Mac and on Windows, whose filesystems match it
+// either way, and breaks nowhere until someone runs on a case-sensitive one.
+const UNPACKED_PATHS: Record<string, string[]> = {
+  darwin: ["mac-arm64", "Meru.app", "Contents", "MacOS", "Meru"],
+  linux: ["linux-unpacked", "meru"],
+  win32: ["win-unpacked", "Meru.exe"],
+};
+
+function resolveExecutablePath() {
+  if (process.env.MERU_EXECUTABLE) {
+    return process.env.MERU_EXECUTABLE;
+  }
+
+  const unpackedPath = UNPACKED_PATHS[process.platform];
+
+  if (!unpackedPath) {
+    throw new Error(
+      `No unpacked app path is known for ${process.platform}. Set MERU_EXECUTABLE to the built app.`,
+    );
+  }
+
+  return path.join(process.cwd(), "dist", ...unpackedPath);
+}
+
+const EXECUTABLE_PATH = resolveExecutablePath();
+
+const CLOSE_TIMEOUT = 15_000;
+
+function launchArguments(userDataDir: string) {
+  const args = [`--user-data-dir=${userDataDir}`];
+
+  // chrome-sandbox ships without its setuid bit outside an installed package,
+  // so an unpacked Linux build cannot use the sandbox. The packaged apps on the
+  // other platforms can, and are left alone.
+  if (process.platform === "linux") {
+    args.push("--no-sandbox");
+  }
+
+  // Hosted runners have no GPU worth using, and Chromium spends a while finding
+  // that out for itself.
+  if (process.env.CI) {
+    args.push("--disable-gpu");
+  }
+
+  return args;
+}
+
+/**
+ * Every Gmail account and workspace app is a window of its own as far as
+ * Playwright is concerned, so the app's own window has to be picked out by the
+ * page it loaded. `firstWindow()` is not that window — it returns whichever one
+ * appeared first, which is usually an account. Nor does asking whether a page
+ * has a `BrowserWindow` separate them, because `BrowserWindow.fromWebContents`
+ * resolves a `WebContentsView` to the window that owns it.
+ */
+async function findRendererWindow(app: ElectronApplication) {
+  await expect
+    .poll(() => app.windows().some((window) => window.url().includes("main.html")))
+    .toBe(true);
+
+  return app.windows().find((window) => window.url().includes("main.html")) as Page;
+}
+
+type LaunchedApp = {
+  app: ElectronApplication;
+  renderer: Page;
+  userDataDir: string;
+};
+
+async function launchApp(seedConfig: Partial<Config>): Promise<LaunchedApp> {
+  /*
+   * A user data directory of its own, for two reasons. The app takes a single
+   * instance lock scoped to that directory and quits when it loses, so runs
+   * sharing one cannot overlap — and several agents do work on this repository
+   * at once. It is also where the config lives, so a fresh directory is what
+   * makes a local run start from the same empty config CI gets.
+   */
+  const userDataDir = await mkdtemp(path.join(tmpdir(), "meru-e2e-"));
+
+  /*
+   * Startup validates the Pro trial against Meru's API before it creates any
+   * window, and on failure waits on a native dialog that no one is here to
+   * dismiss: the app stays up with no window, and even the main process stops
+   * answering. `trial.validate` returns early on this key without calling
+   * anything, so seeding it keeps the test off the network entirely.
+   *
+   * Linux and Windows only pass without this because the call happens to
+   * succeed there, which makes a live third-party service part of the test on
+   * every platform. That is the reason to seed rather than to retry.
+   *
+   * It also settles which entitlement the tests see: no license key and no
+   * running trial is the free version, so every Pro-gated control is locked.
+   */
+  await writeFile(
+    path.join(userDataDir, "config.json"),
+    JSON.stringify({ "trial.expired": true, ...seedConfig }, null, "\t"),
+  );
+
+  // The built binary, not `electron .`: only a packaged app has isPackaged
+  // true, which is what sends loadRenderer down its production loadFile
+  // branch. Running the app the way it ships is the point.
+  const app = await _electron.launch({
+    executablePath: EXECUTABLE_PATH,
+    args: launchArguments(userDataDir),
+    cwd: process.cwd(),
+  });
+
+  // Started by hand rather than through the `trace` option, which only covers
+  // contexts the runner creates itself, and this one is launched here.
+  await app.context().tracing.start({ screenshots: true, snapshots: true, sources: true });
+
+  return { app, renderer: await findRendererWindow(app), userDataDir };
+}
+
+async function attachDiagnostics({ app, renderer }: LaunchedApp, testInfo: TestInfo) {
+  /*
+   * The renderer's own HTML. Gmail and workspace apps are separate views
+   * painted above it by the compositor, so they come out as blank rectangles
+   * here — that is the protocol, not a broken app.
+   */
+  await testInfo.attach("renderer", {
+    body: await renderer.screenshot(),
+    contentType: "image/png",
+  });
+
+  await testInfo.attach("windows", {
+    body: app
+      .windows()
+      .map((window) => window.url())
+      .join("\n"),
+    contentType: "text/plain",
+  });
+
+  // Also to stdout, not only the attachments: a job that is killed for running
+  // long never uploads its artifacts, and that is exactly the run whose state
+  // is worth seeing.
+  console.log(`[e2e] windows: ${JSON.stringify(app.windows().map((window) => window.url()))}`);
+
+  const mainProcessWindows = await app
+    .evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows().map((window) => ({
+        title: window.getTitle(),
+        url: window.webContents.getURL(),
+        isVisible: window.isVisible(),
+        isLoading: window.webContents.isLoading(),
+        crashed: window.webContents.isCrashed(),
+      })),
+    )
+    .catch((error: Error) => `unreachable: ${error.message}`);
+
+  console.log(`[e2e] main process: ${JSON.stringify(mainProcessWindows)}`);
+}
+
+/**
+ * Quitting can hang, and Playwright's own close() takes no timeout until after
+ * 1.62, so the process gets killed rather than left to stall the worker for its
+ * whole teardown budget.
+ */
+async function closeApp(app: ElectronApplication) {
+  const closed = await Promise.race([
+    app.close().then(() => true),
+    new Promise<boolean>((resolve) => {
+      setTimeout(() => resolve(false), CLOSE_TIMEOUT);
+    }),
+  ]).catch(() => false);
+
+  if (!closed) {
+    console.log(`[e2e] the app did not quit within ${CLOSE_TIMEOUT}ms; killing it`);
+
+    app.process().kill("SIGKILL");
+  }
+}
+
+export type MeruApp = {
+  readonly app: ElectronApplication;
+  readonly renderer: Page;
+  readonly userDataDir: string;
+  /** Navigates the renderer to a hash route, such as `/settings/appearance`. */
+  goto(route: string): Promise<void>;
+  /** The config as it stands on disk, which is where the main process wrote it. */
+  readConfig(): Promise<Partial<Config>>;
+};
+
+/**
+ * Launches the app once for the file that calls this, and hands every test in
+ * it the same window.
+ *
+ * A launch costs about a second, so this is not about wall clock. It is that a
+ * file's tests are usually steps through one surface, and reading them as one
+ * session beats relaunching between each. Anything that needs an app of its own
+ * — a different seeded config, a restart — belongs in a file of its own.
+ */
+export function useApp(seedConfig: Partial<Config> = {}): MeruApp {
+  let launched: LaunchedApp | undefined;
+
+  let hasFailed = false;
+
+  function current() {
+    if (!launched) {
+      throw new Error("The app has not been launched yet");
+    }
+
+    return launched;
+  }
+
+  test.beforeAll(async () => {
+    launched = await launchApp(seedConfig);
+  });
+
+  // Playwright resolves which fixtures to set up from the destructuring
+  // pattern, so the empty one is the framework's contract for depending on
+  // nothing.
+  // oxlint-disable-next-line no-empty-pattern
+  test.afterEach(async ({}, testInfo) => {
+    if (testInfo.status === testInfo.expectedStatus) {
+      return;
+    }
+
+    hasFailed = true;
+
+    await attachDiagnostics(current(), testInfo);
+  });
+
+  // oxlint-disable-next-line no-empty-pattern
+  test.afterAll(async ({}, testInfo) => {
+    const { app, userDataDir } = current();
+
+    // One trace covers the whole file, because one launch does. It is written
+    // only when something in the file failed; a passing run has nothing worth
+    // uploading.
+    if (hasFailed) {
+      const tracePath = testInfo.outputPath("trace.zip");
+
+      await app.context().tracing.stop({ path: tracePath });
+
+      await testInfo.attach("trace", { path: tracePath, contentType: "application/zip" });
+    } else {
+      await app.context().tracing.stop();
+    }
+
+    await closeApp(app);
+
+    await rm(userDataDir, { recursive: true, force: true });
+  });
+
+  return {
+    get app() {
+      return current().app;
+    },
+    get renderer() {
+      return current().renderer;
+    },
+    get userDataDir() {
+      return current().userDataDir;
+    },
+    async goto(route) {
+      const { renderer } = current();
+
+      // Routing is hash based, so changing the fragment is what navigates. The
+      // rest of the URL carries the accounts the main process handed over at
+      // load, and dropping it would reload the app without them.
+      const url = new URL(renderer.url());
+
+      url.hash = `#${route}`;
+
+      await renderer.goto(url.href);
+    },
+    async readConfig() {
+      const { userDataDir } = current();
+
+      return JSON.parse(await readFile(path.join(userDataDir, "config.json"), "utf8"));
+    },
+  };
+}

--- a/tests/lib/app.ts
+++ b/tests/lib/app.ts
@@ -46,6 +46,8 @@ const EXECUTABLE_PATH = resolveExecutablePath();
 
 const CLOSE_TIMEOUT = 15_000;
 
+const DIAGNOSTICS_TIMEOUT = 10_000;
+
 function launchArguments(userDataDir: string) {
   const args = [`--user-data-dir=${userDataDir}`];
 
@@ -83,9 +85,26 @@ async function findRendererWindow(app: ElectronApplication) {
 
 type LaunchedApp = {
   app: ElectronApplication;
-  renderer: Page;
+  /** Unset until the app has shown its window, which it may never do. */
+  renderer: Page | undefined;
   userDataDir: string;
 };
+
+/** Resolves true when the work finishes in time, false when it runs over. */
+async function withTimeout(work: Promise<unknown>, timeout: number) {
+  let timer: NodeJS.Timeout | undefined;
+
+  try {
+    return await Promise.race([
+      work.then(() => true),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(false), timeout);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 async function launchApp(seedConfig: Partial<Config>): Promise<LaunchedApp> {
   /*
@@ -129,7 +148,7 @@ async function launchApp(seedConfig: Partial<Config>): Promise<LaunchedApp> {
   // contexts the runner creates itself, and this one is launched here.
   await app.context().tracing.start({ screenshots: true, snapshots: true, sources: true });
 
-  return { app, renderer: await findRendererWindow(app), userDataDir };
+  return { app, renderer: undefined, userDataDir };
 }
 
 async function attachDiagnostics({ app, renderer }: LaunchedApp, testInfo: TestInfo) {
@@ -137,11 +156,17 @@ async function attachDiagnostics({ app, renderer }: LaunchedApp, testInfo: TestI
    * The renderer's own HTML. Gmail and workspace apps are separate views
    * painted above it by the compositor, so they come out as blank rectangles
    * here — that is the protocol, not a broken app.
+   *
+   * There may be no renderer at all: an app that came up and never showed a
+   * window is one of the failures worth reporting on, not a reason to report
+   * nothing.
    */
-  await testInfo.attach("renderer", {
-    body: await renderer.screenshot(),
-    contentType: "image/png",
-  });
+  if (renderer) {
+    await testInfo.attach("renderer", {
+      body: await renderer.screenshot(),
+      contentType: "image/png",
+    });
+  }
 
   await testInfo.attach("windows", {
     body: app
@@ -172,17 +197,33 @@ async function attachDiagnostics({ app, renderer }: LaunchedApp, testInfo: TestI
 }
 
 /**
+ * Capped, because the main process can stop answering while staying up, and
+ * `evaluate` then never returns. Spending a hook's whole budget waiting costs
+ * the trace and the teardown that come after it, which is more than the
+ * diagnostics are worth.
+ */
+async function collectDiagnostics(launched: LaunchedApp, testInfo: TestInfo) {
+  const attached = await withTimeout(
+    attachDiagnostics(launched, testInfo),
+    DIAGNOSTICS_TIMEOUT,
+  ).catch((error: Error) => {
+    console.log(`[e2e] could not collect diagnostics: ${error.message}`);
+
+    return true;
+  });
+
+  if (!attached) {
+    console.log(`[e2e] diagnostics did not finish within ${DIAGNOSTICS_TIMEOUT}ms`);
+  }
+}
+
+/**
  * Quitting can hang, and Playwright's own close() takes no timeout until after
  * 1.62, so the process gets killed rather than left to stall the worker for its
  * whole teardown budget.
  */
 async function closeApp(app: ElectronApplication) {
-  const closed = await Promise.race([
-    app.close().then(() => true),
-    new Promise<boolean>((resolve) => {
-      setTimeout(() => resolve(false), CLOSE_TIMEOUT);
-    }),
-  ]).catch(() => false);
+  const closed = await withTimeout(app.close(), CLOSE_TIMEOUT).catch(() => false);
 
   if (!closed) {
     console.log(`[e2e] the app did not quit within ${CLOSE_TIMEOUT}ms; killing it`);
@@ -223,8 +264,29 @@ export function useApp(seedConfig: Partial<Config> = {}): MeruApp {
     return launched;
   }
 
-  test.beforeAll(async () => {
+  // oxlint-disable-next-line no-empty-pattern
+  test.beforeAll(async ({}, testInfo) => {
     launched = await launchApp(seedConfig);
+
+    /*
+     * Assigned before the window is looked for, not after. An app that starts
+     * and never shows one — the trial dialog nobody is here to dismiss is how
+     * that happens — makes this poll throw, and reporting on that failure and
+     * cleaning up after it both need the handle to the app already running.
+     *
+     * Reported from in here too, because a hook that throws takes its file's
+     * tests with it and `afterEach` never runs. That leaves this the only place
+     * the state of an app that never came up is still there to be read.
+     */
+    try {
+      launched.renderer = await findRendererWindow(launched.app);
+    } catch (error) {
+      hasFailed = true;
+
+      await collectDiagnostics(current(), testInfo);
+
+      throw error;
+    }
   });
 
   // Playwright resolves which fixtures to set up from the destructuring
@@ -238,43 +300,58 @@ export function useApp(seedConfig: Partial<Config> = {}): MeruApp {
 
     hasFailed = true;
 
-    await attachDiagnostics(current(), testInfo);
+    await collectDiagnostics(current(), testInfo);
   });
 
   // oxlint-disable-next-line no-empty-pattern
   test.afterAll(async ({}, testInfo) => {
     const { app, userDataDir } = current();
 
-    // One trace covers the whole file, because one launch does. It is written
-    // only when something in the file failed; a passing run has nothing worth
-    // uploading.
-    if (hasFailed) {
-      const tracePath = testInfo.outputPath("trace.zip");
+    try {
+      // One trace covers the whole file, because one launch does. It is written
+      // only when something in the file failed; a passing run has nothing worth
+      // uploading.
+      if (hasFailed) {
+        const tracePath = testInfo.outputPath("trace.zip");
 
-      await app.context().tracing.stop({ path: tracePath });
+        await app.context().tracing.stop({ path: tracePath });
 
-      await testInfo.attach("trace", { path: tracePath, contentType: "application/zip" });
-    } else {
-      await app.context().tracing.stop();
+        await testInfo.attach("trace", { path: tracePath, contentType: "application/zip" });
+      } else {
+        await app.context().tracing.stop();
+      }
+    } finally {
+      // Whatever the trace did. A file fails because the app is in a bad way,
+      // which is exactly when stopping the trace throws — and leaving the app
+      // running would take the next file's launch down with it.
+      await closeApp(app);
+
+      await rm(userDataDir, { recursive: true, force: true });
+    }
+  });
+
+  function currentRenderer() {
+    const { renderer } = current();
+
+    if (!renderer) {
+      throw new Error("The app has not shown its window");
     }
 
-    await closeApp(app);
-
-    await rm(userDataDir, { recursive: true, force: true });
-  });
+    return renderer;
+  }
 
   return {
     get app() {
       return current().app;
     },
     get renderer() {
-      return current().renderer;
+      return currentRenderer();
     },
     get userDataDir() {
       return current().userDataDir;
     },
     async goto(route) {
-      const { renderer } = current();
+      const renderer = currentRenderer();
 
       // Routing is hash based, so changing the fragment is what navigates. The
       // rest of the URL carries the accounts the main process handed over at
@@ -286,9 +363,19 @@ export function useApp(seedConfig: Partial<Config> = {}): MeruApp {
       await renderer.goto(url.href);
     },
     async readConfig() {
-      const { userDataDir } = current();
+      const configPath = path.join(current().userDataDir, "config.json");
 
-      return JSON.parse(await readFile(path.join(userDataDir, "config.json"), "utf8"));
+      /*
+       * Retried once. The config is written by replacing the file, so a read
+       * landing between the two halves of that rename fails rather than
+       * returning half a file — and on Windows it fails as a sharing violation.
+       * A throw here would end a poll rather than let it come round again.
+       */
+      try {
+        return JSON.parse(await readFile(configPath, "utf8"));
+      } catch {
+        return JSON.parse(await readFile(configPath, "utf8"));
+      }
     },
   };
 }

--- a/tests/lib/app.ts
+++ b/tests/lib/app.ts
@@ -14,7 +14,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Config } from "@meru/shared/types";
 import { expect, test, type TestInfo } from "@playwright/test";
-import { _electron, type ElectronApplication, type Page } from "playwright";
+import { _electron, type ElectronApplication, type Locator, type Page } from "playwright";
 
 // Where electron-builder leaves the unpacked app, per platform. macOS and
 // Windows name it after productName, "Meru"; Linux lowercases it. Getting that
@@ -80,7 +80,22 @@ async function findRendererWindow(app: ElectronApplication) {
     .poll(() => app.windows().some((window) => window.url().includes("main.html")))
     .toBe(true);
 
-  return app.windows().find((window) => window.url().includes("main.html")) as Page;
+  const renderer = app.windows().find((window) => window.url().includes("main.html")) as Page;
+
+  /*
+   * Waiting for the window's URL only says the page was told to load. React
+   * mounts long after that, and the listeners it registers as it imports are
+   * what receive `navigate` from the main process — a menu command issued
+   * before them is delivered to nobody and simply does not happen.
+   *
+   * The root having children is that moment. It is markup rather than anything
+   * a user would look for, which is the trade: a gate that asserts nothing and
+   * only has to be true on every platform, against a piece of the interface
+   * that might not be drawn on all three.
+   */
+  await expect(renderer.locator("#root > *").first()).toBeAttached();
+
+  return renderer;
 }
 
 type LaunchedApp = {
@@ -236,8 +251,13 @@ export type MeruApp = {
   readonly app: ElectronApplication;
   readonly renderer: Page;
   readonly userDataDir: string;
-  /** Navigates the renderer to a hash route, such as `/settings/appearance`. */
-  goto(route: string): Promise<void>;
+  /** Runs a menu command the way the menu bar would, and reports whether it was there. */
+  runMenuCommand(label: string): Promise<boolean>;
+  /**
+   * Opens settings through the menu, and hands back its navigation sidebar to
+   * pick a page from.
+   */
+  openSettings(): Promise<Locator>;
   /** The config as it stands on disk, which is where the main process wrote it. */
   readConfig(): Promise<Partial<Config>>;
 };
@@ -354,17 +374,54 @@ export function useApp(seedConfig: Partial<Config> = {}): MeruApp {
     get userDataDir() {
       return current().userDataDir;
     },
-    async goto(route) {
-      const renderer = currentRenderer();
+    runMenuCommand(label) {
+      return current().app.evaluate(({ Menu }, commandLabel) => {
+        const find = (menuItems: Electron.MenuItem[]): Electron.MenuItem | undefined => {
+          for (const menuItem of menuItems) {
+            if (menuItem.label === commandLabel) {
+              return menuItem;
+            }
 
-      // Routing is hash based, so changing the fragment is what navigates. The
-      // rest of the URL carries the accounts the main process handed over at
-      // load, and dropping it would reload the app without them.
-      const url = new URL(renderer.url());
+            const found = menuItem.submenu ? find(menuItem.submenu.items) : undefined;
 
-      url.hash = `#${route}`;
+            if (found) {
+              return found;
+            }
+          }
 
-      await renderer.goto(url.href);
+          return undefined;
+        };
+
+        const menuItem = find(Menu.getApplicationMenu()?.items ?? []);
+
+        /*
+         * Clicked on the next tick rather than here. A command that navigates
+         * rebuilds the application menu as it goes, and the item this call is
+         * standing in — along with the reply it owes the test — goes with the
+         * menu it belonged to, which reaches the runner as a collected promise.
+         * Letting the reply leave first sidesteps that entirely.
+         */
+        if (menuItem) {
+          setImmediate(() => {
+            menuItem.click();
+          });
+        }
+
+        return Boolean(menuItem);
+      }, label);
+    },
+    async openSettings() {
+      // The menu bar is the way in, and the only one the app offers. Setting the
+      // fragment by hand would reach the same page while proving nothing about
+      // whether anyone could get there.
+      expect(await this.runMenuCommand("Settings")).toBe(true);
+
+      const navigation = currentRenderer().getByTestId("settings-nav");
+
+      // Waiting for the sidebar is also what proves the command arrived.
+      await expect(navigation).toBeVisible();
+
+      return navigation;
     },
     async readConfig() {
       const configPath = path.join(current().userDataDir, "config.json");

--- a/tests/menu.e2e.ts
+++ b/tests/menu.e2e.ts
@@ -1,0 +1,165 @@
+/*
+ * The application menu, read out of the main process.
+ *
+ * What the OS draws is still not assertable — a `Menu.popup` menu, the tray, a
+ * file dialog. The menu Electron was handed is, and so is what its items do
+ * when clicked, which is where the bugs live: a shortcut that quietly stopped
+ * being registered, two commands claiming one key, an item enabled when the
+ * account it acts on isn't there.
+ */
+import { expect, test } from "@playwright/test";
+import { useApp } from "./lib/app";
+
+const meru = useApp();
+
+/** Every menu item, flattened, submenus included. */
+function readMenuItems() {
+  return meru.app.evaluate(({ Menu }) => {
+    const items: { label: string; accelerator: string | null; enabled: boolean }[] = [];
+
+    const collect = (menuItems: Electron.MenuItem[]) => {
+      for (const menuItem of menuItems) {
+        items.push({
+          label: menuItem.label,
+          accelerator: menuItem.accelerator ?? null,
+          enabled: menuItem.enabled,
+        });
+
+        if (menuItem.submenu) {
+          collect(menuItem.submenu.items);
+        }
+      }
+    };
+
+    collect(Menu.getApplicationMenu()?.items ?? []);
+
+    return items;
+  });
+}
+
+/** Runs a command the way the menu bar would, and reports whether it was there. */
+function clickMenuItem(label: string) {
+  return meru.app.evaluate(({ Menu }, itemLabel) => {
+    const find = (menuItems: Electron.MenuItem[]): Electron.MenuItem | undefined => {
+      for (const menuItem of menuItems) {
+        if (menuItem.label === itemLabel) {
+          return menuItem;
+        }
+
+        const found = menuItem.submenu ? find(menuItem.submenu.items) : undefined;
+
+        if (found) {
+          return found;
+        }
+      }
+
+      return undefined;
+    };
+
+    const menuItem = find(Menu.getApplicationMenu()?.items ?? []);
+
+    /*
+     * Clicked on the next tick rather than here. A command that navigates
+     * rebuilds the application menu as it goes, and the item this call is
+     * standing in — along with the reply it owes the test — goes with the menu
+     * it belonged to, which reaches the runner as a collected promise. Letting
+     * the reply leave first sidesteps that entirely.
+     */
+    if (menuItem) {
+      setImmediate(() => {
+        menuItem.click();
+      });
+    }
+
+    return Boolean(menuItem);
+  }, label);
+}
+
+test("the menu bar carries every top-level menu, in order", async () => {
+  const topLevelLabels = await meru.app.evaluate(
+    ({ Menu }) => Menu.getApplicationMenu()?.items.map((menuItem) => menuItem.label) ?? [],
+  );
+
+  const expectedLabels = [
+    "Meru",
+    "File",
+    "Edit",
+    "View",
+    "Message",
+    "History",
+    "Tabs",
+    "Accounts",
+    "Help",
+  ];
+
+  // Filtered rather than compared whole, because macOS ships a Window menu that
+  // the other platforms have no convention for.
+  expect(topLevelLabels.filter((label) => expectedLabels.includes(label))).toEqual(expectedLabels);
+});
+
+test("no two commands share an accelerator", async () => {
+  const accelerators = (await readMenuItems())
+    .map(({ accelerator }) => accelerator)
+    .filter((accelerator) => accelerator !== null);
+
+  const duplicates = accelerators.filter(
+    (accelerator, index) => accelerators.indexOf(accelerator) !== index,
+  );
+
+  // Electron takes one of them and drops the other silently, so the command
+  // that loses simply stops having a shortcut.
+  expect(duplicates).toEqual([]);
+});
+
+test("the pinned tab shortcuts stay registered", async () => {
+  const menuItems = await readMenuItems();
+
+  /*
+   * These nine are hidden in a packaged build and reachable only by their keys,
+   * so nothing on screen would show they had gone. Ctrl is literal on every
+   * platform here: Command+Shift+3 through 6 are macOS screenshot shortcuts
+   * that never reach the app.
+   */
+  const pinnedTabAccelerators = menuItems
+    .filter(({ label }) => label.startsWith("Select Pinned Tab"))
+    .map(({ accelerator }) => accelerator);
+
+  expect(pinnedTabAccelerators).toEqual([
+    "Ctrl+Shift+1",
+    "Ctrl+Shift+2",
+    "Ctrl+Shift+3",
+    "Ctrl+Shift+4",
+    "Ctrl+Shift+5",
+    "Ctrl+Shift+6",
+    "Ctrl+Shift+7",
+    "Ctrl+Shift+8",
+    "Ctrl+Shift+9",
+  ]);
+});
+
+test("a menu command drives the window", async () => {
+  /*
+   * Clicked through the main process rather than typed. A menu accelerator is
+   * handled by Electron before the page ever sees the keys, and Playwright's
+   * keyboard writes into the renderer's input pipeline, so pressing the keys
+   * here would prove nothing about the menu. The keys themselves are covered by
+   * asserting the accelerator each item carries.
+   */
+  expect(await clickMenuItem("Downloads")).toBe(true);
+
+  await expect.poll(() => new URL(meru.renderer.url()).hash).toBe("#/download-history");
+
+  expect(await clickMenuItem("Settings")).toBe(true);
+
+  await expect.poll(() => new URL(meru.renderer.url()).hash).toBe("#/settings/general");
+});
+
+test("Unified Inbox is disabled without a second account", async () => {
+  const menuItems = await readMenuItems();
+
+  // The free version is what these tests run as, and it serves one account, so
+  // there is nothing for a unified inbox to unify.
+  expect(menuItems.find(({ label }) => label === "Unified Inbox")?.enabled).toBe(false);
+
+  expect(menuItems.find(({ label }) => label === "Downloads")?.enabled).toBe(true);
+});

--- a/tests/menu.e2e.ts
+++ b/tests/menu.e2e.ts
@@ -37,44 +37,6 @@ function readMenuItems() {
   });
 }
 
-/** Runs a command the way the menu bar would, and reports whether it was there. */
-function clickMenuItem(label: string) {
-  return meru.app.evaluate(({ Menu }, itemLabel) => {
-    const find = (menuItems: Electron.MenuItem[]): Electron.MenuItem | undefined => {
-      for (const menuItem of menuItems) {
-        if (menuItem.label === itemLabel) {
-          return menuItem;
-        }
-
-        const found = menuItem.submenu ? find(menuItem.submenu.items) : undefined;
-
-        if (found) {
-          return found;
-        }
-      }
-
-      return undefined;
-    };
-
-    const menuItem = find(Menu.getApplicationMenu()?.items ?? []);
-
-    /*
-     * Clicked on the next tick rather than here. A command that navigates
-     * rebuilds the application menu as it goes, and the item this call is
-     * standing in — along with the reply it owes the test — goes with the menu
-     * it belonged to, which reaches the runner as a collected promise. Letting
-     * the reply leave first sidesteps that entirely.
-     */
-    if (menuItem) {
-      setImmediate(() => {
-        menuItem.click();
-      });
-    }
-
-    return Boolean(menuItem);
-  }, label);
-}
-
 test("the menu bar carries every top-level menu, in order", async () => {
   const topLevelLabels = await meru.app.evaluate(
     ({ Menu }) => Menu.getApplicationMenu()?.items.map((menuItem) => menuItem.label) ?? [],
@@ -153,11 +115,11 @@ test("a menu command drives the window", async () => {
    * here would prove nothing about the menu. The keys themselves are covered by
    * asserting the accelerator each item carries.
    */
-  expect(await clickMenuItem("Downloads")).toBe(true);
+  expect(await meru.runMenuCommand("Downloads")).toBe(true);
 
   await expect.poll(() => new URL(meru.renderer.url()).hash).toBe("#/download-history");
 
-  expect(await clickMenuItem("Settings")).toBe(true);
+  expect(await meru.runMenuCommand("Settings")).toBe(true);
 
   await expect.poll(() => new URL(meru.renderer.url()).hash).toBe("#/settings/general");
 });

--- a/tests/menu.e2e.ts
+++ b/tests/menu.e2e.ts
@@ -154,12 +154,18 @@ test("a menu command drives the window", async () => {
   await expect.poll(() => new URL(meru.renderer.url()).hash).toBe("#/settings/general");
 });
 
-test("Unified Inbox is disabled without a second account", async () => {
+test("a command with nothing to act on is disabled", async () => {
   const menuItems = await readMenuItems();
 
-  // The free version is what these tests run as, and it serves one account, so
-  // there is nothing for a unified inbox to unify.
+  /*
+   * Unified Inbox wants a valid license, the setting turned on and more than
+   * one account, and the free version these tests run as has none of the three.
+   * So this says an item can come up disabled and does — not which of the three
+   * disabled it, which would need an app that satisfies the other two.
+   */
   expect(menuItems.find(({ label }) => label === "Unified Inbox")?.enabled).toBe(false);
 
+  // The other half of the claim: something unconditional stays enabled, so a
+  // menu that came up dead all over would not read as this passing.
   expect(menuItems.find(({ label }) => label === "Downloads")?.enabled).toBe(true);
 });

--- a/tests/menu.e2e.ts
+++ b/tests/menu.e2e.ts
@@ -80,6 +80,13 @@ test("the menu bar carries every top-level menu, in order", async () => {
     ({ Menu }) => Menu.getApplicationMenu()?.items.map((menuItem) => menuItem.label) ?? [],
   );
 
+  /*
+   * Written out and compared whole, not derived from the app and not filtered
+   * down to what is expected. Deriving the list would leave nothing asserted —
+   * the menus would be whatever the app says they are — and filtering lets a
+   * menu bar grow a heading nobody reviewed. A menu bar is short and changes
+   * deliberately, so adding to it should fail here until someone says so.
+   */
   const expectedLabels = [
     "Meru",
     "File",
@@ -89,12 +96,13 @@ test("the menu bar carries every top-level menu, in order", async () => {
     "History",
     "Tabs",
     "Accounts",
+    // Zoom and Bring All to Front are macOS-only roles, and a Window menu is a
+    // macOS convention, so the whole menu ships there alone — ahead of Help.
+    ...(process.platform === "darwin" ? ["Window"] : []),
     "Help",
   ];
 
-  // Filtered rather than compared whole, because macOS ships a Window menu that
-  // the other platforms have no convention for.
-  expect(topLevelLabels.filter((label) => expectedLabels.includes(label))).toEqual(expectedLabels);
+  expect(topLevelLabels).toEqual(expectedLabels);
 });
 
 test("no two commands share an accelerator", async () => {

--- a/tests/settings.e2e.ts
+++ b/tests/settings.e2e.ts
@@ -125,8 +125,16 @@ test("a select behind a confirmation writes only once confirmed", async () => {
 });
 
 test("every field label points at its control", async () => {
-  for (const [route] of SETTINGS_ROUTES) {
+  const labelledIds: string[] = [];
+
+  for (const [route, title] of SETTINGS_ROUTES) {
     await meru.goto(route);
+
+    // Waited on before reading the DOM. Every route is statically imported and
+    // renders in the same task as the hash change today, so a scan would find
+    // it anyway — but one lazily loaded route would have this reading the route
+    // before it and reporting nothing at all.
+    await expect(meru.renderer.getByTestId("settings-title"), route).toContainText(title);
 
     /*
      * A label naming an id nothing carries is a field whose text does not click
@@ -134,23 +142,35 @@ test("every field label points at its control", async () => {
      * It is also what the rest of these tests stand on, since they address a
      * control through the label that points at it.
      */
-    const danglingLabels = await meru.renderer
-      .locator("label[for]")
-      .evaluateAll((labels) =>
-        labels
-          .filter((label) => !label.ownerDocument.getElementById(label.getAttribute("for") ?? ""))
-          .map((label) => (label.textContent ?? "").trim()),
-      );
+    const labels = await meru.renderer.locator("label[for]").evaluateAll((labelElements) =>
+      labelElements.map((label) => ({
+        labelledId: label.getAttribute("for") ?? "",
+        resolves: Boolean(label.ownerDocument.getElementById(label.getAttribute("for") ?? "")),
+      })),
+    );
 
-    expect(danglingLabels, route).toEqual([]);
+    expect(
+      labels.filter(({ resolves }) => !resolves).map(({ labelledId }) => labelledId),
+      route,
+    ).toEqual([]);
+
+    labelledIds.push(...labels.map(({ labelledId }) => labelledId));
   }
+
+  // Guards the walk itself, the same way the gating walk does: labels that
+  // stopped naming their control would leave nothing to check and read clean.
+  expect(labelledIds).toContain("downloads.saveAs");
+  expect(labelledIds).toContain("notifications.enabled");
 });
 
 test("every Pro-gated control is locked on the free version", async () => {
   const lockedKeys: string[] = [];
 
-  for (const [route] of SETTINGS_ROUTES) {
+  for (const [route, title] of SETTINGS_ROUTES) {
     await meru.goto(route);
+
+    // As above: read the route this loop is on, not the one before it.
+    await expect(meru.renderer.getByTestId("settings-title"), route).toContainText(title);
 
     /*
      * The badge in a field's label is the claim that the field needs Meru Pro,

--- a/tests/settings.e2e.ts
+++ b/tests/settings.e2e.ts
@@ -1,0 +1,192 @@
+/*
+ * Settings is the densest surface the tests can reach: nearly every route is
+ * `ConfigSwitchField` and `ConfigSelectField` over a config key, and none of it
+ * needs a Gmail account.
+ *
+ * Controls are addressed by their config key rather than by a test id. Both
+ * field components pass the key as the control's `id` and label it with
+ * `<key>-label`, so the key is already a stable handle and adding test ids
+ * would only give the two somewhere to drift apart.
+ */
+import { expect, test } from "@playwright/test";
+import { useApp } from "./lib/app";
+
+const meru = useApp();
+
+/**
+ * Every settings route, with the text its title renders. The list is written
+ * out rather than read from `sidebarNavItems`, because importing the renderer's
+ * own source would pull React through a runner that executes under Node.
+ *
+ * Languages is hidden from the sidebar on macOS but stays routable, so it is
+ * checked on every platform.
+ */
+const SETTINGS_ROUTES = [
+  ["/settings/general", "General"],
+  ["/settings/accounts", "Accounts"],
+  ["/settings/appearance", "Appearance"],
+  ["/settings/blocker", "Blocker"],
+  ["/settings/downloads", "Downloads"],
+  ["/settings/gmail", "Gmail"],
+  ["/settings/workspace-apps", "Workspace apps"],
+  ["/settings/extensions", "Extensions"],
+  ["/settings/languages", "Languages"],
+  ["/settings/notifications", "Notifications"],
+  ["/settings/phishing-protection", "Phishing protection"],
+  ["/settings/saved-searches", "Saved searches"],
+  ["/settings/unified-inbox", "Unified inbox"],
+  ["/settings/updates", "Updates"],
+  ["/settings/verification-codes", "Verification codes"],
+  ["/settings/advanced", "Advanced"],
+  ["/settings/license", "License"],
+  ["/settings/version-history", "What's new"],
+  ["/settings/about", "About Meru"],
+] as const;
+
+/** The switch a config key is rendered by, found through the label it points at. */
+function configSwitch(configKey: string) {
+  return meru.renderer.locator(`[aria-labelledby="${configKey}-label"]`);
+}
+
+test("every settings route renders", async () => {
+  const rendererErrors: Error[] = [];
+
+  meru.renderer.on("pageerror", (error) => {
+    rendererErrors.push(error);
+  });
+
+  for (const [route, title] of SETTINGS_ROUTES) {
+    await meru.goto(route);
+
+    // Not toHaveText: Extensions carries a beta badge inside its title.
+    await expect(meru.renderer.getByTestId("settings-title"), route).toContainText(title);
+  }
+
+  /*
+   * Both field components throw when a key's value isn't the type they render —
+   * a switch over a string, a select over a boolean. That throw takes the whole
+   * route down at render time, which nothing but a run of the built app catches.
+   */
+  expect(rendererErrors.map((error) => error.stack ?? error.message)).toEqual([]);
+});
+
+test("a switch writes its key back to the config", async () => {
+  await meru.goto("/settings/downloads");
+
+  const saveAs = configSwitch("downloads.saveAs");
+
+  await expect(saveAs).toBeVisible();
+
+  expect((await meru.readConfig())["downloads.saveAs"]).toBe(false);
+
+  await saveAs.click();
+
+  // Polled against the file the main process writes, not the switch: what is
+  // being proved is the round trip through IPC to disk, and the switch would
+  // read as on either way.
+  await expect.poll(async () => (await meru.readConfig())["downloads.saveAs"]).toBe(true);
+
+  await saveAs.click();
+
+  await expect.poll(async () => (await meru.readConfig())["downloads.saveAs"]).toBe(false);
+});
+
+test("a select behind a confirmation writes only once confirmed", async () => {
+  await meru.goto("/settings/updates");
+
+  const releaseChannel = meru.renderer.locator('[id="updates.channel"]');
+
+  await releaseChannel.click();
+
+  await meru.renderer.getByRole("option", { name: "Experimental" }).click();
+
+  const confirmation = meru.renderer.getByRole("dialog");
+
+  await expect(confirmation).toContainText("Switch to the experimental channel?");
+
+  await confirmation.getByRole("button", { name: "Cancel" }).click();
+
+  // The field goes on rendering the value from the config while the dialog is
+  // open, so cancelling is meant to leave nothing to revert. Contained rather
+  // than equal, because the trigger renders its own chevron alongside the value.
+  await expect(releaseChannel).toContainText("Stable");
+
+  expect((await meru.readConfig())["updates.channel"]).toBe("stable");
+
+  await releaseChannel.click();
+
+  await meru.renderer.getByRole("option", { name: "Experimental" }).click();
+
+  // Changing the channel sends the updater off to check the new feed. That call
+  // is fire and forget, and the app already makes one like it on every launch.
+  await confirmation.getByRole("button", { name: "Switch to experimental" }).click();
+
+  await expect.poll(async () => (await meru.readConfig())["updates.channel"]).toBe("alpha");
+});
+
+test("every field label points at its control", async () => {
+  for (const [route] of SETTINGS_ROUTES) {
+    await meru.goto(route);
+
+    /*
+     * A label naming an id nothing carries is a field whose text does not click
+     * through to its control and which assistive technology reads as unlabelled.
+     * It is also what the rest of these tests stand on, since they address a
+     * control through the label that points at it.
+     */
+    const danglingLabels = await meru.renderer
+      .locator("label[for]")
+      .evaluateAll((labels) =>
+        labels
+          .filter((label) => !label.ownerDocument.getElementById(label.getAttribute("for") ?? ""))
+          .map((label) => (label.textContent ?? "").trim()),
+      );
+
+    expect(danglingLabels, route).toEqual([]);
+  }
+});
+
+test("every Pro-gated control is locked on the free version", async () => {
+  const lockedKeys: string[] = [];
+
+  for (const [route] of SETTINGS_ROUTES) {
+    await meru.goto(route);
+
+    /*
+     * The badge in a field's label is the claim that the field needs Meru Pro,
+     * and the control being disabled is what makes the claim true. A field
+     * shipped with one and not the other is the regression this catches, so the
+     * two are read off the page together rather than from a list kept here.
+     *
+     * Both field components label their control by pointing at it, and so do
+     * the hand-rolled fields, so `for` resolves to whatever actually holds the
+     * disabled state — the hidden checkbox behind a switch, a select's trigger.
+     */
+    const gatedControls = await meru.renderer.locator("label[for]").evaluateAll((labels) =>
+      labels
+        .filter((label) => (label.textContent ?? "").includes("Meru Pro required"))
+        .map((label) => {
+          const labelledId = label.getAttribute("for") ?? "";
+
+          return {
+            labelledId,
+            isDisabled: Boolean(
+              label.ownerDocument.getElementById(labelledId)?.matches(":disabled"),
+            ),
+          };
+        }),
+    );
+
+    for (const { labelledId, isDisabled } of gatedControls) {
+      expect(isDisabled, `${route} — ${labelledId}`).toBe(true);
+
+      lockedKeys.push(labelledId);
+    }
+  }
+
+  // Guards the walk itself: a selector that stopped matching would otherwise
+  // report every route clean.
+  expect(lockedKeys).toContain("workspaceApps.openInApp");
+  expect(lockedKeys).toContain("gmail.extendDarkTheme");
+  expect(lockedKeys).toContain("unifiedInbox.enabled");
+});

--- a/tests/settings.e2e.ts
+++ b/tests/settings.e2e.ts
@@ -14,52 +14,89 @@ import { useApp } from "./lib/app";
 const meru = useApp();
 
 /**
- * Every settings route, with the text its title renders. The list is written
- * out rather than read from `sidebarNavItems`, because importing the renderer's
- * own source would pull React through a runner that executes under Node.
+ * Settings pages the app has but does not list, with the text their title
+ * renders. Languages is hidden from the sidebar on macOS and stays routable, so
+ * walking what is listed would stop covering it there.
  *
- * Languages is hidden from the sidebar on macOS but stays routable, so it is
- * checked on every platform.
+ * Anything reachable from the sidebar belongs in the sidebar, not here.
  */
-const SETTINGS_ROUTES = [
-  ["/settings/general", "General"],
-  ["/settings/accounts", "Accounts"],
-  ["/settings/appearance", "Appearance"],
-  ["/settings/blocker", "Blocker"],
-  ["/settings/downloads", "Downloads"],
-  ["/settings/gmail", "Gmail"],
-  ["/settings/workspace-apps", "Workspace apps"],
-  ["/settings/extensions", "Extensions"],
-  ["/settings/languages", "Languages"],
-  ["/settings/notifications", "Notifications"],
-  ["/settings/phishing-protection", "Phishing protection"],
-  ["/settings/saved-searches", "Saved searches"],
-  ["/settings/unified-inbox", "Unified inbox"],
-  ["/settings/updates", "Updates"],
-  ["/settings/verification-codes", "Verification codes"],
-  ["/settings/advanced", "Advanced"],
-  ["/settings/license", "License"],
-  ["/settings/version-history", "What's new"],
-  ["/settings/about", "About Meru"],
-] as const;
+const UNLISTED_PAGES = [["/settings/languages", "Languages"]] as const;
 
 /** The switch a config key is rendered by, found through the label it points at. */
 function configSwitch(configKey: string) {
   return meru.renderer.locator(`[aria-labelledby="${configKey}-label"]`);
 }
 
-test("every settings route renders", async () => {
+type SettingsPage = { label: string; open: () => Promise<void> };
+
+/**
+ * Every settings page, taken from the sidebar the app renders rather than from
+ * a list kept here.
+ *
+ * A list kept here is a copy of `sidebarNavItems` that nothing keeps in step: a
+ * page added to the app is simply never walked, and every test below reports
+ * clean without having looked at it. Reading the sidebar costs the walk its
+ * page-by-page route assertions, and buys coverage that arrives on its own —
+ * which for a surface that grows is the better trade. What each page has to
+ * satisfy is still written out below; only which pages exist comes from the app.
+ */
+async function readSettingsPages(): Promise<SettingsPage[]> {
+  // The sidebar only renders on a settings route, so there has to be one open
+  // before there is anything to read.
+  await meru.goto("/settings/general");
+
+  const navigation = meru.renderer.getByTestId("settings-nav");
+
+  await expect(navigation).toBeVisible();
+
+  const labels = await navigation.getByRole("button").allInnerTexts();
+
+  const pages: SettingsPage[] = labels.map((label) => ({
+    label,
+    open: async () => {
+      await navigation.getByRole("button", { name: label, exact: true }).click();
+    },
+  }));
+
+  for (const [route, label] of UNLISTED_PAGES) {
+    if (!labels.includes(label)) {
+      pages.push({ label, open: () => meru.goto(route) });
+    }
+  }
+
+  /*
+   * Guards the reading itself. A selector that stopped matching would hand
+   * every walk an empty list, and each of them would pass having checked
+   * nothing at all.
+   */
+  expect(pages.map(({ label }) => label)).toEqual(
+    expect.arrayContaining(["General", "Appearance", "Notifications", "License", "About Meru"]),
+  );
+
+  return pages;
+}
+
+/**
+ * Opens a page and waits for it, which is what makes the walks safe to read the
+ * DOM afterwards. The title is asserted against the sidebar's own label for the
+ * page, so an item wired to the wrong route still fails.
+ */
+async function openSettingsPage({ label, open }: SettingsPage) {
+  await open();
+
+  // Contained, not equal: Extensions carries a beta badge inside its title.
+  await expect(meru.renderer.getByTestId("settings-title"), label).toContainText(label);
+}
+
+test("every settings page renders", async () => {
   const rendererErrors: Error[] = [];
 
   meru.renderer.on("pageerror", (error) => {
     rendererErrors.push(error);
   });
 
-  for (const [route, title] of SETTINGS_ROUTES) {
-    await meru.goto(route);
-
-    // Not toHaveText: Extensions carries a beta badge inside its title.
-    await expect(meru.renderer.getByTestId("settings-title"), route).toContainText(title);
+  for (const page of await readSettingsPages()) {
+    await openSettingsPage(page);
   }
 
   /*
@@ -127,14 +164,12 @@ test("a select behind a confirmation writes only once confirmed", async () => {
 test("every field label points at its control", async () => {
   const labelledIds: string[] = [];
 
-  for (const [route, title] of SETTINGS_ROUTES) {
-    await meru.goto(route);
-
-    // Waited on before reading the DOM. Every route is statically imported and
-    // renders in the same task as the hash change today, so a scan would find
-    // it anyway — but one lazily loaded route would have this reading the route
-    // before it and reporting nothing at all.
-    await expect(meru.renderer.getByTestId("settings-title"), route).toContainText(title);
+  for (const page of await readSettingsPages()) {
+    // Opened and waited for before the DOM is read. Every page is statically
+    // imported and renders in the same task as the navigation today, so a scan
+    // would find it anyway — but one lazily loaded page would have this reading
+    // the page before it and reporting nothing at all.
+    await openSettingsPage(page);
 
     /*
      * A label naming an id nothing carries is a field whose text does not click
@@ -151,7 +186,7 @@ test("every field label points at its control", async () => {
 
     expect(
       labels.filter(({ resolves }) => !resolves).map(({ labelledId }) => labelledId),
-      route,
+      page.label,
     ).toEqual([]);
 
     labelledIds.push(...labels.map(({ labelledId }) => labelledId));
@@ -166,11 +201,9 @@ test("every field label points at its control", async () => {
 test("every Pro-gated control is locked on the free version", async () => {
   const lockedKeys: string[] = [];
 
-  for (const [route, title] of SETTINGS_ROUTES) {
-    await meru.goto(route);
-
-    // As above: read the route this loop is on, not the one before it.
-    await expect(meru.renderer.getByTestId("settings-title"), route).toContainText(title);
+  for (const page of await readSettingsPages()) {
+    // As above: read the page this loop is on, not the one before it.
+    await openSettingsPage(page);
 
     /*
      * The badge in a field's label is the claim that the field needs Meru Pro,
@@ -198,7 +231,7 @@ test("every Pro-gated control is locked on the free version", async () => {
     );
 
     for (const { labelledId, isDisabled } of gatedControls) {
-      expect(isDisabled, `${route} — ${labelledId}`).toBe(true);
+      expect(isDisabled, `${page.label} — ${labelledId}`).toBe(true);
 
       lockedKeys.push(labelledId);
     }

--- a/tests/settings.e2e.ts
+++ b/tests/settings.e2e.ts
@@ -8,26 +8,15 @@
  * `<key>-label`, so the key is already a stable handle and adding test ids
  * would only give the two somewhere to drift apart.
  */
-import { expect, test } from "@playwright/test";
+import { expect, type Locator, test } from "@playwright/test";
 import { useApp } from "./lib/app";
 
 const meru = useApp();
-
-/**
- * Settings pages the app has but does not list, with the text their title
- * renders. Languages is hidden from the sidebar on macOS and stays routable, so
- * walking what is listed would stop covering it there.
- *
- * Anything reachable from the sidebar belongs in the sidebar, not here.
- */
-const UNLISTED_PAGES = [["/settings/languages", "Languages"]] as const;
 
 /** The switch a config key is rendered by, found through the label it points at. */
 function configSwitch(configKey: string) {
   return meru.renderer.locator(`[aria-labelledby="${configKey}-label"]`);
 }
-
-type SettingsPage = { label: string; open: () => Promise<void> };
 
 /**
  * Every settings page, taken from the sidebar the app renders rather than from
@@ -35,54 +24,35 @@ type SettingsPage = { label: string; open: () => Promise<void> };
  *
  * A list kept here is a copy of `sidebarNavItems` that nothing keeps in step: a
  * page added to the app is simply never walked, and every test below reports
- * clean without having looked at it. Reading the sidebar costs the walk its
- * page-by-page route assertions, and buys coverage that arrives on its own —
- * which for a surface that grows is the better trade. What each page has to
- * satisfy is still written out below; only which pages exist comes from the app.
+ * clean without having looked at it. What each page has to satisfy is still
+ * written out below; only which pages exist comes from the app.
+ *
+ * Walking what the sidebar lists also means walking what anyone can reach.
+ * Languages is hidden from the sidebar on macOS, so it goes uncovered there —
+ * which is right, because there is no way to open it there either.
  */
-async function readSettingsPages(): Promise<SettingsPage[]> {
-  // The sidebar only renders on a settings route, so there has to be one open
-  // before there is anything to read.
-  await meru.goto("/settings/general");
-
-  const navigation = meru.renderer.getByTestId("settings-nav");
-
-  await expect(navigation).toBeVisible();
-
+async function readSettingsPageLabels(navigation: Locator) {
   const labels = await navigation.getByRole("button").allInnerTexts();
-
-  const pages: SettingsPage[] = labels.map((label) => ({
-    label,
-    open: async () => {
-      await navigation.getByRole("button", { name: label, exact: true }).click();
-    },
-  }));
-
-  for (const [route, label] of UNLISTED_PAGES) {
-    if (!labels.includes(label)) {
-      pages.push({ label, open: () => meru.goto(route) });
-    }
-  }
 
   /*
    * Guards the reading itself. A selector that stopped matching would hand
    * every walk an empty list, and each of them would pass having checked
    * nothing at all.
    */
-  expect(pages.map(({ label }) => label)).toEqual(
+  expect(labels).toEqual(
     expect.arrayContaining(["General", "Appearance", "Notifications", "License", "About Meru"]),
   );
 
-  return pages;
+  return labels;
 }
 
 /**
- * Opens a page and waits for it, which is what makes the walks safe to read the
- * DOM afterwards. The title is asserted against the sidebar's own label for the
- * page, so an item wired to the wrong route still fails.
+ * Opens a page from the sidebar and waits for it, which is what makes the walks
+ * safe to read the DOM afterwards. The title is asserted against the label that
+ * was clicked, so an item wired to the wrong page still fails.
  */
-async function openSettingsPage({ label, open }: SettingsPage) {
-  await open();
+async function openSettingsPage(navigation: Locator, label: string) {
+  await navigation.getByRole("button", { name: label, exact: true }).click();
 
   // Contained, not equal: Extensions carries a beta badge inside its title.
   await expect(meru.renderer.getByTestId("settings-title"), label).toContainText(label);
@@ -95,8 +65,10 @@ test("every settings page renders", async () => {
     rendererErrors.push(error);
   });
 
-  for (const page of await readSettingsPages()) {
-    await openSettingsPage(page);
+  const navigation = await meru.openSettings();
+
+  for (const label of await readSettingsPageLabels(navigation)) {
+    await openSettingsPage(navigation, label);
   }
 
   /*
@@ -108,7 +80,7 @@ test("every settings page renders", async () => {
 });
 
 test("a switch writes its key back to the config", async () => {
-  await meru.goto("/settings/downloads");
+  await openSettingsPage(await meru.openSettings(), "Downloads");
 
   const saveAs = configSwitch("downloads.saveAs");
 
@@ -129,7 +101,7 @@ test("a switch writes its key back to the config", async () => {
 });
 
 test("a select behind a confirmation writes only once confirmed", async () => {
-  await meru.goto("/settings/updates");
+  await openSettingsPage(await meru.openSettings(), "Updates");
 
   const releaseChannel = meru.renderer.locator('[id="updates.channel"]');
 
@@ -164,12 +136,14 @@ test("a select behind a confirmation writes only once confirmed", async () => {
 test("every field label points at its control", async () => {
   const labelledIds: string[] = [];
 
-  for (const page of await readSettingsPages()) {
+  const navigation = await meru.openSettings();
+
+  for (const label of await readSettingsPageLabels(navigation)) {
     // Opened and waited for before the DOM is read. Every page is statically
     // imported and renders in the same task as the navigation today, so a scan
     // would find it anyway — but one lazily loaded page would have this reading
     // the page before it and reporting nothing at all.
-    await openSettingsPage(page);
+    await openSettingsPage(navigation, label);
 
     /*
      * A label naming an id nothing carries is a field whose text does not click
@@ -177,10 +151,12 @@ test("every field label points at its control", async () => {
      * It is also what the rest of these tests stand on, since they address a
      * control through the label that points at it.
      */
-    const labels = await meru.renderer.locator("label[for]").evaluateAll((labelElements) =>
-      labelElements.map((label) => ({
-        labelledId: label.getAttribute("for") ?? "",
-        resolves: Boolean(label.ownerDocument.getElementById(label.getAttribute("for") ?? "")),
+    const fieldLabels = await meru.renderer.locator("label[for]").evaluateAll((labelElements) =>
+      labelElements.map((labelElement) => ({
+        labelledId: labelElement.getAttribute("for") ?? "",
+        resolves: Boolean(
+          labelElement.ownerDocument.getElementById(labelElement.getAttribute("for") ?? ""),
+        ),
       })),
     );
 
@@ -189,12 +165,12 @@ test("every field label points at its control", async () => {
     // would report the page before it, over and over.
     expect
       .soft(
-        labels.filter(({ resolves }) => !resolves).map(({ labelledId }) => labelledId),
-        page.label,
+        fieldLabels.filter(({ resolves }) => !resolves).map(({ labelledId }) => labelledId),
+        label,
       )
       .toEqual([]);
 
-    labelledIds.push(...labels.map(({ labelledId }) => labelledId));
+    labelledIds.push(...fieldLabels.map(({ labelledId }) => labelledId));
   }
 
   // Guards the walk itself, the same way the gating walk does: labels that
@@ -206,9 +182,11 @@ test("every field label points at its control", async () => {
 test("every Pro-gated control is locked on the free version", async () => {
   const gatedGroups: string[] = [];
 
-  for (const page of await readSettingsPages()) {
+  const navigation = await meru.openSettings();
+
+  for (const label of await readSettingsPageLabels(navigation)) {
     // As above: read the page this loop is on, not the one before it.
-    await openSettingsPage(page);
+    await openSettingsPage(navigation, label);
 
     /*
      * The badge is the claim that a field needs Meru Pro, and its controls being
@@ -257,7 +235,7 @@ test("every Pro-gated control is locked on the free version", async () => {
     for (const { field, usable } of gatedControls) {
       // Soft, so every gated field on the page reports rather than only the
       // first one to fail.
-      expect.soft(usable, `${page.label} — ${field}`).toEqual([]);
+      expect.soft(usable, `${label} — ${field}`).toEqual([]);
 
       gatedGroups.push(field);
     }

--- a/tests/settings.e2e.ts
+++ b/tests/settings.e2e.ts
@@ -184,10 +184,15 @@ test("every field label points at its control", async () => {
       })),
     );
 
-    expect(
-      labels.filter(({ resolves }) => !resolves).map(({ labelledId }) => labelledId),
-      page.label,
-    ).toEqual([]);
+    // Soft, so one bad page reports and the walk carries on to the rest. The
+    // navigation above stays hard: reading on past a page that never opened
+    // would report the page before it, over and over.
+    expect
+      .soft(
+        labels.filter(({ resolves }) => !resolves).map(({ labelledId }) => labelledId),
+        page.label,
+      )
+      .toEqual([]);
 
     labelledIds.push(...labels.map(({ labelledId }) => labelledId));
   }
@@ -199,47 +204,69 @@ test("every field label points at its control", async () => {
 });
 
 test("every Pro-gated control is locked on the free version", async () => {
-  const lockedKeys: string[] = [];
+  const gatedGroups: string[] = [];
 
   for (const page of await readSettingsPages()) {
     // As above: read the page this loop is on, not the one before it.
     await openSettingsPage(page);
 
     /*
-     * The badge in a field's label is the claim that the field needs Meru Pro,
-     * and the control being disabled is what makes the claim true. A field
-     * shipped with one and not the other is the regression this catches, so the
-     * two are read off the page together rather than from a list kept here.
+     * The badge is the claim that a field needs Meru Pro, and its controls being
+     * disabled is what makes the claim true. A field shipped with one and not
+     * the other is the regression this catches, so the two are read off the page
+     * together rather than from a list kept here.
      *
-     * Both field components label their control by pointing at it, and so do
-     * the hand-rolled fields, so `for` resolves to whatever actually holds the
-     * disabled state — the hidden checkbox behind a switch, a select's trigger.
+     * Found by the badge rather than by the label, because a badge sits in a
+     * `FieldLabel`, a `FieldLegend`, a `FieldTitle` or an `ItemTitle` depending
+     * on the field, and only the first of those is a `label`. Looking for labels
+     * alone saw a third of them — mostly the ones rendered by the two wrapper
+     * components, where badge and lock come from one expression and cannot
+     * disagree. The hand-rolled fields it missed are the ones worth checking.
      */
-    const gatedControls = await meru.renderer.locator("label[for]").evaluateAll((labels) =>
-      labels
-        .filter((label) => (label.textContent ?? "").includes("Meru Pro required"))
-        .map((label) => {
-          const labelledId = label.getAttribute("for") ?? "";
+    const gatedControls = await meru.renderer
+      .getByText("Meru Pro required", { exact: true })
+      .evaluateAll((badges) =>
+        badges.map((badge) => {
+          const group = badge.closest(
+            '[data-slot="field"], [data-slot="field-set"], [data-slot="item"]',
+          );
+
+          /*
+           * Only what can carry a disabled state. A span never matches
+           * `:disabled`, so asserting on one would always read as unlocked.
+           *
+           * Typed off the badge rather than as an `Element`, because the runner
+           * compiles without the DOM library and `querySelectorAll` comes back
+           * as `unknown` there.
+           */
+          const controls = group
+            ? (Array.from(
+                group.querySelectorAll("input, button, select, textarea"),
+              ) as (typeof badge)[])
+            : [];
 
           return {
-            labelledId,
-            isDisabled: Boolean(
-              label.ownerDocument.getElementById(labelledId)?.matches(":disabled"),
-            ),
+            field: (group?.textContent ?? "").trim().slice(0, 60),
+            usable: controls
+              .filter((control) => !control.matches(":disabled"))
+              .map((control) => (control.textContent ?? "").trim()),
           };
         }),
-    );
+      );
 
-    for (const { labelledId, isDisabled } of gatedControls) {
-      expect(isDisabled, `${page.label} — ${labelledId}`).toBe(true);
+    for (const { field, usable } of gatedControls) {
+      // Soft, so every gated field on the page reports rather than only the
+      // first one to fail.
+      expect.soft(usable, `${page.label} — ${field}`).toEqual([]);
 
-      lockedKeys.push(labelledId);
+      gatedGroups.push(field);
     }
   }
 
-  // Guards the walk itself: a selector that stopped matching would otherwise
-  // report every route clean.
-  expect(lockedKeys).toContain("workspaceApps.openInApp");
-  expect(lockedKeys).toContain("gmail.extendDarkTheme");
-  expect(lockedKeys).toContain("unifiedInbox.enabled");
+  /*
+   * Guards the walk itself: a badge that stopped matching would leave every page
+   * with nothing to check and report clean. The count is asserted loosely, since
+   * the point is that gated fields were found at all, not how many there are.
+   */
+  expect(gatedGroups.length).toBeGreaterThan(30);
 });


### PR DESCRIPTION
## Summary
Adds eleven end-to-end tests over two new files, covering every settings route and the application menu, and moves the launch fixture into a shared harness so a file's tests share one app. Also fixes a dangling field label the coverage found. The whole suite runs in about ten seconds against an already-built app, so the `e2e` job's cost stays the build rather than the tests.

## Problem
`tests/launch.e2e.ts` was the only end-to-end test, and its fixture lived inside it, so a second file meant copying it. The reachable surface was also assumed to be much smaller than it is: the older decision entries were written before the tests had main-process access, and they rule out things that now work.

Measured against the built app rather than assumed, `app.evaluate` reaches the whole application menu — labels, accelerators, enabled state, nested submenus — and `MenuItem.click()` runs a command the way the menu bar would. Settings is reachable without a Gmail account, and every control there already carries a stable handle derived from its config key. None of that was covered by anything.

## Solution
- `tests/lib/app.ts` holds the fixture. `useApp()` launches the app once for the file that calls it, and gives that file's tests `goto()` and `readConfig()`. Every comment that came with the fixture moved with it; how the app is launched is unchanged.
- `tests/settings.e2e.ts` walks all nineteen routes for rendering, for labels that resolve, and for Pro-gated controls being locked, and round-trips a switch and a confirmation-backed select through to the config file.
- `tests/menu.e2e.ts` asserts the top-level menus and their order, that no two commands share an accelerator, that the nine hidden pinned-tab shortcuts are still registered, that a command drives the window, and that Unified Inbox is disabled on a single account.

One launch per file, not per test — a launch takes about a second, so this is about a file's tests reading as steps through one surface rather than about cost. It also makes the trace a per-file artifact, which is the right unit when one launch produced every test in it. Anything needing an app of its own, such as a different seeded config, gets a file of its own.

Controls are addressed by config key rather than by test ids. Both field components already pass the key as the control's `id` and label it `<key>-label`, so the key is a handle the app has to keep working anyway; test ids would only give the two somewhere to drift apart.

The gating test reads the "Meru Pro required" badge and the disabled state off the page together, instead of checking a list kept in the test. The regression worth catching is a Pro field shipped without its gate, and a list here would be updated by the same change that introduced one.

Menu commands are run through `MenuItem.click()` rather than by typing their keys. Electron handles an accelerator before the page sees anything, and Playwright's keyboard writes into the renderer's input pipeline, so pressing the keys proves nothing about the menu — verified, not assumed. The keys are covered instead by asserting the accelerator each item carries, which is the only way the pinned-tab shortcuts get covered at all: they are hidden in a packaged build and reachable only by their keys.

The menu click is deferred to the next tick, because a command that navigates rebuilds the menu as it goes and takes the clicked item with it, and the reply owed to the runner never arrives.

Sign-in stays out of scope, so the tests run as the free version. That is what makes the gating test possible and what bounds everything else.

## Try it
```sh
bun run test:e2e
```
On a machine without a display, `xvfb-run -a bun run test:e2e`. The build is the slow part; `MERU_EXECUTABLE=dist/linux-unpacked/meru bunx playwright test` reruns against an existing build in about ten seconds.

`bun run test:e2e --ui` opens the runner, and a failing run leaves a trace per file under `test-results/`.

## Not verified
Nothing. The two assertions that had only run on Linux — accelerator uniqueness, and the top-level menus in order once macOS's Window menu is filtered out — have now passed on all three platforms in CI, as has the `/settings/languages` route rendering on macOS.
