### PR TITLE
Skip the device info query without a license key

### DIFF
--- a/packages/renderer/routes/settings/license.tsx
+++ b/packages/renderer/routes/settings/license.tsx
@@ -154,6 +154,7 @@ export function LicenseSettings() {
   const { data: deviceInfo, refetch: refetchDeviceInfo } = useQuery({
     queryKey: deviceInfoQueryKey,
     queryFn: () => ipc.main.invoke("license.getDeviceInfo"),
+    enabled: Boolean(config?.licenseKey),
   });
 
   const deviceInfoForm = useTanStackForm({


### PR DESCRIPTION
## Summary
Settings → License ran `license.getDeviceInfo` on mount whether or not a license key was configured, so every free-version user printed an unhandled-rejection stack to the main process log just by opening the page. The query is now gated on the key the component already reads. One line of production change; nothing user-facing moves.

## Problem
`packages/renderer/routes/settings/license.tsx` ran the device-info query unconditionally on mount. `getDeviceInfo()` in `packages/app/license-key.ts` treats a missing key as an error, and `packages/app/ipc.ts` wires the method straight through, so with no key the handler rejected and Electron logged the whole stack:

```
Error occurred in handler for 'license.getDeviceInfo': Error: No license key available
```

Nothing broke for the user — the rejection was caught by the IPC layer and surfaced as a failed query for a form that only renders inside the `config.licenseKey` branch anyway. The cost was the log: every free-version user produced that stack on every visit, burying anything real. It turned up in CI's stderr via the settings walk in #963, which is unrelated and unchanged by this.

## Solution
- Adds `enabled: Boolean(config?.licenseKey)` to the `useQuery` in `license.tsx`. `useConfig()` was already in the component, so the gate reads the key that the surrounding JSX branches on a few lines later.

The alternative was softening `getDeviceInfo` to return `null` instead of throwing. It was rejected because the renderer's `!deviceInfo` already means "still loading" and draws a spinner, so a `null` would spin forever in a state the UI never reaches — and it would change a shared IPC contract to describe a call the renderer shouldn't be making.

For the same reason the `No license key available` guards at `license-key.ts:183` and `:217` stay as throws. With the caller gated they can no longer fire in normal use, which makes them invariant assertions in the same class as `Could not find account config` in `accounts.ts`; a future caller that forgets the gate should fail loudly rather than silently receive a null. They are deliberately unlike the `licenseKey.isValid` early returns in `ipc.ts` — those gate a Pro feature a free user can genuinely click, which is a product state rather than a bug. `updateDeviceInfo` is unreachable without a key for the same structural reason and is left alone.

## Try it
No preview deployment; this is the desktop app. `bun run dev` with no license key configured, then open Settings → License. The page renders the free-version copy as before, and the main process log stays clean where it previously carried the handler stack. With a key configured, the Device label field still loads and saves.

## Not verified
- No test asserts the handler stops being invoked on the free version. The end-to-end suite runs as the free version — exactly the provoking state — but no assertion looks at main-process stderr, and adding one is a separate design question rather than something to bolt onto this fix.
- Checked on Linux only; the change is platform-independent.