### PR TITLE
Silence the app bundle's import.meta build warnings

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -115,6 +115,14 @@ function buildAppFiles() {
       transform: {
         ...rolldownOptions.transform,
         target: "node24",
+        define: {
+          ...rolldownOptions.transform?.define,
+          // zustand/middleware is a single barrel, so importing
+          // subscribeWithSelector also pulls in devtools and its
+          // `import.meta.env` reads, which rolldown warns about under the `cjs`
+          // format. devtools is tree-shaken out, so the value never matters.
+          "import.meta": "{}",
+        },
       },
       moduleTypes: {
         ".css": "text",


### PR DESCRIPTION
## Summary
Every production build printed four `EMPTY_IMPORT_META` warnings from zustand's middleware barrel — about thirty lines of source frames at the top of the log, about code that is tree-shaken out and never ships. This defines `import.meta` as `{}` on the main-process bundle, which is rolldown's own suggestion for the case, scoped to that one bundle so the warning stays live everywhere else.

## Problem
The main-process bundle (`packages/app/index.ts`) is written as `cjs`, where `import.meta` has no meaning. `packages/app/gmail/index.ts` imports `subscribeWithSelector` from `zustand/middleware`, which is a single barrel file — it also carries `devtoolsImpl`, which reads `import.meta.env.MODE` in two separate functions. Four sites, four warnings, each with a multi-line source frame.

The warning fires during transform, before tree-shaking, so it describes code that never reaches the app: nothing in `build-js/` contains `__REDUX_DEVTOOLS_EXTENSION__`. They also appear interleaved with Vite's renderer output, because the app and renderer builds run concurrently, which makes them look like a renderer problem. They aren't — the `cjs` in the message is the app bundle's format.

It's cosmetic, but it was the only noise in the build, and a log people learn to scroll past is where a real warning goes to hide.

## Solution
- Adds `"import.meta": "{}"` to the app bundle's `transform.define`.

Importing from a deeper path would have been the better fix, but it isn't available: zustand 5.0.7 ships a `.d.mts` per middleware and only `immer.mjs` as a separate implementation, so the barrel is the only runtime entry for `subscribeWithSelector`.

Scoped to the app bundle rather than hoisted into the shared `rolldownOptions`, so a future dependency using `import.meta` for real in a preload or the extensions facade still warns — a blanket define would silence that quietly.

Placed outside the production-only define block, since that block is `undefined` when `--dev` is passed and the warnings appear in dev builds too.

The define is harmless even in the case where devtools did ship: `import.meta.env` becomes `undefined`, the guard reads `undefined !== "production"` as true, and it reaches for `window.__REDUX_DEVTOOLS_EXTENSION__` — `window` being undefined in the main process throws a ReferenceError that zustand's own `try`/`catch` swallows.

## Not verified
Nothing. `bun run build:js` now emits zero `EMPTY_IMPORT_META` warnings, `build-js/app.js` contains no `import.meta` and devtools is still tree-shaken out. `bun run types`, `bun run lint`, `bun run fmt:check` and `bun test` (521 pass, 0 fail) are clean, and `bun run build:linux -- --dir --x64 --publish never` packages successfully.