### PR TITLE
Drive a real Windows drag-resize end to end

### DIFF
--- a/tests/native-resize.e2e.ts
+++ b/tests/native-resize.e2e.ts
@@ -201,11 +201,45 @@ function readLayout() {
   });
 }
 
-test.beforeEach(() => {
-  test.skip(process.platform !== "win32", "the sizing modal loop is a Windows message loop");
-});
+/**
+ * Collects what a failure would need explaining and prints it only if one
+ * happens. These numbers are the difference between "the app did not keep up"
+ * and "the runner stopped resizing continuously", and a failure here is read
+ * from the job log of a machine nobody can look at — but a passing run has
+ * nothing to say and was saying it six times.
+ */
+function createDiagnostics() {
+  const lines: string[] = [];
+
+  return {
+    record(line: string) {
+      lines.push(line);
+    },
+    async whileReporting(assertions: () => Promise<void> | void) {
+      try {
+        await assertions();
+      } catch (error) {
+        for (const line of lines) {
+          console.log(`[e2e] ${line}`);
+        }
+
+        throw error;
+      }
+    },
+  };
+}
+
+/*
+ * At file scope rather than in a hook. `useApp` registers its own `beforeEach`
+ * when it is called above, and hooks run in registration order, so skipping from
+ * inside one launched the packaged app and waited for its renderer before
+ * deciding not to use it — twice per non-Windows job, every run.
+ */
+test.skip(process.platform !== "win32", "the sizing modal loop is a Windows message loop");
 
 test("the account view follows the window through a native drag-resize", async () => {
+  const diagnostics = createDiagnostics();
+
   const handle = await startRecording();
 
   const scriptPath = await writeScript("drag.ps1", MOUSE_SCRIPT);
@@ -218,9 +252,15 @@ test("the account view follows the window through a native drag-resize", async (
    */
   const { stdout, stderr, error } = await runPowerShell(scriptPath, [handle, "40"]);
 
-  console.log(`[e2e] drag stdout: ${stdout.trim() || "(none)"}`);
-  console.log(`[e2e] drag stderr: ${stderr.trim() || "(none)"}`);
-  console.log(`[e2e] drag error: ${error || "(none)"}`);
+  diagnostics.record(`drag stdout: ${stdout.trim() || "(none)"}`);
+
+  // Unconditional, unlike the rest. A script that failed to compile its P/Invoke
+  // stub is an environment fault rather than a test result, and it would
+  // otherwise be invisible on a run that somehow still passed.
+  if (stderr.trim() || error) {
+    console.log(`[e2e] drag stderr: ${stderr.trim() || "(none)"}`);
+    console.log(`[e2e] drag error: ${error || "(none)"}`);
+  }
 
   const samples = await readSamples();
   const layout = await readLayout();
@@ -231,89 +271,101 @@ test("the account view follows the window through a native drag-resize", async (
     return totals;
   }, {});
 
-  console.log(`[e2e] events: ${JSON.stringify(counts)}`);
-  console.log(`[e2e] final: ${JSON.stringify(layout)}`);
+  diagnostics.record(`events: ${JSON.stringify(counts)}`);
+  diagnostics.record(`final: ${JSON.stringify(layout)}`);
 
-  /*
-   * Asserted before anything about the view, because a gesture that did not
-   * happen would make every assertion below pass on nothing. `will-resize` comes
-   * from `WM_SIZING`, which arrives only inside the modal loop, and the width has
-   * to have actually moved.
-   */
-  expect(
-    counts["will-resize"] ?? 0,
-    "the window never entered the sizing modal loop",
-  ).toBeGreaterThan(0);
-  expect(layout.contentBounds?.width, "the drag did not widen the window").toBeGreaterThan(
-    START_SIZE.width,
-  );
+  await diagnostics.whileReporting(async () => {
+    /*
+     * Asserted before anything about the view, because a gesture that did not
+     * happen would make every assertion below pass on nothing. `will-resize` comes
+     * from `WM_SIZING`, which arrives only inside the modal loop, and the width has
+     * to have actually moved.
+     */
+    expect(
+      counts["will-resize"] ?? 0,
+      "the window never entered the sizing modal loop",
+    ).toBeGreaterThan(0);
+    expect(layout.contentBounds?.width, "the drag did not widen the window").toBeGreaterThan(
+      START_SIZE.width,
+    );
 
-  /*
-   * The guard that stops the assertion below passing on nothing. A drag that
-   * resizes once is a drag Windows drew as a rubber band and applied on release,
-   * and a view has no continuous phase to lag through — which is the whole of
-   * what this test is for. `SPI_SETDRAGFULLWINDOWS` is set before the gesture for
-   * exactly that reason, and this is what says it took.
-   */
-  expect(
-    counts.resize ?? 0,
-    "the window did not resize continuously, so the drag says nothing about a view keeping up",
-  ).toBeGreaterThan(5);
+    /*
+     * The guard that stops the assertion below passing on nothing. A drag that
+     * resizes once is a drag Windows drew as a rubber band and applied on release,
+     * and a view has no continuous phase to lag through — which is the whole of
+     * what this test is for. `SPI_SETDRAGFULLWINDOWS` is set before the gesture for
+     * exactly that reason, and this is what says it took.
+     */
+    expect(
+      counts.resize ?? 0,
+      "the window did not resize continuously, so the drag says nothing about a view keeping up",
+    ).toBeGreaterThan(5);
 
-  /*
-   * Every `resize` during the drag, not only the state it settled at. A view
-   * that lags the window is wrong for the whole gesture and right at the end of
-   * it, which is exactly what the report describes and exactly what asserting on
-   * the final state alone would miss.
-   */
-  const lagging = samples
-    .filter((sample) => sample.name === "resize")
-    .filter((sample) => {
-      const [contentWidth, contentHeight] = sample.content;
-      const view = sample.view;
+    /*
+     * Every `resize` during the drag, not only the state it settled at. A view
+     * that lags the window is wrong for the whole gesture and right at the end of
+     * it, which is exactly what the report describes and exactly what asserting on
+     * the final state alone would miss.
+     */
+    const lagging = samples
+      .filter((sample) => sample.name === "resize")
+      .filter((sample) => {
+        const [contentWidth, contentHeight] = sample.content;
+        const view = sample.view;
 
-      if (!view || contentWidth === undefined || contentHeight === undefined) {
-        return true;
-      }
+        if (!view || contentWidth === undefined || contentHeight === undefined) {
+          return true;
+        }
 
-      const [x, y, width, height] = view as [number, number, number, number];
+        const [x, y, width, height] = view as [number, number, number, number];
 
-      return x + width !== contentWidth || y + height !== contentHeight;
-    });
+        return x + width !== contentWidth || y + height !== contentHeight;
+      });
 
-  console.log(`[e2e] lagging samples: ${JSON.stringify(lagging.slice(0, 8))}`);
+    diagnostics.record(`lagging samples: ${JSON.stringify(lagging.slice(0, 8))}`);
 
-  expect(
-    lagging.length,
-    `the account view did not fill the window on ${lagging.length} of ${counts.resize ?? 0} resizes during the drag`,
-  ).toBe(0);
+    expect(
+      lagging.length,
+      `the account view did not fill the window on ${lagging.length} of ${counts.resize ?? 0} resizes during the drag`,
+    ).toBe(0);
+  });
 });
 
 test("the account view follows the window through a keyboard resize", async () => {
+  const diagnostics = createDiagnostics();
+
   const handle = await startRecording();
 
   const scriptPath = await writeScript("size.ps1", KEYBOARD_SCRIPT);
 
   const { stdout, stderr, error } = await runPowerShell(scriptPath, [handle]);
 
-  console.log(`[e2e] keyboard stdout: ${stdout.trim() || "(none)"}`);
-  console.log(`[e2e] keyboard stderr: ${stderr.trim() || "(none)"}`);
-  console.log(`[e2e] keyboard error: ${error || "(none)"}`);
+  diagnostics.record(`keyboard stdout: ${stdout.trim() || "(none)"}`);
+
+  // Unconditional, unlike the rest. A script that failed to compile its P/Invoke
+  // stub is an environment fault rather than a test result, and it would
+  // otherwise be invisible on a run that somehow still passed.
+  if (stderr.trim() || error) {
+    console.log(`[e2e] keyboard stderr: ${stderr.trim() || "(none)"}`);
+    console.log(`[e2e] keyboard error: ${error || "(none)"}`);
+  }
 
   const samples = await readSamples();
   const layout = await readLayout();
 
   const willResize = samples.filter((sample) => sample.name === "will-resize").length;
 
-  console.log(`[e2e] will-resize: ${willResize}, total: ${samples.length}`);
-  console.log(`[e2e] final: ${JSON.stringify(layout)}`);
+  diagnostics.record(`will-resize: ${willResize}, total: ${samples.length}`);
+  diagnostics.record(`final: ${JSON.stringify(layout)}`);
 
-  expect(willResize, "the window never entered the sizing modal loop").toBeGreaterThan(0);
+  await diagnostics.whileReporting(() => {
+    expect(willResize, "the window never entered the sizing modal loop").toBeGreaterThan(0);
 
-  const [view] = layout.views ?? [];
+    const [view] = layout.views ?? [];
 
-  expect({
-    right: (layout.contentBounds?.width ?? 0) - ((view?.x ?? 0) + (view?.width ?? 0)),
-    bottom: (layout.contentBounds?.height ?? 0) - ((view?.y ?? 0) + (view?.height ?? 0)),
-  }).toEqual({ right: 0, bottom: 0 });
+    expect({
+      right: (layout.contentBounds?.width ?? 0) - ((view?.x ?? 0) + (view?.width ?? 0)),
+      bottom: (layout.contentBounds?.height ?? 0) - ((view?.y ?? 0) + (view?.height ?? 0)),
+    }).toEqual({ right: 0, bottom: 0 });
+  });
 });

--- a/tests/native-resize.e2e.ts
+++ b/tests/native-resize.e2e.ts
@@ -1,0 +1,319 @@
+/*
+ * Windows only. Drives the real sizing modal loop — the one an edge-drag runs
+ * inside — and asserts the account view keeps up with the window all the way
+ * through it, not merely once it is over.
+ *
+ * Playwright cannot reach this path. `page.mouse` goes over CDP into Blink's
+ * input pipeline, below the OS, so it never produces the `WM_NCHITTEST` a native
+ * resize starts from. The way round is to post the message that starts the loop
+ * rather than to imitate a mouse: `WM_SYSCOMMAND` with `SC_SIZE` is the
+ * documented way in, and a posted window message needs no interactive desktop,
+ * being a message to a window rather than input to a session. It is posted from
+ * the test process to the app's `HWND`, so no FFI goes anywhere near the
+ * packaged app, and PowerShell can P/Invoke `PostMessage` with no dependency
+ * added for it.
+ *
+ * Two gestures, because they exercise different halves. Keyboard sizing draws a
+ * rubber band and applies the size once, on Enter, so it covers entering and
+ * leaving the loop. Only the mouse live-resizes, emitting a `resize` per motion,
+ * and that continuous phase is the one where a view can visibly lag the window.
+ */
+import { execFile } from "node:child_process";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { useApp } from "./lib/app";
+
+const meru = useApp({ "window.restrictMinimumSize": false });
+
+/** The size the window is put at before a gesture, leaving room to grow on a 1024x768 runner. */
+const START_SIZE = { width: 700, height: 500 };
+
+/*
+ * The messages both gestures are built from. WM_SYSCOMMAND is 0x0112 and SC_SIZE
+ * 0xF000; adding WMSZ_RIGHT (2) attaches the loop to the right border and warps
+ * the cursor to it. WM_KEYDOWN is 0x0100, with VK_RIGHT 0x27, VK_RETURN 0x0D and
+ * VK_ESCAPE 0x1B. Escape is posted after Return in both scripts as the way out
+ * of a loop that did not take the commit: a loop left turning hangs the main
+ * process, and every later test with it.
+ */
+const NATIVE_METHODS = `
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class NativeWindow {
+  [DllImport("user32.dll", SetLastError = true)]
+  public static extern bool PostMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+  [DllImport("user32.dll", SetLastError = true)]
+  public static extern bool SetCursorPos(int x, int y);
+  [DllImport("user32.dll", SetLastError = true)]
+  public static extern bool GetCursorPos(out POINT point);
+  [DllImport("user32.dll", SetLastError = true)]
+  public static extern bool SystemParametersInfo(uint action, uint param, IntPtr value, uint winIni);
+  [StructLayout(LayoutKind.Sequential)]
+  public struct POINT { public int X; public int Y; }
+}
+"@
+`;
+
+const KEYBOARD_SCRIPT = `param([string]$Hwnd)
+${NATIVE_METHODS}
+$handle = [IntPtr][long]$Hwnd
+
+[void][NativeWindow]::PostMessage($handle, 0x0112, [IntPtr]0xF000, [IntPtr]0)
+Start-Sleep -Milliseconds 500
+
+for ($i = 0; $i -lt 60; $i++) {
+  [void][NativeWindow]::PostMessage($handle, 0x0100, [IntPtr]0x27, [IntPtr]0)
+  Start-Sleep -Milliseconds 15
+}
+
+[void][NativeWindow]::PostMessage($handle, 0x0100, [IntPtr]0x0D, [IntPtr]0)
+Start-Sleep -Milliseconds 300
+[void][NativeWindow]::PostMessage($handle, 0x0100, [IntPtr]0x1B, [IntPtr]0)
+`;
+
+const MOUSE_SCRIPT = `param([string]$Hwnd, [int]$Steps)
+${NATIVE_METHODS}
+$handle = [IntPtr][long]$Hwnd
+$point = New-Object NativeWindow+POINT
+
+# SPI_SETDRAGFULLWINDOWS. Off, Windows draws a rubber band through the drag and
+# applies the size once on release, so the window never resizes while the mouse
+# moves and there is no continuous phase to test. A runner has it off.
+$enabled = [NativeWindow]::SystemParametersInfo(0x0025, 1, [IntPtr]::Zero, 2)
+Write-Output "dragfullwindows $enabled"
+
+# Windows warps the cursor to the border it attaches to, so where it lands is
+# read back rather than guessed at.
+[void][NativeWindow]::PostMessage($handle, 0x0112, [IntPtr]0xF002, [IntPtr]0)
+Start-Sleep -Milliseconds 500
+
+[void][NativeWindow]::GetCursorPos([ref]$point)
+Write-Output "cursor-at-border $($point.X),$($point.Y)"
+
+$startX = $point.X
+$startY = $point.Y
+
+for ($i = 1; $i -le $Steps; $i++) {
+  $moved = [NativeWindow]::SetCursorPos($startX + ($i * 8), $startY)
+  if ($i -eq 1) { Write-Output "setcursorpos $moved" }
+  Start-Sleep -Milliseconds 25
+}
+
+[void][NativeWindow]::GetCursorPos([ref]$point)
+Write-Output "cursor-final $($point.X),$($point.Y)"
+
+[void][NativeWindow]::PostMessage($handle, 0x0100, [IntPtr]0x0D, [IntPtr]0)
+Start-Sleep -Milliseconds 300
+[void][NativeWindow]::PostMessage($handle, 0x0100, [IntPtr]0x1B, [IntPtr]0)
+`;
+
+/** Resolves with whatever the script printed, rather than rejecting on a non-zero exit. */
+function runPowerShell(scriptPath: string, args: string[]) {
+  return new Promise<{ stdout: string; stderr: string; error: string }>((resolve) => {
+    execFile(
+      "powershell.exe",
+      ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", scriptPath, ...args],
+      { timeout: 120_000 },
+      (error, stdout, stderr) => {
+        resolve({ stdout, stderr, error: error ? error.message : "" });
+      },
+    );
+  });
+}
+
+async function writeScript(name: string, contents: string) {
+  const directory = await mkdtemp(path.join(tmpdir(), "meru-native-"));
+  const scriptPath = path.join(directory, name);
+
+  await writeFile(scriptPath, contents, "utf8");
+
+  return scriptPath;
+}
+
+/**
+ * Puts the window at a known size and starts recording, then hands back the
+ * window's `HWND` for a gesture to be aimed at.
+ *
+ * The recording listener is registered after the app's own, and `EventEmitter`
+ * calls them in that order, so every sample is taken once the app has already
+ * had its chance to lay the views out. A sample that does not fill the window is
+ * therefore the app failing to keep up rather than the test reading too early.
+ */
+async function startRecording() {
+  return meru.app.evaluate(({ BrowserWindow }, startSize) => {
+    const [window] = BrowserWindow.getAllWindows();
+
+    if (!window) {
+      throw new Error("The app has no window");
+    }
+
+    window.setBounds(startSize);
+
+    const samples: { name: string; content: number[]; view: number[] | null }[] = [];
+
+    (globalThis as unknown as { __samples: typeof samples }).__samples = samples;
+
+    const record = (name: string) => () => {
+      const content = window.getContentBounds();
+      const view = window.contentView.children[0]?.getBounds();
+
+      samples.push({
+        name,
+        content: [content.width, content.height],
+        view: view ? [view.x, view.y, view.width, view.height] : null,
+      });
+    };
+
+    window.on("will-resize", record("will-resize"));
+    window.on("resize", record("resize"));
+    window.on("resized", record("resized"));
+
+    const handle = window.getNativeWindowHandle();
+
+    // Returned as a string: an HWND is pointer-sized, and a BigInt does not
+    // survive the trip back out of the main process.
+    return handle.length >= 8 ? handle.readBigInt64LE().toString() : String(handle.readUInt32LE());
+  }, START_SIZE);
+}
+
+function readSamples() {
+  return meru.app.evaluate(
+    () =>
+      (
+        globalThis as unknown as {
+          __samples: { name: string; content: number[]; view: number[] | null }[];
+        }
+      ).__samples,
+  );
+}
+
+function readLayout() {
+  return meru.app.evaluate(({ BrowserWindow }) => {
+    const [window] = BrowserWindow.getAllWindows();
+
+    return {
+      contentBounds: window?.getContentBounds(),
+      views: window?.contentView.children.map((child) => child.getBounds()),
+    };
+  });
+}
+
+test.beforeEach(() => {
+  test.skip(process.platform !== "win32", "the sizing modal loop is a Windows message loop");
+});
+
+test("the account view follows the window through a native drag-resize", async () => {
+  const handle = await startRecording();
+
+  const scriptPath = await writeScript("drag.ps1", MOUSE_SCRIPT);
+
+  /*
+   * The whole gesture runs with nothing read back in between. The modal loop is
+   * Windows' own rather than Chromium's, so while it turns the main process may
+   * service nothing at all, and an `evaluate` issued mid-loop can simply never
+   * return.
+   */
+  const { stdout, stderr, error } = await runPowerShell(scriptPath, [handle, "40"]);
+
+  console.log(`[e2e] drag stdout: ${stdout.trim() || "(none)"}`);
+  console.log(`[e2e] drag stderr: ${stderr.trim() || "(none)"}`);
+  console.log(`[e2e] drag error: ${error || "(none)"}`);
+
+  const samples = await readSamples();
+  const layout = await readLayout();
+
+  const counts = samples.reduce<Record<string, number>>((totals, sample) => {
+    totals[sample.name] = (totals[sample.name] ?? 0) + 1;
+
+    return totals;
+  }, {});
+
+  console.log(`[e2e] events: ${JSON.stringify(counts)}`);
+  console.log(`[e2e] final: ${JSON.stringify(layout)}`);
+
+  /*
+   * Asserted before anything about the view, because a gesture that did not
+   * happen would make every assertion below pass on nothing. `will-resize` comes
+   * from `WM_SIZING`, which arrives only inside the modal loop, and the width has
+   * to have actually moved.
+   */
+  expect(
+    counts["will-resize"] ?? 0,
+    "the window never entered the sizing modal loop",
+  ).toBeGreaterThan(0);
+  expect(layout.contentBounds?.width, "the drag did not widen the window").toBeGreaterThan(
+    START_SIZE.width,
+  );
+
+  /*
+   * The guard that stops the assertion below passing on nothing. A drag that
+   * resizes once is a drag Windows drew as a rubber band and applied on release,
+   * and a view has no continuous phase to lag through — which is the whole of
+   * what this test is for. `SPI_SETDRAGFULLWINDOWS` is set before the gesture for
+   * exactly that reason, and this is what says it took.
+   */
+  expect(
+    counts.resize ?? 0,
+    "the window did not resize continuously, so the drag says nothing about a view keeping up",
+  ).toBeGreaterThan(5);
+
+  /*
+   * Every `resize` during the drag, not only the state it settled at. A view
+   * that lags the window is wrong for the whole gesture and right at the end of
+   * it, which is exactly what the report describes and exactly what asserting on
+   * the final state alone would miss.
+   */
+  const lagging = samples
+    .filter((sample) => sample.name === "resize")
+    .filter((sample) => {
+      const [contentWidth, contentHeight] = sample.content;
+      const view = sample.view;
+
+      if (!view || contentWidth === undefined || contentHeight === undefined) {
+        return true;
+      }
+
+      const [x, y, width, height] = view as [number, number, number, number];
+
+      return x + width !== contentWidth || y + height !== contentHeight;
+    });
+
+  console.log(`[e2e] lagging samples: ${JSON.stringify(lagging.slice(0, 8))}`);
+
+  expect(
+    lagging.length,
+    `the account view did not fill the window on ${lagging.length} of ${counts.resize ?? 0} resizes during the drag`,
+  ).toBe(0);
+});
+
+test("the account view follows the window through a keyboard resize", async () => {
+  const handle = await startRecording();
+
+  const scriptPath = await writeScript("size.ps1", KEYBOARD_SCRIPT);
+
+  const { stdout, stderr, error } = await runPowerShell(scriptPath, [handle]);
+
+  console.log(`[e2e] keyboard stdout: ${stdout.trim() || "(none)"}`);
+  console.log(`[e2e] keyboard stderr: ${stderr.trim() || "(none)"}`);
+  console.log(`[e2e] keyboard error: ${error || "(none)"}`);
+
+  const samples = await readSamples();
+  const layout = await readLayout();
+
+  const willResize = samples.filter((sample) => sample.name === "will-resize").length;
+
+  console.log(`[e2e] will-resize: ${willResize}, total: ${samples.length}`);
+  console.log(`[e2e] final: ${JSON.stringify(layout)}`);
+
+  expect(willResize, "the window never entered the sizing modal loop").toBeGreaterThan(0);
+
+  const [view] = layout.views ?? [];
+
+  expect({
+    right: (layout.contentBounds?.width ?? 0) - ((view?.x ?? 0) + (view?.width ?? 0)),
+    bottom: (layout.contentBounds?.height ?? 0) - ((view?.y ?? 0) + (view?.height ?? 0)),
+  }).toEqual({ right: 0, bottom: 0 });
+});


### PR DESCRIPTION
## Summary
Adds end-to-end coverage of the one gesture nothing could reach: dragging a window edge on Windows. It drives the real sizing modal loop by posting `WM_SYSCOMMAND`/`SC_SIZE` to the app's `HWND`, and asserts the account view keeps up with the window on every resize during the drag rather than only once it is over. Proved against the symptom before landing — with the layout deliberately broken it fails on 40 of 40 resizes.

## Problem
The account views are children of the window rather than part of the page, so nothing lays them out on the window's behalf: the app hears `resize` and sets their bounds itself. The gesture that exercises that most is dragging an edge, and no test could perform one.

Playwright's `page.mouse` goes over CDP into Blink's input pipeline, below the OS, so it never produces the `WM_NCHITTEST` a native resize starts from. For a frameless window it is further out of reach still: the resize border is non-client area outside the content — 8px of it, measured as window bounds of 1040x736 against content bounds of 1024x720 — so there is no coordinate `page.mouse` could target even in principle.

That left a report of the view keeping its size while the window moved with nothing able to confirm or deny it, and the whole interactive path uncovered.

## Solution
- `tests/native-resize.e2e.ts`, Windows only, run by the existing Playwright job

The way in is to post the message that starts the loop rather than to imitate a mouse. `WM_SYSCOMMAND` with `SC_SIZE` is the documented way into the sizing modal loop. It needs no interactive desktop, being a message to a window rather than input to a session — which is the part that matters on a hosted runner, since those execute as a service and it is input injection that gets unreliable there, not the display. `SetCursorPos` then drives the drag, and it does work on a runner: it returned true and moved the cursor 512 to 832, with the window following.

The messages are posted from the test process to the `HWND` that `getNativeWindowHandle` hands back, so no FFI goes anywhere near the packaged app, and PowerShell can P/Invoke `PostMessage` with no dependency added for it. `nut.js`, AutoHotkey and WinAppDriver were the alternatives and all three need the interactive session this avoids needing.

`SPI_SETDRAGFULLWINDOWS` is turned on before the gesture. A runner has it off, and Windows then draws a rubber band through the drag and applies the size once on release — the first run produced 36 `will-resize` against a single `resize`, so there was no continuous phase for a view to lag through and the assertion passed on an empty set. With it on the same gesture emits a resize per motion. The resize count is asserted before the view is looked at, so a run that did not resize continuously fails saying that rather than passing on nothing.

Every resize during the gesture is checked, not the state it settles at. A view that lags is wrong for the whole drag and correct the instant it ends, so asserting the final layout would miss precisely the bug this exists for.

The keyboard gesture is kept alongside the mouse one. It covers entering and leaving the loop — where Electron defers `setBounds` until `WM_EXITSIZEMOVE` — and needs no cursor, so it holds even where cursor motion does not.

## Not verified
- Nothing here proves a bug in the shipped app: the account view tracks all 40 resizes today, on `main` as it stands. This is coverage of a path that had none.
- It does not catch the startup gap fixed in #966, and cannot. That gap lasts until Gmail has loaded — measured at 1.09s to 2.22s of uptime on this runner — and this test does an `evaluate` round trip, writes a script to disk, spawns PowerShell and waits for `Add-Type` to compile a C# stub before it posts anything, so the first resize lands several seconds in. Dragging inside that window would mean racing the page load, which passes or fails on how fast the machine is rather than on whether the code is right. #966 asserts the gap directly instead. Two failure modes, two detectors, and this branch is cut from `main` precisely because it needs neither fix to pass.
- The detector itself is proved rather than assumed. Moving the layout to `resized`, which is the reported symptom written deliberately into the code, fails the test on 40 of 40 resizes, with samples showing the window at 708, 716, 724 and 732 wide against a view stuck at 1024. That mutation is not part of this branch.
- Windows only. The other two platforms skip, so the interactive path stays uncovered on macOS and Linux.
- The runner's cursor and drag-full-windows behavior are environment, not contract. If a future image forbids `SetCursorPos` the test fails rather than passing quietly, which is the intended direction.
