### PR TITLE
Gate the leak check's heap figures on every platform

### DIFF
--- a/tests/memory.perf.ts
+++ b/tests/memory.perf.ts
@@ -49,8 +49,10 @@ const MEASURED_CYCLES = 5;
  * say so cleanly.
  *
  * The room left over each figure is deliberate slack for a slower or busier
- * machine, not headroom anyone should grow into. Tighten these when the numbers
- * a real runner produces are known.
+ * machine, not headroom anyone should grow into. Tighten these when a runner's
+ * own spread over repeated runs is known — hosted runners have since reported
+ * figures close to these, but one run apiece says how three platforms compare,
+ * not how far one of them wanders.
  */
 const NODE_GROWTH_LIMIT = 20;
 
@@ -240,28 +242,29 @@ test("navigating settings repeatedly does not leak", async ({}, testInfo) => {
   expect.soft(growth.listeners, "JS event listeners").toBeLessThanOrEqual(LISTENER_GROWTH_LIMIT);
 
   /*
-   * The heaps are asserted on Linux alone for now, and reported everywhere.
+   * The heaps are asserted everywhere too, which they were not at first.
    *
-   * Their limits come from how caches fill on one Linux machine, which is not
-   * something anyone has watched a hosted macOS or Windows runner do — and this
-   * test gates a required job with no retry, so a limit that is merely wrong
-   * there turns an unrelated pull request red. That is the same objection
-   * already accepted against thresholds on absolute memory, and it applies to
-   * exactly the part of this check that shares their weakness rather than to the
-   * counts.
+   * Their limits come from how caches fill on one Linux machine, and until a
+   * hosted macOS or Windows runner had been watched doing the same, a limit
+   * merely wrong there would have turned an unrelated pull request red — this
+   * test gates a required job with no retry. So they reported on those
+   * platforms and gated only here. The first CI run retired that: over five
+   * cycles the renderer heap grew 537 KB on macOS, 601 KB on Linux and 522 KB
+   * on Windows, the Blink heap shrank on all three, and the main heap moved
+   * between 43 and 58 KB. Three platforms within 80 KB of each other, each
+   * figure at roughly a third of its limit.
    *
-   * Make these gate everywhere once each platform has produced a green run and
-   * its figures are known. The growth is in the report either way.
+   * The limits stay where they are. Agreement across three platforms is not the
+   * same as knowing one platform's spread over repeated runs, and that spread is
+   * what a tighter limit would have to be set against.
    */
-  if (process.platform === "linux") {
-    expect
-      .soft(growth.rendererHeapKb, "renderer JS heap in KB")
-      .toBeLessThanOrEqual(RENDERER_HEAP_GROWTH_LIMIT_KB);
-    expect
-      .soft(growth.rendererEmbedderHeapKb, "renderer Blink heap in KB")
-      .toBeLessThanOrEqual(RENDERER_EMBEDDER_HEAP_GROWTH_LIMIT_KB);
-    expect
-      .soft(growth.mainHeapKb, "main JS heap in KB")
-      .toBeLessThanOrEqual(MAIN_HEAP_GROWTH_LIMIT_KB);
-  }
+  expect
+    .soft(growth.rendererHeapKb, "renderer JS heap in KB")
+    .toBeLessThanOrEqual(RENDERER_HEAP_GROWTH_LIMIT_KB);
+  expect
+    .soft(growth.rendererEmbedderHeapKb, "renderer Blink heap in KB")
+    .toBeLessThanOrEqual(RENDERER_EMBEDDER_HEAP_GROWTH_LIMIT_KB);
+  expect
+    .soft(growth.mainHeapKb, "main JS heap in KB")
+    .toBeLessThanOrEqual(MAIN_HEAP_GROWTH_LIMIT_KB);
 });

--- a/tests/memory.perf.ts
+++ b/tests/memory.perf.ts
@@ -50,9 +50,9 @@ const MEASURED_CYCLES = 5;
  *
  * The room left over each figure is deliberate slack for a slower or busier
  * machine, not headroom anyone should grow into. Tighten these when a runner's
- * own spread over repeated runs is known — hosted runners have since reported
- * figures close to these, but one run apiece says how three platforms compare,
- * not how far one of them wanders.
+ * own spread over repeated runs is known — hosted runners report figures close
+ * to these, but runs agreeing with each other is not the same as knowing how
+ * far one of them can wander.
  */
 const NODE_GROWTH_LIMIT = 20;
 
@@ -61,11 +61,19 @@ const LISTENER_GROWTH_LIMIT = 10;
 const RENDERER_HEAP_GROWTH_LIMIT_KB = 1536;
 
 /**
- * Blink's own memory sits flat where the JavaScript heap climbs — 2.1 MB to
- * 2.2 MB across the same cycles, growing by -153 KB — so it gets a tight limit
- * rather than the JavaScript heap's slack. It is the figure that moves for a
- * leak the counts cannot see, an object URL never revoked or a decoded-image
- * cache that only grows, so a loose limit here would waste it.
+ * Blink's own memory sits flat where the JavaScript heap climbs — between 2.1
+ * and 2.2 MB across the same cycles, ending 153 KB below where it started — so
+ * it gets a smaller limit rather than the JavaScript heap's slack.
+ *
+ * What it reads is `embedderHeapUsedSize`, which is Oilpan, the garbage-collected
+ * heap Blink allocates its own C++ objects in. So it is retention on that heap
+ * this catches and nothing else: a detached DOM tree held alive by a C++
+ * reference is the case worth having, because the node count cannot see one
+ * that JavaScript no longer points at. It is not a general second opinion on
+ * renderer memory — a blob whose object URL is never revoked keeps its payload
+ * in the browser process, and a decoded-image cache lives in Skia's discardable
+ * memory, so neither moves this figure. Both would show up in the working set,
+ * which these cycles deliberately do not read.
  */
 const RENDERER_EMBEDDER_HEAP_GROWTH_LIMIT_KB = 512;
 
@@ -242,21 +250,40 @@ test("navigating settings repeatedly does not leak", async ({}, testInfo) => {
   expect.soft(growth.listeners, "JS event listeners").toBeLessThanOrEqual(LISTENER_GROWTH_LIMIT);
 
   /*
+   * The Blink reading, before it is compared to anything. `embedderHeapUsedSize`
+   * is absent from Electron's type for the heap usage response and read through
+   * a cast, so a rename or a removal in some future Chromium reaches this file
+   * as zero rather than as an error. Every sample would then read zero, growth
+   * would be zero, and the limit below would pass forever on a figure nobody was
+   * measuring — and it is the one figure where that failure is invisible, since
+   * a healthy Blink heap shrinks across these cycles and a broken reading sits
+   * at zero, both comfortably under an upper bound. This is the same guard the
+   * cold-launch test puts on its own figures, for the same reason.
+   */
+  expect(
+    first.rendererEmbedderHeapKb,
+    "no Blink heap was reported, so its limit is guarding nothing",
+  ).toBeGreaterThan(0);
+
+  /*
    * The heaps are asserted everywhere too, which they were not at first.
    *
    * Their limits come from how caches fill on one Linux machine, and until a
    * hosted macOS or Windows runner had been watched doing the same, a limit
    * merely wrong there would have turned an unrelated pull request red — this
    * test gates a required job with no retry. So they reported on those
-   * platforms and gated only here. The first CI run retired that: over five
-   * cycles the renderer heap grew 537 KB on macOS, 601 KB on Linux and 522 KB
-   * on Windows, the Blink heap shrank on all three, and the main heap moved
-   * between 43 and 58 KB. Three platforms within 80 KB of each other, each
-   * figure at roughly a third of its limit.
+   * platforms and gated on Linux alone. CI retired that: over five cycles the
+   * renderer JS heap grew between 513 and 601 KB across the three, the Blink
+   * heap shrank on all of them, and the main heap moved between 43 and 58 KB.
+   * Every figure sits inside its limit with room to spare — the renderer heap,
+   * the closest, at about two fifths of it.
    *
-   * The limits stay where they are. Agreement across three platforms is not the
-   * same as knowing one platform's spread over repeated runs, and that spread is
-   * what a tighter limit would have to be set against.
+   * The limits stay where they are. A tighter one would have to be set against
+   * a platform's own spread over repeated runs, and two runs agreeing within
+   * 10 KB apiece is two points, not a spread. The threat to a tight limit is
+   * not run-to-run wander anyway but a step change — an Electron upgrade or a
+   * new runner image moving cache-fill behavior wholesale — which no spread
+   * data predicts and slack absorbs.
    */
   expect
     .soft(growth.rendererHeapKb, "renderer JS heap in KB")


### PR DESCRIPTION
## Summary
The leak check in `tests/memory.perf.ts` asserted its three heap growth figures on Linux only, because their limits came from one Linux machine and no hosted macOS or Windows runner had ever produced a figure to check them against. #973's first CI run produced those figures on all three platforms, they agree closely, and every one sits well inside its limit — so the condition comes out and the heaps gate everywhere. The limits themselves are unchanged, deliberately. Review then found three things wrong in the comments around that gate, all fixed here: a false summary of the evidence, a silent-zero path that could have made the Blink limit guard nothing, and a claim about what that limit catches that is not true of the figure it reads.

## Problem
When the harness landed in #973, its assertions were split. DOM node and listener counts gated on every platform: they are counted rather than sampled, so there is nothing in them for a machine to differ about. The three heap figures — renderer JS heap, renderer Blink heap, main JS heap — reported everywhere but gated inside an `if (process.platform === "linux")`, because their limits were derived from cache-fill behavior on one Linux machine. This test gates a required job with no retry, so a limit that was merely wrong on another platform would have turned an unrelated pull request red.

That reason was that no figure had ever been observed off Linux. It has now expired. Growth over five cycles at `b4b929c`, with this PR's own run beside it:

| Growth | macOS | Linux | Windows | Limit |
|---|---|---|---|---|
| Renderer JS heap | 537 → 545 KB | 601 → 597 KB | 522 → 513 KB | 1536 KB |
| Renderer Blink heap | -198 → -168 KB | -67 → -146 KB | -158 → -136 KB | 512 KB |
| Main JS heap | 43 → 44 KB | 58 → 58 KB | 45 → 52 KB | 512 KB |

## Solution
- Removes the `process.platform === "linux"` condition, so all five figures in the leak check gate on every platform.
- Asserts the Blink heap reading is greater than zero before comparing it. `embedderHeapUsedSize` is absent from Electron's type for the heap usage response and read through a cast defaulting to zero (`tests/lib/profile.ts:217`), so a rename or removal in a future Chromium would arrive as zero rather than as an error — every sample zero, growth zero, and the limit passing forever on a figure nobody was measuring. It is the one figure where that failure is invisible, because a healthy Blink heap *shrinks* across these cycles and a broken reading sits at zero, and an upper bound cannot tell those apart. This is the guard the cold-launch test already puts on its own figures.
- Corrects what the Blink limit's comment claims to catch. It cited an unrevoked object URL or a growing decoded-image cache; neither moves this figure, since a blob payload lives in the browser process and decoded images in Skia's discardable memory — both would show in the working set, which these cycles deliberately do not read. What it does catch is Oilpan retention, a detached DOM tree held by a C++ reference that the node count cannot see once JavaScript has stopped pointing at it.
- Rewrites the evidence summary, which said the platforms agreed within 80 KB with each figure at roughly a third of its limit. Both halves were true of the renderer JS heap alone: the main heap sits at a ninth of its limit, and the Blink spread is 131 KB and negative.
- Updates `docs/features/performance-profiling.md` for all of the above and for the lifted gating, and drops a duplicated bullet pair left behind by `f6d5c8e`.

The limits are not tightened, which the observed figures would superficially support. A tighter limit would have to be set against a platform's own spread over repeated runs, and two runs agreeing within 10 KB apiece is two points, not a spread. The threat to a tight limit is not run-to-run wander anyway but a step change — an Electron upgrade or a new runner image moving cache-fill behavior wholesale — which no spread data predicts and slack absorbs. The comments now state that criterion rather than a run count that goes stale with every CI run.

The `docs/todo.md` row about thresholds on absolute memory mentions this change alongside the per-platform absolute threshold question, which stays open and is not part of this. The row comes out at merge.

## Not verified
- The new zero-guard is verified to fail as intended: renaming `embedderHeapUsedSize` in `profile.ts` turns the test red with "no Blink heap was reported, so its limit is guarding nothing". `profile.ts` is unmodified in this branch — the rename was temporary.
- `xvfb-run -a bun run test:perf` passes locally on Linux with the heaps gating. macOS and Windows passed CI at `98958b5`; the review fixes in `3edcac7` touch comments and add one assertion, and their CI is running.
- No repeat runs beyond two on any hosted platform, which is the evidence that would justify tightening the limits and is why they were left alone.
- The Oilpan reasoning behind the corrected Blink comment comes from review rather than from a cited Chromium source. It changes a comment, not behavior.