### PR TITLE
Name the renderer no webContents claims

### DIFF
--- a/tests/lib/profile.ts
+++ b/tests/lib/profile.ts
@@ -19,10 +19,12 @@
  *
  * Attribution. `getAppMetrics()` reports a `Tab` process with a pid and nothing
  * else, so the mapping from process to what it is running has to be built from
- * `webContents.getOSProcessId()`. Some processes belong to no `webContents` at
- * all — Chromium keeps spare renderers and isolates cross-origin subframes —
- * and those are labeled as unattributed rather than folded silently into a
- * total.
+ * `webContents.getOSProcessId()`. That alone leaves a gap: site isolation puts
+ * a cross-origin subframe in a process of its own, and no `webContents` reports
+ * it. Frames are therefore walked as well, so that the sign-in page's
+ * `accounts.youtube.com` frame is named rather than turning up as 86 MB nobody
+ * can account for. Anything still unclaimed keeps the unattributed label, which
+ * now means genuinely unexplained.
  */
 import { ms } from "@meru/shared/ms";
 import type { ElectronApplication, Page } from "playwright";
@@ -228,10 +230,13 @@ async function sampleRenderer(app: ElectronApplication, page: Page): Promise<Ren
 /**
  * What a process is, for a report to line up two runs by.
  *
- * A process no `webContents` claims is normal rather than a bug: Chromium keeps
- * spare renderers warm and isolates cross-origin subframes into processes of
- * their own. It gets named as such, because a nameless 86 MB inside a total is
- * worse than an honestly unexplained one.
+ * Hostnames are deduplicated because two accounts can embed the same
+ * cross-origin site, and Chromium may put both of those frames in one process —
+ * which would otherwise read as `renderer:host+host`.
+ *
+ * A renderer nothing claims should no longer happen now that frames are walked
+ * too. It keeps a label rather than being folded into a total, because a
+ * nameless 86 MB inside one is worse than an honestly unexplained process.
  */
 function processLabel(type: string, serviceName: string | null, urls: string[]) {
   if (type === "Browser") {
@@ -246,7 +251,9 @@ function processLabel(type: string, serviceName: string | null, urls: string[]) 
     return `utility:${serviceName ?? "unknown"}`;
   }
 
-  return urls.length > 0 ? `renderer:${urls.map(pageLabel).join("+")}` : "renderer:unattributed";
+  const pages = [...new Set(urls.map(pageLabel))];
+
+  return pages.length > 0 ? `renderer:${pages.join("+")}` : "renderer:unattributed";
 }
 
 /**
@@ -324,16 +331,30 @@ export async function takeSample(app: ElectronApplication): Promise<Sample> {
        */
       const urlsByPid = new Map<number, string[]>();
 
-      for (const contents of webContents.getAllWebContents()) {
-        let pid: number;
+      const claim = (pid: number, url: string) => {
+        urlsByPid.set(pid, [...(urlsByPid.get(pid) ?? []), url]);
+      };
 
+      for (const contents of webContents.getAllWebContents()) {
         try {
-          pid = contents.getOSProcessId();
+          const pid = contents.getOSProcessId();
+
+          claim(pid, contents.getURL());
+
+          /*
+           * Subframes in a process of their own, which is the only part of the
+           * app no `webContents` can name. Ones sharing their contents' process
+           * are skipped rather than claimed: the line above already names that
+           * process, and a same-origin frame would only repeat its hostname.
+           */
+          for (const frame of contents.mainFrame.framesInSubtree) {
+            if (frame.osProcessId !== pid) {
+              claim(frame.osProcessId, frame.url);
+            }
+          }
         } catch {
           continue;
         }
-
-        urlsByPid.set(pid, [...(urlsByPid.get(pid) ?? []), contents.getURL()]);
       }
 
       // Awaited, unlike the two below it: this one alone answers with a promise,


### PR DESCRIPTION
## Summary
The cold-launch report carried a nameless 87 MB renderer, a ninth of the total. It is a site-isolated subframe of Google's sign-in page, not a Chromium spare renderer, and the app cannot get rid of it. The harness now names it by walking `mainFrame.framesInSubtree`. Identifying it turned up a larger finding along the way: working set charges shared pages to every process holding them, so the report's totals overstate real cost by roughly a factor of two, and that process costs about 8 MB rather than 87 MB.

## Problem
`tests/lib/profile.ts` maps a pid back to what runs in it through `webContents.getOSProcessId()`, and labels anything unclaimed `renderer:unattributed`. On a cold launch one renderer always came out that way, at 87 MB against a total of 835 MB, and the doc recorded two candidates without picking one: a spare renderer kept warm for the next navigation, or a cross-origin subframe of the sign-in page the app lands on when nobody is signed in. The two have opposite consequences — one is a Chromium policy that might be switchable off, the other is Google's own markup that the app has no say in — so the number could not be acted on either way.

It is the subframe: `https://accounts.youtube.com/accounts/CheckConnection`, which is how Google links a session across its properties. Three independent readings agree, taken by driving the built app under Playwright. `Target.getTargets` on the browser debugging endpoint returns a third target of type `iframe` for that URL. Walking `mainFrame.framesInSubtree` puts the frame in a different pid from its own `webContents`, and that pid is the unattributed one. And deleting the `<iframe>` element from the sign-in page's DOM drops the process count from six to five with the 87 MB gone, which makes it causal rather than circumstantial — the same test also shows there is no spare renderer at all, so the first hypothesis is false rather than merely unproven.

Nothing in the app puts that frame on the page, and the two levers that reach it are both worse than the cost. Turning off site isolation folds cross-origin frames into their parent renderer, in a mail client rendering untrusted web content. Blocking the request breaks Google's cross-property session linking on the sign-in page.

The figure is also much smaller than it looks. `workingSetSize` on Linux is RSS, which charges every shared page in full to every process holding it, and renderers share a great deal. Read from `/proc/<pid>/smaps_rollup` on the same launches, and reproducible to within 2 MB across two runs:

| Process | Working set | PSS | Private |
|---|---|---|---|
| main | 240 MB | 138 MB | 91 MB |
| gpu | 150 MB | 82 MB | 42 MB |
| renderer:main.html | 122 MB | 52 MB | 29 MB |
| renderer:accounts.google.com | 135 MB | 61 MB | 35 MB |
| renderer:accounts.youtube.com | 86 MB | 25 MB | **8 MB** |
| utility:network.mojom.NetworkService | 84 MB | 29 MB | 15 MB |
| **Total** | **817 MB** | **387 MB** | **221 MB** |

That correction applies to every figure the harness reports, not just this process. Reporting it is deferred to [its own todo row](https://github.com/zoidsh/meru/blob/main/docs/todo.md) rather than folded in here, because PSS has no single cross-platform source and Electron exposes none of them per child process — Linux has `smaps_rollup`, macOS `phys_footprint`, Windows private working set.

## Solution
- Walks `mainFrame.framesInSubtree` alongside `getAllWebContents()`, and claims a pid for any frame whose `osProcessId` differs from its own contents'. The line reads `renderer:accounts.youtube.com` instead of `renderer:unattributed`, and an unattributed line now means genuinely unexplained rather than routine.
- Only cross-process frames claim anything. A same-origin subframe shares its parent's process and would add a repeat of its parent's hostname — the sign-in page has one of those too, `accounts.google.com/_/bscframe`.
- Deduplicates hostnames in the label, for the case that survives anyway: two accounts embedding the same cross-origin site, which Chromium may put in one process, would otherwise read `renderer:host+host`.
- Reading `Target.getTargets` over the browser debugging endpoint was the alternative, and it does list iframe targets — it was how the frame was first identified. It needs a `--remote-debugging-port` on the launch and a websocket client in the harness, to learn what `WebFrameMain` already answers.

The findings and the evidence are in `docs/features/performance-profiling.md`, which closes its `[NEEDS DECISION]` on this and gains a section on the process and on working set against PSS. The todo row that raised the unattributed renderer as an open question now points at the answer.

## Try it
```sh
bun run build:linux -- --dir --x64 --publish never
MERU_SKIP_BUILD=1 xvfb-run -a bun run test:perf
```

The cold-launch table prints `renderer:accounts.youtube.com  87.4 MB` where it printed `renderer:unattributed`, and no unattributed line remains. The label depends on Google serving that frame on the sign-in page, so a future change on their side would put the unattributed line back — correctly, since it would then be a different process.

## Not verified
- Only run on Linux. macOS and Windows should behave the same, since site isolation and `WebFrameMain` are not platform-specific, but the label has only been seen on one platform.
- Nothing signs in, which is the harness's standing boundary. This frame belongs to the sign-in flow, so a signed-in user probably does not load this particular one — but Gmail embeds cross-origin frames of its own, so the likely direction is more such processes rather than none. Nothing here measures that.
- The PSS figures come from `/proc` in a throwaway script, not from the harness, and only from this machine.