### PR TITLE
Compare a pull request's memory against its own base commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,19 @@ on:
   pull_request:
   workflow_call:
 
+# One run per pull request, with a superseded one cancelled rather than left to
+# finish. Two pushes seconds apart otherwise finish in whatever order they
+# finish, and the performance comment is whichever of them wrote last — which is
+# not necessarily the commit anyone is looking at. It also stops three app
+# builds being paid for on a commit that has already been replaced.
+#
+# Everything else gets a group of its own, because `run_id` is unique to a run:
+# a push to main and a release build never wait on each other, which is what a
+# shared group without cancellation would make them do.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,14 @@ jobs:
           # The build this skips turns out to be cheap, so what the skip is
           # really for is the comment: a table of pure noise on a pull request
           # that changed no code teaches whoever reads it to skip the next one.
-          if [ -z "$(git diff --name-only "$base" HEAD -- . ':(exclude)*.md')" ]; then
+          # Assigned rather than tested inline, so that a git failure stops the
+          # job. Inside `[ -z "$(...)" ]` its exit status is discarded and its
+          # empty output reads as a clean documentation-only diff, which would
+          # silently skip the comparison on exactly the error the fetch above
+          # exists to prevent.
+          changed=$(git diff --name-only "$base" HEAD -- . ':(exclude)*.md') || exit 1
+
+          if [ -z "$changed" ]; then
             echo "The diff against $base is documentation only, so the app cannot have changed."
             exit 0
           fi
@@ -211,6 +218,11 @@ jobs:
           MERU_SKIP_BUILD: "1"
           MERU_PERF_REPORT: perf-reports/base.json
           MERU_PERF_COMMIT: ${{ steps.base.outputs.sha }}
+          # Records the base build's bundle sizes without checking them against
+          # a budget file belonging to head. Pairing those two is not a check:
+          # a pull request that adds a chunk, removes one, or lowers a ceiling
+          # fails against a build made before it did any of them.
+          MERU_PERF_BASELINE: "1"
       # Printed into this job's log as well as posted as a comment later, because
       # a pull request from a fork gets a token that cannot comment and a job
       # killed for running long never uploads an artifact. The log survives both.
@@ -230,15 +242,18 @@ jobs:
     # column per platform, and three legs racing to rewrite one comment would
     # leave whichever finished last standing as the whole report.
     needs: e2e
-    # always(), because a leg that failed still measured whatever it reached, and
-    # a red pull request is exactly when someone wants to know what memory did.
+    # !cancelled() rather than always(), because a leg that failed still measured
+    # whatever it reached and a red pull request is exactly when someone wants to
+    # know what memory did — while a run someone cancelled has no such claim, and
+    # would overwrite a complete comment with whatever half of the matrix had
+    # finished.
     #
     # A pull request from a fork is skipped rather than failed: its token is
     # read-only by design, and there is nothing to fix about that. Meru has one
     # maintainer, so this may never happen — but a job that goes red on somebody
     # else's first contribution would be a poor way to find out.
     if: >-
-      always() && github.event_name == 'pull_request' &&
+      !cancelled() && github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     # Naming any permission drops every one that is not named, which is why the
@@ -266,3 +281,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERU_PULL_REQUEST: ${{ github.event.pull_request.number }}
+          # Whether every leg of the matrix got there. A platform that failed
+          # before it uploaded is simply absent from the table, and a table with
+          # two columns where three belong reads as three that were fine.
+          MERU_E2E_RESULT: ${{ needs.e2e.result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,15 @@ jobs:
     # A test that hangs rather than fails would otherwise sit on a runner for
     # GitHub's six hour default. Two attempts of a two minute test, its build
     # and its teardown fit inside this several times over, and the performance
-    # run that follows takes about a minute. Doubled from twenty when the base
-    # commit started being built and measured here as well, which is a second
-    # build of the whole app on every leg.
-    timeout-minutes: 45
+    # run that follows takes about a minute.
+    #
+    # Unchanged by the base measurement below, which was expected to need a much
+    # larger ceiling and does not. A second build of the whole app costs 5 to 12
+    # seconds here rather than the minutes the first one took: the first build
+    # in this job downloads Electron and fills the module cache, and the second
+    # reuses both. Measured across three platforms and two runs, base build and
+    # base measurement together add 10 to 24 seconds to a leg.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -87,9 +92,10 @@ jobs:
           # would fail the diff below rather than explain itself.
           git cat-file -e "$base^{tree}" 2>/dev/null || git fetch --depth=1 origin "$base"
 
-          # A diff of nothing but Markdown cannot have moved a byte of the app,
-          # and a second build on three platforms to prove that costs more than
-          # the answer is worth.
+          # A diff of nothing but Markdown cannot have moved a byte of the app.
+          # The build this skips turns out to be cheap, so what the skip is
+          # really for is the comment: a table of pure noise on a pull request
+          # that changed no code teaches whoever reads it to skip the next one.
           if [ -z "$(git diff --name-only "$base" HEAD -- . ':(exclude)*.md')" ]; then
             echo "The diff against $base is documentation only, so the app cannot have changed."
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,10 @@ jobs:
     # A test that hangs rather than fails would otherwise sit on a runner for
     # GitHub's six hour default. Two attempts of a two minute test, its build
     # and its teardown fit inside this several times over, and the performance
-    # run that follows takes about a minute.
-    timeout-minutes: 20
+    # run that follows takes about a minute. Doubled from twenty when the base
+    # commit started being built and measured here as well, which is a second
+    # build of the whole app on every leg.
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -56,8 +58,45 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # The merge commit's first parent is the base branch tip GitHub merged
+          # against, and that is the commit the performance comparison measures.
+          # The default depth of one does not include it.
+          fetch-depth: 2
       - uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile
+      # The comparison measures the base commit on this runner, in this job,
+      # minutes apart from head. Nothing else makes an absolute memory figure
+      # mean anything: the same commit reads 549 MB on a hosted Windows runner
+      # and 772 MB on a hosted Linux one, so a baseline from another machine, or
+      # another day, is not something a delta can honestly be taken against.
+      - name: Decide whether there is a base commit to compare against
+        id: base
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "Not a pull request, so there is no base commit to compare against."
+            exit 0
+          fi
+
+          base=$(git rev-parse HEAD^1)
+
+          # Depth two should already carry the base commit's contents alongside
+          # the merge commit's, and this is what makes it not matter whether it
+          # does: a shallow clone holding the parent's hash without its tree
+          # would fail the diff below rather than explain itself.
+          git cat-file -e "$base^{tree}" 2>/dev/null || git fetch --depth=1 origin "$base"
+
+          # A diff of nothing but Markdown cannot have moved a byte of the app,
+          # and a second build on three platforms to prove that costs more than
+          # the answer is worth.
+          if [ -z "$(git diff --name-only "$base" HEAD -- . ':(exclude)*.md')" ]; then
+            echo "The diff against $base is documentation only, so the app cannot have changed."
+            exit 0
+          fi
+
+          echo "sha=$base" >> "$GITHUB_OUTPUT"
+          echo "head=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       # Only Linux needs a display server invented for it. -a takes a free
       # display rather than colliding on :99.
       - if: runner.os == 'Linux'
@@ -76,14 +115,22 @@ jobs:
       # runner yet. What can fail is the leak check, which compares a run to
       # itself and so means the same thing on any machine, and the bundle
       # budgets, which are the same bytes everywhere.
+      #
+      # MERU_PERF_REPORT is what puts the figures somewhere a program can find
+      # them by name, next to the attachments a person reads. Set on both this
+      # run and the base run below, into two files the comparison then subtracts.
       - if: runner.os == 'Linux'
         run: xvfb-run -a bun run test:perf
         env:
           MERU_SKIP_BUILD: "1"
+          MERU_PERF_REPORT: perf-reports/head.json
+          MERU_PERF_COMMIT: ${{ github.event.pull_request.head.sha }}
       - if: runner.os != 'Linux'
         run: bun run test:perf
         env:
           MERU_SKIP_BUILD: "1"
+          MERU_PERF_REPORT: perf-reports/head.json
+          MERU_PERF_COMMIT: ${{ github.event.pull_request.head.sha }}
       # always(), not failure(): a job killed for running long counts as
       # cancelled rather than failed, and that is the run whose trace is most
       # worth having.
@@ -103,6 +150,10 @@ jobs:
           path: |
             test-results/e2e/
             playwright-report/e2e/
+      # Uploaded here rather than at the end of the job, because the base
+      # measurement below is a second `playwright test` run of the same project
+      # and empties both of these directories before it writes. This is the head
+      # run's report, and it is taken out of the way before that happens.
       - if: always()
         uses: actions/upload-artifact@v7
         with:
@@ -113,3 +164,99 @@ jobs:
           path: |
             test-results/perf/
             playwright-report/perf/
+      # Built after head has been measured, because it overwrites dist and
+      # build-js with its own output. Head is then checked back out, so that the
+      # base binary is measured by this pull request's harness rather than by its
+      # own: the base commit has neither the report writer nor whatever this pull
+      # request changed in the profiler, and a comparison whose two readings came
+      # from different instruments is not a comparison.
+      #
+      # The build command is spelled out per platform instead of reusing
+      # `scripts/e2e.ts`, and that is not a duplication anyone can remove — the
+      # base checkout has only the scripts the base commit shipped.
+      - name: Build the base commit
+        if: steps.base.outputs.sha != ''
+        shell: bash
+        run: |
+          git checkout --detach ${{ steps.base.outputs.sha }}
+          bun install --frozen-lockfile
+          case "${{ runner.os }}" in
+            Linux) bun run build:linux -- --dir --x64 --publish never ;;
+            macOS) bun run build:mac -- --dir --arm64 --publish never ;;
+            Windows) bun run build:win -- --dir --x64 --publish never ;;
+          esac
+          git checkout --detach ${{ steps.base.outputs.head }}
+          bun install --frozen-lockfile
+      # Everything except the leak check, which compares a run to itself and has
+      # nothing to gain from a second run against another commit. The bundle
+      # sizes come along nearly free — build-js holds the base build at this
+      # point, and bytes are the one figure here carrying no measurement noise
+      # at all.
+      - name: Measure the base commit
+        if: steps.base.outputs.sha != ''
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            xvfb-run -a bun run test:perf "--grep-invert=does not leak"
+          else
+            bun run test:perf "--grep-invert=does not leak"
+          fi
+        env:
+          MERU_SKIP_BUILD: "1"
+          MERU_PERF_REPORT: perf-reports/base.json
+          MERU_PERF_COMMIT: ${{ steps.base.outputs.sha }}
+      # Printed into this job's log as well as posted as a comment later, because
+      # a pull request from a fork gets a token that cannot comment and a job
+      # killed for running long never uploads an artifact. The log survives both.
+      - name: Compare the two measurements
+        if: steps.base.outputs.sha != ''
+        run: bun run scripts/perf-compare.ts perf-reports
+      - if: always() && steps.base.outputs.sha != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: perf-reports-${{ matrix.os }}
+          if-no-files-found: ignore
+          # The two reports this leg took, which the job after the matrix turns
+          # into one comment with a column per platform.
+          path: perf-reports/
+  perf-comment:
+    # After the matrix rather than inside it. The comment is one table with a
+    # column per platform, and three legs racing to rewrite one comment would
+    # leave whichever finished last standing as the whole report.
+    needs: e2e
+    # always(), because a leg that failed still measured whatever it reached, and
+    # a red pull request is exactly when someone wants to know what memory did.
+    #
+    # A pull request from a fork is skipped rather than failed: its token is
+    # read-only by design, and there is nothing to fix about that. Meru has one
+    # maintainer, so this may never happen — but a job that goes red on somebody
+    # else's first contribution would be a poor way to find out.
+    if: >-
+      always() && github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    # Naming any permission drops every one that is not named, which is why the
+    # checkout's own read is spelled out here.
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+      # One directory per platform, which is the shape the comparison expects.
+      # Merging them would collide: every leg names its two reports the same.
+      #
+      # Allowed to fail, because finding nothing is an ordinary outcome — a pull
+      # request whose diff is documentation only never measured anything, and the
+      # step after this says so and stops.
+      - uses: actions/download-artifact@v7
+        continue-on-error: true
+        with:
+          pattern: perf-reports-*
+          path: perf-reports
+      # No `bun install`: these two scripts import nothing outside node builtins,
+      # which is most of what keeps this job at seconds rather than minutes.
+      - run: bun run scripts/perf-comment.ts perf-reports
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERU_PULL_REQUEST: ${{ github.event.pull_request.number }}

--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,7 @@ dist
 # Meru
 /test-results/
 /playwright-report/
+/perf-reports/
 build/embedded.provisionprofile
 build/entitlements.mac.plist
 build-js

--- a/scripts/perf-comment.ts
+++ b/scripts/perf-comment.ts
@@ -84,17 +84,27 @@ async function findExistingComment(repository: string, pullRequest: string, toke
   }
 }
 
+/**
+ * What stands in the comment's place when a push measured nothing.
+ *
+ * Posted only over a comment that is already there, never as a new one. An
+ * earlier push's table describes code the branch no longer has, and leaving it
+ * up is worse than having none: it reads as current, and nothing in it says
+ * which push it belongs to until someone checks the commit in its heading.
+ * A pull request that never measured anything gets no comment at all.
+ */
+const SKIPPED_BODY = [
+  MARKER,
+  "### Performance not measured",
+  "",
+  "Nothing was measured for this push, so the figures from an earlier one have been taken down rather than left standing as though they were current.",
+  "",
+  "A diff of nothing but Markdown skips the comparison, and so does a run whose reports never reached this job.",
+].join("\n");
+
 const roots = Bun.argv.slice(2);
 
 const comparisons = await readComparisons(roots.length > 0 ? roots : ["perf-reports"]);
-
-if (comparisons.length === 0) {
-  console.log(
-    `[perf] no reports were found in ${(roots.length > 0 ? roots : ["perf-reports"]).join(", ")}, so there is nothing to comment.`,
-  );
-
-  process.exit(0);
-}
 
 /*
  * Whether the matrix finished. A leg that failed before uploading is absent
@@ -104,14 +114,17 @@ if (comparisons.length === 0) {
  */
 const e2eResult = process.env.MERU_E2E_RESULT;
 
-const body = renderComparison(
-  comparisons,
-  e2eResult && e2eResult !== "success"
-    ? [
-        `The end-to-end matrix finished as \`${e2eResult}\`. A platform missing from this table was not measured, rather than measured and unchanged.`,
-      ]
-    : [],
-);
+const body =
+  comparisons.length === 0
+    ? SKIPPED_BODY
+    : renderComparison(
+        comparisons,
+        e2eResult && e2eResult !== "success"
+          ? [
+              `The end-to-end matrix finished as \`${e2eResult}\`. A platform missing from this table was not measured, rather than measured and unchanged.`,
+            ]
+          : [],
+      );
 
 const repository = requireEnvironment("GITHUB_REPOSITORY");
 
@@ -127,7 +140,13 @@ try {
       body,
     });
 
-    console.log(`[perf] rewrote comment ${existing.id} on #${pullRequest}.`);
+    console.log(
+      comparisons.length === 0
+        ? `[perf] nothing was measured; took down the figures in comment ${existing.id} on #${pullRequest}.`
+        : `[perf] rewrote comment ${existing.id} on #${pullRequest}.`,
+    );
+  } else if (comparisons.length === 0) {
+    console.log(`[perf] nothing was measured and #${pullRequest} carries no report to take down.`);
   } else {
     await call("POST", `${API}/repos/${repository}/issues/${pullRequest}/comments`, token, {
       body,

--- a/scripts/perf-comment.ts
+++ b/scripts/perf-comment.ts
@@ -96,7 +96,22 @@ if (comparisons.length === 0) {
   process.exit(0);
 }
 
-const body = renderComparison(comparisons);
+/*
+ * Whether the matrix finished. A leg that failed before uploading is absent
+ * from the table rather than marked absent, and a table of two platforms where
+ * three belong reads as three that were fine — so the job's own result is
+ * carried in and said plainly.
+ */
+const e2eResult = process.env.MERU_E2E_RESULT;
+
+const body = renderComparison(
+  comparisons,
+  e2eResult && e2eResult !== "success"
+    ? [
+        `The end-to-end matrix finished as \`${e2eResult}\`. A platform missing from this table was not measured, rather than measured and unchanged.`,
+      ]
+    : [],
+);
 
 const repository = requireEnvironment("GITHUB_REPOSITORY");
 

--- a/scripts/perf-comment.ts
+++ b/scripts/perf-comment.ts
@@ -1,0 +1,133 @@
+/*
+ * Puts the performance comparison on the pull request, in one comment that is
+ * rewritten on every push.
+ *
+ * One comment rather than one per run, because the figures are only ever worth
+ * reading against the commit they were taken at: a pull request with twenty
+ * pushes would otherwise carry nineteen tables that describe code nobody is
+ * looking at any more. The marker at the top of the body is how the comment is
+ * found again.
+ *
+ * Nothing in here is allowed to fail the job, and there are three ordinary ways
+ * for it to have nothing to do or no way to do it: a push to main has no pull
+ * request, a documentation-only diff skips the base measurement, and a pull
+ * request from a fork gets a read-only token that cannot comment. None of those
+ * is a broken build, so each one says so and exits.
+ *
+ *   bun run scripts/perf-comment.ts perf-reports
+ */
+import { MARKER, readComparisons, renderComparison } from "./perf-compare";
+
+const API = "https://api.github.com";
+
+type Comment = { id: number; body: string };
+
+function requireEnvironment(name: string) {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(
+      `${name} is not set, so there is no way to know which pull request to comment on.`,
+    );
+  }
+
+  return value;
+}
+
+async function call(method: string, url: string, token: string, body?: unknown) {
+  const response = await fetch(url, {
+    method,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "x-github-api-version": "2022-11-28",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(`${method} ${url} answered ${response.status}: ${await response.text()}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * The comment this job wrote last time, if it is still there.
+ *
+ * Matched on the marker rather than on who wrote it, so that the report keeps
+ * its place when the token behind it changes — the Actions token and a personal
+ * one comment as different authors, and a pull request that switched between
+ * them should not end up with two tables.
+ */
+async function findExistingComment(repository: string, pullRequest: string, token: string) {
+  let page = 1;
+
+  while (true) {
+    const comments = (await call(
+      "GET",
+      `${API}/repos/${repository}/issues/${pullRequest}/comments?per_page=100&page=${page}`,
+      token,
+    )) as Comment[];
+
+    const existing = comments.find((comment) => comment.body?.startsWith(MARKER));
+
+    if (existing) {
+      return existing;
+    }
+
+    if (comments.length < 100) {
+      return undefined;
+    }
+
+    page += 1;
+  }
+}
+
+const roots = Bun.argv.slice(2);
+
+const comparisons = await readComparisons(roots.length > 0 ? roots : ["perf-reports"]);
+
+if (comparisons.length === 0) {
+  console.log(
+    `[perf] no reports were found in ${(roots.length > 0 ? roots : ["perf-reports"]).join(", ")}, so there is nothing to comment.`,
+  );
+
+  process.exit(0);
+}
+
+const body = renderComparison(comparisons);
+
+const repository = requireEnvironment("GITHUB_REPOSITORY");
+
+const pullRequest = requireEnvironment("MERU_PULL_REQUEST");
+
+const token = requireEnvironment("GITHUB_TOKEN");
+
+try {
+  const existing = await findExistingComment(repository, pullRequest, token);
+
+  if (existing) {
+    await call("PATCH", `${API}/repos/${repository}/issues/comments/${existing.id}`, token, {
+      body,
+    });
+
+    console.log(`[perf] rewrote comment ${existing.id} on #${pullRequest}.`);
+  } else {
+    await call("POST", `${API}/repos/${repository}/issues/${pullRequest}/comments`, token, {
+      body,
+    });
+
+    console.log(`[perf] commented on #${pullRequest}.`);
+  }
+} catch (error) {
+  /*
+   * Reported and survived rather than thrown. The comparison itself is in this
+   * job's log — printed below, whatever happens to the comment — and a
+   * performance report that could not be posted is not a reason to turn a pull
+   * request red.
+   */
+  console.log(`[perf] could not post the comparison: ${(error as Error).message}`);
+
+  console.log(body);
+}

--- a/scripts/perf-compare.ts
+++ b/scripts/perf-compare.ts
@@ -108,6 +108,26 @@ function total<Item>(items: Item[] | undefined, read: (item: Item) => number) {
   return items?.reduce((sum, item) => sum + read(item), 0);
 }
 
+/*
+ * The app's own pages and the web content it hosts, summed apart rather than
+ * together.
+ *
+ * They are close enough in size to hide each other — Meru's renderer reads
+ * 5.2 MB of JavaScript heap against a signed-out Gmail view's 5.0 MB — so one
+ * total means a change of ours reads at half its size. The halves also differ
+ * in what they are worth reading: measured over three CI runs, the sign-in
+ * page reported 663 nodes in fifteen samples out of eighteen, while Meru's own
+ * renderer came back with either 250 or 78. Whichever of those two is a bug, it
+ * is not one a summed row would ever have shown.
+ */
+function appRenderers(report: PerfReport) {
+  return report.coldLaunch?.renderers.filter((renderer) => renderer.isAppPage);
+}
+
+function webRenderers(report: PerfReport) {
+  return report.coldLaunch?.renderers.filter((renderer) => !renderer.isAppPage);
+}
+
 type Figure = {
   label: string;
   read: (report: PerfReport) => number | undefined;
@@ -179,28 +199,47 @@ const SUMMARY_FIGURES: Figure[] = [
     floor: MEMORY_FLOOR_KB,
   },
   {
-    label: "Renderer JS heap",
-    read: (report) => total(report.coldLaunch?.renderers, (renderer) => renderer.usedHeapKb),
+    label: "Meru renderer JS heap",
+    read: (report) => total(appRenderers(report), (renderer) => renderer.usedHeapKb),
     format: formatKb,
     proportional: true,
     floor: MEMORY_FLOOR_KB,
   },
   {
-    label: "Renderer Blink heap",
-    read: (report) => total(report.coldLaunch?.renderers, (renderer) => renderer.embedderHeapKb),
+    label: "Meru renderer Blink heap",
+    read: (report) => total(appRenderers(report), (renderer) => renderer.embedderHeapKb),
     format: formatKb,
     proportional: true,
     floor: MEMORY_FLOOR_KB,
   },
   {
-    label: "DOM nodes",
-    read: (report) => total(report.coldLaunch?.renderers, (renderer) => renderer.nodes),
+    label: "Meru renderer DOM nodes",
+    read: (report) => total(appRenderers(report), (renderer) => renderer.nodes),
     format: formatCount,
   },
   {
-    label: "Event listeners",
-    read: (report) => total(report.coldLaunch?.renderers, (renderer) => renderer.jsEventListeners),
+    label: "Meru renderer listeners",
+    read: (report) => total(appRenderers(report), (renderer) => renderer.jsEventListeners),
     format: formatCount,
+  },
+  {
+    // Both heaps and neither count. A Gmail view's nodes and listeners are
+    // Google's markup, which changes when Google changes it and never because
+    // of anything in this repository. The heaps are here because one thing in
+    // this repository does reach them: the Gmail preload, which finding 1.4 is
+    // about, evaluates on that page before its hostname check bails out.
+    label: "Account views JS heap",
+    read: (report) => total(webRenderers(report), (renderer) => renderer.usedHeapKb),
+    format: formatKb,
+    proportional: true,
+    floor: MEMORY_FLOOR_KB,
+  },
+  {
+    label: "Account views Blink heap",
+    read: (report) => total(webRenderers(report), (renderer) => renderer.embedderHeapKb),
+    format: formatKb,
+    proportional: true,
+    floor: MEMORY_FLOOR_KB,
   },
   {
     label: "Shipped bytes",

--- a/scripts/perf-compare.ts
+++ b/scripts/perf-compare.ts
@@ -1,0 +1,529 @@
+/*
+ * Turns two performance reports into the table someone reads on a pull request.
+ *
+ * The pair it compares is the base commit and the head commit, built and
+ * measured back to back on one runner inside one job. That ordering is the
+ * whole design: every absolute figure the profiler takes belongs to the machine
+ * that took it — the same commit reads 549 MB on a hosted Windows runner and
+ * 772 MB on a hosted Linux one — so a number is only worth showing next to
+ * another number the same machine produced minutes earlier.
+ *
+ * It is also why the base app is measured by *this* checkout's harness rather
+ * than by its own. The base commit does not have this file, or the report
+ * writer, or whatever the pull request changed in `tests/lib/profile.ts`; a
+ * comparison where the measuring instrument differs between the two readings is
+ * not a comparison. CI therefore builds the base app, checks head back out, and
+ * points the head harness at the base binary.
+ *
+ * Nothing here fails anything. A delta over the flag threshold gets a marker so
+ * it is seen, and that is the end of what this is allowed to do.
+ *
+ *   bun run scripts/perf-compare.ts perf-reports
+ *
+ * where the directory holds `base.json` and `head.json`, or holds one
+ * subdirectory per platform that does.
+ */
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import type { PerfReport } from "../tests/lib/report";
+
+/**
+ * How far a figure has to move before it is marked, as a proportion and as an
+ * absolute amount.
+ *
+ * Both, for the reason the bundle budgets give about their own slack warning: a
+ * proportion alone marks every small figure in the table, because five percent
+ * of a three kilobyte counter is noise that any run produces. The floor is what
+ * keeps the marker on figures large enough for a move to mean something.
+ *
+ * The proportion is set where it is because nobody yet knows what a hosted
+ * runner's own spread between two runs of the same commit is — one run per
+ * platform is what exists. Five percent of the smallest total in that first
+ * baseline is 27 MB, which is far more than the one percent three local runs
+ * agreed to. Tighten it when a runner has said what it does at rest.
+ */
+const FLAG_RATIO = 0.05;
+
+const MEMORY_FLOOR_KB = 256;
+
+/**
+ * Well above the proportion, unlike the other two floors, because CPU to idle is
+ * the noisiest figure the profiler takes. Two runs of the same binary on one
+ * machine, minutes apart, came out 3.12 s and 3.26 s — a 4.5% spread with
+ * nothing whatsoever changed between them, which a five percent marker would
+ * have been within a rounding error of calling news. A marker that fires on half
+ * of all runs is one nobody reads by the third pull request.
+ */
+const CPU_FLOOR_SECONDS = 0.5;
+
+const BUNDLE_FLOOR_BYTES = 4 * 1024;
+
+const FLAG = "⚠️";
+
+const PLATFORM_NAMES: Record<string, string> = {
+  darwin: "macOS",
+  linux: "Linux",
+  win32: "Windows",
+};
+
+/** The order the baseline table in the design doc uses, so the two read alike. */
+const PLATFORM_ORDER = ["darwin", "linux", "win32"];
+
+/**
+ * What makes the comment findable again on the next push, so that a pull
+ * request with twenty commits carries one report rather than twenty.
+ */
+export const MARKER = "<!-- meru-perf-report -->";
+
+export type Comparison = {
+  platform: string;
+  /** Absent when the base could not be measured, which leaves the head figures worth showing on their own. */
+  base: PerfReport | undefined;
+  head: PerfReport;
+};
+
+function formatKb(kilobytes: number) {
+  return Math.abs(kilobytes) >= 1024
+    ? `${(kilobytes / 1024).toFixed(1)} MB`
+    : `${Math.round(kilobytes)} KB`;
+}
+
+function formatBytes(bytes: number) {
+  return formatKb(bytes / 1024);
+}
+
+function formatSeconds(seconds: number) {
+  return `${seconds.toFixed(2)} s`;
+}
+
+function formatMilliseconds(milliseconds: number) {
+  return `${Math.round(milliseconds)} ms`;
+}
+
+function formatCount(count: number) {
+  return String(Math.round(count));
+}
+
+function formatSigned(value: number, format: (magnitude: number) => string) {
+  // Unsigned at zero. "+0" is the sort of thing a reader stops on to work out
+  // what it is trying to say, and it is trying to say nothing moved.
+  if (value === 0) {
+    return format(0);
+  }
+
+  return `${value < 0 ? "-" : "+"}${format(Math.abs(value))}`;
+}
+
+function total<Item>(items: Item[] | undefined, read: (item: Item) => number) {
+  return items?.reduce((sum, item) => sum + read(item), 0);
+}
+
+type Figure = {
+  label: string;
+  read: (report: PerfReport) => number | undefined;
+  format: (value: number) => string;
+  /**
+   * Set for figures that are sampled, and left off for figures that are
+   * counted. A process count moving from six to seven is a whole fact on its
+   * own, and putting "+16.7%" next to it says nothing a reader wanted.
+   */
+  floor?: number;
+};
+
+const SUMMARY_FIGURES: Figure[] = [
+  {
+    label: "Total working set",
+    read: (report) => report.coldLaunch?.totalWorkingSetKb,
+    format: formatKb,
+    floor: MEMORY_FLOOR_KB,
+  },
+  {
+    label: "Total CPU to idle",
+    read: (report) => report.coldLaunch?.totalCpuSeconds,
+    format: formatSeconds,
+    floor: CPU_FLOOR_SECONDS,
+  },
+  {
+    // Never marked, however far it moves. It is a reading on how loaded the
+    // runner was as much as on the app, and the profiler already reports it for
+    // that reason — a run that took three times as long to go quiet is one
+    // whose other figures deserve a second look, not a regression in itself.
+    label: "Settled after",
+    read: (report) => report.coldLaunch?.settleMs,
+    format: formatMilliseconds,
+  },
+  {
+    label: "Processes",
+    read: (report) => report.coldLaunch?.processCount,
+    format: formatCount,
+  },
+  {
+    label: "Main JS heap",
+    read: (report) => report.coldLaunch?.main.usedHeapKb,
+    format: formatKb,
+    floor: MEMORY_FLOOR_KB,
+  },
+  {
+    label: "Main private",
+    read: (report) => report.coldLaunch?.main.privateKb,
+    format: formatKb,
+    floor: MEMORY_FLOOR_KB,
+  },
+  {
+    label: "Renderer JS heap",
+    read: (report) => total(report.coldLaunch?.renderers, (renderer) => renderer.usedHeapKb),
+    format: formatKb,
+    floor: MEMORY_FLOOR_KB,
+  },
+  {
+    label: "Renderer Blink heap",
+    read: (report) => total(report.coldLaunch?.renderers, (renderer) => renderer.embedderHeapKb),
+    format: formatKb,
+    floor: MEMORY_FLOOR_KB,
+  },
+  {
+    label: "DOM nodes",
+    read: (report) => total(report.coldLaunch?.renderers, (renderer) => renderer.nodes),
+    format: formatCount,
+  },
+  {
+    label: "Event listeners",
+    read: (report) => total(report.coldLaunch?.renderers, (renderer) => renderer.jsEventListeners),
+    format: formatCount,
+  },
+  {
+    label: "Shipped bytes",
+    read: (report) =>
+      report.bundles === undefined
+        ? undefined
+        : total(Object.values(report.bundles), (size) => size),
+    format: formatBytes,
+    floor: BUNDLE_FLOOR_BYTES,
+  },
+];
+
+/** Growth within the head run, which has no base to be compared against. */
+const LEAK_FIGURES: { label: string; read: (report: PerfReport) => string | undefined }[] = [
+  {
+    label: "Leak growth, nodes / listeners",
+    read: (report) => {
+      const growth = report.settingsCycles?.growth;
+
+      return (
+        growth &&
+        `${formatSigned(growth.nodes, formatCount)} / ${formatSigned(growth.listeners, formatCount)}`
+      );
+    },
+  },
+  {
+    label: "Leak growth, renderer JS heap",
+    read: (report) => {
+      const growth = report.settingsCycles?.growth;
+
+      return growth && formatSigned(growth.rendererHeapKb, formatKb);
+    },
+  },
+];
+
+/**
+ * One figure as it appears in a cell: what it reads now, and how far it moved.
+ *
+ * A delta of nothing is left out rather than printed as `(+0)`. Most of this
+ * table is unmoved on most pull requests, and a column of zeroes is what stops
+ * anyone reading the one row that did move.
+ */
+function summaryCell(figure: Figure, comparison: Comparison) {
+  const head = figure.read(comparison.head);
+
+  if (head === undefined) {
+    return "—";
+  }
+
+  const base = comparison.base && figure.read(comparison.base);
+
+  if (base === undefined || base === head) {
+    return figure.format(head);
+  }
+
+  const delta = head - base;
+
+  if (figure.floor === undefined) {
+    return `${figure.format(head)} (${formatSigned(delta, figure.format)})`;
+  }
+
+  const ratio = base === 0 ? Number.POSITIVE_INFINITY : delta / base;
+
+  const flagged = Math.abs(ratio) > FLAG_RATIO && Math.abs(delta) >= figure.floor;
+
+  const percentage = Number.isFinite(ratio)
+    ? `${formatSigned(ratio * 100, (value) => value.toFixed(1))}%`
+    : "new";
+
+  return `${figure.format(head)} (${percentage})${flagged ? ` ${FLAG}` : ""}`;
+}
+
+function renderRow(cells: string[]) {
+  return `| ${cells.join(" | ")} |`;
+}
+
+function renderSummary(comparisons: Comparison[]) {
+  const header = ["", ...comparisons.map(({ platform }) => PLATFORM_NAMES[platform] ?? platform)];
+
+  const lines = [
+    renderRow(header),
+    renderRow(header.map(() => "---")),
+    ...SUMMARY_FIGURES.map((figure) =>
+      renderRow([
+        figure.label,
+        ...comparisons.map((comparison) => summaryCell(figure, comparison)),
+      ]),
+    ),
+    ...LEAK_FIGURES.map((figure) =>
+      renderRow([
+        figure.label,
+        ...comparisons.map((comparison) => figure.read(comparison.head) ?? "—"),
+      ]),
+    ),
+  ];
+
+  return lines.join("\n");
+}
+
+/**
+ * A figure in a detail table, where the two sides are shown separately rather
+ * than folded into one cell.
+ *
+ * A process or a file present on one side only is the news in these tables —
+ * a renderer that stopped being created, a chunk that appeared — so it is named
+ * as such instead of being dropped or compared against zero.
+ */
+function detailCells(
+  base: number | undefined,
+  head: number | undefined,
+  format: (value: number) => string,
+) {
+  if (head === undefined) {
+    return [`~~${base === undefined ? "" : format(base)}~~`, "gone"];
+  }
+
+  if (base === undefined) {
+    return [format(head), "new"];
+  }
+
+  return [format(head), base === head ? "" : formatSigned(head - base, format)];
+}
+
+function byLabel<Item extends { label: string }>(items: Item[] | undefined) {
+  return new Map((items ?? []).map((item) => [item.label, item]));
+}
+
+/** Every key either side has, so nothing is invisible for having disappeared. */
+function unionOfKeys(left: Iterable<string>, right: Iterable<string>) {
+  return [...new Set([...left, ...right])].sort((one, other) => one.localeCompare(other));
+}
+
+function renderProcesses(comparison: Comparison) {
+  const base = byLabel(comparison.base?.coldLaunch?.processes);
+
+  const head = byLabel(comparison.head.coldLaunch?.processes);
+
+  const header = ["Process", "Working set", "Δ", "CPU", "Δ", "Wakeups/s"];
+
+  return [
+    renderRow(header),
+    renderRow(header.map(() => "---")),
+    ...unionOfKeys(base.keys(), head.keys()).map((label) =>
+      renderRow([
+        label,
+        ...detailCells(base.get(label)?.workingSetKb, head.get(label)?.workingSetKb, formatKb),
+        ...detailCells(base.get(label)?.cpuSeconds, head.get(label)?.cpuSeconds, formatSeconds),
+        // Always zero on Windows, which Electron does not report and this does
+        // not pretend to have.
+        formatCount(head.get(label)?.idleWakeupsPerSecond ?? 0),
+      ]),
+    ),
+  ].join("\n");
+}
+
+function renderRenderers(comparison: Comparison) {
+  const base = byLabel(comparison.base?.coldLaunch?.renderers);
+
+  const head = byLabel(comparison.head.coldLaunch?.renderers);
+
+  const header = ["Renderer", "JS heap", "Δ", "Blink heap", "Δ", "Nodes", "Δ", "Listeners", "Δ"];
+
+  return [
+    renderRow(header),
+    renderRow(header.map(() => "---")),
+    ...unionOfKeys(base.keys(), head.keys()).map((label) =>
+      renderRow([
+        label,
+        ...detailCells(base.get(label)?.usedHeapKb, head.get(label)?.usedHeapKb, formatKb),
+        ...detailCells(base.get(label)?.embedderHeapKb, head.get(label)?.embedderHeapKb, formatKb),
+        ...detailCells(base.get(label)?.nodes, head.get(label)?.nodes, formatCount),
+        ...detailCells(
+          base.get(label)?.jsEventListeners,
+          head.get(label)?.jsEventListeners,
+          formatCount,
+        ),
+      ]),
+    ),
+  ].join("\n");
+}
+
+/**
+ * Only the files whose size moved.
+ *
+ * The build ships around thirty-five files and a pull request touches two of
+ * them, so listing all of them would bury the pair that changed under the
+ * thirty that did not. The budget check in `tests/bundles.perf.ts` is what
+ * covers the rest, and it names every file it measured in the job log.
+ */
+function renderBundles(comparison: Comparison) {
+  const base = comparison.base?.bundles;
+
+  const head = comparison.head.bundles;
+
+  if (!head) {
+    return undefined;
+  }
+
+  const changed = unionOfKeys(Object.keys(base ?? {}), Object.keys(head)).filter(
+    (bundle) => base?.[bundle] !== head[bundle],
+  );
+
+  if (changed.length === 0) {
+    return "Every shipped file is byte-identical.";
+  }
+
+  const header = ["File", "Size", "Δ"];
+
+  return [
+    renderRow(header),
+    renderRow(header.map(() => "---")),
+    ...changed.map((bundle) =>
+      renderRow([`\`${bundle}\``, ...detailCells(base?.[bundle], head[bundle], formatBytes)]),
+    ),
+  ].join("\n");
+}
+
+function renderDetails(comparison: Comparison) {
+  const platform = PLATFORM_NAMES[comparison.platform] ?? comparison.platform;
+
+  const bundles = renderBundles(comparison);
+
+  return [
+    "<details>",
+    `<summary>${platform} in detail</summary>`,
+    "",
+    renderProcesses(comparison),
+    "",
+    renderRenderers(comparison),
+    ...(bundles ? ["", bundles] : []),
+    "",
+    "</details>",
+  ].join("\n");
+}
+
+function shortCommit(commit: string | undefined) {
+  return commit ? `\`${commit.slice(0, 7)}\`` : "the base commit";
+}
+
+export function renderComparison(comparisons: Comparison[]) {
+  const ordered = [...comparisons].sort(
+    (one, other) => PLATFORM_ORDER.indexOf(one.platform) - PLATFORM_ORDER.indexOf(other.platform),
+  );
+
+  const base = ordered.find(({ base: report }) => report?.commit)?.base;
+
+  return [
+    MARKER,
+    `### Performance against ${shortCommit(base?.commit)}`,
+    "",
+    "Both commits were built and measured back to back on the same runner, in the same job. That is what makes the delta mean something: the figures themselves belong to the machine that produced them and are not comparable to any other run.",
+    "",
+    renderSummary(ordered),
+    "",
+    `${FLAG} marks a sampled figure that moved by more than ${FLAG_RATIO * 100}%. Nothing here fails the job.`,
+    "",
+    "The leak rows are growth *within* the head run, across repeated passes over the settings pages. They have no base to compare against because they already compare a run to itself, which is why that check is the part of this that can fail.",
+    "",
+    ...ordered.map(renderDetails),
+  ].join("\n");
+}
+
+async function readReport(reportPath: string) {
+  try {
+    return JSON.parse(await readFile(reportPath, "utf8")) as PerfReport;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Where the report pairs are.
+ *
+ * A matrix leg has one directory holding both files. The job that posts the
+ * comment downloads one artifact per platform, which lands them one directory
+ * deeper, so a directory with no `head.json` of its own is looked into rather
+ * than reported as empty.
+ */
+async function collectReportDirectories(root: string) {
+  if (await readReport(path.join(root, "head.json"))) {
+    return [root];
+  }
+
+  const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
+
+  const directories: string[] = [];
+
+  for (const entry of entries.filter((candidate) => candidate.isDirectory())) {
+    const directory = path.join(root, entry.name);
+
+    if (await readReport(path.join(directory, "head.json"))) {
+      directories.push(directory);
+    }
+  }
+
+  return directories;
+}
+
+export async function readComparisons(roots: string[]): Promise<Comparison[]> {
+  const comparisons: Comparison[] = [];
+
+  for (const root of roots) {
+    for (const directory of await collectReportDirectories(root)) {
+      const head = await readReport(path.join(directory, "head.json"));
+
+      if (head) {
+        comparisons.push({
+          platform: head.platform,
+          base: await readReport(path.join(directory, "base.json")),
+          head,
+        });
+      }
+    }
+  }
+
+  return comparisons;
+}
+
+if (import.meta.main) {
+  const roots = Bun.argv.slice(2);
+
+  if (roots.length === 0) {
+    throw new Error(
+      "Name at least one directory holding base.json and head.json, as in `bun run scripts/perf-compare.ts perf-reports`.",
+    );
+  }
+
+  const comparisons = await readComparisons(roots);
+
+  // Not an error. A run with nothing to compare is the ordinary outcome on a
+  // push to main, or on a pull request whose diff never touched the app.
+  console.log(
+    comparisons.length === 0
+      ? `No performance reports were found in ${roots.join(", ")}.`
+      : renderComparison(comparisons),
+  );
+}

--- a/scripts/perf-compare.ts
+++ b/scripts/perf-compare.ts
@@ -46,16 +46,6 @@ const FLAG_RATIO = 0.05;
 
 const MEMORY_FLOOR_KB = 256;
 
-/**
- * Well above the proportion, unlike the other two floors, because CPU to idle is
- * the noisiest figure the profiler takes. Two runs of the same binary on one
- * machine, minutes apart, came out 3.12 s and 3.26 s — a 4.5% spread with
- * nothing whatsoever changed between them, which a five percent marker would
- * have been within a rounding error of calling news. A marker that fires on half
- * of all runs is one nobody reads by the third pull request.
- */
-const CPU_FLOOR_SECONDS = 0.5;
-
 const BUNDLE_FLOOR_BYTES = 4 * 1024;
 
 const FLAG = "⚠️";
@@ -127,6 +117,12 @@ type Figure = {
    * counted. A process count moving from six to seven is a whole fact on its
    * own, and putting "+16.7%" next to it says nothing a reader wanted.
    */
+  proportional?: true;
+  /**
+   * How far the figure has to move in absolute terms before the marker is
+   * allowed, on top of the proportion. Left off for a row that is reported and
+   * never marked however far it moves.
+   */
   floor?: number;
 };
 
@@ -135,19 +131,30 @@ const SUMMARY_FIGURES: Figure[] = [
     label: "Total working set",
     read: (report) => report.coldLaunch?.totalWorkingSetKb,
     format: formatKb,
+    proportional: true,
     floor: MEMORY_FLOOR_KB,
   },
   {
+    /*
+     * Reported without a marker, for the reason the row below it carries.
+     *
+     * Measured rather than assumed: the first run of this comparison built one
+     * commit twice and read -14.2% on macOS, +4.8% on Linux and -3.4% on
+     * Windows for two launches of an identical binary. A threshold quiet enough
+     * to sit above a fifteen percent swing is so loose that only a doubling
+     * would reach it, and a doubling is perfectly legible in the number itself.
+     */
     label: "Total CPU to idle",
     read: (report) => report.coldLaunch?.totalCpuSeconds,
     format: formatSeconds,
-    floor: CPU_FLOOR_SECONDS,
+    proportional: true,
   },
   {
-    // Never marked, however far it moves. It is a reading on how loaded the
-    // runner was as much as on the app, and the profiler already reports it for
-    // that reason — a run that took three times as long to go quiet is one
-    // whose other figures deserve a second look, not a regression in itself.
+    // Never marked either, and for the plainer version of the same reason. It is
+    // a reading on how loaded the runner was as much as on the app, which is
+    // why the profiler reports it at all — a run that took three times as long
+    // to go quiet is one whose other figures deserve a second look, rather than
+    // a regression in itself.
     label: "Settled after",
     read: (report) => report.coldLaunch?.settleMs,
     format: formatMilliseconds,
@@ -161,24 +168,28 @@ const SUMMARY_FIGURES: Figure[] = [
     label: "Main JS heap",
     read: (report) => report.coldLaunch?.main.usedHeapKb,
     format: formatKb,
+    proportional: true,
     floor: MEMORY_FLOOR_KB,
   },
   {
     label: "Main private",
     read: (report) => report.coldLaunch?.main.privateKb,
     format: formatKb,
+    proportional: true,
     floor: MEMORY_FLOOR_KB,
   },
   {
     label: "Renderer JS heap",
     read: (report) => total(report.coldLaunch?.renderers, (renderer) => renderer.usedHeapKb),
     format: formatKb,
+    proportional: true,
     floor: MEMORY_FLOOR_KB,
   },
   {
     label: "Renderer Blink heap",
     read: (report) => total(report.coldLaunch?.renderers, (renderer) => renderer.embedderHeapKb),
     format: formatKb,
+    proportional: true,
     floor: MEMORY_FLOOR_KB,
   },
   {
@@ -198,6 +209,7 @@ const SUMMARY_FIGURES: Figure[] = [
         ? undefined
         : total(Object.values(report.bundles), (size) => size),
     format: formatBytes,
+    proportional: true,
     floor: BUNDLE_FLOOR_BYTES,
   },
 ];
@@ -247,19 +259,18 @@ function summaryCell(figure: Figure, comparison: Comparison) {
 
   const delta = head - base;
 
-  if (figure.floor === undefined) {
+  if (!figure.proportional || base === 0) {
     return `${figure.format(head)} (${formatSigned(delta, figure.format)})`;
   }
 
-  const ratio = base === 0 ? Number.POSITIVE_INFINITY : delta / base;
+  const ratio = delta / base;
 
-  const flagged = Math.abs(ratio) > FLAG_RATIO && Math.abs(delta) >= figure.floor;
+  const flagged =
+    figure.floor !== undefined && Math.abs(ratio) > FLAG_RATIO && Math.abs(delta) >= figure.floor;
 
-  const percentage = Number.isFinite(ratio)
-    ? `${formatSigned(ratio * 100, (value) => value.toFixed(1))}%`
-    : "new";
+  const percentage = formatSigned(ratio * 100, (value) => value.toFixed(1));
 
-  return `${figure.format(head)} (${percentage})${flagged ? ` ${FLAG}` : ""}`;
+  return `${figure.format(head)} (${percentage}%)${flagged ? ` ${FLAG}` : ""}`;
 }
 
 function renderRow(cells: string[]) {
@@ -444,7 +455,7 @@ export function renderComparison(comparisons: Comparison[]) {
     "",
     renderSummary(ordered),
     "",
-    `${FLAG} marks a sampled figure that moved by more than ${FLAG_RATIO * 100}%. Nothing here fails the job.`,
+    `${FLAG} marks a sampled figure that moved by more than ${FLAG_RATIO * 100}%. CPU to idle and settle time carry no marker: both read how loaded the runner was as much as what the app did, and two launches of one binary have come out fifteen percent apart on CPU. Nothing here fails the job.`,
     "",
     "The leak rows are growth *within* the head run, across repeated passes over the settings pages. They have no base to compare against because they already compare a run to itself, which is why that check is the part of this that can fail.",
     "",

--- a/scripts/perf-compare.ts
+++ b/scripts/perf-compare.ts
@@ -163,6 +163,13 @@ const SUMMARY_FIGURES: Figure[] = [
      * Windows for two launches of an identical binary. A threshold quiet enough
      * to sit above a fifteen percent swing is so loose that only a doubling
      * would reach it, and a doubling is perfectly legible in the number itself.
+     *
+     * One caveat on that evidence, found afterwards and not yet retaken:
+     * every one of those launches ran with Playwright's tracer recording, which
+     * costs about 0.6 s of the CPU being measured. The spread was between two
+     * traced runs rather than caused by tracing, so it stands as a reading of
+     * what this harness reports — but the figure to set any future threshold
+     * against is the untraced one, which nobody has yet.
      */
     label: "Total CPU to idle",
     read: (report) => report.coldLaunch?.totalCpuSeconds,
@@ -476,24 +483,56 @@ function renderDetails(comparison: Comparison) {
 }
 
 function shortCommit(commit: string | undefined) {
-  return commit ? `\`${commit.slice(0, 7)}\`` : "the base commit";
+  return commit ? `\`${commit.slice(0, 7)}\`` : "an unnamed commit";
 }
 
-export function renderComparison(comparisons: Comparison[]) {
+/**
+ * What this report is not saying, said out loud.
+ *
+ * A column with no base reads as a column that simply did not move, and a
+ * platform whose leg died before it uploaded is not in the table at all — which
+ * looks exactly like a table of the platforms there are. Both are the failure
+ * where a report looks complete and is not, so both get a line of their own.
+ */
+function renderGaps(comparisons: Comparison[], warnings: string[]) {
+  const withoutBase = comparisons
+    .filter(({ base }) => !base)
+    .map(({ platform }) => PLATFORM_NAMES[platform] ?? platform);
+
+  return [
+    ...warnings,
+    ...(withoutBase.length > 0
+      ? [
+          `Columns for ${withoutBase.join(", ")} show this commit's figures alone: no base measurement completed there, so nothing in them is a delta.`,
+        ]
+      : []),
+  ];
+}
+
+export function renderComparison(comparisons: Comparison[], warnings: string[] = []) {
   const ordered = [...comparisons].sort(
     (one, other) => PLATFORM_ORDER.indexOf(one.platform) - PLATFORM_ORDER.indexOf(other.platform),
   );
 
   const base = ordered.find(({ base: report }) => report?.commit)?.base;
 
+  const head = ordered.find(({ head: report }) => report.commit)?.head;
+
+  const gaps = renderGaps(ordered, warnings);
+
   return [
     MARKER,
-    `### Performance against ${shortCommit(base?.commit)}`,
+    // Both commits named, because without the head one there is no way to tell
+    // a current report from one an out-of-order run left behind: two pushes
+    // seconds apart finish in whatever order they finish, and the later comment
+    // wins whichever push it describes.
+    `### Performance of ${shortCommit(head?.commit)} against ${shortCommit(base?.commit)}`,
     "",
     "Both commits were built and measured back to back on the same runner, in the same job. That is what makes the delta mean something: the figures themselves belong to the machine that produced them and are not comparable to any other run.",
     "",
     renderSummary(ordered),
     "",
+    ...(gaps.length > 0 ? [gaps.map((gap) => `> [!WARNING]\n> ${gap}`).join("\n\n"), ""] : []),
     `${FLAG} marks a sampled figure that moved by more than ${FLAG_RATIO * 100}%. CPU to idle and settle time carry no marker: both read how loaded the runner was as much as what the app did, and two launches of one binary have come out fifteen percent apart on CPU. Nothing here fails the job.`,
     "",
     "The leak rows are growth *within* the head run, across repeated passes over the settings pages. They have no base to compare against because they already compare a run to itself, which is why that check is the part of this that can fail.",

--- a/tests/bundles.perf.ts
+++ b/tests/bundles.perf.ts
@@ -24,6 +24,7 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
+import { recordSection } from "./lib/report";
 
 const BUNDLES_DIRECTORY = path.join(process.cwd(), "build-js");
 
@@ -164,6 +165,8 @@ test("no bundle is over budget", async ({}, testInfo) => {
     body: JSON.stringify(measured, null, 2),
     contentType: "application/json",
   });
+
+  await recordSection("bundles", measured);
 
   console.log(
     `[perf] bundle sizes\n${Object.entries(measured)

--- a/tests/bundles.perf.ts
+++ b/tests/bundles.perf.ts
@@ -168,6 +168,28 @@ test("no bundle is over budget", async ({}, testInfo) => {
 
   await recordSection("bundles", measured);
 
+  /*
+   * A base-commit run stops here, having recorded the sizes and checked nothing.
+   *
+   * It pairs an older build with this checkout's budget file, and that pairing
+   * is not a check of anything. A pull request that adds a chunk, removes one,
+   * or lowers a ceiling to lock in a win — the three things the header above
+   * tells people to do — fails an assertion below against a build made before
+   * it did any of them, and the failure surfaces in a step named after the base
+   * commit on a pull request that is perfectly healthy. Reproduced both ways:
+   * one added budget row and one lowered ceiling turn the base run red.
+   *
+   * The sizes are still recorded, because the delta between the two runs is the
+   * whole reason the base one happens.
+   */
+  if (process.env.MERU_PERF_BASELINE) {
+    console.log(
+      `[perf] recorded ${built.size} bundle sizes from the base build; the budgets belong to head and are not checked against it`,
+    );
+
+    return;
+  }
+
   console.log(
     `[perf] bundle sizes\n${Object.entries(measured)
       .map(([bundle, size]) => {

--- a/tests/lib/profile.ts
+++ b/tests/lib/profile.ts
@@ -297,6 +297,15 @@ export type CycleSample = {
   mainUsedHeapKb: number;
 };
 
+/** What the last measured cycle retains over the first, figure by figure. */
+export type CycleGrowth = {
+  nodes: number;
+  listeners: number;
+  rendererHeapKb: number;
+  rendererEmbedderHeapKb: number;
+  mainHeapKb: number;
+};
+
 export async function takeCycleSample(app: ElectronApplication, page: Page): Promise<CycleSample> {
   await collectGarbage(app, [page]);
 

--- a/tests/lib/profile.ts
+++ b/tests/lib/profile.ts
@@ -62,6 +62,16 @@ export type ProcessSample = {
 
 export type RendererSample = {
   label: string;
+  /**
+   * Whether this is one of the app's own pages rather than web content.
+   *
+   * Worth carrying, because only one of the two is something a change to this
+   * repository can move. Meru's renderer and the signed-out Gmail view weigh
+   * about the same — 5.2 MB against 5.0 MB of JavaScript heap — so a report
+   * that adds them together halves the size every figure of ours reads at, and
+   * mixes in a page whose markup Google changes without telling anyone.
+   */
+  isAppPage: boolean;
   usedHeapKb: number;
   totalHeapKb: number;
   /** Blink's share, which is the DOM rather than the JavaScript heap proper. */
@@ -114,6 +124,19 @@ function pageLabel(url: string) {
     return protocol === "file:" ? (pathname.split("/").pop() ?? url) : hostname;
   } catch {
     return url;
+  }
+}
+
+/**
+ * Whether a page came out of the app bundle rather than off the network. Meru
+ * loads its own pages from disk, which is the same `file:` test `pageLabel`
+ * makes to decide whether a path or a hostname is the useful name.
+ */
+function isAppUrl(url: string) {
+  try {
+    return new URL(url).protocol === "file:";
+  } catch {
+    return false;
   }
 }
 
@@ -213,6 +236,7 @@ async function sampleRenderer(app: ElectronApplication, page: Page): Promise<Ren
 
     return {
       label: pageLabel(page.url()),
+      isAppPage: isAppUrl(page.url()),
       usedHeapKb: bytesToKb(heap.usedSize),
       totalHeapKb: bytesToKb(heap.totalSize),
       embedderHeapKb: bytesToKb(

--- a/tests/lib/report.ts
+++ b/tests/lib/report.ts
@@ -1,0 +1,68 @@
+/*
+ * Where a performance run's figures go when something outside the run has to
+ * read them.
+ *
+ * They are attached to the Playwright report either way, and that is the right
+ * shape for a person: someone opening a run browses to the test and reads its
+ * JSON. It is the wrong shape for a program. An attachment is a file under a
+ * content-hashed directory in `test-results`, named after the test that wrote
+ * it, and subtracting one run from another by digging two of those out is more
+ * fragile than naming a path and asking for it.
+ *
+ * So MERU_PERF_REPORT names one file, and every section of the run merges into
+ * it. Unset — which is every local run, and every CI run that has no base
+ * commit to compare against — none of this happens and the attachments are
+ * still there.
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { CycleGrowth, CycleSample, Sample } from "./profile";
+
+export type PerfReport = {
+  platform: string;
+  /** What was measured, when the runner was told. Absent from a local run. */
+  commit?: string;
+  coldLaunch?: Sample;
+  settingsCycles?: { pages: number; samples: CycleSample[]; growth: CycleGrowth };
+  /** Bytes per shipped file, keyed the way a budget names it. Linux only. */
+  bundles?: Record<string, number>;
+};
+
+type Section = Exclude<keyof PerfReport, "platform" | "commit">;
+
+/**
+ * Merges one section into the report file, leaving the others alone.
+ *
+ * Read-modify-write, which is safe here for the reason the Playwright config
+ * gives: the app takes a single instance lock, so the whole suite runs on one
+ * worker and no two tests are ever between the read and the write together.
+ */
+export async function recordSection<Name extends Section>(
+  section: Name,
+  payload: NonNullable<PerfReport[Name]>,
+) {
+  const reportPath = process.env.MERU_PERF_REPORT;
+
+  if (!reportPath) {
+    return;
+  }
+
+  const resolvedPath = path.resolve(reportPath);
+
+  await mkdir(path.dirname(resolvedPath), { recursive: true });
+
+  const existing: Partial<PerfReport> = await readFile(resolvedPath, "utf8")
+    .then((contents) => JSON.parse(contents))
+    // A first section of a first run has nothing to merge into, and a file left
+    // half-written by a killed run is not worth failing a measurement over.
+    .catch(() => ({}));
+
+  const report: PerfReport = {
+    ...existing,
+    platform: process.platform,
+    ...(process.env.MERU_PERF_COMMIT ? { commit: process.env.MERU_PERF_COMMIT } : {}),
+    [section]: payload,
+  };
+
+  await writeFile(resolvedPath, `${JSON.stringify(report, null, 2)}\n`);
+}

--- a/tests/memory.perf.ts
+++ b/tests/memory.perf.ts
@@ -18,7 +18,14 @@
  */
 import { expect, test } from "@playwright/test";
 import { useApp } from "./lib/app";
-import { type CycleSample, type Sample, takeCycleSample, takeSample } from "./lib/profile";
+import {
+  type CycleGrowth,
+  type CycleSample,
+  type Sample,
+  takeCycleSample,
+  takeSample,
+} from "./lib/profile";
+import { recordSection } from "./lib/report";
 
 const meru = useApp({}, { profile: true });
 
@@ -149,6 +156,8 @@ test("cold launch", async ({}, testInfo) => {
     contentType: "application/json",
   });
 
+  await recordSection("coldLaunch", sample);
+
   console.log(`[perf] cold launch on ${process.platform}\n${formatSample(sample)}`);
 
   /*
@@ -210,7 +219,7 @@ test("navigating settings repeatedly does not leak", async ({}, testInfo) => {
 
   const last = samples[samples.length - 1] as CycleSample;
 
-  const growth = {
+  const growth: CycleGrowth = {
     nodes: last.rendererNodes - first.rendererNodes,
     listeners: last.rendererListeners - first.rendererListeners,
     rendererHeapKb: last.rendererUsedHeapKb - first.rendererUsedHeapKb,
@@ -226,6 +235,8 @@ test("navigating settings repeatedly does not leak", async ({}, testInfo) => {
     ),
     contentType: "application/json",
   });
+
+  await recordSection("settingsCycles", { pages: pageLabels.length, samples, growth });
 
   console.log(
     `[perf] ${MEASURED_CYCLES} measured cycles over ${pageLabels.length} settings pages\n${samples


### PR DESCRIPTION
## Summary
Puts the performance profile on the pull request as a before/after table instead of leaving it as JSON in an artifact. Each matrix leg now builds and measures the pull request's own base commit alongside head, on the same runner in the same job, and a job after the matrix posts one comment with a column per platform. Nothing here can fail a build — a delta over 5% gets a marker and that is all it does. The second build was expected to roughly double the `e2e` job and adds 10 to 24 seconds to a leg instead, because the first build in the same job already downloaded Electron and filled the module cache.

## Problem
The cold-launch snapshot from #973 deliberately asserts nothing about its figures: an absolute memory figure belongs to the machine that produced it, and the same commit reads 549 MB on a hosted Windows runner against 772 MB on a hosted Linux one. That was the right call and it left the report somewhere nobody looks — a JSON attachment inside an artifact a reviewer would have to know exists, download and read by hand. A memory regression could land without anyone seeing a number.

## Solution
- `MERU_PERF_REPORT` names one file that every section of a perf run merges into, next to the Playwright attachments that stay as they are. A program asking for a path is what makes two runs subtractable; an attachment is a file under a content-hashed directory named after the test that wrote it.
- `scripts/perf-compare.ts` subtracts two report files and renders the markdown. It runs on every leg so the table is in the job log too, which is what a fork's pull request and a job killed for running long still get.
- `scripts/perf-comment.ts` combines one report pair per platform into a single comment, found again on the next push by a marker in its body.
- CI measures head first, uploads the head report, then builds the base commit, checks head back out and measures the base binary.

**The base is measured by head's harness, not its own.** The obvious version is to let the base commit measure itself, and it cannot: the base has neither the report writer nor whatever this pull request changed in `tests/lib/profile.ts`, so a change in how memory is measured would be reported as a change in how much is used. Building the base and pointing the head profiler at the resulting binary keeps the instrument fixed across both readings.

**The base run skips the leak check, and keeps the bundle sizes.** Repeated cycles already compare a run to itself, so running them against a second commit compares two self-relative figures and says nothing. The bundle sizes cost nothing there — `build-js` holds the base build at that moment — and are the one figure in the report with no measurement noise at all.

**The 5% marker is paired with an absolute floor per unit**, for the reason the bundle budgets give about their own slack warning: a proportion alone marks every small figure, because 5% of a three kilobyte counter is what any run produces.

**CPU to idle and settle time report their figures and are never marked.** The first CI run of this measured why. It builds one commit twice on each runner, so the comment on this pull request — which touches no app code — is a direct reading of a hosted runner's run-to-run spread: total CPU moved -14.2% on macOS, +4.8% on Linux and -3.4% on Windows for two launches of an identical binary, and macOS tripped the marker. A threshold quiet enough to sit above a fifteen percent swing is so loose that only a doubling would reach it, and a doubling is legible in the figure itself.

That same reading puts every memory row under 1.5% on all three platforms, which is the first evidence that a per-platform threshold on a memory *delta* is reachable. It is recorded against the deferred decision in `docs/features/performance-profiling.md` rather than acted on here.

Four cases skip the comparison rather than fail: a push to main has no base commit, a Markdown-only diff cannot have moved a byte of the app, a fork's token is read-only by design, and a leg that died still contributes whatever it measured.

**What it costs, measured rather than estimated.** Across three platforms and two runs, the base build takes 5 to 12 seconds and the base measurement another 5 to 12, against legs that run one to three minutes. The `e2e` timeout was raised to 45 minutes on the assumption this would double the job and is back at 20.

| Added to a leg | macOS | Linux | Windows |
|---|---|---|---|
| Base build | 8-12 s | 5-6 s | 11-12 s |
| Base measurement | 12 s | 5 s | 7-8 s |

## What it catches, measured

Finding 1.4 — the Gmail preload de-Reacted — landed as `0122c73` while this was in review, so it never got a comment of its own. Run by hand afterwards, `06543a2` against `0122c73` on one Linux machine:

| | Linux |
|---|---|
| Account views JS heap | 4.1 MB (-17.6%) ⚠️ |
| Shipped bytes | 5.6 MB (-9.8%) ⚠️ |
| Meru renderer JS heap | 5.1 MB |
| Meru renderer DOM nodes | 251 |
| Total working set | 843.7 MB (+0.3%) |

The per-file table named one file out of thirty-five: `preload-gmail.js`, 101 KB, -619 KB. Both markers fired on the two rows that should fire and on nothing else, Meru's own renderer read a flat zero because the change was not its, and the headline working-set figure moved +0.3% and would have said nothing on its own.

## Try it
The comment on this pull request is the change — a column per platform, comparing this branch against its base. Every figure in it should read as noise, since nothing here touches the app, and the CPU row is the interesting exception discussed above.

Locally, against a build already in `dist`:

```sh
MERU_SKIP_BUILD=1 MERU_PERF_REPORT=perf-reports/head.json xvfb-run -a bun run test:perf
MERU_SKIP_BUILD=1 MERU_PERF_REPORT=perf-reports/base.json xvfb-run -a bun run test:perf "--grep-invert=does not leak"
bun run scripts/perf-compare.ts perf-reports
```

That is the exact pair of commands CI runs, and it renders the same table against the same build twice — which is also a reading on how much of the table is noise.

## Not verified
- No fork pull request has exercised the read-only-token path, and no Markdown-only diff has exercised the skip or the comment take-down that follows it. Both were reasoned through rather than run.
- The concurrency group has never cancelled anything, since no two pushes here have overlapped.
- Re-running a single failed leg mixes artifacts across attempts, and if main moves between them the columns compare against different base commits while the heading names one. Believed but unverified; left as it stands.
- The rendering of a regression — the marker, a process appearing, a renderer disappearing, bundles added and removed — was checked against synthetic reports. Real CI reports have only produced the no-change case.

A review of this branch found the base run asserting head's bundle budgets against the base build; both failure modes were reproduced, fixed, and the fix verified. Five CI runs have exercised the rest end to end on all three platforms: the base build and the checkout around it, `fetch-depth: 2` carrying the base commit's tree, the artifact pattern, and both the create and update paths of the comment.

