### PR TITLE
Stop tracing the launches the performance tests measure

### DIFF
--- a/tests/lib/app.ts
+++ b/tests/lib/app.ts
@@ -124,6 +124,8 @@ type LaunchedApp = {
   /** Unset until the app has shown its window, which it may never do. */
   renderer: Page | undefined;
   userDataDir: string;
+  /** False for a profiled run, which is launched with no trace to stop. */
+  isTraced: boolean;
 };
 
 /** Resolves true when the work finishes in time, false when it runs over. */
@@ -183,11 +185,29 @@ async function launchApp(
     cwd: process.cwd(),
   });
 
-  // Started by hand rather than through the `trace` option, which only covers
-  // contexts the runner creates itself, and this one is launched here.
-  await app.context().tracing.start({ screenshots: true, snapshots: true, sources: true });
+  /*
+   * Started by hand rather than through the `trace` option, which only covers
+   * contexts the runner creates itself, and this one is launched here.
+   *
+   * Never for a profiled run, because a trace instruments the page it records.
+   * With snapshots on, a sample of Meru's own window reads 173 nodes, 3
+   * listeners and about 112 KB of JavaScript heap that are Playwright's rather
+   * than the app's — none of them in the document, which walks to the same 75
+   * nodes traced or not — and the screencast keeps the app busy enough to add
+   * a quarter to its CPU to idle and roughly double how long it takes to
+   * settle. All of that lands in the report as the app's own cost. It is also
+   * what put `main.html` in two DOM states on hosted Linux: the samples
+   * reading 78 nodes are the ones the snapshotter never reached, and the app
+   * rendered the same DOM in both. A performance test that fails still has its
+   * report, its stdout and its screenshot.
+   */
+  const isTraced = !options.profile;
 
-  return { app, renderer: undefined, userDataDir };
+  if (isTraced) {
+    await app.context().tracing.start({ screenshots: true, snapshots: true, sources: true });
+  }
+
+  return { app, renderer: undefined, userDataDir, isTraced };
 }
 
 async function attachDiagnostics({ app, renderer }: LaunchedApp, testInfo: TestInfo) {
@@ -351,19 +371,21 @@ export function useApp(seedConfig: Partial<Config> = {}, options: UseAppOptions 
       await collectDiagnostics(current(), testInfo);
     }
 
-    const { app, userDataDir } = current();
+    const { app, userDataDir, isTraced } = current();
 
     try {
-      // Written only when the test failed; a passing run has nothing worth
-      // uploading.
-      if (hasFailed) {
-        const tracePath = testInfo.outputPath("trace.zip");
+      if (isTraced) {
+        // Written only when the test failed; a passing run has nothing worth
+        // uploading.
+        if (hasFailed) {
+          const tracePath = testInfo.outputPath("trace.zip");
 
-        await app.context().tracing.stop({ path: tracePath });
+          await app.context().tracing.stop({ path: tracePath });
 
-        await testInfo.attach("trace", { path: tracePath, contentType: "application/zip" });
-      } else {
-        await app.context().tracing.stop();
+          await testInfo.attach("trace", { path: tracePath, contentType: "application/zip" });
+        } else {
+          await app.context().tracing.stop();
+        }
       }
     } finally {
       // Whatever the trace did. A test fails because the app is in a bad way,


### PR DESCRIPTION
## Summary
`useApp` started a Playwright trace on every launch, and a trace with `snapshots` on instruments the page it records. That is what put Meru's renderer in two DOM states on hosted Linux, and it is a quarter of the CPU figure the performance report prints. A profiled launch now starts no trace at all. Nothing in the app changes; the end-to-end suite still traces every launch.

## Problem
`main.html` reported either 250 nodes and 173 listeners or 78 and 170 on hosted Linux, in about half the samples each, with nothing in between. A base and a head sample landing in different states put a 172-node and 270 KB delta on a pull request that changed no application code. The two readings on the table were a gap in `settle`, which waits for CPU to go quiet and could be sampling an app that is quiet in more than one state, or an application bug rendering a third of the interface a third of the time. The fix for the first would have hidden the second, so the investigation came first.

It is neither. The extra nodes are Playwright's. Five launches per configuration on one Linux machine, sampled through the harness itself:

| Tracing | `main.html` nodes | Listeners | Renderer JS heap |
|---|---|---|---|
| None | 78 | 170 | 5077–5084 KB |
| `screenshots` only | 78 | 170 | 5065–5079 KB |
| `screenshots` and `snapshots` | 251 | 173 | 5180–5202 KB |

Deterministic, five out of five in each, and those are CI's two states on all three figures at once — the heap gap of about 112 KB matches the 120 to 200 KB CI saw. The app rendered the same DOM in every one of them: walking the page from `document` reads 75 nodes and 55 elements traced or untraced, with no shadow roots, so none of Playwright's nodes are in the tree the app built. The extra nodes appear the moment Playwright first drives a locator on the page — 87 nodes before the `#root > *` wait and 261 after — and repeated `HeapProfiler.collectGarbage` never frees them. The 78-node samples are the ones the snapshotter never reached.

So `settle` was never the problem, and the readiness gate that was the obvious fix would have gated on a DOM that was already complete and already correct in both states.

## Solution
- `launchApp` starts a trace only when the launch did not ask to be profiled, and `afterEach` stops one only when there is one to stop
- The docs record the answer, and every figure measured through the instrument is re-measured: the hosted-runner baseline, the local baseline, the renderer heaps in the base-comparison section, the per-platform node counts and the GPU process reading

Turning `snapshots` off and keeping the screencast was considered and rejected. It removes the DOM and heap contamination exactly as well, but the screencast costs separately: 3.15 s of CPU to idle against 2.51 s untraced, and 5.4 to 6.0 s to settle against 3.6 s, over the same five launches each. An app being recorded never quite goes quiet, so the wait for it to stop spending CPU was partly a wait on the recorder — in a report whose whole purpose is those numbers.

What a failing performance test loses is the trace artifact. What it keeps is its JSON report, the same report printed to stdout, a screenshot of the renderer and the window list, all of which `collectDiagnostics` already attaches on failure.

## Try it
Nothing to open — this changes how the performance project launches the app. The reading is in this pull request's own `e2e` job logs, and all three platforms agree:

| `main.html` | Traced | This run |
|---|---|---|
| macOS | 219–220 | **72 / 169** |
| Linux | 250–251 or 78 | **78 / 170** |
| Windows | 250–251 | **78 / 170** |

Linux and Windows now agree exactly, where before Windows sat at 250 and Linux flipped between 250 and 78 across eight samples on #979. macOS reads six nodes fewer because `AppMenuButton` draws nothing there. There is one sample per platform rather than two: the base comparison that produces the second one lives on #979 and has not landed on main.

## Not verified
- One CI run, one sample per platform. A single Linux sample reading 78 would have been a coin toss on its own; three platforms dropping together to the figures measured locally is what carries it. The causal evidence is local, on one machine, five launches per configuration.
- The CPU claim does not reproduce on a single CI run and is not asserted from one: macOS read 3.41 s here against 2.67 s traced, in the wrong direction, which is a hosted runner's own 15% CPU spread rather than a contrary reading. It is measured locally, where five launches per mode group tightly.
- Why Playwright's snapshotter reaches the page on roughly half of hosted Linux runs and reliably on macOS and Windows is not explained here. It does not need to be for the fix, since an untraced launch has no snapshotter at all.