### PR TITLE
Give the main process's JavaScript heap a checked-in ceiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,12 +139,16 @@ jobs:
       # binary.
       #
       # Allowed to fail the job, unlike a typical performance run, because of
-      # what is actually asserted in there. The cold-launch snapshot asserts
-      # nothing about its figures and only reports them — absolute memory belongs
-      # to the runner that produced it, and no threshold has been set from a
-      # runner yet. What can fail is the leak check, which compares a run to
-      # itself and so means the same thing on any machine, and the bundle
-      # budgets, which are the same bytes everywhere.
+      # what is actually asserted in there. Three things can fail, and none of
+      # them is a figure read off this runner and compared to another machine's.
+      # The leak check compares a run to itself, so it means the same thing
+      # anywhere. The bundle budgets are the same bytes everywhere. And the main
+      # process's JavaScript heap is held to a ceiling in
+      # tests/memory-budget.json — the one absolute memory figure measured to
+      # transfer between machines, at 7682 to 7734 KB across 21 samples on these
+      # three runners. Every other figure in the cold-launch snapshot is
+      # reported and asserted on only far enough to catch a reading that did not
+      # happen.
       #
       # MERU_PERF_REPORT is what puts the figures somewhere a program can find
       # them by name, next to the attachments a person reads. Set on both this

--- a/tests/bundles.perf.ts
+++ b/tests/bundles.perf.ts
@@ -1,10 +1,13 @@
 /*
  * What the app ships, in bytes, against a budget kept next to this file.
  *
- * The only measurement here that is not a measurement at all. Every other figure
- * the performance tests take belongs to the machine that took it; a bundle is
- * the same number of bytes on every machine that builds it, so this one can hold
- * a checked-in budget and fail when the build outgrows it.
+ * The measurement here that is not a measurement at all. Most of what the
+ * performance tests take belongs to the machine that took it; a bundle is the
+ * same number of bytes on every machine that builds it, so this one can hold a
+ * checked-in budget and fail when the build outgrows it. The main process's
+ * JavaScript heap now holds one too, and `tests/memory.perf.ts` explains what
+ * earned it — a figure V8 counts rather than the operating system attributes,
+ * measured across three platforms before it was gated. Nothing else does.
  *
  * That makes most of the audit's P4 tier — bundle size — into something CI can
  * enforce. It is the direct proof for finding 1.4, a preload that carries React

--- a/tests/memory-budget.json
+++ b/tests/memory-budget.json
@@ -1,0 +1,3 @@
+{
+  "main.usedHeapKb": 8000
+}

--- a/tests/memory.perf.ts
+++ b/tests/memory.perf.ts
@@ -2,11 +2,23 @@
  * What the app costs to run, and whether repeating something makes it cost more.
  *
  * Two tests with deliberately different standing. The cold-launch snapshot
- * reports and never fails: its figures are absolute, and an absolute figure
- * belongs to the machine that produced it, so a threshold set from one machine
- * says nothing on another. The leak check fails, because it compares a run to
+ * mostly reports: its figures are absolute, and an absolute figure belongs to
+ * the machine that produced it, so a threshold set from one machine says
+ * nothing on another. The leak check fails, because it compares a run to
  * itself — the same app, the same machine, the same minute — and growth across
  * cycles means the same thing everywhere.
+ *
+ * One figure in the snapshot is the exception, and it is measured rather than
+ * argued. Over 21 CI samples — three platforms across seven runs, spanning two
+ * real code changes — the main process's JavaScript heap held between 7682 and
+ * 7734 KB, a 52 KB band, while total working set on those same samples ranged
+ * 530 to 776 MB. The reason is structural rather than lucky: a JavaScript heap
+ * figure is V8 counting objects the app allocated, and the same code allocates
+ * the same objects anywhere, where working set is the operating system
+ * attributing pages with shared ones charged in full to every process holding
+ * them. So that one figure carries a ceiling from `tests/memory-budget.json`
+ * and fails on every platform, the way bundle bytes already do. Every other
+ * figure here still only reports.
  *
  * What is not covered, and cannot be: no Gmail account signs in. The audit's
  * argument is that the dominant cost is Gmail's own document and heap in a view
@@ -16,6 +28,8 @@
  * hostname check, so everything it drags in is loaded and measured on the
  * sign-in page too.
  */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import { expect, test } from "@playwright/test";
 import { useApp } from "./lib/app";
 import {
@@ -28,6 +42,28 @@ import {
 import { recordSection } from "./lib/report";
 
 const meru = useApp({}, { profile: true });
+
+const MEMORY_BUDGET_PATH = path.join(process.cwd(), "tests", "memory-budget.json");
+
+/**
+ * The one figure in the snapshot with a ceiling over it, named as the report
+ * spells it so that the budget file reads as a figure rather than as a number.
+ */
+const MAIN_HEAP_BUDGET_KEY = "main.usedHeapKb";
+
+/**
+ * When the heap comes in under its ceiling by more than a tenth, the ceiling is
+ * asked to come down.
+ *
+ * A proportion alone, where the bundle budgets pair one with an absolute gap.
+ * Their reason for the pair does not apply here: a proportion fires on every
+ * small chunk from the day those budgets are written, because the floor that
+ * keeps a 144-byte chunk from tripping over whitespace is most of its size.
+ * This is one figure of about 7.7 MB, so a tenth of its ceiling is 800 KB — a
+ * win worth locking in by any measure, and nothing a second threshold makes
+ * clearer.
+ */
+const SLACK_WARNING_RATIO = 0.9;
 
 /**
  * Discarded rather than measured. A first pass through a route allocates things
@@ -183,6 +219,64 @@ test("cold launch", async ({}, testInfo) => {
     sample.totalCpuSeconds,
     "no CPU was reported, so settling degraded to a fixed sleep",
   ).toBeGreaterThan(0);
+
+  /*
+   * The one figure here that is held to a number, and the only place in this
+   * report where an absolute reading fails a run. Why this figure and no other
+   * is in the file header; what the ceiling is for is this:
+   *
+   * Comparing a pull request against its own base commit on the same runner
+   * catches a change, and marks it with the pull request that made it and the
+   * process it landed in. It structurally cannot catch drift — a figure
+   * creeping a percent per pull request stays under that marker forever and
+   * adds up to anything. A ceiling is the second net, and the only one that
+   * ever sees the absolute number.
+   *
+   * It says "over" and nothing more. Which pull request, and which process, is
+   * the comparison's job, and a ceiling that tried to diagnose would be a worse
+   * copy of it.
+   *
+   * Read after the report is attached and printed, so a budget file that is
+   * missing or malformed still leaves the run's figures somewhere readable.
+   */
+  const budget: Record<string, number> = JSON.parse(await readFile(MEMORY_BUDGET_PATH, "utf8"));
+
+  const ceilingKb = budget[MAIN_HEAP_BUDGET_KEY];
+
+  /*
+   * Thrown rather than compared, and before anything is compared to it. A key
+   * renamed on one side of the pair, or an edit that drops it, would otherwise
+   * leave `undefined` on the right of a soft comparison that passes — a gate
+   * reporting green while measuring nothing, which is the failure every guard
+   * in this file exists to prevent.
+   */
+  if (ceilingKb === undefined || ceilingKb <= 0) {
+    throw new Error(
+      `tests/memory-budget.json has no usable ${MAIN_HEAP_BUDGET_KEY} ceiling, so nothing is gated.`,
+    );
+  }
+
+  console.log(
+    `[perf] main JS heap ${sample.main.usedHeapKb} KB of ${ceilingKb} KB ceiling in tests/memory-budget.json`,
+  );
+
+  // Soft for the reason the leak check's are, so that a run reports every figure
+  // that tripped rather than sending someone round the loop once per figure.
+  expect
+    .soft(sample.main.usedHeapKb, "main JS heap in KB is over its ceiling")
+    .toBeLessThanOrEqual(ceilingKb);
+
+  /*
+   * Reported, never failed. A build coming in well under its ceiling is a win,
+   * and failing the run for it would have the next person raise the ceiling to
+   * get green — the opposite of what a ceiling is for. Saying so in the log is
+   * what gets it lowered instead.
+   */
+  if (sample.main.usedHeapKb < ceilingKb * SLACK_WARNING_RATIO) {
+    console.log(
+      `[perf] main JS heap is under its ceiling by more than a tenth — lower ${MAIN_HEAP_BUDGET_KEY} in tests/memory-budget.json to keep the win`,
+    );
+  }
 });
 
 // oxlint-disable-next-line no-empty-pattern

--- a/tests/memory.perf.ts
+++ b/tests/memory.perf.ts
@@ -17,8 +17,15 @@
  * the same objects anywhere, where working set is the operating system
  * attributing pages with shared ones charged in full to every process holding
  * them. So that one figure carries a ceiling from `tests/memory-budget.json`
- * and fails on every platform, the way bundle bytes already do. Every other
- * figure here still only reports.
+ * and fails against it. Every other figure here still only reports.
+ *
+ * It is checked on every platform, where the other checked-in ceiling in this
+ * suite is not: `tests/bundles.perf.ts` runs on Linux alone, because one
+ * platform's byte count is every platform's and running it three times would
+ * make a budget file into a claim about three toolchains nobody checked. A heap
+ * is read out of a process that is actually running, so there is no one
+ * platform whose answer stands for the others — the reason it can be gated
+ * everywhere is that the three were measured and agreed to 0.7%.
  *
  * What is not covered, and cannot be: no Gmail account signs in. The audit's
  * argument is that the dominant cost is Gmail's own document and heap in a view
@@ -238,7 +245,24 @@ test("cold launch", async ({}, testInfo) => {
    *
    * Read after the report is attached and printed, so a budget file that is
    * missing or malformed still leaves the run's figures somewhere readable.
+   *
+   * A base-commit run stops before it, having reported the figures and checked
+   * nothing, for the reason `tests/bundles.perf.ts` gives about its own
+   * budgets: that run pairs an older build with this checkout's ceiling, and a
+   * pull request that lowers the ceiling to lock a win in — which is what the
+   * warning below tells people to do — would fail against a build made before
+   * it did. The failure would surface in a step named after the base commit, on
+   * a pull request that is perfectly healthy.
+   *
+   * Worth knowing that it fails late rather than at once, which is why the
+   * guard is here and not left for whoever first trips it. A base binary passes
+   * this ceiling today, so the mismatch appears only the first time someone
+   * lowers the number.
    */
+  if (process.env.MERU_PERF_BASELINE) {
+    return;
+  }
+
   const budget: Record<string, number> = JSON.parse(await readFile(MEMORY_BUDGET_PATH, "utf8"));
 
   const ceilingKb = budget[MAIN_HEAP_BUDGET_KEY];


### PR DESCRIPTION
## Summary
Adds `tests/memory-budget.json` with one number, `main.usedHeapKb: 8000`, and makes the cold-launch snapshot fail against it on every platform. It is the first absolute memory figure the performance tests gate on, and it is deliberately meant to stay the only one for a while. It exists alongside #979 rather than instead of it: that comparison catches a change and names it, and this ceiling catches drift that stays under any per-change marker forever.

## Problem
The performance snapshot has never gated on an absolute number, on the stated grounds that an absolute figure belongs to the machine that produced it. That is true of most of the report and measurably false of one figure in it.

Twenty-one CI samples — three platforms across seven runs, spanning two real code changes — measured the two spreads separately:

| Figure | Same machine, minutes apart | Across the three platforms |
|---|---|---|
| Main JS heap | 0.1% | **0.7%** |
| Meru renderer JS heap | 0.1% | 2.8% |
| Total working set | 0.4% | **33.8%** |
| Main private | 1.8% | **43.6%** |

Main JS heap held 7682 to 7734 KB across all 21 samples — a 52 KB band — while total working set on those same samples ranged 530 to 776 MB. The reason is structural rather than lucky: a JavaScript heap figure is V8 counting objects the app allocated, and the same code allocates the same objects anywhere, whereas working set is the operating system attributing pages, with shared ones charged in full to every process holding them.

Separately, #979 compares each pull request against its own base commit on the same runner and marks a move over 5%. That catches a change, and names which pull request and which process. It structurally cannot catch **drift**: a figure creeping up a percent per pull request stays under the marker forever and adds up to anything. A checked-in ceiling is the second net, and the only one that ever sees the absolute number.

## Solution
- `tests/memory-budget.json` holds `main.usedHeapKb: 8000`, and the cold-launch test asserts against it softly, on every platform, alongside its existing guards.
- Coming in under the ceiling is reported and never failed; more than a tenth under logs a line asking for the ceiling to be lowered to lock the win in. That is the bundle budgets' arrangement, and their reasoning: fail a build for coming in under and the next person raises the ceiling to get green.
- A base-commit run returns before the ceiling is read, the way `tests/bundles.perf.ts` already returns before its budgets. See the note on #979 below.
- Four comments that said the snapshot asserts nothing about its figures are updated rather than left contradicting the code: the header of `tests/memory.perf.ts`, the header of `tests/bundles.perf.ts` (which claimed to be the suite's only checked-in budget), the justification in `.github/workflows/ci.yml` for letting the perf run fail the job, and the `docs/decisions.md` entry, now marked partly superseded — its reasoning still holds for every other figure in the report.

**8000 KB is 3.4% over the highest sample**, about five times the cross-platform spread and fifty times the same-machine spread. A round 8192 was rejected the other way: 5.9% would let 458 KB of drift through, most of the size of the win the de-Reacted Gmail preload was measured at. Tighter than this was rejected too — the perf job is required and never retried, and the real threat to a tight ceiling is a step change from an Electron upgrade or a new runner image rather than run-to-run wander.

**A separate file rather than a second key in `tests/bundle-budget.json`.** That file is a flat map of bundle name to bytes, and `tests/bundles.perf.ts` reports any key the build does not produce as a budget for a bundle that no longer exists — so a runtime figure filed there would turn its own check red. It also misfiles a runtime figure in a file about shipped bytes.

**It gates from the first day rather than reporting for a few merges first.** The leak check's heap assertions were held to Linux out of exactly that caution and it bought nothing; there the data arrived after the caution, and here it arrived first.

**It gates on every platform, where the bundle budgets gate on Linux alone.** Not an inconsistency: one platform's byte count is every platform's, so running that check three times would turn one budget file into a claim about three toolchains nobody has checked, while a heap is read out of a process that is actually running and has no single platform whose answer stands for the others. What makes gating it everywhere safe is that the three were measured and agreed.

**It says "over" and nothing more.** Which pull request moved the figure and which process it moved in is #979's job, and a ceiling that tried to diagnose would only be a worse copy of it.

Renderer heaps are deliberately left out. They spread 2.8 to 3.4% across platforms against main's 0.7%, so their ceilings would need enough slack to catch only a large regression — a separate argument to make once this one has run for a while. The new file is where they would go.

### On #979
#979 adds `MERU_PERF_BASELINE`, which makes the base-commit run record figures and check no budget, because pairing an older build with head's budget file fails whenever a pull request legitimately lowers a ceiling. This change gives the cold-launch test its first budget assertion, so it inherits that problem, and the guard is written here rather than left to whichever merges second. Nothing on `main` sets the variable yet, so the two lines are inert until #979 lands — but the failure they prevent is latent rather than immediate: the base binary passes this ceiling today, and the mismatch first appears when someone lowers the ceiling to lock in a win, which is exactly what the slack warning tells them to do and could be long after both have landed. Expect a rebase; the two changes overlap in `tests/memory.perf.ts` and `.github/workflows/ci.yml` and conflict in neither's substance.

## Try it
```sh
bun run build:linux -- --dir --x64 --publish never
MERU_SKIP_BUILD=1 xvfb-run -a bun run test:perf
```

The cold-launch test logs `[perf] main JS heap 7704 KB of 8000 KB ceiling in tests/memory-budget.json`. Lower the number in `tests/memory-budget.json` to 7000 to watch it fail, raise it to 9000 to watch the slack warning fire, or rename the key to watch the guard throw rather than pass on `undefined`. `MERU_PERF_BASELINE=1` skips the check and logs nothing.

## Not verified
- The 21 samples span two code changes and seven runs, which is enough to measure a spread but says nothing about how the figure moves across an Electron upgrade or a change of runner image. Either could need the ceiling raised on purpose.

Resolved since this was opened: all three platforms have now run against the ceiling on this branch, reading 7686 KB on macOS, 7722 KB on Linux and 7730 KB on Windows — inside the 7682 to 7734 KB band the ceiling was set from, and a 44 KB spread across the three.
