### PR TITLE
Drop the extension permissions that make a main process fetch segfault

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -568,11 +568,24 @@ export class Gmail {
         await this.view.webContents.executeJavaScript("window.GM_INBOX_TYPE"),
       );
 
-      const body = await this.session
-        .fetch(
-          `${GMAIL_INBOX_FEED_URL}${inboxType === "SECTIONED" && config.get("gmail.inboxCategoriesToMonitor") === "primary" ? "/^sq_ig_i_personal" : ""}?t=${Date.now()}`,
-        )
-        .then((res) => res.text());
+      const feedUrl = `${GMAIL_INBOX_FEED_URL}${inboxType === "SECTIONED" && config.get("gmail.inboxCategoriesToMonitor") === "primary" ? "/^sq_ig_i_personal" : ""}?t=${Date.now()}`;
+
+      /*
+       * Fetched from the page rather than through `session.fetch`, because a
+       * main process request carries no frame. Electron hands its browser
+       * process loader factory to the extensions layer as a navigation with a
+       * null `RenderFrameHost`, and `MaybeProxyURLLoaderFactory` dereferences
+       * it — a segfault, not an exception, whenever an extension declaring
+       * `webRequest` or `declarativeNetRequest` is loaded into the session
+       * (electron/electron#45050). The blocker's own `onBeforeRequest` listener
+       * happens to suppress the proxy, so the crash only surfaced where that
+       * listener was absent: development, and Pro installs with the blocker
+       * turned off. The feed is same-origin with the page, so fetching it here
+       * carries the same cookies and keeps `Set-Cookie` rotation in the session.
+       */
+      const body: string = await this.view.webContents.executeJavaScript(
+        `fetch(${JSON.stringify(feedUrl)}).then((response) => response.text())`,
+      );
 
       const { feed } = inboxFeedSchema.parse(xmlParser.parse(body));
 

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -568,24 +568,11 @@ export class Gmail {
         await this.view.webContents.executeJavaScript("window.GM_INBOX_TYPE"),
       );
 
-      const feedUrl = `${GMAIL_INBOX_FEED_URL}${inboxType === "SECTIONED" && config.get("gmail.inboxCategoriesToMonitor") === "primary" ? "/^sq_ig_i_personal" : ""}?t=${Date.now()}`;
-
-      /*
-       * Fetched from the page rather than through `session.fetch`, because a
-       * main process request carries no frame. Electron hands its browser
-       * process loader factory to the extensions layer as a navigation with a
-       * null `RenderFrameHost`, and `MaybeProxyURLLoaderFactory` dereferences
-       * it — a segfault, not an exception, whenever an extension declaring
-       * `webRequest` or `declarativeNetRequest` is loaded into the session
-       * (electron/electron#45050). The blocker's own `onBeforeRequest` listener
-       * happens to suppress the proxy, so the crash only surfaced where that
-       * listener was absent: development, and Pro installs with the blocker
-       * turned off. The feed is same-origin with the page, so fetching it here
-       * carries the same cookies and keeps `Set-Cookie` rotation in the session.
-       */
-      const body: string = await this.view.webContents.executeJavaScript(
-        `fetch(${JSON.stringify(feedUrl)}).then((response) => response.text())`,
-      );
+      const body = await this.session
+        .fetch(
+          `${GMAIL_INBOX_FEED_URL}${inboxType === "SECTIONED" && config.get("gmail.inboxCategoriesToMonitor") === "primary" ? "/^sq_ig_i_personal" : ""}?t=${Date.now()}`,
+        )
+        .then((res) => res.text());
 
       const { feed } = inboxFeedSchema.parse(xmlParser.parse(body));
 

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -16,7 +16,7 @@ const FACADE_FILE_NAME = "chrome-facade.js";
 const SERVICE_WORKER_FILE_NAME = "chrome-facade-service-worker.js";
 
 /** Bump whenever what is written into a derived copy changes. */
-const DERIVE_VERSION = 4;
+const DERIVE_VERSION = 5;
 
 export type DeriveExtensionOptions = {
   /** The unpacked extension the embedder handed over, never written to. */

--- a/packages/electron-extensions/derive/manifest.test.ts
+++ b/packages/electron-extensions/derive/manifest.test.ts
@@ -98,6 +98,28 @@ describe("deriveManifest", () => {
     expect(manifest.permissions).toEqual(["storage", "nativeMessaging", "tabs"]);
   });
 
+  test("drops the permissions that arm the WebRequest proxy, and their rulesets", () => {
+    const { manifest } = deriveManifest(
+      {
+        permissions: [
+          "storage",
+          "declarativeNetRequest",
+          "declarativeNetRequestWithHostAccess",
+          "declarativeNetRequestFeedback",
+          "declarativeWebRequest",
+          "tabs",
+        ],
+        declarative_net_request: { rule_resources: [{ id: "ruleset_1", path: "rules_1.json" }] },
+      },
+      fileNames,
+    );
+
+    // A main process `session.fetch` segfaults while any of these is declared,
+    // so this is load-bearing rather than tidying.
+    expect(manifest.permissions).toEqual(["storage", "tabs"]);
+    expect(manifest.declarative_net_request).toBeUndefined();
+  });
+
   test("leaves a manifest without permissions alone", () => {
     const { manifest } = deriveManifest({ name: "No permissions" }, fileNames);
 

--- a/packages/electron-extensions/derive/manifest.ts
+++ b/packages/electron-extensions/derive/manifest.ts
@@ -59,8 +59,46 @@ function createServiceWorkerWrapper(
  */
 const DROPPED_PERMISSIONS = new Set(["webRequest", "webRequestAuthProvider"]);
 
+/**
+ * Permissions that put an extension into Chromium's WebRequest proxy count.
+ * Chromium proxies every URL loader factory built for the browser context as
+ * soon as one loaded extension declares any of them, counted from the manifest
+ * alone with no listener and no ruleset content required. Electron then hands
+ * it a browser process factory as a navigation with a null `RenderFrameHost`
+ * and `MaybeProxyURLLoaderFactory` dereferences it, which is a segfault rather
+ * than an exception, so no caller can catch it. electron/electron#45050 carries
+ * the one line that fixes it and has sat open and unmerged, so no upgrade
+ * avoids this.
+ *
+ * Dropped so a main process `session.fetch` against an account session stays a
+ * usable primitive. An account with no view has no other way to read its unread
+ * feed, which is what the hibernation and lazy view work is built on.
+ *
+ * The cost is 1Password's rules, which scrub `user-agent`, `accept-language`
+ * and `origin` from its DNS-over-HTTPS lookups and from the
+ * `/.well-known/webauthn` request behind related-origin passkeys. Every rule it
+ * ships is `modifyHeaders`, so nothing it asks for stops being requested, and
+ * its own call site reads the namespace through `?.` and carries on without it.
+ */
+const DROPPED_NETWORK_PERMISSIONS = new Set([
+  "declarativeWebRequest",
+  "declarativeNetRequest",
+  "declarativeNetRequestWithHostAccess",
+  "declarativeNetRequestFeedback",
+]);
+
+/**
+ * The rulesets those permissions carry. Chromium rejects a manifest declaring
+ * `declarative_net_request` without a permission to match, so the key has to go
+ * with them rather than be left behind as a load error.
+ */
+const DROPPED_MANIFEST_KEYS = ["declarative_net_request"];
+
 function derivePermissions(permissions: ExtensionManifest["permissions"]) {
-  return permissions?.filter((permission) => !DROPPED_PERMISSIONS.has(permission));
+  return permissions?.filter(
+    (permission) =>
+      !DROPPED_PERMISSIONS.has(permission) && !DROPPED_NETWORK_PERMISSIONS.has(permission),
+  );
 }
 
 function parseDirectives(contentSecurityPolicy: string) {
@@ -156,7 +194,8 @@ function deriveContentScripts(
 /**
  * Points the manifest's service worker at a generated wrapper, lets its content
  * security policy reach the native messaging bridge, clamps its content scripts
- * to the sites they may run on and drops the permissions Electron cannot serve.
+ * to the sites they may run on, and drops both the permissions Electron cannot
+ * serve and the ones that arm the extensions WebRequest proxy.
  * Everything else is carried over untouched — `key`
  * above all, since without it Chromium derives the extension id from the
  * directory it was loaded from and the derived copy would answer to a different
@@ -189,6 +228,10 @@ export function deriveManifest(
     content_security_policy: deriveContentSecurityPolicy(manifest, bridgeConnectSource),
     content_scripts: deriveContentScripts(manifest.content_scripts, contentScriptMatches),
   };
+
+  for (const droppedManifestKey of DROPPED_MANIFEST_KEYS) {
+    delete derivedManifest[droppedManifestKey];
+  }
 
   for (const strippedManifestKey of strippedManifestKeys) {
     delete derivedManifest[strippedManifestKey];


### PR DESCRIPTION
## Summary
Meru segfaults on launch whenever an extension is loaded into an account session and the content blocker is off — reproduced on a signed build, not only in development. Chromium routes main process fetches through the extensions WebRequest proxy, which dereferences a null frame. Dropping the permissions that arm that proxy closes it and keeps `session.fetch` usable, which is what the lazy view and hibernation work is built on.

## Problem
A main process request carries no frame. Electron hands its browser process loader factory to the extensions layer as a navigation with a null `RenderFrameHost`, and `extensions::WebRequestAPI::MaybeProxyURLLoaderFactory` builds an `ExtensionNavigationUIData` out of that null pointer: `ldr x0, [x25, #0x130]` with `x25` null, thirteen of sixteen crash reports at the identical address, symbolicated against Breakpad symbols matching the crashed binary's UUID. It is a segfault rather than an exception, so nothing catches it and the app dies.

Chromium proxies as soon as one loaded extension declares `webRequest` or any of the `declarativeNetRequest` family, counted off the manifest alone with no listener registered and no ruleset content required. Its contract is that a navigation type factory always has a frame, enforced by a `DCHECK` that compiles out of the builds Meru ships. [electron/electron#45050](https://github.com/electron/electron/pull/45050) carries the one line that fixes it — `if (!web_request->HasListener() && frame_host)` — and has sat open and unmerged, with the unguarded code still on `main`, so no Electron upgrade avoids it. [#32271](https://github.com/electron/electron/issues/32271) reported the same crash in 2022 and was closed as no longer reproducing, incorrectly.

What hid it is that Electron skips extension proxying entirely when the session already has a `webRequest` listener, and `Blocker.setupSession` registers exactly that. So the crash only surfaced where the blocker was absent: development, where the extensions folder loads without a license while the missing license switches the blocker off, and Pro installs with the blocker turned off. The packaged app was protected by accident, since Pro is what both enables extensions and turns on the listener that suppresses the bug.

Today the only main process fetch is the Gmail inbox feed poll. That is not where this ends: `memory-plans/1-2-lazy-view-creation.md` specifies a main process poller doing that same `session.fetch` for accounts with no view, and `memory-plans/1-3-idle-hibernation.md` gates Gmail hibernation on that poller existing. Left alone, the next person following either plan reintroduces a native crash with nothing pointing back here.

## Solution
- Drops `declarativeWebRequest`, `declarativeNetRequest`, `declarativeNetRequestWithHostAccess` and `declarativeNetRequestFeedback` in the derive, alongside the `webRequest` pair already dropped
- Takes the `declarative_net_request` ruleset key with them, since Chromium rejects a manifest declaring the key with no permission to match — dropping only the permission trades a crash for a load error
- Bumps `DERIVE_VERSION`, without which every install already holding a derived copy keeps the old manifest and goes on crashing with the fix apparently applied. The source tree hash cannot see a change that lives in this repository rather than in the extension
- Asserts both the permissions and the ruleset key are gone, since the failure mode is a native crash rather than something a later test would surface

Fixing the call site instead was tried first and reverted. Fetching the feed from the page removed the frameless request rather than the reason a frameless request was fatal, and bought that by depending on a live view — the exact dependency 1-2 exists to remove. It was also the only unverified behavior change of the two: `session.fetch` has read this feed since long before `v3.59.0`, where a page context `fetch` is subject to whatever Gmail's CSP allows.

The cost is 1Password's rules, which are its only ones: header scrubbing on its DNS-over-HTTPS lookups and on the `/.well-known/webauthn` request behind related-origin passkeys. Every rule it ships is `modifyHeaders`, so nothing it asks for stops being requested, and its own call site reads the namespace through `?.` and logs "proceeding without it" when absent. Autofill never touches the API.

Relying on Electron's precedence rule instead — leaving the blocker's listener to suppress the proxy — was rejected, since it leaves whether the app segfaults hanging off an unrelated setting.

## Try it
No preview deployment for a desktop app. `bun run extensions:download` to put 1Password in `extensions/`, then `bun run dev` signed into Gmail. Before this the app segfaults shortly after the window appears with `Electron exited with signal SIGSEGV`; after it the window stays up. On a packaged build the same is reachable with Pro, 1Password installed from the extensions settings page, and the content blocker switched off. Confirm the derive took by checking that the copy under `derived-extensions/` has neither `declarativeNetRequestWithHostAccess` in `permissions` nor a `declarative_net_request` key.

## Not verified
- `test:e2e` and `test:perf` were not run. `bun test` (523 pass), `types`, `lint` and `fmt:check` all pass.

Verified on a machine that reproduces the crash: no crash reading or receiving inbox mail with the blocker both on and off, which is the `session.fetch` feed poll running; password login and passkey login on `accounts.google.com`; creating a passkey on `myaccount.google.com`; and a passkey saved against `myaccount.google.com` then used to sign in on `accounts.google.com`.

Related-origin passkeys, the one flow the dropped rules could still affect, were not exercised and cannot arise on the surface 1Password is loaded for: the content script clamp is `accounts.google.com` and `myaccount.google.com`, which share the registrable domain `google.com`, so ordinary WebAuthn subdomain scoping applies and `/.well-known/webauthn` is never consulted.

