### PR TITLE
Cover the child view machinery end to end

### DIFF
--- a/tests/lib/accounts.ts
+++ b/tests/lib/accounts.ts
@@ -1,0 +1,73 @@
+/*
+ * Account and saved-tab config, built up for a seed.
+ *
+ * Both shapes are wide, and almost none of each matters to a given test. These
+ * fill in the parts that don't so that what a test writes out is only what it
+ * is actually making a claim about.
+ */
+import type { AccountConfig, SavedTab } from "@meru/shared/schemas";
+import type { SupportedWorkspaceApp } from "@meru/shared/workspace-apps";
+
+/**
+ * A pinned tab as the app restores it on the next launch.
+ *
+ * `loadOnLaunch` is the one worth naming at a call site: it is the difference
+ * between a tab that comes back as a live view during startup and one that
+ * comes back as an entry in the strip with nothing behind it until it is
+ * clicked.
+ */
+export function seedSavedTab({
+  app,
+  url,
+  title,
+  loadOnLaunch = false,
+}: {
+  app: SupportedWorkspaceApp;
+  url: string;
+  title: string;
+  loadOnLaunch?: boolean;
+}): SavedTab {
+  return {
+    app,
+    url,
+    title,
+    loadOnLaunch,
+    hibernatesWhenIdle: false,
+    windowed: false,
+    opensLinksForApp: null,
+  };
+}
+
+/**
+ * An account, with an id the test chooses rather than a generated one — the
+ * account's session is partitioned on that id, so naming it is what lets a test
+ * say which account a view is running in.
+ */
+export function seedAccount({
+  id,
+  label,
+  selected = true,
+  savedTabs = [],
+}: {
+  id: string;
+  label: string;
+  selected?: boolean;
+  savedTabs?: SavedTab[];
+}): AccountConfig {
+  return {
+    id,
+    label,
+    color: null,
+    selected,
+    notifications: true,
+    gmail: {
+      unreadBadge: true,
+      delegatedAccountId: null,
+      unifiedInbox: true,
+    },
+    workspaceApps: {
+      savedTabs,
+      bookmarks: [],
+    },
+  };
+}

--- a/tests/lib/app.ts
+++ b/tests/lib/app.ts
@@ -164,10 +164,25 @@ async function launchApp(seedConfig: SeedConfig, options: UseAppOptions): Promis
    */
   const userDataDir = await mkdtemp(path.join(tmpdir(), "meru-e2e-"));
 
-  // Resolved here rather than where the file is read, so a seed can name the
-  // directory the app is about to run in.
-  const seededConfig =
-    typeof seedConfig === "function" ? await seedConfig({ userDataDir }) : seedConfig;
+  /*
+   * Resolved here rather than where the file is read, so a seed can name the
+   * directory the app is about to run in.
+   *
+   * A seed that throws takes the directory with it. Nothing has been assigned
+   * to `launched` yet, so `afterEach` would throw "The app has not been
+   * launched yet" over the top of the real error and leave the directory behind
+   * on every test in the file.
+   */
+  let seededConfig: Partial<Config>;
+
+  try {
+    seededConfig =
+      typeof seedConfig === "function" ? await seedConfig({ userDataDir }) : seedConfig;
+  } catch (error) {
+    await rm(userDataDir, { recursive: true, force: true });
+
+    throw error;
+  }
 
   /*
    * Startup validates the Pro trial against Meru's API before it creates any

--- a/tests/lib/app.ts
+++ b/tests/lib/app.ts
@@ -144,10 +144,17 @@ async function withTimeout(work: Promise<unknown>, timeout: number) {
   }
 }
 
-async function launchApp(
-  seedConfig: Partial<Config>,
-  options: UseAppOptions,
-): Promise<LaunchedApp> {
+/**
+ * What a test seeds the config with. A function, when what it seeds has to
+ * depend on the directory the app is about to run in — a download location
+ * inside it, say — which is made per test and so is not there to be named
+ * while the file is being read.
+ */
+export type SeedConfig =
+  | Partial<Config>
+  | ((context: { userDataDir: string }) => Partial<Config> | Promise<Partial<Config>>);
+
+async function launchApp(seedConfig: SeedConfig, options: UseAppOptions): Promise<LaunchedApp> {
   /*
    * A user data directory of its own, for two reasons. The app takes a single
    * instance lock scoped to that directory and quits when it loses, so runs
@@ -156,6 +163,11 @@ async function launchApp(
    * makes a local run start from the same empty config CI gets.
    */
   const userDataDir = await mkdtemp(path.join(tmpdir(), "meru-e2e-"));
+
+  // Resolved here rather than where the file is read, so a seed can name the
+  // directory the app is about to run in.
+  const seededConfig =
+    typeof seedConfig === "function" ? await seedConfig({ userDataDir }) : seedConfig;
 
   /*
    * Startup validates the Pro trial against Meru's API before it creates any
@@ -173,7 +185,7 @@ async function launchApp(
    */
   await writeFile(
     path.join(userDataDir, "config.json"),
-    JSON.stringify({ "trial.expired": true, ...seedConfig }, null, "\t"),
+    JSON.stringify({ "trial.expired": true, ...seededConfig }, null, "\t"),
   );
 
   // The built binary, not `electron .`: only a packaged app has isPackaged
@@ -320,7 +332,7 @@ export type MeruApp = {
  * started from is the thing the rule exists to prevent, and it is worth more
  * than the ten seconds it costs across this suite.
  */
-export function useApp(seedConfig: Partial<Config> = {}, options: UseAppOptions = {}): MeruApp {
+export function useApp(seedConfig: SeedConfig = {}, options: UseAppOptions = {}): MeruApp {
   let launched: LaunchedApp | undefined;
 
   let hasFailed = false;
@@ -531,6 +543,16 @@ function requireLicenseKey() {
  * walk in `settings.e2e.ts` possible, and this is what makes its inverse
  * possible here.
  */
-export function useProApp(seedConfig: Partial<Config> = {}): MeruApp {
-  return useApp({ licenseKey: requireLicenseKey(), ...seedConfig });
+export function useProApp(seedConfig: SeedConfig = {}): MeruApp {
+  // Read here rather than inside the seed, so a file missing the key still
+  // fails as the module is read rather than once per test inside a launch.
+  const licenseKey = requireLicenseKey();
+
+  // A seed function cannot be spread — doing so would quietly drop everything
+  // it seeds and launch a Pro app with none of it.
+  if (typeof seedConfig === "function") {
+    return useApp(async (context) => ({ licenseKey, ...(await seedConfig(context)) }));
+  }
+
+  return useApp({ licenseKey, ...seedConfig });
 }

--- a/tests/lib/server.ts
+++ b/tests/lib/server.ts
@@ -11,7 +11,7 @@
  * Deliberately `node:http` rather than `Bun.serve`: Playwright runs the suite
  * in workers it starts under Node, where Bun's globals are not there to use.
  */
-import { createServer, type Server } from "node:http";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 
 /** What the download route sends, and what the file on disk should end up holding. */
@@ -20,9 +20,13 @@ export const DOWNLOAD_BODY = "Downloaded by an end-to-end test.\n";
 export const DOWNLOAD_FILE_NAME = "meru-e2e-download.txt";
 
 /**
- * A page named after the app it stands in for, so a view can be told from its
- * neighbours by title as well as by URL, and so the tab that loads it can be
- * seen taking the page's title the way a real one does.
+ * A page titled by whatever asked for it, so a view can be told from its
+ * neighbours by title as well as by URL.
+ *
+ * A caller should title these differently from the workspace app's own label.
+ * `WorkspaceApp.resolveTitle` falls back to that label when no page title ever
+ * arrives, so a page titled "Calendar" leaves a Calendar tab reading "Calendar"
+ * whether it loaded or not — and an assertion on the tab would hold either way.
  */
 function renderPage(pageTitle: string) {
   return `<!doctype html>
@@ -36,37 +40,54 @@ function renderPage(pageTitle: string) {
 `;
 }
 
+function respond(request: IncomingMessage, response: ServerResponse) {
+  const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+
+  if (requestUrl.pathname === "/download") {
+    /*
+     * The attachment disposition is what makes this a download rather than a
+     * navigation, which is the whole point: it reaches Chromium's download
+     * pipeline, and so `will-download` and the app's own handling of it.
+     */
+    response.writeHead(200, {
+      "content-type": "text/plain",
+      "content-disposition": `attachment; filename="${DOWNLOAD_FILE_NAME}"`,
+    });
+
+    response.end(DOWNLOAD_BODY);
+
+    return;
+  }
+
+  response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+
+  response.end(renderPage(decodeURIComponent(requestUrl.pathname.replace(/^\/app\//, ""))));
+}
+
 export type TestServer = {
   /** The origin to point a saved tab at, with an ephemeral port already resolved. */
   origin: string;
-  /** The URL of a page titled after the app it stands in for. */
+  /** The URL of a page carrying the given title. */
   pageUrl(pageTitle: string): string;
   close(): Promise<void>;
 };
 
 export async function startTestServer(): Promise<TestServer> {
   const server: Server = createServer((request, response) => {
-    const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+    /*
+     * Guarded, because an exception thrown out of a `node:http` handler is an
+     * uncaught exception: it takes down the Playwright worker rather than
+     * failing the test that caused it, and the run then reports a worker that
+     * died instead of an assertion. `decodeURIComponent` is the reachable way
+     * in, on a path carrying a malformed percent escape.
+     */
+    try {
+      respond(request, response);
+    } catch {
+      response.writeHead(400);
 
-    if (requestUrl.pathname === "/download") {
-      /*
-       * The attachment disposition is what makes this a download rather than a
-       * navigation, which is the whole point: it reaches Chromium's download
-       * pipeline, and so `will-download` and the app's own handling of it.
-       */
-      response.writeHead(200, {
-        "content-type": "text/plain",
-        "content-disposition": `attachment; filename="${DOWNLOAD_FILE_NAME}"`,
-      });
-
-      response.end(DOWNLOAD_BODY);
-
-      return;
+      response.end();
     }
-
-    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
-
-    response.end(renderPage(decodeURIComponent(requestUrl.pathname.replace(/^\/app\//, ""))));
   });
 
   // Port 0, so concurrent runs — and several agents do work on this repository

--- a/tests/lib/server.ts
+++ b/tests/lib/server.ts
@@ -1,0 +1,101 @@
+/*
+ * A page for a workspace app view to load, served from this machine.
+ *
+ * A workspace app normally loads a Google property, and pointing a test at one
+ * would put a live third-party site inside the assertion: a slow morning at
+ * Google reads as a broken view, and nothing served there is stable enough to
+ * click. Serving the page here keeps what the view loads under the test's
+ * control while leaving the view itself entirely real — it is the same
+ * `WebContentsView`, in the same session, loaded through the same `loadUrl`.
+ *
+ * Deliberately `node:http` rather than `Bun.serve`: Playwright runs the suite
+ * in workers it starts under Node, where Bun's globals are not there to use.
+ */
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+/** What the download route sends, and what the file on disk should end up holding. */
+export const DOWNLOAD_BODY = "Downloaded by an end-to-end test.\n";
+
+export const DOWNLOAD_FILE_NAME = "meru-e2e-download.txt";
+
+/**
+ * A page named after the app it stands in for, so a view can be told from its
+ * neighbours by title as well as by URL, and so the tab that loads it can be
+ * seen taking the page's title the way a real one does.
+ */
+function renderPage(pageTitle: string) {
+  return `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>${pageTitle}</title></head>
+<body>
+<h1>${pageTitle}</h1>
+<a id="download" href="/download" download>Download the file</a>
+</body>
+</html>
+`;
+}
+
+export type TestServer = {
+  /** The origin to point a saved tab at, with an ephemeral port already resolved. */
+  origin: string;
+  /** The URL of a page titled after the app it stands in for. */
+  pageUrl(pageTitle: string): string;
+  close(): Promise<void>;
+};
+
+export async function startTestServer(): Promise<TestServer> {
+  const server: Server = createServer((request, response) => {
+    const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+
+    if (requestUrl.pathname === "/download") {
+      /*
+       * The attachment disposition is what makes this a download rather than a
+       * navigation, which is the whole point: it reaches Chromium's download
+       * pipeline, and so `will-download` and the app's own handling of it.
+       */
+      response.writeHead(200, {
+        "content-type": "text/plain",
+        "content-disposition": `attachment; filename="${DOWNLOAD_FILE_NAME}"`,
+      });
+
+      response.end(DOWNLOAD_BODY);
+
+      return;
+    }
+
+    response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+
+    response.end(renderPage(decodeURIComponent(requestUrl.pathname.replace(/^\/app\//, ""))));
+  });
+
+  // Port 0, so concurrent runs — and several agents do work on this repository
+  // at once — cannot collide on a number chosen here.
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const { port } = server.address() as AddressInfo;
+
+  const origin = `http://127.0.0.1:${port}`;
+
+  return {
+    origin,
+    pageUrl(pageTitle) {
+      return `${origin}/app/${encodeURIComponent(pageTitle)}`;
+    },
+    close() {
+      return new Promise<void>((resolve) => {
+        /*
+         * Connections closed first. A view that loaded a page holds its socket
+         * open on keep-alive, and `close` alone waits for it — which hangs the
+         * hook rather than failing it, because the view outlives this call and
+         * lets go only when the app quits.
+         */
+        server.closeAllConnections();
+
+        server.close(() => resolve());
+      });
+    },
+  };
+}

--- a/tests/lib/strip.ts
+++ b/tests/lib/strip.ts
@@ -1,0 +1,23 @@
+/*
+ * The vertical tab strip, waited for rather than assumed.
+ *
+ * Anything asserted about what the strip does or does not contain has to happen
+ * after it has rendered with the config in hand. Asserting an absence before
+ * that is the trap: `toHaveCount(0)` is satisfied the instant it finds nothing,
+ * so it passes against a strip that has not been drawn yet — and reports the
+ * app as gating something it is in fact showing.
+ */
+import { expect } from "@playwright/test";
+import type { MeruApp } from "./app";
+
+/**
+ * Resolves once `VerticalTabs` has rendered.
+ *
+ * The width toggle is the signal because that component draws it and nothing
+ * else does. The bookmarks button beside the launcher looks like the closer
+ * anchor and is not usable: the titlebar renders one too, and it arrives before
+ * the strip, so waiting on it lets an assertion run a commit early.
+ */
+export async function waitForVerticalTabs(meru: MeruApp) {
+  await expect(meru.renderer.getByRole("button", { name: "Widen the tab strip" })).toBeVisible();
+}

--- a/tests/lib/views.ts
+++ b/tests/lib/views.ts
@@ -15,7 +15,6 @@ export type ViewSnapshot = {
   url: string;
   title: string;
   bounds: Rectangle;
-  visible: boolean;
   /**
    * Where the view's session keeps its data. A partitioned session names the
    * partition in that path, which is what makes the account a view belongs to
@@ -48,7 +47,6 @@ export function readViews(meru: MeruApp): Promise<ViewSnapshot[]> {
         url: webContents ? webContents.getURL() : "",
         title: webContents ? webContents.getTitle() : "",
         bounds: child.getBounds(),
-        visible: child.getVisible(),
         storagePath: webContents ? (webContents.session.storagePath ?? "") : "",
         isDefaultSession: webContents ? webContents.session === session.defaultSession : false,
       };

--- a/tests/lib/views.ts
+++ b/tests/lib/views.ts
@@ -1,0 +1,94 @@
+/*
+ * The child views of the main window, read out of the main process.
+ *
+ * Accounts and workspace apps are `WebContentsView`s the app attaches to the
+ * window itself, painted above the renderer's HTML by the compositor. That is
+ * what puts them out of reach of a screenshot — they come out as blank
+ * rectangles — and it is why everything about them is asserted from here
+ * instead: how many there are, what each has loaded, where it sits, which
+ * session it runs in, and which of them is in front.
+ */
+import type { Rectangle } from "electron";
+import type { MeruApp } from "./app";
+
+export type ViewSnapshot = {
+  url: string;
+  title: string;
+  bounds: Rectangle;
+  visible: boolean;
+  /**
+   * Where the view's session keeps its data. A partitioned session names the
+   * partition in that path, which is what makes the account a view belongs to
+   * readable from the outside.
+   */
+  storagePath: string;
+  isDefaultSession: boolean;
+};
+
+/**
+ * Every child view, in the window's own order — which is z-order, bottom
+ * first. The last entry is therefore the view in front, and the app puts the
+ * active tab's view there by removing and re-adding it.
+ */
+export function readViews(meru: MeruApp): Promise<ViewSnapshot[]> {
+  return meru.app.evaluate(({ BrowserWindow, session }) => {
+    const [window] = BrowserWindow.getAllWindows();
+
+    if (!window) {
+      throw new Error("The app has no window");
+    }
+
+    return window.contentView.children.map((child) => {
+      // Every child is a `WebContentsView` today. Read defensively anyway, so a
+      // plain `View` added later reports as a view with nothing loaded rather
+      // than throwing somewhere that reads as the app being broken.
+      const { webContents } = child as Electron.WebContentsView;
+
+      return {
+        url: webContents ? webContents.getURL() : "",
+        title: webContents ? webContents.getTitle() : "",
+        bounds: child.getBounds(),
+        visible: child.getVisible(),
+        storagePath: webContents ? (webContents.session.storagePath ?? "") : "",
+        isDefaultSession: webContents ? webContents.session === session.defaultSession : false,
+      };
+    });
+  });
+}
+
+/** The view that has loaded a URL starting with `urlPrefix`, if one has. */
+export function findViewByUrl(views: ViewSnapshot[], urlPrefix: string) {
+  return views.find((view) => view.url.startsWith(urlPrefix));
+}
+
+/**
+ * The space a view leaves over on each side of the window's content area.
+ *
+ * A workspace app view starts below the titlebar and to the right of the
+ * vertical tab strip, and spans everything left — so the left and top gaps are
+ * the two chrome measurements, and the right and bottom are zero. Reported as
+ * gaps rather than as coordinates because that is what says how far out a view
+ * is when it is wrong, and it does not restate the window size the app was
+ * given.
+ */
+export async function readUnfilledSpace(meru: MeruApp, view: ViewSnapshot) {
+  const contentBounds = await meru.app.evaluate(({ BrowserWindow }) => {
+    const [window] = BrowserWindow.getAllWindows();
+
+    if (!window) {
+      throw new Error("The app has no window");
+    }
+
+    // The content bounds rather than the window bounds: on Windows the window
+    // spans an invisible resize border the content stops short of, and only the
+    // content bounds share a coordinate space with the child views.
+    return window.getContentBounds();
+  });
+
+  return {
+    left: view.bounds.x,
+    top: view.bounds.y,
+    right: contentBounds.width - (view.bounds.x + view.bounds.width),
+    bottom: contentBounds.height - (view.bounds.y + view.bounds.height),
+  };
+}

--- a/tests/workspace-apps-pro.e2e.ts
+++ b/tests/workspace-apps-pro.e2e.ts
@@ -1,30 +1,64 @@
 /*
- * The half of the child view machinery that a license unlocks.
+ * The child `WebContentsView` machinery, which is what the app is built out of.
  *
- * Two things here are unreachable on the free version, and neither can be
- * faked: `getAccountConfigs` slices the account list down to one whenever
- * `licenseKey.isValid` is false, and the launcher is not rendered at all. Both
- * read a flag set only by a successful API response, so this file launches with
- * a real key — see `useProApp` in `tests/lib/app.ts` for what that costs.
+ * A Gmail account is one of these views and every workspace app is another, so
+ * creating them, laying them out, keeping them in the right order and running
+ * each in the right session is the mechanism nearly every feature sits on. None
+ * of it is reachable below this level: a component test cannot construct a
+ * `WebContentsView` at all, and a screenshot cannot see one, because the
+ * compositor paints them above the renderer's HTML and they come out blank.
  *
- * A file is entirely one entitlement or the other, because `useApp` is called
- * once at module scope and seeds every test in the file. The free version's
- * side of both claims lives in `tests/workspace-apps.e2e.ts`.
+ * Under a license, because workspace apps are a Pro feature. Every way of
+ * acquiring one is gated — the launcher at `workspaceApps.openApp`, a link at
+ * `WorkspaceApp.handleWindowOpen` — so a free version has no business holding
+ * the saved tabs this file seeds. Restoring and waking them is not itself gated
+ * today, which would let all of this run without a key; that gap is recorded in
+ * the todo rather than leaned on here, because a test depending on it would
+ * fail the day someone closes it and read as a regression when it was the fix.
+ *
+ * Two accounts, because a second one is the other thing a license buys, and it
+ * is what makes session partitioning assertable at all: `getAccountConfigs`
+ * slices the list to one whenever the license is invalid.
+ *
+ * What the views load is served from this machine — see `tests/lib/server.ts`
+ * for why. The view, its session and its layout are all the app's own.
+ *
+ * The free version's side of the launcher claim is in
+ * `tests/workspace-apps.e2e.ts`.
  */
+import { mkdir, readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { APP_TITLEBAR_HEIGHT, VERTICAL_TABS_NARROW_WIDTH } from "@meru/shared/constants";
 import { expect, test } from "@playwright/test";
 import { seedAccount, seedSavedTab } from "./lib/accounts";
 import { useProApp } from "./lib/app";
-import { startTestServer, type TestServer } from "./lib/server";
-import { readViews } from "./lib/views";
+import { DOWNLOAD_BODY, DOWNLOAD_FILE_NAME, startTestServer, type TestServer } from "./lib/server";
+import { findViewByUrl, readUnfilledSpace, readViews } from "./lib/views";
 
-/* Fixed, because each account's session is partitioned on its id. */
+/*
+ * Fixed rather than generated, because each account's session is partitioned on
+ * its id: a literal here is what the storage paths below are asserted against,
+ * and a generated one would leave those assertions comparing the app to itself.
+ */
 const FIRST_ACCOUNT_ID = "5eeded00-0000-4000-8000-00000000ac01";
 
 const SECOND_ACCOUNT_ID = "5eeded00-0000-4000-8000-00000000ac02";
 
-const FIRST_TAB_TITLE = "Calendar";
+/** The saved tab seeded without `loadOnLaunch`, so it comes back as an entry with nothing behind it. */
+const DORMANT_TAB_TITLE = "Keep";
 
-const SECOND_TAB_TITLE = "Tasks";
+/*
+ * What the served pages are titled, deliberately not the workspace app labels
+ * the tabs carry. `WorkspaceApp.resolveTitle` falls back to the app's label when
+ * no page title ever arrives, so a page titled "Calendar" would leave a Calendar
+ * tab reading "Calendar" whether it loaded or not — and an assertion on the tab
+ * would hold against a view that never fetched anything.
+ */
+const RESTORED_PAGE_TITLE = "Restored Stand-In";
+
+const DORMANT_PAGE_TITLE = "Woken Stand-In";
+
+const SECOND_ACCOUNT_PAGE_TITLE = "Second Account Stand-In";
 
 let server: TestServer;
 
@@ -36,46 +70,74 @@ test.afterAll(async () => {
   await server.close();
 });
 
-const meru = useProApp(() => ({
-  /*
-   * Two, so the menu has more than one thing in it and so one of them is an app
-   * the selected account has never had as a saved tab. The strip's launcher is
-   * a single button with a dropdown whatever the count — the display setting
-   * that lays apps out inline is a titlebar concern.
-   */
-  "workspaceApps.launcherApps": ["calendar", "tasks"],
-  accounts: [
-    seedAccount({
-      id: FIRST_ACCOUNT_ID,
-      label: "First",
-      selected: true,
-      savedTabs: [
-        seedSavedTab({
-          app: "calendar",
-          url: server.pageUrl(FIRST_TAB_TITLE),
-          title: FIRST_TAB_TITLE,
-          loadOnLaunch: true,
-        }),
-      ],
-    }),
-    seedAccount({
-      id: SECOND_ACCOUNT_ID,
-      label: "Second",
-      selected: false,
-      savedTabs: [
-        seedSavedTab({
-          app: "tasks",
-          url: server.pageUrl(SECOND_TAB_TITLE),
-          title: SECOND_TAB_TITLE,
-          loadOnLaunch: true,
-        }),
-      ],
-    }),
-  ],
-}));
+/*
+ * A function rather than an object, because two of the things seeded cannot be
+ * named while this file is being read: the port the server ends up on, and the
+ * user data directory the app is about to run in, which is where the downloads
+ * go so that they land inside what the harness already cleans up.
+ */
+const meru = useProApp(async ({ userDataDir }) => {
+  const downloadsLocation = path.join(userDataDir, "downloads");
 
-/** Waits until both accounts have brought their saved tab back as a view. */
-async function waitForBothRestoredViews() {
+  await mkdir(downloadsLocation, { recursive: true });
+
+  return {
+    "downloads.location": downloadsLocation,
+    /*
+     * Two, so the launcher menu has more than one thing in it and so one of them
+     * is an app the selected account has never held as a saved tab. The strip's
+     * launcher is a single button with a dropdown whatever the count — the
+     * display setting that lays apps out inline is a titlebar concern.
+     */
+    "workspaceApps.launcherApps": ["calendar", "tasks"],
+    accounts: [
+      seedAccount({
+        id: FIRST_ACCOUNT_ID,
+        label: "First",
+        selected: true,
+        savedTabs: [
+          seedSavedTab({
+            app: "calendar",
+            url: server.pageUrl(RESTORED_PAGE_TITLE),
+            title: "Calendar",
+            loadOnLaunch: true,
+          }),
+          seedSavedTab({
+            app: "keep",
+            url: server.pageUrl(DORMANT_PAGE_TITLE),
+            title: DORMANT_TAB_TITLE,
+          }),
+        ],
+      }),
+      seedAccount({
+        id: SECOND_ACCOUNT_ID,
+        label: "Second",
+        selected: false,
+        savedTabs: [
+          seedSavedTab({
+            app: "tasks",
+            url: server.pageUrl(SECOND_ACCOUNT_PAGE_TITLE),
+            title: "Tasks",
+            loadOnLaunch: true,
+          }),
+        ],
+      }),
+    ],
+  };
+});
+
+/** The downloads directory the seed above pointed the app at. */
+function downloadsLocation() {
+  return path.join(meru.userDataDir, "downloads");
+}
+
+/**
+ * Waits for both accounts to have brought their saved tab back as a view.
+ *
+ * `loadLaunchTabs` runs during startup, which the harness does not wait on — it
+ * waits for the renderer, and the two are not ordered against each other.
+ */
+async function waitForRestoredViews() {
   await expect
     .poll(
       async () =>
@@ -84,23 +146,129 @@ async function waitForBothRestoredViews() {
     .toBe(2);
 }
 
+test("a saved tab is restored into a child view of its own", async () => {
+  await waitForRestoredViews();
+
+  /*
+   * One view for that page and no more. Counted by URL rather than as a total,
+   * because what would go wrong here is a saved tab materialized twice — which a
+   * total shared with two accounts' Gmail views would not single out.
+   */
+  const restoredViews = (await readViews(meru)).filter(
+    (view) => view.url === server.pageUrl(RESTORED_PAGE_TITLE),
+  );
+
+  expect(restoredViews).toHaveLength(1);
+
+  // The view really loaded the page, rather than being attached with a URL set
+  // on it: a title only exists once a document has parsed.
+  expect(restoredViews[0]?.title).toBe(RESTORED_PAGE_TITLE);
+
+  /*
+   * And the strip is showing the page's title rather than the one the tab was
+   * saved with, which is a restored tab following the app it holds. The two are
+   * deliberately different, so this fails against a view that was attached and
+   * never fetched anything — where the tab would fall back to the workspace
+   * app's own label.
+   */
+  await expect(meru.renderer.getByRole("button", { name: RESTORED_PAGE_TITLE })).toBeVisible();
+
+  await expect(meru.renderer.getByRole("button", { name: "Calendar", exact: true })).toHaveCount(0);
+});
+
+test("a restored view is inset by the chrome the renderer owns", async () => {
+  await waitForRestoredViews();
+
+  const restoredView = findViewByUrl(await readViews(meru), server.pageUrl(RESTORED_PAGE_TITLE));
+
+  if (!restoredView) {
+    throw new Error("The saved tab was never restored into a view");
+  }
+
+  const unfilled = await readUnfilledSpace(meru, restoredView);
+
+  /*
+   * Exact on both insets, and against the app's own constants rather than the
+   * numbers they currently come to. Nothing platform-dependent goes into either:
+   * the titlebar and the tab strip are Meru's own measurements, drawn by the
+   * renderer, and a view laid over either of them is covering the app's own
+   * interface.
+   *
+   * The strip is at its narrow width because the selected account has more than
+   * one tab and none of them is an unpinned second tab for the same app, which
+   * is the only thing that widens it while `verticalTabs.width` is left at
+   * `auto`.
+   */
+  expect(unfilled.left).toBe(VERTICAL_TABS_NARROW_WIDTH);
+  expect(unfilled.top).toBe(APP_TITLEBAR_HEIGHT);
+
+  // And it spans everything left over, so no strip of window shows through
+  // beside or beneath it.
+  expect(unfilled.right).toBe(0);
+  expect(unfilled.bottom).toBe(0);
+});
+
+test("waking a dormant tab adds a view and brings it to the front", async () => {
+  await waitForRestoredViews();
+
+  const viewsBefore = await readViews(meru);
+
+  /*
+   * In front is last: the window lists its children bottom first, and the app
+   * puts the active tab's view at the end by removing and re-adding it. Every
+   * view here has the same bounds, so which one the user is actually looking at
+   * is this and nothing else.
+   *
+   * Named by what it is not, because the view in front at launch is an account's
+   * Gmail one, and its title is whatever Google served — a sign-in page, or
+   * Chromium's network error page on a runner with no route out.
+   */
+  expect(viewsBefore.at(-1)?.url.startsWith(server.origin)).toBe(false);
+
+  /*
+   * Opened by clicking the tab, which is how anyone opens one. The dormant tab
+   * is still showing its seeded title, because nothing has loaded to replace it
+   * — that is what makes it findable by the name the seed gave it.
+   */
+  await meru.renderer.getByRole("button", { name: DORMANT_TAB_TITLE }).click();
+
+  await expect.poll(async () => (await readViews(meru)).length).toBe(viewsBefore.length + 1);
+
+  // The woken tab is the active one, so its view is the one in front now.
+  await expect
+    .poll(async () => (await readViews(meru)).at(-1)?.url)
+    .toBe(server.pageUrl(DORMANT_PAGE_TITLE));
+
+  // And the tab that was already open kept its view rather than being torn down
+  // and rebuilt behind the new one.
+  expect(findViewByUrl(await readViews(meru), server.pageUrl(RESTORED_PAGE_TITLE))).toBeDefined();
+});
+
 test("each account's views run in a session of its own", async () => {
-  await waitForBothRestoredViews();
+  await waitForRestoredViews();
 
   const views = await readViews(meru);
 
   /*
    * Four: a Gmail view and a restored workspace app for each of the two
-   * accounts. This is the assertion the free version cannot make at all —
-   * there, the second account is sliced off before any of it is created.
+   * accounts. This is the claim the free version cannot make at all — there, the
+   * second account is sliced off before any of it is created.
    */
   expect(views).toHaveLength(4);
 
   const viewUrlsByAccount = new Map<string, string[]>();
 
   for (const view of views) {
+    /*
+     * Never the session Electron hands out by default. A view that fell back to
+     * it would share cookies with every other account, which is the failure this
+     * is here for.
+     */
     expect(view.isDefaultSession, view.url).toBe(false);
 
+    // Contained rather than compared against a built path: the partition
+    // directory is named for the account, but the separator around it is the
+    // platform's.
     const accountId = [FIRST_ACCOUNT_ID, SECOND_ACCOUNT_ID].find((id) =>
       view.storagePath.includes(id),
     );
@@ -115,8 +283,8 @@ test("each account's views run in a session of its own", async () => {
 
   /*
    * Two accounts, two views each, and no view in the wrong one. A workspace app
-   * that landed in the other account's partition would be signed in as the
-   * wrong person — which is the whole reason the sessions are split.
+   * that landed in the other account's partition would be signed in as the wrong
+   * person, which is the whole reason the sessions are split.
    */
   expect(viewUrlsByAccount.size).toBe(2);
 
@@ -125,21 +293,19 @@ test("each account's views run in a session of its own", async () => {
 
   // The two partitions really are different directories, rather than one path
   // that happens to contain both ids.
-  const storagePaths = new Set(views.map((view) => view.storagePath));
-
-  expect(storagePaths.size).toBe(2);
+  expect(new Set(views.map((view) => view.storagePath)).size).toBe(2);
 });
 
 test("the launcher opens a workspace app that was never a saved tab", async () => {
-  await waitForBothRestoredViews();
+  await waitForRestoredViews();
 
   const viewCountBefore = (await readViews(meru)).length;
 
   /*
    * The launcher is in the tab strip, and it is a renderer-drawn menu rather
-   * than a native one, so it can be driven from here. It is only rendered at
-   * all because the license is valid — the free version's side of that is
-   * asserted in `workspace-apps.e2e.ts`.
+   * than a native one, so it can be driven from here. It is only rendered at all
+   * because the license is valid — the free version's side of that is asserted
+   * in `workspace-apps.e2e.ts`.
    */
   await meru.renderer.getByRole("button", { name: "Open app" }).click();
 
@@ -161,13 +327,62 @@ test("the launcher opens a workspace app that was never a saved tab", async () =
    * A view is created for it. What that view goes on to load is a real Google
    * property, so nothing here waits on the page: the view exists the moment the
    * app opens the tab, and a load that never arrives is logged rather than
-   * thrown. Asserting the count and not the URL is what keeps this test's
-   * answer independent of a third party being up.
+   * thrown. Asserting the count and not the URL is what keeps this test's answer
+   * independent of a third party being up.
    */
   await expect.poll(async () => (await readViews(meru)).length).toBe(viewCountBefore + 1);
 
-  // And it is in front, the way a tab opened by hand should be.
+  // And it is in front, in the selected account's session, the way a tab opened
+  // by hand should be.
   await expect
     .poll(async () => (await readViews(meru)).at(-1)?.storagePath)
     .toContain(FIRST_ACCOUNT_ID);
+});
+
+test("a download from a workspace app lands on disk and in the history", async () => {
+  await waitForRestoredViews();
+
+  /*
+   * The view is a page in its own right as far as Playwright is concerned, so
+   * the link is clicked in the workspace app itself rather than driven through
+   * the main process. That is the path a real download takes: the click is in
+   * the view, and everything after it is the app's.
+   */
+  const restoredPageUrl = server.pageUrl(RESTORED_PAGE_TITLE);
+
+  await expect
+    .poll(() => meru.app.windows().some((page) => page.url() === restoredPageUrl))
+    .toBe(true);
+
+  const workspaceAppPage = meru.app.windows().find((page) => page.url() === restoredPageUrl);
+
+  if (!workspaceAppPage) {
+    throw new Error("The restored view never became a page");
+  }
+
+  await workspaceAppPage.getByRole("link", { name: "Download the file" }).click();
+
+  // On disk, in the directory the config named, with what the server sent.
+  await expect.poll(() => readdir(downloadsLocation())).toEqual([DOWNLOAD_FILE_NAME]);
+
+  expect(await readFile(path.join(downloadsLocation(), DOWNLOAD_FILE_NAME), "utf8")).toBe(
+    DOWNLOAD_BODY,
+  );
+
+  /*
+   * And recorded. Polled against the config on disk rather than the page,
+   * because what is being proved is the main process writing the download
+   * through to the file it keeps history in.
+   */
+  await expect
+    .poll(async () =>
+      (await meru.readConfig())["downloads.history"]?.map(({ fileName }) => fileName),
+    )
+    .toEqual([DOWNLOAD_FILE_NAME]);
+
+  // Then where a user would look for it. The menu is the way in, as everywhere
+  // else in this suite.
+  expect(await meru.runMenuCommand("Downloads")).toBe(true);
+
+  await expect(meru.renderer.getByTitle(DOWNLOAD_FILE_NAME)).toBeVisible();
 });

--- a/tests/workspace-apps-pro.e2e.ts
+++ b/tests/workspace-apps-pro.e2e.ts
@@ -37,8 +37,12 @@ test.afterAll(async () => {
 });
 
 const meru = useProApp(() => ({
-  // Two, so the launcher resolves to a button with a menu behind it rather than
-  // laying its apps out inline, and so the menu has more than one thing in it.
+  /*
+   * Two, so the menu has more than one thing in it and so one of them is an app
+   * the selected account has never had as a saved tab. The strip's launcher is
+   * a single button with a dropdown whatever the count — the display setting
+   * that lays apps out inline is a titlebar concern.
+   */
   "workspaceApps.launcherApps": ["calendar", "tasks"],
   accounts: [
     seedAccount({
@@ -92,7 +96,7 @@ test("each account's views run in a session of its own", async () => {
    */
   expect(views).toHaveLength(4);
 
-  const storagePathsByAccount = new Map<string, string[]>();
+  const viewUrlsByAccount = new Map<string, string[]>();
 
   for (const view of views) {
     expect(view.isDefaultSession, view.url).toBe(false);
@@ -103,8 +107,8 @@ test("each account's views run in a session of its own", async () => {
 
     expect(accountId, `${view.url} is in no account's partition`).toBeDefined();
 
-    storagePathsByAccount.set(accountId as string, [
-      ...(storagePathsByAccount.get(accountId as string) ?? []),
+    viewUrlsByAccount.set(accountId as string, [
+      ...(viewUrlsByAccount.get(accountId as string) ?? []),
       view.url,
     ]);
   }
@@ -114,10 +118,10 @@ test("each account's views run in a session of its own", async () => {
    * that landed in the other account's partition would be signed in as the
    * wrong person — which is the whole reason the sessions are split.
    */
-  expect(storagePathsByAccount.size).toBe(2);
+  expect(viewUrlsByAccount.size).toBe(2);
 
-  expect(storagePathsByAccount.get(FIRST_ACCOUNT_ID)).toHaveLength(2);
-  expect(storagePathsByAccount.get(SECOND_ACCOUNT_ID)).toHaveLength(2);
+  expect(viewUrlsByAccount.get(FIRST_ACCOUNT_ID)).toHaveLength(2);
+  expect(viewUrlsByAccount.get(SECOND_ACCOUNT_ID)).toHaveLength(2);
 
   // The two partitions really are different directories, rather than one path
   // that happens to contain both ids.
@@ -145,7 +149,13 @@ test("the launcher opens a workspace app that was never a saved tab", async () =
 
   await expect(launcherMenu.getByRole("menuitem")).toHaveCount(2);
 
-  await launcherMenu.getByRole("menuitem").first().click();
+  /*
+   * The last item is Tasks, which the selected account has never held as a saved
+   * tab — the first is Calendar, which it has, so opening that one would prove
+   * nothing this test's name claims. Tasks is seeded on the other account, and
+   * an account's tabs are its own.
+   */
+  await launcherMenu.getByRole("menuitem").last().click();
 
   /*
    * A view is created for it. What that view goes on to load is a real Google

--- a/tests/workspace-apps-pro.e2e.ts
+++ b/tests/workspace-apps-pro.e2e.ts
@@ -1,0 +1,163 @@
+/*
+ * The half of the child view machinery that a license unlocks.
+ *
+ * Two things here are unreachable on the free version, and neither can be
+ * faked: `getAccountConfigs` slices the account list down to one whenever
+ * `licenseKey.isValid` is false, and the launcher is not rendered at all. Both
+ * read a flag set only by a successful API response, so this file launches with
+ * a real key — see `useProApp` in `tests/lib/app.ts` for what that costs.
+ *
+ * A file is entirely one entitlement or the other, because `useApp` is called
+ * once at module scope and seeds every test in the file. The free version's
+ * side of both claims lives in `tests/workspace-apps.e2e.ts`.
+ */
+import { expect, test } from "@playwright/test";
+import { seedAccount, seedSavedTab } from "./lib/accounts";
+import { useProApp } from "./lib/app";
+import { startTestServer, type TestServer } from "./lib/server";
+import { readViews } from "./lib/views";
+
+/* Fixed, because each account's session is partitioned on its id. */
+const FIRST_ACCOUNT_ID = "5eeded00-0000-4000-8000-00000000ac01";
+
+const SECOND_ACCOUNT_ID = "5eeded00-0000-4000-8000-00000000ac02";
+
+const FIRST_TAB_TITLE = "Calendar";
+
+const SECOND_TAB_TITLE = "Tasks";
+
+let server: TestServer;
+
+test.beforeAll(async () => {
+  server = await startTestServer();
+});
+
+test.afterAll(async () => {
+  await server.close();
+});
+
+const meru = useProApp(() => ({
+  // Two, so the launcher resolves to a button with a menu behind it rather than
+  // laying its apps out inline, and so the menu has more than one thing in it.
+  "workspaceApps.launcherApps": ["calendar", "tasks"],
+  accounts: [
+    seedAccount({
+      id: FIRST_ACCOUNT_ID,
+      label: "First",
+      selected: true,
+      savedTabs: [
+        seedSavedTab({
+          app: "calendar",
+          url: server.pageUrl(FIRST_TAB_TITLE),
+          title: FIRST_TAB_TITLE,
+          loadOnLaunch: true,
+        }),
+      ],
+    }),
+    seedAccount({
+      id: SECOND_ACCOUNT_ID,
+      label: "Second",
+      selected: false,
+      savedTabs: [
+        seedSavedTab({
+          app: "tasks",
+          url: server.pageUrl(SECOND_TAB_TITLE),
+          title: SECOND_TAB_TITLE,
+          loadOnLaunch: true,
+        }),
+      ],
+    }),
+  ],
+}));
+
+/** Waits until both accounts have brought their saved tab back as a view. */
+async function waitForBothRestoredViews() {
+  await expect
+    .poll(
+      async () =>
+        (await readViews(meru)).filter((view) => view.url.startsWith(server.origin)).length,
+    )
+    .toBe(2);
+}
+
+test("each account's views run in a session of its own", async () => {
+  await waitForBothRestoredViews();
+
+  const views = await readViews(meru);
+
+  /*
+   * Four: a Gmail view and a restored workspace app for each of the two
+   * accounts. This is the assertion the free version cannot make at all —
+   * there, the second account is sliced off before any of it is created.
+   */
+  expect(views).toHaveLength(4);
+
+  const storagePathsByAccount = new Map<string, string[]>();
+
+  for (const view of views) {
+    expect(view.isDefaultSession, view.url).toBe(false);
+
+    const accountId = [FIRST_ACCOUNT_ID, SECOND_ACCOUNT_ID].find((id) =>
+      view.storagePath.includes(id),
+    );
+
+    expect(accountId, `${view.url} is in no account's partition`).toBeDefined();
+
+    storagePathsByAccount.set(accountId as string, [
+      ...(storagePathsByAccount.get(accountId as string) ?? []),
+      view.url,
+    ]);
+  }
+
+  /*
+   * Two accounts, two views each, and no view in the wrong one. A workspace app
+   * that landed in the other account's partition would be signed in as the
+   * wrong person — which is the whole reason the sessions are split.
+   */
+  expect(storagePathsByAccount.size).toBe(2);
+
+  expect(storagePathsByAccount.get(FIRST_ACCOUNT_ID)).toHaveLength(2);
+  expect(storagePathsByAccount.get(SECOND_ACCOUNT_ID)).toHaveLength(2);
+
+  // The two partitions really are different directories, rather than one path
+  // that happens to contain both ids.
+  const storagePaths = new Set(views.map((view) => view.storagePath));
+
+  expect(storagePaths.size).toBe(2);
+});
+
+test("the launcher opens a workspace app that was never a saved tab", async () => {
+  await waitForBothRestoredViews();
+
+  const viewCountBefore = (await readViews(meru)).length;
+
+  /*
+   * The launcher is in the tab strip, and it is a renderer-drawn menu rather
+   * than a native one, so it can be driven from here. It is only rendered at
+   * all because the license is valid — the free version's side of that is
+   * asserted in `workspace-apps.e2e.ts`.
+   */
+  await meru.renderer.getByRole("button", { name: "Open app" }).click();
+
+  const launcherMenu = meru.renderer.getByRole("menu");
+
+  await expect(launcherMenu).toBeVisible();
+
+  await expect(launcherMenu.getByRole("menuitem")).toHaveCount(2);
+
+  await launcherMenu.getByRole("menuitem").first().click();
+
+  /*
+   * A view is created for it. What that view goes on to load is a real Google
+   * property, so nothing here waits on the page: the view exists the moment the
+   * app opens the tab, and a load that never arrives is logged rather than
+   * thrown. Asserting the count and not the URL is what keeps this test's
+   * answer independent of a third party being up.
+   */
+  await expect.poll(async () => (await readViews(meru)).length).toBe(viewCountBefore + 1);
+
+  // And it is in front, the way a tab opened by hand should be.
+  await expect
+    .poll(async () => (await readViews(meru)).at(-1)?.storagePath)
+    .toContain(FIRST_ACCOUNT_ID);
+});

--- a/tests/workspace-apps.e2e.ts
+++ b/tests/workspace-apps.e2e.ts
@@ -1,0 +1,280 @@
+/*
+ * The child `WebContentsView` machinery, which is what the app is built out of.
+ *
+ * A Gmail account is one of these views and every workspace app is another, so
+ * creating them, laying them out, keeping them in the right order and running
+ * each in the right session is the mechanism nearly every feature sits on. None
+ * of it is reachable below this level: a component test cannot construct a
+ * `WebContentsView` at all, and a screenshot cannot see one, because the
+ * compositor paints them above the renderer's HTML and they come out blank.
+ *
+ * What a view loads is served from this machine — see `tests/lib/server.ts` for
+ * why. The view, its session and its layout are all the app's own.
+ *
+ * `tests/workspace-apps-pro.e2e.ts` carries the half of this that needs a
+ * license: the launcher, and two accounts kept in separate sessions.
+ */
+import { mkdir, readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { APP_TITLEBAR_HEIGHT, VERTICAL_TABS_NARROW_WIDTH } from "@meru/shared/constants";
+import { expect, test } from "@playwright/test";
+import { seedAccount, seedSavedTab } from "./lib/accounts";
+import { useApp } from "./lib/app";
+import { DOWNLOAD_BODY, DOWNLOAD_FILE_NAME, startTestServer, type TestServer } from "./lib/server";
+import { findViewByUrl, readUnfilledSpace, readViews } from "./lib/views";
+
+/*
+ * Fixed rather than generated, because the account's session is partitioned on
+ * it: a literal here is what the storage path below is asserted against, and a
+ * generated one would leave that assertion comparing the app to itself.
+ */
+const ACCOUNT_ID = "5eeded00-0000-4000-8000-00000000ac01";
+
+/** The saved tab seeded with `loadOnLaunch`, so startup brings it back as a live view. */
+const RESTORED_TAB_TITLE = "Calendar";
+
+/** The saved tab seeded without it, so it comes back as an entry with nothing behind it. */
+const DORMANT_TAB_TITLE = "Keep";
+
+let server: TestServer;
+
+test.beforeAll(async () => {
+  server = await startTestServer();
+});
+
+test.afterAll(async () => {
+  await server.close();
+});
+
+/*
+ * A function rather than an object, because two of the things seeded cannot be
+ * named while this file is being read: the port the server ends up on, and the
+ * user data directory the app is about to run in, which is where the downloads
+ * go so that they land inside what the harness already cleans up.
+ */
+const meru = useApp(async ({ userDataDir }) => {
+  const downloadsLocation = path.join(userDataDir, "downloads");
+
+  await mkdir(downloadsLocation, { recursive: true });
+
+  return {
+    "downloads.location": downloadsLocation,
+    accounts: [
+      seedAccount({
+        id: ACCOUNT_ID,
+        label: "Default",
+        savedTabs: [
+          seedSavedTab({
+            app: "calendar",
+            url: server.pageUrl(RESTORED_TAB_TITLE),
+            title: RESTORED_TAB_TITLE,
+            loadOnLaunch: true,
+          }),
+          seedSavedTab({
+            app: "keep",
+            url: server.pageUrl(DORMANT_TAB_TITLE),
+            title: DORMANT_TAB_TITLE,
+          }),
+        ],
+      }),
+    ],
+  };
+});
+
+/** The downloads directory the seed above pointed the app at. */
+function downloadsLocation() {
+  return path.join(meru.userDataDir, "downloads");
+}
+
+/**
+ * Waits for the view a saved tab was restored into.
+ *
+ * `loadLaunchTabs` runs during startup, which the harness does not wait on —
+ * it waits for the renderer, and the two are not ordered against each other.
+ */
+async function waitForRestoredView() {
+  await expect
+    .poll(async () => (await readViews(meru)).map((view) => view.url.startsWith(server.origin)))
+    .toContain(true);
+}
+
+test("a saved tab is restored into a child view of its own", async () => {
+  await waitForRestoredView();
+
+  const views = await readViews(meru);
+
+  /*
+   * Two: the account's Gmail view, and the workspace app restored beside it.
+   * Asserted as a count as well as by URL, because a second view of the same
+   * app — a saved tab materialized twice — would satisfy every other assertion
+   * here while being exactly the sort of thing this machinery gets wrong.
+   */
+  expect(views).toHaveLength(2);
+
+  const restoredView = findViewByUrl(views, server.origin);
+
+  expect(restoredView?.url).toBe(server.pageUrl(RESTORED_TAB_TITLE));
+
+  // The view really loaded the page, rather than being attached with a URL set
+  // on it: a title only exists once a document has parsed.
+  expect(restoredView?.title).toBe(RESTORED_TAB_TITLE);
+
+  /*
+   * The tab the seed named is in the strip, and it is showing the page's title
+   * rather than the one it was saved with. A restored tab follows the app it
+   * holds, so those two agreeing here is the seeded title being overwritten by
+   * a page that actually arrived.
+   */
+  await expect(meru.renderer.getByRole("button", { name: RESTORED_TAB_TITLE })).toBeVisible();
+});
+
+test("a restored view is inset by the chrome the renderer owns", async () => {
+  await waitForRestoredView();
+
+  const restoredView = findViewByUrl(await readViews(meru), server.origin);
+
+  if (!restoredView) {
+    throw new Error("The saved tab was never restored into a view");
+  }
+
+  const unfilled = await readUnfilledSpace(meru, restoredView);
+
+  /*
+   * Exact on both insets, and against the app's own constants rather than the
+   * numbers they currently come to. Nothing platform-dependent goes into
+   * either: the titlebar and the tab strip are Meru's own measurements, drawn
+   * by the renderer, and a view laid over either of them is covering the
+   * app's own interface.
+   *
+   * The strip is at its narrow width because the account has more than one tab
+   * and none of them is an unpinned second tab for the same app, which is the
+   * only thing that widens it while `verticalTabs.width` is left at `auto`.
+   */
+  expect(unfilled.left).toBe(VERTICAL_TABS_NARROW_WIDTH);
+  expect(unfilled.top).toBe(APP_TITLEBAR_HEIGHT);
+
+  // And it spans everything left over, so no strip of window shows through
+  // beside or beneath it.
+  expect(unfilled.right).toBe(0);
+  expect(unfilled.bottom).toBe(0);
+});
+
+test("waking a dormant tab adds a view and brings it to the front", async () => {
+  await waitForRestoredView();
+
+  /*
+   * In front is last: the window lists its children bottom first, and the app
+   * puts the active tab's view at the end by removing and re-adding it. Every
+   * view here has the same bounds, so which one the user is actually looking
+   * at is this and nothing else.
+   */
+  const viewsBefore = await readViews(meru);
+
+  expect(viewsBefore.at(-1)?.title).toBe("Gmail");
+
+  /*
+   * Opened by clicking the tab, which is how anyone opens one. The dormant tab
+   * is still showing its seeded title, because nothing has loaded to replace
+   * it — that is what makes it findable by the name the seed gave it.
+   */
+  await meru.renderer.getByRole("button", { name: DORMANT_TAB_TITLE }).click();
+
+  await expect.poll(async () => (await readViews(meru)).length).toBe(3);
+
+  const viewsAfter = await readViews(meru);
+
+  // The woken tab is the active one, so its view is the one in front now.
+  await expect
+    .poll(async () => (await readViews(meru)).at(-1)?.url)
+    .toBe(server.pageUrl(DORMANT_TAB_TITLE));
+
+  // And the tab that was already open kept its view rather than being torn down
+  // and rebuilt behind the new one.
+  expect(findViewByUrl(viewsAfter, server.pageUrl(RESTORED_TAB_TITLE))).toBeDefined();
+});
+
+test("a workspace app view runs in its account's session", async () => {
+  await waitForRestoredView();
+
+  const views = await readViews(meru);
+
+  /*
+   * Every view belongs to the account, so every one of them runs in the
+   * account's partition rather than the session Electron hands out by default.
+   * A view that fell back to the default session would share cookies with every
+   * other account, which is the failure this is here for.
+   */
+  for (const view of views) {
+    expect(view.isDefaultSession, view.url).toBe(false);
+
+    // Contained rather than compared to a built path: the partition directory
+    // is named for the account, but the separator around it is the platform's.
+    expect(view.storagePath, view.url).toContain(ACCOUNT_ID);
+  }
+
+  // The workspace app is in the same session as the account's Gmail view, which
+  // is what lets it be signed in at all.
+  const storagePaths = new Set(views.map((view) => view.storagePath));
+
+  expect(storagePaths.size).toBe(1);
+});
+
+test("the workspace apps launcher is absent without a license", async () => {
+  /*
+   * The inverse of the assertion in `workspace-apps-pro.e2e.ts`, and the reason
+   * it is worth making from both sides: neither file keeps a list of what the
+   * license unlocks, so a launcher that stopped being gated fails here, and one
+   * that stopped appearing at all fails there.
+   */
+  await expect(meru.renderer.getByRole("button", { name: "Open app" })).toHaveCount(0);
+
+  // Read against something that is on screen, so a strip that failed to render
+  // at all cannot pass this by having nothing in it.
+  await expect(meru.renderer.getByRole("button", { name: "Gmail" })).toBeVisible();
+});
+
+test("a download from a workspace app lands on disk and in the history", async () => {
+  await waitForRestoredView();
+
+  /*
+   * The view is a page in its own right as far as Playwright is concerned, so
+   * the link is clicked in the workspace app itself rather than driven through
+   * the main process. That is the path a real download takes: the click is in
+   * the view, and everything after it is the app's.
+   */
+  await expect
+    .poll(() => meru.app.windows().some((page) => page.url().startsWith(server.origin)))
+    .toBe(true);
+
+  const workspaceAppPage = meru.app.windows().find((page) => page.url().startsWith(server.origin));
+
+  if (!workspaceAppPage) {
+    throw new Error("The restored view never became a page");
+  }
+
+  await workspaceAppPage.getByRole("link", { name: "Download the file" }).click();
+
+  // On disk, in the directory the config named, with what the server sent.
+  await expect.poll(() => readdir(downloadsLocation())).toEqual([DOWNLOAD_FILE_NAME]);
+
+  expect(await readFile(path.join(downloadsLocation(), DOWNLOAD_FILE_NAME), "utf8")).toBe(
+    DOWNLOAD_BODY,
+  );
+
+  /*
+   * And recorded. Polled against the config on disk rather than the page,
+   * because what is being proved is the main process writing the download
+   * through to the file it keeps history in.
+   */
+  await expect
+    .poll(async () =>
+      (await meru.readConfig())["downloads.history"]?.map(({ fileName }) => fileName),
+    )
+    .toEqual([DOWNLOAD_FILE_NAME]);
+
+  // Then where a user would look for it. The menu is the way in, as everywhere
+  // else in this suite.
+  expect(await meru.runMenuCommand("Downloads")).toBe(true);
+
+  await expect(meru.renderer.getByTitle(DOWNLOAD_FILE_NAME)).toBeVisible();
+});

--- a/tests/workspace-apps.e2e.ts
+++ b/tests/workspace-apps.e2e.ts
@@ -1,313 +1,55 @@
 /*
- * The child `WebContentsView` machinery, which is what the app is built out of.
+ * What the free version does not get of the workspace apps surface.
  *
- * A Gmail account is one of these views and every workspace app is another, so
- * creating them, laying them out, keeping them in the right order and running
- * each in the right session is the mechanism nearly every feature sits on. None
- * of it is reachable below this level: a component test cannot construct a
- * `WebContentsView` at all, and a screenshot cannot see one, because the
- * compositor paints them above the renderer's HTML and they come out blank.
+ * The machinery itself — creating child views, laying them out, ordering them,
+ * partitioning their sessions — is covered in
+ * `tests/workspace-apps-pro.e2e.ts`, under the license workspace apps ship
+ * behind. What is left here is the gate, asserted from the side a license does
+ * not open.
  *
- * What a view loads is served from this machine — see `tests/lib/server.ts` for
- * why. The view, its session and its layout are all the app's own.
- *
- * `tests/workspace-apps-pro.e2e.ts` carries the half of this that needs a
- * license: the launcher, and two accounts kept in separate sessions.
+ * The pair is the point. Neither file keeps a list of what a license unlocks, so
+ * a launcher that stopped being gated fails here, and one that stopped appearing
+ * at all fails there.
  */
-import { mkdir, readdir, readFile } from "node:fs/promises";
-import path from "node:path";
-import { APP_TITLEBAR_HEIGHT, VERTICAL_TABS_NARROW_WIDTH } from "@meru/shared/constants";
 import { expect, test } from "@playwright/test";
-import { seedAccount, seedSavedTab } from "./lib/accounts";
+import { seedAccount } from "./lib/accounts";
 import { useApp } from "./lib/app";
-import { DOWNLOAD_BODY, DOWNLOAD_FILE_NAME, startTestServer, type TestServer } from "./lib/server";
 import { waitForVerticalTabs } from "./lib/strip";
-import { findViewByUrl, readUnfilledSpace, readViews } from "./lib/views";
 
-/*
- * Fixed rather than generated, because the account's session is partitioned on
- * it: a literal here is what the storage path below is asserted against, and a
- * generated one would leave that assertion comparing the app to itself.
- */
 const ACCOUNT_ID = "5eeded00-0000-4000-8000-00000000ac01";
 
-/** The saved tab seeded with `loadOnLaunch`, so startup brings it back as a live view. */
-const RESTORED_TAB_TITLE = "Calendar";
-
-/** The saved tab seeded without it, so it comes back as an entry with nothing behind it. */
-const DORMANT_TAB_TITLE = "Keep";
-
-/*
- * What the served pages are titled, deliberately not the workspace app labels
- * above. `WorkspaceApp.resolveTitle` falls back to the app's label when no page
- * title ever arrives, so a page titled "Calendar" would leave the Calendar tab
- * reading "Calendar" whether it loaded or not — and every assertion on the tab
- * would hold against a view that never fetched anything.
- */
-const RESTORED_PAGE_TITLE = "Restored Stand-In";
-
-const DORMANT_PAGE_TITLE = "Woken Stand-In";
-
-let server: TestServer;
-
-test.beforeAll(async () => {
-  server = await startTestServer();
-});
-
-test.afterAll(async () => {
-  await server.close();
-});
-
-/*
- * A function rather than an object, because two of the things seeded cannot be
- * named while this file is being read: the port the server ends up on, and the
- * user data directory the app is about to run in, which is where the downloads
- * go so that they land inside what the harness already cleans up.
- */
-const meru = useApp(async ({ userDataDir }) => {
-  const downloadsLocation = path.join(userDataDir, "downloads");
-
-  await mkdir(downloadsLocation, { recursive: true });
-
-  return {
-    "downloads.location": downloadsLocation,
-    /*
-     * Seeded so that the launcher has apps to offer. Both hosts gate it on
-     * `isLicenseKeyValid && launcherApps.length > 0`, and the default list is
-     * empty — so without this the launcher is absent because it has nothing to
-     * show, and the assertion below would hold with the license check deleted.
-     */
-    "workspaceApps.launcherApps": ["calendar", "tasks"],
-    accounts: [
-      seedAccount({
-        id: ACCOUNT_ID,
-        label: "Default",
-        savedTabs: [
-          seedSavedTab({
-            app: "calendar",
-            url: server.pageUrl(RESTORED_PAGE_TITLE),
-            title: RESTORED_TAB_TITLE,
-            loadOnLaunch: true,
-          }),
-          seedSavedTab({
-            app: "keep",
-            url: server.pageUrl(DORMANT_PAGE_TITLE),
-            title: DORMANT_TAB_TITLE,
-          }),
-        ],
-      }),
-    ],
-  };
-});
-
-/** The downloads directory the seed above pointed the app at. */
-function downloadsLocation() {
-  return path.join(meru.userDataDir, "downloads");
-}
-
-/**
- * Waits for the view a saved tab was restored into.
- *
- * `loadLaunchTabs` runs during startup, which the harness does not wait on —
- * it waits for the renderer, and the two are not ordered against each other.
- */
-async function waitForRestoredView() {
-  await expect
-    .poll(async () => (await readViews(meru)).map((view) => view.url.startsWith(server.origin)))
-    .toContain(true);
-}
-
-test("a saved tab is restored into a child view of its own", async () => {
-  await waitForRestoredView();
-
-  const views = await readViews(meru);
-
+const meru = useApp({
   /*
-   * Two: the account's Gmail view, and the workspace app restored beside it.
-   * Asserted as a count as well as by URL, because a second view of the same
-   * app — a saved tab materialized twice — would satisfy every other assertion
-   * here while being exactly the sort of thing this machinery gets wrong.
+   * Seeded so that the launcher has apps to offer. Both hosts gate it on
+   * `isLicenseKeyValid && launcherApps.length > 0`, and the default list is
+   * empty — so without this the launcher would be absent for having nothing to
+   * show, and the assertion below would hold with the license check deleted.
    */
-  expect(views).toHaveLength(2);
-
-  const restoredView = findViewByUrl(views, server.origin);
-
-  expect(restoredView?.url).toBe(server.pageUrl(RESTORED_PAGE_TITLE));
-
-  // The view really loaded the page, rather than being attached with a URL set
-  // on it: a title only exists once a document has parsed.
-  expect(restoredView?.title).toBe(RESTORED_PAGE_TITLE);
-
+  "workspaceApps.launcherApps": ["calendar", "tasks"],
   /*
-   * And the strip is showing the page's title rather than the one the tab was
-   * saved with, which is a restored tab following the app it holds. The two
-   * titles are deliberately different, so this fails against a view that was
-   * attached and never fetched anything — where the tab would fall back to the
-   * workspace app's own label.
-   */
-  await expect(meru.renderer.getByRole("button", { name: RESTORED_PAGE_TITLE })).toBeVisible();
-
-  await expect(meru.renderer.getByRole("button", { name: RESTORED_TAB_TITLE })).toHaveCount(0);
-});
-
-test("a restored view is inset by the chrome the renderer owns", async () => {
-  await waitForRestoredView();
-
-  const restoredView = findViewByUrl(await readViews(meru), server.origin);
-
-  if (!restoredView) {
-    throw new Error("The saved tab was never restored into a view");
-  }
-
-  const unfilled = await readUnfilledSpace(meru, restoredView);
-
-  /*
-   * Exact on both insets, and against the app's own constants rather than the
-   * numbers they currently come to. Nothing platform-dependent goes into
-   * either: the titlebar and the tab strip are Meru's own measurements, drawn
-   * by the renderer, and a view laid over either of them is covering the
-   * app's own interface.
+   * And so that the strip is drawn at all. `getVerticalTabsWidth` gives it no
+   * width for an account with a single tab, and a free account has exactly that
+   * — the saved tabs that would make a second are a Pro feature. `sidebar` is
+   * the one placement that keeps the strip for good, because it hands it the
+   * launcher and the bookmarks button permanently.
    *
-   * The strip is at its narrow width because the account has more than one tab
-   * and none of them is an unpinned second tab for the same app, which is the
-   * only thing that widens it while `verticalTabs.width` is left at `auto`.
+   * The alternative was seeding saved tabs here, which is the path this version
+   * of the app wrongly allows without a license, and the one the todo has
+   * against it. A gating test standing on a gating bug is not worth having.
    */
-  expect(unfilled.left).toBe(VERTICAL_TABS_NARROW_WIDTH);
-  expect(unfilled.top).toBe(APP_TITLEBAR_HEIGHT);
-
-  // And it spans everything left over, so no strip of window shows through
-  // beside or beneath it.
-  expect(unfilled.right).toBe(0);
-  expect(unfilled.bottom).toBe(0);
-});
-
-test("waking a dormant tab adds a view and brings it to the front", async () => {
-  await waitForRestoredView();
-
-  /*
-   * In front is last: the window lists its children bottom first, and the app
-   * puts the active tab's view at the end by removing and re-adding it. Every
-   * view here has the same bounds, so which one the user is actually looking
-   * at is this and nothing else.
-   */
-  const viewsBefore = await readViews(meru);
-
-  /*
-   * Named by what it is not, because the only other view is Gmail's and its
-   * title is whatever Google served — a sign-in page, or Chromium's network
-   * error page on a runner with no route out. Asserting that the restored
-   * workspace app is behind says the same thing about z-order and asks nothing
-   * of a third party.
-   */
-  expect(viewsBefore.at(-1)?.url.startsWith(server.origin)).toBe(false);
-
-  /*
-   * Opened by clicking the tab, which is how anyone opens one. The dormant tab
-   * is still showing its seeded title, because nothing has loaded to replace
-   * it — that is what makes it findable by the name the seed gave it.
-   */
-  await meru.renderer.getByRole("button", { name: DORMANT_TAB_TITLE }).click();
-
-  await expect.poll(async () => (await readViews(meru)).length).toBe(3);
-
-  const viewsAfter = await readViews(meru);
-
-  // The woken tab is the active one, so its view is the one in front now.
-  await expect
-    .poll(async () => (await readViews(meru)).at(-1)?.url)
-    .toBe(server.pageUrl(DORMANT_PAGE_TITLE));
-
-  // And the tab that was already open kept its view rather than being torn down
-  // and rebuilt behind the new one.
-  expect(findViewByUrl(viewsAfter, server.pageUrl(RESTORED_PAGE_TITLE))).toBeDefined();
-});
-
-test("a workspace app view runs in its account's session", async () => {
-  await waitForRestoredView();
-
-  const views = await readViews(meru);
-
-  /*
-   * Every view belongs to the account, so every one of them runs in the
-   * account's partition rather than the session Electron hands out by default.
-   * A view that fell back to the default session would share cookies with every
-   * other account, which is the failure this is here for.
-   */
-  for (const view of views) {
-    expect(view.isDefaultSession, view.url).toBe(false);
-
-    // Contained rather than compared to a built path: the partition directory
-    // is named for the account, but the separator around it is the platform's.
-    expect(view.storagePath, view.url).toContain(ACCOUNT_ID);
-  }
-
-  // The workspace app is in the same session as the account's Gmail view, which
-  // is what lets it be signed in at all.
-  const storagePaths = new Set(views.map((view) => view.storagePath));
-
-  expect(storagePaths.size).toBe(1);
+  "workspaceApps.launcherAndBookmarksPlacement": "sidebar",
+  accounts: [seedAccount({ id: ACCOUNT_ID, label: "Default" })],
 });
 
 test("the workspace apps launcher is absent without a license", async () => {
   /*
-   * The inverse of the assertion in `workspace-apps-pro.e2e.ts`, and the reason
-   * it is worth making from both sides: neither file keeps a list of what the
-   * license unlocks, so a launcher that stopped being gated fails here, and one
-   * that stopped appearing at all fails there.
-   */
-  /*
    * The strip is waited for first, which is what makes the absence below a
    * decision the app made rather than a moment arriving too early. An earlier
    * version of this test asserted straight away and passed while the app was
-   * showing the launcher — see `waitForVerticalTabs`.
+   * showing the launcher — see `waitForVerticalTabs` for why this anchor and not
+   * the bookmarks button beside it.
    */
   await waitForVerticalTabs(meru);
 
   await expect(meru.renderer.getByRole("button", { name: "Open app" })).toHaveCount(0);
-});
-
-test("a download from a workspace app lands on disk and in the history", async () => {
-  await waitForRestoredView();
-
-  /*
-   * The view is a page in its own right as far as Playwright is concerned, so
-   * the link is clicked in the workspace app itself rather than driven through
-   * the main process. That is the path a real download takes: the click is in
-   * the view, and everything after it is the app's.
-   */
-  await expect
-    .poll(() => meru.app.windows().some((page) => page.url().startsWith(server.origin)))
-    .toBe(true);
-
-  const workspaceAppPage = meru.app.windows().find((page) => page.url().startsWith(server.origin));
-
-  if (!workspaceAppPage) {
-    throw new Error("The restored view never became a page");
-  }
-
-  await workspaceAppPage.getByRole("link", { name: "Download the file" }).click();
-
-  // On disk, in the directory the config named, with what the server sent.
-  await expect.poll(() => readdir(downloadsLocation())).toEqual([DOWNLOAD_FILE_NAME]);
-
-  expect(await readFile(path.join(downloadsLocation(), DOWNLOAD_FILE_NAME), "utf8")).toBe(
-    DOWNLOAD_BODY,
-  );
-
-  /*
-   * And recorded. Polled against the config on disk rather than the page,
-   * because what is being proved is the main process writing the download
-   * through to the file it keeps history in.
-   */
-  await expect
-    .poll(async () =>
-      (await meru.readConfig())["downloads.history"]?.map(({ fileName }) => fileName),
-    )
-    .toEqual([DOWNLOAD_FILE_NAME]);
-
-  // Then where a user would look for it. The menu is the way in, as everywhere
-  // else in this suite.
-  expect(await meru.runMenuCommand("Downloads")).toBe(true);
-
-  await expect(meru.renderer.getByTitle(DOWNLOAD_FILE_NAME)).toBeVisible();
 });

--- a/tests/workspace-apps.e2e.ts
+++ b/tests/workspace-apps.e2e.ts
@@ -21,6 +21,7 @@ import { expect, test } from "@playwright/test";
 import { seedAccount, seedSavedTab } from "./lib/accounts";
 import { useApp } from "./lib/app";
 import { DOWNLOAD_BODY, DOWNLOAD_FILE_NAME, startTestServer, type TestServer } from "./lib/server";
+import { waitForVerticalTabs } from "./lib/strip";
 import { findViewByUrl, readUnfilledSpace, readViews } from "./lib/views";
 
 /*
@@ -35,6 +36,17 @@ const RESTORED_TAB_TITLE = "Calendar";
 
 /** The saved tab seeded without it, so it comes back as an entry with nothing behind it. */
 const DORMANT_TAB_TITLE = "Keep";
+
+/*
+ * What the served pages are titled, deliberately not the workspace app labels
+ * above. `WorkspaceApp.resolveTitle` falls back to the app's label when no page
+ * title ever arrives, so a page titled "Calendar" would leave the Calendar tab
+ * reading "Calendar" whether it loaded or not — and every assertion on the tab
+ * would hold against a view that never fetched anything.
+ */
+const RESTORED_PAGE_TITLE = "Restored Stand-In";
+
+const DORMANT_PAGE_TITLE = "Woken Stand-In";
 
 let server: TestServer;
 
@@ -59,6 +71,13 @@ const meru = useApp(async ({ userDataDir }) => {
 
   return {
     "downloads.location": downloadsLocation,
+    /*
+     * Seeded so that the launcher has apps to offer. Both hosts gate it on
+     * `isLicenseKeyValid && launcherApps.length > 0`, and the default list is
+     * empty — so without this the launcher is absent because it has nothing to
+     * show, and the assertion below would hold with the license check deleted.
+     */
+    "workspaceApps.launcherApps": ["calendar", "tasks"],
     accounts: [
       seedAccount({
         id: ACCOUNT_ID,
@@ -66,13 +85,13 @@ const meru = useApp(async ({ userDataDir }) => {
         savedTabs: [
           seedSavedTab({
             app: "calendar",
-            url: server.pageUrl(RESTORED_TAB_TITLE),
+            url: server.pageUrl(RESTORED_PAGE_TITLE),
             title: RESTORED_TAB_TITLE,
             loadOnLaunch: true,
           }),
           seedSavedTab({
             app: "keep",
-            url: server.pageUrl(DORMANT_TAB_TITLE),
+            url: server.pageUrl(DORMANT_PAGE_TITLE),
             title: DORMANT_TAB_TITLE,
           }),
         ],
@@ -113,19 +132,22 @@ test("a saved tab is restored into a child view of its own", async () => {
 
   const restoredView = findViewByUrl(views, server.origin);
 
-  expect(restoredView?.url).toBe(server.pageUrl(RESTORED_TAB_TITLE));
+  expect(restoredView?.url).toBe(server.pageUrl(RESTORED_PAGE_TITLE));
 
   // The view really loaded the page, rather than being attached with a URL set
   // on it: a title only exists once a document has parsed.
-  expect(restoredView?.title).toBe(RESTORED_TAB_TITLE);
+  expect(restoredView?.title).toBe(RESTORED_PAGE_TITLE);
 
   /*
-   * The tab the seed named is in the strip, and it is showing the page's title
-   * rather than the one it was saved with. A restored tab follows the app it
-   * holds, so those two agreeing here is the seeded title being overwritten by
-   * a page that actually arrived.
+   * And the strip is showing the page's title rather than the one the tab was
+   * saved with, which is a restored tab following the app it holds. The two
+   * titles are deliberately different, so this fails against a view that was
+   * attached and never fetched anything — where the tab would fall back to the
+   * workspace app's own label.
    */
-  await expect(meru.renderer.getByRole("button", { name: RESTORED_TAB_TITLE })).toBeVisible();
+  await expect(meru.renderer.getByRole("button", { name: RESTORED_PAGE_TITLE })).toBeVisible();
+
+  await expect(meru.renderer.getByRole("button", { name: RESTORED_TAB_TITLE })).toHaveCount(0);
 });
 
 test("a restored view is inset by the chrome the renderer owns", async () => {
@@ -170,7 +192,14 @@ test("waking a dormant tab adds a view and brings it to the front", async () => 
    */
   const viewsBefore = await readViews(meru);
 
-  expect(viewsBefore.at(-1)?.title).toBe("Gmail");
+  /*
+   * Named by what it is not, because the only other view is Gmail's and its
+   * title is whatever Google served — a sign-in page, or Chromium's network
+   * error page on a runner with no route out. Asserting that the restored
+   * workspace app is behind says the same thing about z-order and asks nothing
+   * of a third party.
+   */
+  expect(viewsBefore.at(-1)?.url.startsWith(server.origin)).toBe(false);
 
   /*
    * Opened by clicking the tab, which is how anyone opens one. The dormant tab
@@ -186,11 +215,11 @@ test("waking a dormant tab adds a view and brings it to the front", async () => 
   // The woken tab is the active one, so its view is the one in front now.
   await expect
     .poll(async () => (await readViews(meru)).at(-1)?.url)
-    .toBe(server.pageUrl(DORMANT_TAB_TITLE));
+    .toBe(server.pageUrl(DORMANT_PAGE_TITLE));
 
   // And the tab that was already open kept its view rather than being torn down
   // and rebuilt behind the new one.
-  expect(findViewByUrl(viewsAfter, server.pageUrl(RESTORED_TAB_TITLE))).toBeDefined();
+  expect(findViewByUrl(viewsAfter, server.pageUrl(RESTORED_PAGE_TITLE))).toBeDefined();
 });
 
 test("a workspace app view runs in its account's session", async () => {
@@ -226,11 +255,15 @@ test("the workspace apps launcher is absent without a license", async () => {
    * license unlocks, so a launcher that stopped being gated fails here, and one
    * that stopped appearing at all fails there.
    */
-  await expect(meru.renderer.getByRole("button", { name: "Open app" })).toHaveCount(0);
+  /*
+   * The strip is waited for first, which is what makes the absence below a
+   * decision the app made rather than a moment arriving too early. An earlier
+   * version of this test asserted straight away and passed while the app was
+   * showing the launcher — see `waitForVerticalTabs`.
+   */
+  await waitForVerticalTabs(meru);
 
-  // Read against something that is on screen, so a strip that failed to render
-  // at all cannot pass this by having nothing in it.
-  await expect(meru.renderer.getByRole("button", { name: "Gmail" })).toBeVisible();
+  await expect(meru.renderer.getByRole("button", { name: "Open app" })).toHaveCount(0);
 });
 
 test("a download from a workspace app lands on disk and in the history", async () => {


### PR DESCRIPTION
## Summary
Adds end-to-end coverage for the child `WebContentsView` machinery — the layer accounts and workspace apps are actually built out of, which nothing touched before. Seven tests assert view creation, layout, z-order, session partitioning and the download pipeline. Writing them turned up a licensing bug, recorded in the todo and deliberately not leaned on or fixed here. The Pro file depends on the production license API, and its launcher test loads a real Google property; both are explained below.

## Problem
Every account and every workspace app is a child `WebContentsView` attached to the window, and the app is responsible for all of it: creating them, laying them out under the titlebar and beside the tab strip, keeping the active one in front, and running each in its account's session. None of that had a test.

It is also only reachable at this level. A component test cannot construct a `WebContentsView` at all, and a screenshot cannot see one — the compositor paints them above the renderer's HTML, so they come out as blank rectangles. `window-bounds.e2e.ts` reaches the layer but deliberately stops at a single visible view: `readUnfilledSpace` throws unless there is exactly one, and it asserts the top, right and bottom gaps. The multi-view case, the left inset by the tab strip, and z-order were all unclaimed.

## Solution
Everything is asserted from the main process, through a new `readViews` helper that reports each child's URL, bounds, session and position in the window's own child order. That order is z-order, bottom first, so the last entry is the view in front — and since every view here shares the same bounds, it is the only thing that says which one the user is actually looking at.

- `tests/workspace-apps-pro.e2e.ts` — a saved tab restored into a view at launch, its inset against `VERTICAL_TABS_NARROW_WIDTH` and `APP_TITLEBAR_HEIGHT`, waking a dormant tab by clicking it, two accounts each in a session of its own, the launcher, and a download from inside a view through to disk, the config history and the Downloads page.
- `tests/workspace-apps.e2e.ts` — the free version's side of the launcher gate, and nothing else.

The machinery is tested **under a license** because workspace apps are a Pro feature. It was on the free version first, and passed, which is what exposed the bug below: restoring a saved tab and waking one are not gated, so all of it ran without a key. A test standing on that would fail the day someone closes the hole and report a fix as a regression.

The views load a page served from this machine rather than a Google property. Pointing them at the real thing would put a live third-party site inside the assertion while proving nothing extra — the view, its session, its layout and the download coming out of it are the app's own either way. The one exception is the launcher, which opens a hardcoded Google URL: that test asserts a view appeared and not what it holds, so its answer does not depend on a third party being up.

Saved tabs are seeded into the config and then opened the way anyone opens one, by clicking in the strip. Reaching a view by setting a location would arrive at the same place while saying nothing about whether the app offers a way there. Page titles are deliberately different from the workspace apps' own labels, because `resolveTitle` falls back to the label — so a page titled "Calendar" would leave a Calendar tab reading "Calendar" whether it ever loaded or not.

The launcher is asserted from both sides, absent on free and present under a license, so a launcher that stopped being gated fails in one file and one that stopped appearing fails in the other. That split is forced anyway: `useApp` is called once at module scope, so a file is entirely one entitlement or the other.

`useApp` also gains a seed *function*, handed the directory the app is about to run in. A test seeding a downloads location, or a saved tab pointing at a server it starts itself, has nothing to name while the file is being read. Seeding a path inside that directory is also what keeps downloaded files inside what the harness already removes. `useProApp` spread its seed, which would have silently dropped a function, so it now composes with one.

## Try it
```sh
MERU_SKIP_BUILD=1 bun run test:e2e -- tests/workspace-apps.e2e.ts tests/workspace-apps-pro.e2e.ts
```
Drop `MERU_SKIP_BUILD=1` to build first; on a machine without a display, wrap it in `xvfb-run -a`. Both files need `MERU_TEST_LICENSE_KEY` in `.env.test.local`, as `tests/pro.e2e.ts` does. Expect 7 passed in roughly 20 seconds.

To see the tests bite rather than pass vacuously, either:
- Flip `loadOnLaunch` to `false` in the Pro file's seed — the machinery tests fail.
- Change the free file's `useApp` import to `useProApp as useApp` — the gating test fails with `Received: 1`. It passed this mutation twice before the fix, which is how the defect in it was found.

## Not verified
- `tests/workspace-apps-pro.e2e.ts` depends on the production license API on every launch, the same trade `tests/pro.e2e.ts` already makes, and its launcher test additionally loads a real Google property. A backend or network failure surfaces as a windowless app rather than a clean assertion failure. Six of the seven tests now carry that dependency, where before only two did — the cost of testing a Pro feature under Pro.
- Not covered, and left for later in the todo: hibernation (`hibernatesWhenIdle` is seeded false throughout), windowed tabs and the detach/adopt paths, bookmarks, and the 30-day pruning of download history.
- **A bug found and not fixed here.** Workspace app tabs and bookmarks survive a downgrade to the free version: `restoreSavedTabs`, `loadLaunchTabs`, `tabs.selectTab` and `bookmarks.openBookmark` never check the license, though every path that *acquires* a workspace app does. A trial ending reaches it with nothing edited by hand. `accounts.getAccountConfigs` does slice a downgraded user back to one account, so that gate survives the downgrade and this one does not. Written up in the todo with the call sites; out of scope for a test-only change, and the fix needs a product decision about what happens to tabs already saved.
