### PR TITLE
Clamp a content script to the sites it already reached

### DIFF
--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -16,7 +16,7 @@ const FACADE_FILE_NAME = "chrome-facade.js";
 const SERVICE_WORKER_FILE_NAME = "chrome-facade-service-worker.js";
 
 /** Bump whenever what is written into a derived copy changes. */
-const DERIVE_VERSION = 5;
+const DERIVE_VERSION = 6;
 
 export type DeriveExtensionOptions = {
   /** The unpacked extension the embedder handed over, never written to. */

--- a/packages/electron-extensions/derive/manifest.test.ts
+++ b/packages/electron-extensions/derive/manifest.test.ts
@@ -167,6 +167,51 @@ describe("deriveManifest", () => {
     ]);
   });
 
+  test("drops a content script the clamped sites were never in reach of", () => {
+    const { manifest } = deriveManifest(
+      {
+        name: "1Password",
+        content_scripts: [
+          { matches: ["<all_urls>"], js: ["inline/inject-content-scripts.js"] },
+          { matches: ["https://app.kolide.com/*"], js: ["inline/injected/kolide.js"] },
+        ],
+      },
+      { ...fileNames, contentScriptMatches: ["https://accounts.google.com/*"] },
+    );
+
+    // Handed the clamp, Kolide's script would run on a Google sign-in page it
+    // never reached in the first place — 427 KB of 1Password's own such scripts
+    expect(manifest.content_scripts).toEqual([
+      { matches: ["https://accounts.google.com/*"], js: ["inline/inject-content-scripts.js"] },
+    ]);
+  });
+
+  test("clamps a content script to the sites it reaches, not to every site named", () => {
+    const { manifest } = deriveManifest(
+      {
+        name: "1Password",
+        content_scripts: [{ matches: ["https://myaccount.google.com/*"], js: ["content.js"] }],
+      },
+      {
+        ...fileNames,
+        contentScriptMatches: ["https://accounts.google.com/*", "https://myaccount.google.com/*"],
+      },
+    );
+
+    expect(manifest.content_scripts).toEqual([
+      { matches: ["https://myaccount.google.com/*"], js: ["content.js"] },
+    ]);
+  });
+
+  test("drops a content script with no matches of its own to narrow", () => {
+    const { manifest } = deriveManifest(
+      { name: "1Password", content_scripts: [{ js: ["content.js"] }] },
+      { ...fileNames, contentScriptMatches: ["https://accounts.google.com/*"] },
+    );
+
+    expect(manifest.content_scripts).toEqual([]);
+  });
+
   test("clamps nothing in a manifest without content scripts", () => {
     const { manifest } = deriveManifest(
       { name: "No content scripts" },

--- a/packages/electron-extensions/derive/manifest.ts
+++ b/packages/electron-extensions/derive/manifest.ts
@@ -1,3 +1,4 @@
+import { reachesClampedSite } from "./match-pattern";
 import { findWebAccessiblePattern, type WebAccessibleResources } from "./web-accessible";
 
 /** Only what the derive reads or rewrites is spelled out; the rest is carried. */
@@ -177,8 +178,15 @@ function deriveContentSecurityPolicy(
  * extension controls, so the manifest is the only lever: an extension declaring
  * `<all_urls>` injects into every frame of every view otherwise.
  *
- * Every entry keeps the rest of what its author wrote — which scripts run, when
- * they run, which frames they reach — and only the sites they run on change.
+ * Each entry is clamped to the sites it already reached, and an entry that
+ * reached none of them is dropped rather than rewritten. Writing the clamp over
+ * every entry alike would widen the ones an author aimed at other sites: five of
+ * 1Password's eight entries name its own web app, Kolide, director.ai and
+ * autofill.me, and being handed the clamp put 427 KB of scripts that never ran
+ * on a Google page on every one of them.
+ *
+ * Every surviving entry keeps the rest of what its author wrote — which scripts
+ * run, when they run, which frames they reach — and only the sites change.
  */
 function deriveContentScripts(
   contentScripts: ExtensionManifest["content_scripts"],
@@ -188,7 +196,25 @@ function deriveContentScripts(
     return contentScripts;
   }
 
-  return contentScripts.map((contentScript) => ({ ...contentScript, matches }));
+  const clampedContentScripts: NonNullable<ExtensionManifest["content_scripts"]> = [];
+
+  for (const contentScript of contentScripts) {
+    // An entry with no patterns of its own runs nowhere, so there is nothing to
+    // narrow and nothing the clamp could hand it without inventing reach
+    const clampedMatches = matches.filter((clampPattern) =>
+      contentScript.matches?.some((contentScriptPattern) =>
+        reachesClampedSite(contentScriptPattern, clampPattern),
+      ),
+    );
+
+    if (clampedMatches.length === 0) {
+      continue;
+    }
+
+    clampedContentScripts.push({ ...contentScript, matches: clampedMatches });
+  }
+
+  return clampedContentScripts;
 }
 
 /**

--- a/packages/electron-extensions/derive/match-pattern.test.ts
+++ b/packages/electron-extensions/derive/match-pattern.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { reachesClampedSite } from "./match-pattern";
+
+const CLAMPED_SITE = "https://accounts.google.com/*";
+
+describe("reachesClampedSite", () => {
+  test("reaches the site from a pattern naming every URL", () => {
+    expect(reachesClampedSite("<all_urls>", CLAMPED_SITE)).toBe(true);
+  });
+
+  test("reaches the site from a wildcard host", () => {
+    expect(reachesClampedSite("https://*/*", CLAMPED_SITE)).toBe(true);
+  });
+
+  test("reaches the site from a subdomain wildcard covering it", () => {
+    expect(reachesClampedSite("https://*.google.com/*", CLAMPED_SITE)).toBe(true);
+  });
+
+  test("reaches the site from a subdomain wildcard spelling it exactly", () => {
+    expect(reachesClampedSite("https://*.accounts.google.com/*", CLAMPED_SITE)).toBe(true);
+  });
+
+  test("reaches the site from the host itself, whatever path it names", () => {
+    expect(reachesClampedSite("https://accounts.google.com/signin/*", CLAMPED_SITE)).toBe(true);
+  });
+
+  test("reaches the site from a wildcard scheme", () => {
+    expect(reachesClampedSite("*://accounts.google.com/*", CLAMPED_SITE)).toBe(true);
+  });
+
+  test("does not reach the site from another host", () => {
+    expect(reachesClampedSite("https://app.kolide.com/*", CLAMPED_SITE)).toBe(false);
+  });
+
+  test("does not reach the site from a suffix it only ends with", () => {
+    expect(reachesClampedSite("https://*.notgoogle.com/*", CLAMPED_SITE)).toBe(false);
+  });
+
+  test("does not reach an https site from an http pattern", () => {
+    expect(reachesClampedSite("http://accounts.google.com/*", CLAMPED_SITE)).toBe(false);
+  });
+
+  test("does not reach an http site from a wildcard scheme on another scheme", () => {
+    expect(reachesClampedSite("*://accounts.google.com/*", "file://accounts.google.com/*")).toBe(
+      false,
+    );
+  });
+
+  test("reaches everything a clamp with no single site to ask about names", () => {
+    expect(reachesClampedSite("https://app.kolide.com/*", "<all_urls>")).toBe(true);
+    expect(reachesClampedSite("https://app.kolide.com/*", "https://*.google.com/*")).toBe(true);
+  });
+
+  test("reaches nothing from a pattern that cannot be read", () => {
+    expect(reachesClampedSite("accounts.google.com", CLAMPED_SITE)).toBe(false);
+  });
+});

--- a/packages/electron-extensions/derive/match-pattern.ts
+++ b/packages/electron-extensions/derive/match-pattern.ts
@@ -1,0 +1,93 @@
+/**
+ * The sites a clamp names, and whether a content script could ever have run on
+ * one of them.
+ *
+ * The clamp is a host allowlist: the catalog names the sites an extension is
+ * offered for, and the derive writes them over every content script's own
+ * patterns. So the question asked here is about scheme and host, never path — a
+ * content script restricted to a path within an allowed host keeps running on
+ * that host, which is what the clamp already does to every entry it rewrites.
+ */
+
+const ALL_URLS = "<all_urls>";
+
+type MatchPattern = {
+  scheme: string;
+  host: string;
+};
+
+/**
+ * The schemes `*` stands for in a match pattern's scheme position, which is
+ * `http` and `https` alone — not the `file` and `ftp` schemes a bare `*` covers
+ * nowhere in Chrome's grammar.
+ */
+const WILDCARD_SCHEMES = new Set(["http", "https"]);
+
+function parseMatchPattern(pattern: string): MatchPattern | undefined {
+  const separatorIndex = pattern.indexOf("://");
+
+  if (separatorIndex === -1) {
+    return undefined;
+  }
+
+  const scheme = pattern.slice(0, separatorIndex);
+
+  const afterScheme = pattern.slice(separatorIndex + "://".length);
+
+  const pathIndex = afterScheme.indexOf("/");
+
+  return {
+    scheme,
+    host: pathIndex === -1 ? afterScheme : afterScheme.slice(0, pathIndex),
+  };
+}
+
+function schemeCovers(patternScheme: string, siteScheme: string) {
+  if (patternScheme === "*") {
+    return WILDCARD_SCHEMES.has(siteScheme);
+  }
+
+  return patternScheme === siteScheme;
+}
+
+function hostCovers(patternHost: string, siteHost: string) {
+  if (patternHost === "*") {
+    return true;
+  }
+
+  if (patternHost.startsWith("*.")) {
+    const suffix = patternHost.slice("*.".length);
+
+    return siteHost === suffix || siteHost.endsWith(`.${suffix}`);
+  }
+
+  return patternHost === siteHost;
+}
+
+/**
+ * Whether a content script's own match pattern reaches the site a clamp pattern
+ * names. A clamp pattern naming a wildcard host has no single site to ask
+ * about, so it is taken as reaching everything rather than guessed at.
+ */
+export function reachesClampedSite(contentScriptPattern: string, clampPattern: string) {
+  if (contentScriptPattern === ALL_URLS || clampPattern === ALL_URLS) {
+    return true;
+  }
+
+  const clampedSite = parseMatchPattern(clampPattern);
+
+  if (!clampedSite || clampedSite.host.includes("*")) {
+    return true;
+  }
+
+  const contentScriptSites = parseMatchPattern(contentScriptPattern);
+
+  if (!contentScriptSites) {
+    return false;
+  }
+
+  return (
+    schemeCovers(contentScriptSites.scheme, clampedSite.scheme) &&
+    hostCovers(contentScriptSites.host, clampedSite.host)
+  );
+}


### PR DESCRIPTION
## Summary
The content-script clamp writes the catalog's site list over every `content_scripts[].matches` entry, which narrows the broad entries and widens every other one — five of 1Password's eight, aimed at other people's sites, were being put on Google's sign-in pages. Each entry now keeps only the clamped sites its own patterns already reached, cutting the JavaScript injected there from 558 KB to 132 KB. The four flows it must not break (log in with a password or a passkey, create one of each) need testing on a real machine.

## Problem
`deriveContentScripts` overwrites `matches` on every entry alike. That is right for the three 1Password entries declaring `<all_urls>` or `https://*/*`, which is what the clamp was written for. It is wrong for the other five, which name 1Password's own web app, Kolide, director.ai and autofill.me: in Chrome none of them runs on a Google page, and handed the clamp all five do.

That is 427 KB of the 558 KB of content-script JavaScript parsed on every navigation to `accounts.google.com` or `myaccount.google.com`, and — the part that outweighs the memory — five scripts written for other people's sites running on the page where a Google password is typed. The clamp exists to shrink an extension's reach, and for most of the entries it passed through it was doing the opposite.

Found while picking up [the todo row on what a loaded extension costs in memory](https://github.com/zoidsh/meru-docs/blob/main/todo.md), which named `offscreen` as the lead. That lead is a dud and no longer worth anyone's time: 1Password has one `chrome.offscreen.createDocument` call site, it is a one-time `window.localStorage` migration guarded by a stored timestamp, and it calls `closeDocument` as soon as the migration returns. Nothing steady-state to reclaim, and stripping the permission would break a storage path to buy nothing.

## Solution
- `reachesClampedSite` in the new `derive/match-pattern.ts` answers whether one of a content script's own match patterns reaches the site a clamp pattern names. `deriveContentScripts` keeps the clamp patterns that pass, and drops an entry that passes none rather than rewriting it.
- Scheme and host decide it and path never does. The clamp is a host allowlist, and a path-restricted entry inside an allowed host is exactly what the clamp already widens — testing paths would need glob-against-glob intersection and would drop entries that belong, for no gain on a list of concrete hosts.
- `DERIVE_VERSION` goes to 6. The source tree's hash cannot see a change that lives in this repository, so without the bump every existing install keeps its old derived manifest.

The wider question this came from — what a loaded extension costs in memory — is written up in [the feature doc](https://github.com/zoidsh/meru-docs/blob/main/features/chrome-extensions.md#content-script-scoping-to-sign-in-pages) and is being taken forward separately on `extension-worker-memory`. **An earlier revision of this description reported 1Password's service worker as holding 103 MB of PSS and never idle-stopping. That was a harness artifact and is withdrawn**: Playwright's `_electron.launch` attaches a CDP debugger, which disables Chromium's MV3 idle timer. In an undebugged launch the worker starts with the session and stops about 30 seconds later, taking its process with it, so it is a transient rather than a resident. `tests/lib/app.ts:182` launches that way, which means worker lifetime cannot be read from `test:e2e` or `test:perf` at all — worth knowing beyond this PR.

The figures below are unaffected. Both sides of the comparison ran through the same harness, and the idle timer has no bearing on how much memory a renderer spends parsing content scripts.

The memory this buys is real but small: measured on Linux over nine cold launches each, the sign-in page's renderer falls from 62.7 MB of PSS to 60.9 MB, and from 145.9 MB of working set to 144.2 MB. Working set is used here only alongside PSS, since [it overstates real cost by roughly a factor of two](https://github.com/zoidsh/meru-docs/blob/main/todo.md).

## Try it
No preview deployment exists for the app. On a machine with a display and a Google account:

```sh
bun install --frozen-lockfile
bun run extensions:download
bun run dev
```

Sign out of Google in a Meru account, and on the sign-in page confirm 1Password still offers to fill and still answers the passkey challenge. Then on `https://myaccount.google.com/signinoptions/passkeys` and `.../password`, confirm it still offers to create and save each. `chrome://extensions` is not available, so the check that the drop happened is the derived manifest under `<userData>/derived-extensions`: `content_scripts` should hold three entries rather than eight.

## Not verified
- The four flows — log in with a password, log in with a passkey, create a password, create a passkey. The sandbox has no display and no Google account, so nothing below the manifest was exercised here.
- That no 1Password behavior depends on one of the five dropped entries reaching a Google page. Nothing in the extension reads `content_scripts` back out of its own manifest, and each of the five names hosts that have nothing to do with Google, but only the flows above can show it.
- Anything on macOS or Windows. Every measurement in this description is Linux, from `/proc/<pid>/smaps_rollup`.
- That the content-script figures are free of the harness distortion described above. The CDP debugger is known to disable the MV3 idle timer; whether it perturbs renderer memory too is untested, and the defence here is only that both sides ran identically.
