### PR TITLE
One shared extension instance, reaching its content scripts and its pages

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { is } from "@electron-toolkit/utils";
 import {
+  createSharedExtensionInstance,
   Extensions,
   findExtensionDirs,
   getInstalledExtension,
@@ -116,6 +117,18 @@ export const extensions = new Extensions({
   derivedExtensionsDir: DERIVED_EXTENSIONS_DIR,
   strippedManifestKeys: getStrippedManifestKeys(),
   getContentScriptMatches,
+  // One shared extension instance across all account sessions — one 1Password
+  // sign-in instead of one per account. It has never been run against
+  // 1Password itself, so nothing loads it by default: development builds opt
+  // in with MERU_EXTENSIONS_SHARED_INSTANCE=1, and deleting this one option
+  // removes the whole feature.
+  sharedInstance:
+    is.dev && process.env.MERU_EXTENSIONS_SHARED_INSTANCE
+      ? createSharedExtensionInstance({
+          shimScriptPath: path.join(__dirname, "extensions-runtime-proxy-shim.js"),
+          relayScriptPath: path.join(__dirname, "extensions-runtime-proxy-relay.js"),
+        })
+      : undefined,
   logger: {
     info: (message, details) => {
       log.info(message, details);

--- a/packages/electron-extensions/bridge/bridge.test.ts
+++ b/packages/electron-extensions/bridge/bridge.test.ts
@@ -77,18 +77,20 @@ function createSession() {
       requestHeaders.origin = sendOptions.origin;
     }
 
-    beforeSendHeadersListener?.(
-      {
-        url,
-        frame: sendOptions.frame ?? null,
-        requestHeaders,
-      } as OnBeforeSendHeadersListenerDetails,
-      ({ requestHeaders: stampedHeaders }) => {
-        if (stampedHeaders) {
-          requestHeaders = stampedHeaders;
-        }
-      },
-    );
+    if (sendOptions.frame !== undefined) {
+      beforeSendHeadersListener?.(
+        {
+          url,
+          frame: sendOptions.frame,
+          requestHeaders,
+        } as OnBeforeSendHeadersListenerDetails,
+        ({ requestHeaders: stampedHeaders }) => {
+          if (stampedHeaders) {
+            requestHeaders = stampedHeaders;
+          }
+        },
+      );
+    }
 
     return requestHeaders;
   };
@@ -279,7 +281,7 @@ describe("ExtensionBridge", () => {
     expect(senderFrames).toEqual([undefined]);
   });
 
-  test("a caller writing the stamp header itself buys nothing", async () => {
+  test("a stamp a caller wrote itself names no frame", async () => {
     const { session, request } = createSession();
 
     const bridge = createBridge(session);
@@ -294,8 +296,13 @@ describe("ExtensionBridge", () => {
       return new Response(null, { status: 204, headers });
     });
 
-    // A frameless caller cannot conjure a frame by naming a nonce, and a
-    // caller with a frame gets its own frame recorded, not the header it wrote
+    /*
+     * The frameless caller keeps the header it wrote, because the listener that
+     * would have stripped it is the one thing it never reaches — and it gains
+     * nothing, because the value names no record. The caller with a frame is
+     * stripped and stamped, so it is recorded as itself rather than as whatever
+     * it claimed.
+     */
     await request(
       "/echo",
       { token: BRIDGE_TOKEN },
@@ -305,13 +312,13 @@ describe("ExtensionBridge", () => {
     await request(
       "/echo",
       { token: BRIDGE_TOKEN },
-      { frame, headers: { "x-extension-bridge-caller": "guessed" } },
+      { frame, headers: { "X-Extension-Bridge-Caller": "guessed" } },
     );
 
     expect(senderFrames).toEqual([undefined, frame]);
   });
 
-  test("a stolen stamp is dropped before the bridge's own goes on", async () => {
+  test("a nonce is spent by the request it was minted for", async () => {
     const { session, stampHeaders, sendWithHeaders } = createSession();
 
     const bridge = createBridge(session);
@@ -326,17 +333,21 @@ describe("ExtensionBridge", () => {
       return new Response(null, { status: 204, headers });
     });
 
-    // A frameless caller presenting a live stamp lifted from another request
-    // is stripped of it, so the victim's frame is never handed over
+    /*
+     * A frameless caller replaying a stamp is the shape of the only attack the
+     * stripping never covers, and it is not reachable: a nonce is minted in the
+     * main process after the request has left the renderer, so nothing that
+     * runs in one can read a live value. Constructed here by hand for that
+     * reason. What answers it is that a record is spent when it is read — the
+     * victim's own request takes it, and the replay that follows finds nothing.
+     */
     const victimHeaders = stampHeaders(`${EXTENSION_BRIDGE_ORIGIN}/echo`, { frame: victimFrame });
 
-    const thiefHeaders = stampHeaders(`${EXTENSION_BRIDGE_ORIGIN}/echo`, {
-      headers: victimHeaders,
-    });
+    await sendWithHeaders("/echo", JSON.stringify({ token: BRIDGE_TOKEN }), victimHeaders);
 
-    await sendWithHeaders("/echo", JSON.stringify({ token: BRIDGE_TOKEN }), thiefHeaders);
+    await sendWithHeaders("/echo", JSON.stringify({ token: BRIDGE_TOKEN }), { ...victimHeaders });
 
-    expect(senderFrames).toEqual([undefined]);
+    expect(senderFrames).toEqual([victimFrame, undefined]);
   });
 
   test("a caller record answers exactly once", async () => {

--- a/packages/electron-extensions/bridge/bridge.test.ts
+++ b/packages/electron-extensions/bridge/bridge.test.ts
@@ -1,16 +1,37 @@
 import { describe, expect, test } from "bun:test";
-import type { Session } from "electron";
-import { ExtensionBridge, MAX_BRIDGE_REQUEST_BYTES } from "./bridge";
+import type { OnBeforeSendHeadersListenerDetails, Session, WebFrameMain } from "electron";
+import { ExtensionBridge, MAX_BRIDGE_REQUEST_BYTES, MAX_RECORDED_CALLER_FRAMES } from "./bridge";
 import { EXTENSION_BRIDGE_ORIGIN, EXTENSION_BRIDGE_SCHEME } from "./protocol";
 
 const EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
 
 const BRIDGE_TOKEN = "bridge-token";
 
+function createFrame(url: string): WebFrameMain {
+  return { url, parent: null, isDestroyed: () => false } as unknown as WebFrameMain;
+}
+
+type BeforeSendHeadersListener = (
+  details: OnBeforeSendHeadersListenerDetails,
+  callback: (response: { requestHeaders?: Record<string, string> }) => void,
+) => void;
+
+type SendOptions = {
+  origin?: string;
+  /** The frame Electron would name as the request's initiator, if any. */
+  frame?: WebFrameMain;
+  /** Headers the caller wrote itself, the way a forger would. */
+  headers?: Record<string, string>;
+};
+
 function createSession() {
   const handledSchemes: string[] = [];
 
   let requestHandler: ((request: GlobalRequest) => Promise<Response>) | undefined;
+
+  let beforeSendHeadersListener: BeforeSendHeadersListener | null = null;
+
+  const webRequestFilters: unknown[] = [];
 
   const session = {
     protocol: {
@@ -25,23 +46,83 @@ function createSession() {
         requestHandler = undefined;
       },
     },
+    webRequest: {
+      onBeforeSendHeaders: (
+        filterOrListener: unknown,
+        maybeListener?: BeforeSendHeadersListener | null,
+      ) => {
+        if (maybeListener === undefined) {
+          beforeSendHeadersListener = filterOrListener as BeforeSendHeadersListener | null;
+
+          return;
+        }
+
+        webRequestFilters.push(filterOrListener);
+
+        beforeSendHeadersListener = maybeListener;
+      },
+    },
   } as unknown as Session;
 
-  const sendRequest = (pathName: string, bodySource: string, origin?: string) =>
+  /**
+   * What Electron does with a request: the headers listener runs first, its
+   * callback decides the headers the request proceeds with, and only then does
+   * the protocol handler see it — measured on 43.2.0, and gated by the
+   * callback either way.
+   */
+  const stampHeaders = (url: string, sendOptions: SendOptions) => {
+    let requestHeaders: Record<string, string> = { ...sendOptions.headers };
+
+    if (sendOptions.origin !== undefined) {
+      requestHeaders.origin = sendOptions.origin;
+    }
+
+    beforeSendHeadersListener?.(
+      {
+        url,
+        frame: sendOptions.frame ?? null,
+        requestHeaders,
+      } as OnBeforeSendHeadersListenerDetails,
+      ({ requestHeaders: stampedHeaders }) => {
+        if (stampedHeaders) {
+          requestHeaders = stampedHeaders;
+        }
+      },
+    );
+
+    return requestHeaders;
+  };
+
+  const sendWithHeaders = (
+    pathName: string,
+    bodySource: string,
+    requestHeaders: Record<string, string>,
+  ) =>
     requestHandler?.(
       new Request(`${EXTENSION_BRIDGE_ORIGIN}${pathName}`, {
         method: "POST",
-        headers: origin === undefined ? {} : { origin },
+        headers: requestHeaders,
         body: bodySource,
       }) as GlobalRequest,
     ) as Promise<Response>;
 
+  const sendRequest = (pathName: string, bodySource: string, sendOptions: SendOptions = {}) =>
+    sendWithHeaders(
+      pathName,
+      bodySource,
+      stampHeaders(`${EXTENSION_BRIDGE_ORIGIN}${pathName}`, sendOptions),
+    );
+
   return {
     session,
     handledSchemes,
+    webRequestFilters,
+    hasBeforeSendHeadersListener: () => beforeSendHeadersListener !== null,
+    stampHeaders,
+    sendWithHeaders,
     sendRequest,
-    request: (pathName: string, body: Record<string, unknown>, origin?: string) =>
-      sendRequest(pathName, JSON.stringify(body), origin),
+    request: (pathName: string, body: Record<string, unknown>, sendOptions?: SendOptions) =>
+      sendRequest(pathName, JSON.stringify(body), sendOptions),
   };
 }
 
@@ -68,7 +149,7 @@ describe("ExtensionBridge", () => {
     const response = await request(
       "/echo",
       { token: BRIDGE_TOKEN, value: 42 },
-      "chrome-extension://aaa",
+      { origin: "chrome-extension://aaa" },
     );
 
     expect(response.status).toBe(200);
@@ -134,19 +215,222 @@ describe("ExtensionBridge", () => {
   });
 
   test("handles the scheme for the session's lifetime", () => {
-    const { session, handledSchemes } = createSession();
+    const { session, handledSchemes, hasBeforeSendHeadersListener } = createSession();
 
     const bridge = createBridge(session);
 
     expect(handledSchemes).toEqual([EXTENSION_BRIDGE_SCHEME]);
+    expect(hasBeforeSendHeadersListener()).toBe(true);
 
     bridge.teardownSession(session);
 
     expect(handledSchemes).toEqual([]);
+    expect(hasBeforeSendHeadersListener()).toBe(false);
 
     // A session that was never set up has nothing to unhandle
     bridge.teardownSession(session);
 
     expect(handledSchemes).toEqual([]);
+  });
+
+  test("watches only the bridge scheme, leaving the session's other traffic alone", () => {
+    const { session, webRequestFilters } = createSession();
+
+    createBridge(session);
+
+    expect(webRequestFilters).toEqual([{ urls: [`${EXTENSION_BRIDGE_SCHEME}://*/*`] }]);
+  });
+
+  test("hands the handler the frame Chromium recorded for the request", async () => {
+    const { session, request } = createSession();
+
+    const bridge = createBridge(session);
+
+    const frame = createFrame("https://accounts.google.com/");
+
+    let handledSenderFrame: WebFrameMain | undefined;
+
+    bridge.handle("/echo", ({ senderFrame, headers }) => {
+      handledSenderFrame = senderFrame;
+
+      return new Response(null, { status: 204, headers });
+    });
+
+    await request("/echo", { token: BRIDGE_TOKEN }, { frame });
+
+    expect(handledSenderFrame).toBe(frame);
+  });
+
+  test("a request without a frame — a service worker's — carries no sender frame", async () => {
+    const { session, request } = createSession();
+
+    const bridge = createBridge(session);
+
+    const senderFrames: (WebFrameMain | undefined)[] = [];
+
+    bridge.handle("/echo", ({ senderFrame, headers }) => {
+      senderFrames.push(senderFrame);
+
+      return new Response(null, { status: 204, headers });
+    });
+
+    await request("/echo", { token: BRIDGE_TOKEN });
+
+    expect(senderFrames).toEqual([undefined]);
+  });
+
+  test("a caller writing the stamp header itself buys nothing", async () => {
+    const { session, request } = createSession();
+
+    const bridge = createBridge(session);
+
+    const frame = createFrame("https://accounts.google.com/");
+
+    const senderFrames: (WebFrameMain | undefined)[] = [];
+
+    bridge.handle("/echo", ({ senderFrame, headers }) => {
+      senderFrames.push(senderFrame);
+
+      return new Response(null, { status: 204, headers });
+    });
+
+    // A frameless caller cannot conjure a frame by naming a nonce, and a
+    // caller with a frame gets its own frame recorded, not the header it wrote
+    await request(
+      "/echo",
+      { token: BRIDGE_TOKEN },
+      { headers: { "X-Extension-Bridge-Caller": "guessed" } },
+    );
+
+    await request(
+      "/echo",
+      { token: BRIDGE_TOKEN },
+      { frame, headers: { "x-extension-bridge-caller": "guessed" } },
+    );
+
+    expect(senderFrames).toEqual([undefined, frame]);
+  });
+
+  test("a stolen stamp is dropped before the bridge's own goes on", async () => {
+    const { session, stampHeaders, sendWithHeaders } = createSession();
+
+    const bridge = createBridge(session);
+
+    const victimFrame = createFrame("https://accounts.google.com/");
+
+    const senderFrames: (WebFrameMain | undefined)[] = [];
+
+    bridge.handle("/echo", ({ senderFrame, headers }) => {
+      senderFrames.push(senderFrame);
+
+      return new Response(null, { status: 204, headers });
+    });
+
+    // A frameless caller presenting a live stamp lifted from another request
+    // is stripped of it, so the victim's frame is never handed over
+    const victimHeaders = stampHeaders(`${EXTENSION_BRIDGE_ORIGIN}/echo`, { frame: victimFrame });
+
+    const thiefHeaders = stampHeaders(`${EXTENSION_BRIDGE_ORIGIN}/echo`, {
+      headers: victimHeaders,
+    });
+
+    await sendWithHeaders("/echo", JSON.stringify({ token: BRIDGE_TOKEN }), thiefHeaders);
+
+    expect(senderFrames).toEqual([undefined]);
+  });
+
+  test("a caller record answers exactly once", async () => {
+    const { session, stampHeaders, sendWithHeaders } = createSession();
+
+    const bridge = createBridge(session);
+
+    const frame = createFrame("https://accounts.google.com/");
+
+    const senderFrames: (WebFrameMain | undefined)[] = [];
+
+    bridge.handle("/echo", ({ senderFrame, headers }) => {
+      senderFrames.push(senderFrame);
+
+      return new Response(null, { status: 204, headers });
+    });
+
+    const stampedHeaders = stampHeaders(`${EXTENSION_BRIDGE_ORIGIN}/echo`, { frame });
+
+    const bodySource = JSON.stringify({ token: BRIDGE_TOKEN });
+
+    await sendWithHeaders("/echo", bodySource, stampedHeaders);
+
+    // Replaying the stamped nonce finds its record already consumed
+    await sendWithHeaders("/echo", bodySource, stampedHeaders);
+
+    expect(senderFrames).toEqual([frame, undefined]);
+  });
+
+  test("caller records left by requests that never arrive are bounded", async () => {
+    const { session, stampHeaders, sendWithHeaders } = createSession();
+
+    const bridge = createBridge(session);
+
+    const senderFrames: (WebFrameMain | undefined)[] = [];
+
+    bridge.handle("/echo", ({ senderFrame, headers }) => {
+      senderFrames.push(senderFrame);
+
+      return new Response(null, { status: 204, headers });
+    });
+
+    const echoUrl = `${EXTENSION_BRIDGE_ORIGIN}/echo`;
+
+    const oldestFrame = createFrame("https://oldest.test/");
+
+    const oldestHeaders = stampHeaders(echoUrl, { frame: oldestFrame });
+
+    for (let stamped = 0; stamped < MAX_RECORDED_CALLER_FRAMES; stamped += 1) {
+      stampHeaders(echoUrl, { frame: createFrame("https://filler.test/") });
+    }
+
+    const newestFrame = createFrame("https://newest.test/");
+
+    const newestHeaders = stampHeaders(echoUrl, { frame: newestFrame });
+
+    const bodySource = JSON.stringify({ token: BRIDGE_TOKEN });
+
+    // The oldest record was evicted to make room; the newest one is intact
+    await sendWithHeaders("/echo", bodySource, oldestHeaders);
+
+    await sendWithHeaders("/echo", bodySource, newestHeaders);
+
+    expect(senderFrames).toEqual([undefined, newestFrame]);
+  });
+
+  test("a frame destroyed since its request was stamped is not handed over", async () => {
+    const { session, stampHeaders, sendWithHeaders } = createSession();
+
+    const bridge = createBridge(session);
+
+    let isFrameDestroyed = false;
+
+    const frame = {
+      url: "https://accounts.google.com/",
+      parent: null,
+      isDestroyed: () => isFrameDestroyed,
+    } as unknown as WebFrameMain;
+
+    const senderFrames: (WebFrameMain | undefined)[] = [];
+
+    bridge.handle("/echo", ({ senderFrame, headers }) => {
+      senderFrames.push(senderFrame);
+
+      return new Response(null, { status: 204, headers });
+    });
+
+    // The frame goes away between the request's headers and its handling
+    const stampedHeaders = stampHeaders(`${EXTENSION_BRIDGE_ORIGIN}/echo`, { frame });
+
+    isFrameDestroyed = true;
+
+    await sendWithHeaders("/echo", JSON.stringify({ token: BRIDGE_TOKEN }), stampedHeaders);
+
+    expect(senderFrames).toEqual([undefined]);
   });
 });

--- a/packages/electron-extensions/bridge/bridge.ts
+++ b/packages/electron-extensions/bridge/bridge.ts
@@ -1,4 +1,5 @@
-import type { Session } from "electron";
+import { randomUUID } from "node:crypto";
+import type { OnBeforeSendHeadersListenerDetails, Session, WebFrameMain } from "electron";
 import type { ExtensionsLogger } from "../logger";
 import { EXTENSION_BRIDGE_SCHEME, type ExtensionBridgeRequest } from "./protocol";
 
@@ -10,10 +11,39 @@ import { EXTENSION_BRIDGE_SCHEME, type ExtensionBridgeRequest } from "./protocol
  */
 export const MAX_BRIDGE_REQUEST_BYTES = 64 * 1024 * 1024;
 
+/**
+ * The header the bridge stamps onto every request from a frame, carrying the
+ * nonce its caller record is filed under. `protocol.handle` hands the bridge
+ * only the session, but the session's `webRequest` sees the same request first
+ * and Chromium tells it the frame that made it — so the bridge's own
+ * `onBeforeSendHeaders` listener records that frame under a fresh nonce and
+ * writes the nonce into the request the handler is about to receive (measured
+ * on Electron 43.2.0: the listener runs before the handler, its callback gating
+ * the request, and the stamped header arrives intact). Whatever a caller puts
+ * in the header itself is dropped before the stamp goes on, so the nonce is
+ * only ever the main process's own word.
+ */
+export const EXTENSION_BRIDGE_CALLER_HEADER = "x-extension-bridge-caller";
+
+/**
+ * Bounds the caller records that were stamped but never consumed — a request
+ * canceled between its headers and the handler leaves its record behind. The
+ * live gap between the two stages is a handful of requests, so evicting the
+ * oldest past this many loses nothing that was still coming.
+ */
+export const MAX_RECORDED_CALLER_FRAMES = 1024;
+
 export type ExtensionBridgeHandler = (request: {
   session: Session;
   /** The extension whose facade copy carried the request's token. */
   extensionId: string;
+  /**
+   * The live frame Chromium recorded as the request's initiator — the page a
+   * content script runs in, or an extension page of the session. Missing when
+   * the request came from a service worker, which has no frame, and when the
+   * frame is gone by the time the request is handled.
+   */
+  senderFrame: WebFrameMain | undefined;
   body: Record<string, unknown>;
   /** For the handler's `Response`, so every answer carries the CORS headers. */
   headers: Record<string, string>;
@@ -24,18 +54,24 @@ type ExtensionBridgeSession = {
   getExtensionId: (bridgeToken: string) => string | undefined;
 };
 
+type ExtensionBridgeSessionState = ExtensionBridgeSession & {
+  /** The frames recorded as callers of in-flight requests, by stamped nonce. */
+  callerFramesByNonce: Map<string, WebFrameMain>;
+};
+
 /**
  * The main-process end of the facade's transport: one privileged custom scheme
  * per session, answered here and routed by path to whichever `chrome.*`
  * implementation registered it. The bridge owns what every route needs alike —
- * telling which extension is calling from the request's token, and turning
- * anything else away — so a route handler only ever receives an authenticated
- * caller.
+ * telling which extension is calling from the request's token, which frame is
+ * calling from the caller stamp its own `webRequest` listener put on the
+ * request, and turning anything else away — so a route handler only ever
+ * receives an authenticated caller.
  */
 export class ExtensionBridge {
   private logger: ExtensionsLogger | undefined;
 
-  private sessions = new Map<Session, ExtensionBridgeSession>();
+  private sessions = new Map<Session, ExtensionBridgeSessionState>();
 
   private routes = new Map<string, ExtensionBridgeHandler>();
 
@@ -48,7 +84,21 @@ export class ExtensionBridge {
   }
 
   setupSession(session: Session, sessionOptions: ExtensionBridgeSession) {
-    this.sessions.set(session, sessionOptions);
+    const callerFramesByNonce = new Map<string, WebFrameMain>();
+
+    this.sessions.set(session, { ...sessionOptions, callerFramesByNonce });
+
+    // The filter keeps every other request of the session — Gmail's own
+    // traffic above all — out of the listener entirely. `onBeforeSendHeaders`
+    // rather than `onBeforeRequest`, which is left free for an embedder's own
+    // listener — a session takes exactly one per event (`blocker` in
+    // `packages/app` holds that one).
+    session.webRequest.onBeforeSendHeaders(
+      { urls: [`${EXTENSION_BRIDGE_SCHEME}://*/*`] },
+      (details, callback) => {
+        callback({ requestHeaders: this.stampCaller(callerFramesByNonce, details) });
+      },
+    );
 
     session.protocol.handle(EXTENSION_BRIDGE_SCHEME, (request) =>
       this.handleRequest(session, request),
@@ -60,7 +110,68 @@ export class ExtensionBridge {
       return;
     }
 
+    session.webRequest.onBeforeSendHeaders(null);
+
     session.protocol.unhandle(EXTENSION_BRIDGE_SCHEME);
+  }
+
+  /**
+   * The request's headers with the caller stamp on: the frame Chromium names
+   * as the initiator goes on record under a fresh nonce, and the nonce rides
+   * the request to `handleRequest`. A request without a live frame — a service
+   * worker's — is passed through unstamped, and any caller-written stamp is
+   * dropped either way, so a header the handler reads is always the bridge's
+   * own.
+   */
+  private stampCaller(
+    callerFramesByNonce: Map<string, WebFrameMain>,
+    details: OnBeforeSendHeadersListenerDetails,
+  ) {
+    const requestHeaders: Record<string, string> = {};
+
+    for (const [headerName, headerValue] of Object.entries(details.requestHeaders)) {
+      if (headerName.toLowerCase() !== EXTENSION_BRIDGE_CALLER_HEADER) {
+        requestHeaders[headerName] = headerValue;
+      }
+    }
+
+    if (!details.frame || details.frame.isDestroyed()) {
+      return requestHeaders;
+    }
+
+    const callerNonce = randomUUID();
+
+    callerFramesByNonce.set(callerNonce, details.frame);
+
+    if (callerFramesByNonce.size > MAX_RECORDED_CALLER_FRAMES) {
+      const oldestNonce = callerFramesByNonce.keys().next().value;
+
+      if (oldestNonce !== undefined) {
+        callerFramesByNonce.delete(oldestNonce);
+      }
+    }
+
+    requestHeaders[EXTENSION_BRIDGE_CALLER_HEADER] = callerNonce;
+
+    return requestHeaders;
+  }
+
+  /**
+   * The frame recorded for the request's stamped nonce, consumed on the way
+   * out so a nonce answers exactly once, and only while the frame is alive.
+   */
+  private takeCallerFrame(sessionState: ExtensionBridgeSessionState, request: GlobalRequest) {
+    const callerNonce = request.headers.get(EXTENSION_BRIDGE_CALLER_HEADER);
+
+    if (callerNonce === null) {
+      return undefined;
+    }
+
+    const callerFrame = sessionState.callerFramesByNonce.get(callerNonce);
+
+    sessionState.callerFramesByNonce.delete(callerNonce);
+
+    return callerFrame && !callerFrame.isDestroyed() ? callerFrame : undefined;
   }
 
   private async handleRequest(session: Session, request: GlobalRequest) {
@@ -72,6 +183,12 @@ export class ExtensionBridge {
     const { pathname } = new URL(request.url);
 
     try {
+      const sessionState = this.sessions.get(session);
+
+      // Consumed whatever else the request turns out to be, so a nonce that
+      // reached a refused request cannot be presented again
+      const senderFrame = sessionState && this.takeCallerFrame(sessionState, request);
+
       const bodySource = await this.readBody(request);
 
       if (bodySource === null) {
@@ -83,7 +200,7 @@ export class ExtensionBridge {
       // Everything else in the session — Gmail, workspace apps, any page a user
       // navigated to — can reach this scheme too, and only the loaded extensions
       // hold a token.
-      const extensionId = this.sessions.get(session)?.getExtensionId(body.token);
+      const extensionId = sessionState?.getExtensionId(body.token);
 
       if (!extensionId) {
         return new Response(null, { status: 403, headers });
@@ -95,7 +212,7 @@ export class ExtensionBridge {
         return new Response(null, { status: 404, headers });
       }
 
-      return await handler({ session, extensionId, body, headers });
+      return await handler({ session, extensionId, senderFrame, body, headers });
     } catch (error) {
       this.logger?.error("Extension bridge request failed", { pathname, error });
 

--- a/packages/electron-extensions/bridge/bridge.ts
+++ b/packages/electron-extensions/bridge/bridge.ts
@@ -27,9 +27,16 @@ export const EXTENSION_BRIDGE_CALLER_HEADER = "x-extension-bridge-caller";
 
 /**
  * Bounds the caller records that were stamped but never consumed — a request
- * canceled between its headers and the handler leaves its record behind. The
- * live gap between the two stages is a handful of requests, so evicting the
- * oldest past this many loses nothing that was still coming.
+ * canceled between its headers and the handler leaves its record behind.
+ *
+ * Records go in before the handler has read the token, because the token is in
+ * the body and this listener sees only headers, so every document in the
+ * session reaches it: a page with no token at all is recorded and then refused.
+ * A document making enough concurrent bridge requests can therefore evict an
+ * honest caller's record that was still coming, which costs that caller its
+ * frame and leaves it delivering a sender of `id` alone — refused rather than
+ * misattributed. Ordinary traffic never approaches this, and the eviction is
+ * oldest-first.
  */
 export const MAX_RECORDED_CALLER_FRAMES = 1024;
 
@@ -88,6 +95,12 @@ export class ExtensionBridge {
 
     this.sessions.set(session, { ...sessionOptions, callerFramesByNonce });
 
+    // A blocking callback is what puts the record in the map before the handler
+    // reads it. That ordering is measured on Electron 43.2.0 rather than
+    // promised by it, and it is allowed to be: a record that was not there
+    // leaves the sender at `id` alone, which the extension refuses, so the
+    // failure is a refusal rather than a wrong answer.
+    //
     // The filter keeps every other request of the session — Gmail's own
     // traffic above all — out of the listener entirely. `onBeforeSendHeaders`
     // rather than `onBeforeRequest`, which is left free for an embedder's own
@@ -118,10 +131,21 @@ export class ExtensionBridge {
   /**
    * The request's headers with the caller stamp on: the frame Chromium names
    * as the initiator goes on record under a fresh nonce, and the nonce rides
-   * the request to `handleRequest`. A request without a live frame — a service
-   * worker's — is passed through unstamped, and any caller-written stamp is
-   * dropped either way, so a header the handler reads is always the bridge's
-   * own.
+   * the request to `handleRequest`.
+   *
+   * The strip loop earns its place on case: a caller writing
+   * `X-Extension-Bridge-Caller` and a stamp written in lower case are two keys
+   * on the same object and both reach the handler, where the header lookup is
+   * case-insensitive and may read either. Removing the loop is caught by
+   * `a stamp a caller wrote itself names no frame`. It covers frame requests only, because
+   * this listener is the one thing a frameless caller never reaches: measured
+   * on Electron 43.2.0, a service worker's and a dedicated worker's requests
+   * skip `onBeforeSendHeaders` entirely and arrive at the handler with whatever
+   * headers they set. What makes that safe is not the stripping but the nonce:
+   * it is minted here, after the request has left the renderer, so no caller
+   * can name a live one, and a forged value simply misses the map and delivers
+   * a sender of `id` alone. The routes that read a frame are called from the
+   * shim, which only ever runs in one.
    */
   private stampCaller(
     callerFramesByNonce: Map<string, WebFrameMain>,

--- a/packages/electron-extensions/derive/html.test.ts
+++ b/packages/electron-extensions/derive/html.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { injectFacadeScript } from "./html";
+import { allowPageConnectSource, injectPageScripts } from "./html";
 
-describe("injectFacadeScript", () => {
-  test("runs the facade before the page's own scripts", () => {
-    const page = injectFacadeScript(
+describe("injectPageScripts", () => {
+  test("runs the loader's scripts before the page's own", () => {
+    const page = injectPageScripts(
       '<!doctype html><html><head><title>Popup</title><script src="/popup.js"></script></head></html>',
-      "/chrome-facade.js",
+      ["/chrome-facade.js"],
     );
 
     expect(page).toStartWith(
@@ -14,21 +14,85 @@ describe("injectFacadeScript", () => {
     expect(page.indexOf("/chrome-facade.js")).toBeLessThan(page.indexOf("/popup.js"));
   });
 
+  test("keeps the order it was given", () => {
+    const page = injectPageScripts('<html><head><script src="/popup.js"></script></head></html>', [
+      "/chrome-facade.js",
+      "/chrome-runtime-proxy-shim.js",
+    ]);
+
+    expect(page).toBe(
+      '<html><head><script src="/chrome-facade.js"></script><script src="/chrome-runtime-proxy-shim.js"></script><script src="/popup.js"></script></head></html>',
+    );
+  });
+
   test("falls back to the html tag when there is no head", () => {
-    expect(injectFacadeScript("<html><body>Hi</body></html>", "/chrome-facade.js")).toBe(
+    expect(injectPageScripts("<html><body>Hi</body></html>", ["/chrome-facade.js"])).toBe(
       '<html><script src="/chrome-facade.js"></script><body>Hi</body></html>',
     );
   });
 
   test("prepends when there is no markup to anchor to", () => {
-    expect(injectFacadeScript("Hi", "/chrome-facade.js")).toBe(
+    expect(injectPageScripts("Hi", ["/chrome-facade.js"])).toBe(
       '<script src="/chrome-facade.js"></script>Hi',
     );
   });
 
-  test("injects once", () => {
-    const page = injectFacadeScript("<html><head></head></html>", "/chrome-facade.js");
+  test("injects each script once", () => {
+    const scriptUrls = ["/chrome-facade.js", "/chrome-runtime-proxy-shim.js"];
 
-    expect(injectFacadeScript(page, "/chrome-facade.js")).toBe(page);
+    const page = injectPageScripts("<html><head></head></html>", scriptUrls);
+
+    expect(injectPageScripts(page, scriptUrls)).toBe(page);
+  });
+});
+
+describe("allowPageConnectSource", () => {
+  test("widens a page policy that pins connect-src", () => {
+    expect(
+      allowPageConnectSource(
+        `<html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src https://1password.com" /></head></html>`,
+        "extension-bridge:",
+      ),
+    ).toBe(
+      `<html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src https://1password.com extension-bridge:" /></head></html>`,
+    );
+  });
+
+  test("gives a page policy without connect-src one, the way the manifest gets it", () => {
+    expect(
+      allowPageConnectSource(
+        `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'">`,
+        "extension-bridge:",
+      ),
+    ).toBe(
+      `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; connect-src extension-bridge:">`,
+    );
+  });
+
+  test("leaves a page that declares no policy of its own alone", () => {
+    const page = `<html><head><meta charset="utf-8"><title>Popup</title></head></html>`;
+
+    expect(allowPageConnectSource(page, "extension-bridge:")).toBe(page);
+  });
+
+  test("widens every policy the page declares", () => {
+    const page = allowPageConnectSource(
+      `<meta http-equiv="content-security-policy" content="default-src 'none'"><meta http-equiv="Content-Security-Policy" content="connect-src 'self'">`,
+      "extension-bridge:",
+    );
+
+    expect(page).toContain(`content="default-src 'none'; connect-src extension-bridge:"`);
+    expect(page).toContain(`content="connect-src 'self' extension-bridge:"`);
+  });
+
+  test("reads and writes the attribute's escapes rather than through them", () => {
+    expect(
+      allowPageConnectSource(
+        `<meta http-equiv="Content-Security-Policy" content='default-src &#39;none&#39;'>`,
+        "extension-bridge:",
+      ),
+    ).toBe(
+      `<meta http-equiv="Content-Security-Policy" content='default-src &#39;none&#39;; connect-src extension-bridge:'>`,
+    );
   });
 });

--- a/packages/electron-extensions/derive/html.test.ts
+++ b/packages/electron-extensions/derive/html.test.ts
@@ -95,4 +95,53 @@ describe("allowPageConnectSource", () => {
       `<meta http-equiv="Content-Security-Policy" content='default-src &#39;none&#39;; connect-src extension-bridge:'>`,
     );
   });
+
+  /*
+   * A hexadecimal reference is as ordinary as a decimal one and is what several
+   * bundlers emit for an apostrophe. Left undecoded, the `;` ending it reads as
+   * the end of a directive, the policy comes apart along the wrong boundaries,
+   * and every `&` in it is doubled on the way back out — a page whose unlock UI
+   * then cannot reach the bridge at all.
+   */
+  test("decodes hexadecimal references, in either case and zero-padded", () => {
+    for (const escapedQuote of ["&#x27;", "&#X27;", "&#x0027;"]) {
+      expect(
+        allowPageConnectSource(
+          `<meta http-equiv="Content-Security-Policy" content="default-src ${escapedQuote}none${escapedQuote}; script-src ${escapedQuote}self${escapedQuote}">`,
+          "extension-bridge:",
+        ),
+      ).toBe(
+        `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; connect-src extension-bridge:">`,
+      );
+    }
+  });
+
+  test("decodes each reference once, so an escaped ampersand stays escaped", () => {
+    // Asserted whole rather than by `toContain`, which an untouched tag passes
+    expect(
+      allowPageConnectSource(
+        `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src https://a.test/?a=1&amp;b=2">`,
+        "extension-bridge:",
+      ),
+    ).toBe(
+      `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src https://a.test/?a=1&amp;b=2; connect-src extension-bridge:">`,
+    );
+  });
+
+  test("leaves a policy carrying a reference it cannot read exactly as it was", () => {
+    const page = `<meta http-equiv="Content-Security-Policy" content="default-src &nbsp;none">`;
+
+    expect(allowPageConnectSource(page, "extension-bridge:")).toBe(page);
+  });
+
+  test("widens a connect-src pinned to none, which the added source then overrides", () => {
+    expect(
+      allowPageConnectSource(
+        `<meta http-equiv="Content-Security-Policy" content="connect-src 'none'">`,
+        "extension-bridge:",
+      ),
+    ).toBe(
+      `<meta http-equiv="Content-Security-Policy" content="connect-src 'none' extension-bridge:">`,
+    );
+  });
 });

--- a/packages/electron-extensions/derive/html.ts
+++ b/packages/electron-extensions/derive/html.ts
@@ -1,27 +1,78 @@
+import { allowConnectSource } from "./manifest";
+
 const HEAD_TAG = /<head\b[^>]*>/i;
 
 const HTML_TAG = /<html\b[^>]*>/i;
 
+const META_CONTENT_SECURITY_POLICY_TAG =
+  /<meta\b[^>]*\bhttp-equiv\s*=\s*["']?content-security-policy["']?[^>]*>/gi;
+
+const CONTENT_ATTRIBUTE = /(\bcontent\s*=\s*)(["'])([\s\S]*?)\2/i;
+
 /**
- * Puts the facade in front of every script an extension page runs. Extension
- * pages get the same incomplete `chrome` object the service worker does, and a
- * page has no preload of its own that reliably reaches its main world, so the
- * script tag is written into the page when the extension is derived.
+ * Puts the loader's scripts in front of every script an extension page runs, in
+ * the order given. Extension pages get the same incomplete `chrome` object the
+ * service worker does, and a page has no preload of its own that reliably
+ * reaches its main world, so the script tags are written into the page when the
+ * extension is derived.
  */
-export function injectFacadeScript(html: string, facadeUrl: string) {
-  if (html.includes(facadeUrl)) {
+export function injectPageScripts(html: string, scriptUrls: string[]) {
+  const missingScriptUrls = scriptUrls.filter((scriptUrl) => !html.includes(scriptUrl));
+
+  if (missingScriptUrls.length === 0) {
     return html;
   }
 
-  const scriptTag = `<script src="${facadeUrl}"></script>`;
+  const scriptTags = missingScriptUrls
+    .map((scriptUrl) => `<script src="${scriptUrl}"></script>`)
+    .join("");
 
   const openingTag = HEAD_TAG.exec(html) ?? HTML_TAG.exec(html);
 
   if (!openingTag) {
-    return `${scriptTag}${html}`;
+    return `${scriptTags}${html}`;
   }
 
   const insertAt = openingTag.index + openingTag[0].length;
 
-  return `${html.slice(0, insertAt)}${scriptTag}${html.slice(insertAt)}`;
+  return `${html.slice(0, insertAt)}${scriptTags}${html.slice(insertAt)}`;
+}
+
+function decodeAttribute(value: string) {
+  return value
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;|&#0*39;/gi, "'")
+    .replace(/&amp;/gi, "&");
+}
+
+function encodeAttribute(value: string, quote: string) {
+  const encoded = value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+  return quote === '"' ? encoded.replace(/"/g, "&quot;") : encoded.replace(/'/g, "&#39;");
+}
+
+/**
+ * Widens the `connect-src` of a page's own `<meta>` content security policy,
+ * the way `allowConnectSource` widens the manifest's.
+ *
+ * Both policies govern an extension page and the stricter one decides, so a
+ * page declaring `default-src 'none'` — which is what 1Password's popup and
+ * each of its inline frames declare — refuses the bridge however wide the
+ * manifest was made. Measured on Electron 43: the fetch fails with "Refused to
+ * connect because it violates the document's Content Security Policy" before
+ * any handler is asked.
+ */
+export function allowPageConnectSource(html: string, source: string) {
+  return html.replace(META_CONTENT_SECURITY_POLICY_TAG, (metaTag) =>
+    metaTag.replace(
+      CONTENT_ATTRIBUTE,
+      (_attribute, assignment: string, quote: string, policy: string) =>
+        `${assignment}${quote}${encodeAttribute(
+          allowConnectSource(decodeAttribute(policy), source),
+          quote,
+        )}${quote}`,
+    ),
+  );
 }

--- a/packages/electron-extensions/derive/html.ts
+++ b/packages/electron-extensions/derive/html.ts
@@ -38,13 +38,59 @@ export function injectPageScripts(html: string, scriptUrls: string[]) {
   return `${html.slice(0, insertAt)}${scriptTags}${html.slice(insertAt)}`;
 }
 
+/**
+ * Every character reference in one pass, so nothing is decoded twice — a
+ * sequence of replacements ending at `&amp;` turns a literal `&amp;#x27;` into
+ * an apostrophe, which is not what the page said.
+ */
+const CHARACTER_REFERENCE_SOURCE = "&(?:#[Xx]([0-9A-Fa-f]+)|#([0-9]+)|([A-Za-z][A-Za-z0-9]*));";
+
+const CHARACTER_REFERENCES = new RegExp(CHARACTER_REFERENCE_SOURCE, "g");
+
+const ANY_CHARACTER_REFERENCE = new RegExp(CHARACTER_REFERENCE_SOURCE);
+
+/** The five with names; a policy has no use for any of the others. */
+const NAMED_CHARACTER_REFERENCES: Record<string, string | undefined> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+};
+
+function decodeCharacterReference(reference: string, hex: string, decimal: string, name: string) {
+  if (name !== undefined) {
+    return NAMED_CHARACTER_REFERENCES[name.toLowerCase()] ?? reference;
+  }
+
+  const codePoint = Number.parseInt(hex ?? decimal, hex !== undefined ? 16 : 10);
+
+  try {
+    return String.fromCodePoint(codePoint);
+  } catch {
+    // Not a code point at all, so it is not a reference either
+    return reference;
+  }
+}
+
 function decodeAttribute(value: string) {
-  return value
-    .replace(/&lt;/gi, "<")
-    .replace(/&gt;/gi, ">")
-    .replace(/&quot;/gi, '"')
-    .replace(/&apos;|&#0*39;/gi, "'")
-    .replace(/&amp;/gi, "&");
+  return value.replace(CHARACTER_REFERENCES, decodeCharacterReference);
+}
+
+/**
+ * Whether every reference in the value is one this understands. What is asked
+ * is of the decoded value: anything still shaped like a reference after
+ * decoding is one that was not decoded — a name outside the five, or a number
+ * that is no code point — and re-encoding would write its `&` back as `&amp;`
+ * and corrupt it. Such an attribute is left exactly as the extension wrote it.
+ * The page then keeps a policy the shim cannot reach the bridge through, which
+ * is the safe direction to fail in.
+ *
+ * A decoded `&` on its own is not that. `&amp;` in a URL source decodes to `&`
+ * and is written back as `&amp;`, which is the round trip working.
+ */
+function hasOnlyKnownCharacterReferences(value: string) {
+  return !ANY_CHARACTER_REFERENCE.test(decodeAttribute(value));
 }
 
 function encodeAttribute(value: string, quote: string) {
@@ -68,11 +114,16 @@ export function allowPageConnectSource(html: string, source: string) {
   return html.replace(META_CONTENT_SECURITY_POLICY_TAG, (metaTag) =>
     metaTag.replace(
       CONTENT_ATTRIBUTE,
-      (_attribute, assignment: string, quote: string, policy: string) =>
-        `${assignment}${quote}${encodeAttribute(
+      (attribute, assignment: string, quote: string, policy: string) => {
+        if (!hasOnlyKnownCharacterReferences(policy)) {
+          return attribute;
+        }
+
+        return `${assignment}${quote}${encodeAttribute(
           allowConnectSource(decodeAttribute(policy), source),
           quote,
-        )}${quote}`,
+        )}${quote}`;
+      },
     ),
   );
 }

--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -464,7 +464,7 @@ describe("deriveExtension for a shared instance", () => {
     );
   });
 
-  test("the worker copy's pages are derived exactly as the ordinary copy's", async () => {
+  test("the worker copy's pages skip the shim but still reach the bridge", async () => {
     const { derivedDir } = await deriveExtension({
       sourceDir,
       derivedExtensionsDir,
@@ -475,7 +475,27 @@ describe("deriveExtension for a shared instance", () => {
     const page = await readFile(path.join(derivedDir, "popup.html"), "utf8");
 
     expect(page).not.toContain("chrome-runtime-proxy-shim.js");
-    expect(page).toContain(`content="default-src 'none'; script-src 'self'"`);
+
+    // The facade calls the bridge from pages whatever the copy's role —
+    // `connectNative` above all — and the page's own policy would refuse it
+    expect(page).toContain(
+      `content="default-src 'none'; script-src 'self'; connect-src extension-bridge:"`,
+    );
+  });
+
+  test("the ordinary copy's pages reach the bridge too, shared instance or none", async () => {
+    const { derivedDir } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+    });
+
+    const page = await readFile(path.join(derivedDir, "popup.html"), "utf8");
+
+    expect(page).not.toContain("chrome-runtime-proxy-shim.js");
+    expect(page).toContain(
+      `content="default-src 'none'; script-src 'self'; connect-src extension-bridge:"`,
+    );
   });
 
   test("the two copies exist side by side, from one source, as one extension id", async () => {

--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -368,6 +368,146 @@ describe("deriveExtension", () => {
   });
 });
 
+describe("deriveExtension for a shared instance", () => {
+  let shimScriptPath: string;
+
+  let relayScriptPath: string;
+
+  beforeEach(async () => {
+    shimScriptPath = path.join(workDir, "shim.js");
+
+    relayScriptPath = path.join(workDir, "relay.js");
+
+    await writeFile(shimScriptPath, "// shim\n");
+
+    await writeFile(relayScriptPath, "// relay\n");
+
+    await writeManifest({
+      ...manifest,
+      content_scripts: [{ matches: ["https://*/*"], js: ["content.js"] }],
+    });
+
+    await writeSourceFile("content.js", "// content\n");
+  });
+
+  test("the worker copy carries the relay client under the facade's token", async () => {
+    const { derivedDir, bridgeToken } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      sharedInstance: { role: "worker", relayScriptPath },
+    });
+
+    const relaySource = await readFile(
+      path.join(derivedDir, "chrome-runtime-proxy-relay.js"),
+      "utf8",
+    );
+
+    expect(relaySource).toContain(bridgeToken);
+    expect(relaySource).toEndWith("// relay\n");
+
+    expect(
+      await readFile(path.join(derivedDir, "chrome-facade-service-worker.js"), "utf8"),
+    ).toContain('import "./chrome-runtime-proxy-relay.js";');
+  });
+
+  test("the content-script-only copy loses the worker and gains the shim", async () => {
+    const { derivedDir, bridgeToken } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      sharedInstance: { role: "contentScriptOnly", shimScriptPath },
+    });
+
+    const derivedManifest = JSON.parse(
+      await readFile(path.join(derivedDir, "manifest.json"), "utf8"),
+    );
+
+    expect("background" in derivedManifest).toBe(false);
+    expect(derivedManifest.content_scripts).toEqual([
+      { matches: ["https://*/*"], js: ["chrome-runtime-proxy-shim.js", "content.js"] },
+    ]);
+
+    const shimSource = await readFile(
+      path.join(derivedDir, "chrome-runtime-proxy-shim.js"),
+      "utf8",
+    );
+
+    expect(shimSource).toContain(bridgeToken);
+    expect(shimSource).toEndWith("// shim\n");
+  });
+
+  test("the two copies exist side by side, from one source, as one extension id", async () => {
+    const workerCopy = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      sharedInstance: { role: "worker", relayScriptPath },
+    });
+
+    const contentScriptCopy = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      sharedInstance: { role: "contentScriptOnly", shimScriptPath },
+    });
+
+    expect(contentScriptCopy.derivedDir).not.toBe(workerCopy.derivedDir);
+    expect(contentScriptCopy.extensionId).toBe(workerCopy.extensionId);
+
+    expect(
+      JSON.parse(await readFile(path.join(workerCopy.derivedDir, "manifest.json"), "utf8"))
+        .background,
+    ).toBeDefined();
+  });
+
+  test("a role toggle re-derives the copy in place", async () => {
+    const { derivedDir } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      sharedInstance: { role: "worker", relayScriptPath },
+    });
+
+    const { derivedDir: plainDerivedDir } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+    });
+
+    expect(plainDerivedDir).toBe(derivedDir);
+
+    expect(
+      await readFile(path.join(plainDerivedDir, "chrome-facade-service-worker.js"), "utf8"),
+    ).not.toContain("chrome-runtime-proxy-relay.js");
+  });
+
+  test("pruning spares both copies of a kept source", async () => {
+    const workerCopy = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      sharedInstance: { role: "worker", relayScriptPath },
+    });
+
+    const contentScriptCopy = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      sharedInstance: { role: "contentScriptOnly", shimScriptPath },
+    });
+
+    await pruneDerivedExtensions({ derivedExtensionsDir, keptSourceDirs: [sourceDir] });
+
+    expect(await readdir(workerCopy.derivedDir)).toContain("manifest.json");
+    expect(await readdir(contentScriptCopy.derivedDir)).toContain("manifest.json");
+
+    await pruneDerivedExtensions({ derivedExtensionsDir, keptSourceDirs: [] });
+
+    expect(await readdir(derivedExtensionsDir)).toEqual([]);
+  });
+});
+
 describe("pruneDerivedExtensions", () => {
   async function deriveOtherExtension() {
     const otherSourceDir = path.join(workDir, "other-source");

--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -388,6 +388,11 @@ describe("deriveExtension for a shared instance", () => {
     });
 
     await writeSourceFile("content.js", "// content\n");
+
+    await writeSourceFile(
+      "popup.html",
+      `<html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'"><script src="/popup.js"></script></head></html>`,
+    );
   });
 
   test("the worker copy carries the relay client under the facade's token", async () => {
@@ -435,6 +440,42 @@ describe("deriveExtension for a shared instance", () => {
 
     expect(shimSource).toContain(bridgeToken);
     expect(shimSource).toEndWith("// shim\n");
+  });
+
+  test("the content-script-only copy's pages run the shim and may reach the bridge", async () => {
+    const { derivedDir } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      sharedInstance: { role: "contentScriptOnly", shimScriptPath },
+    });
+
+    const page = await readFile(path.join(derivedDir, "popup.html"), "utf8");
+
+    // The popup is where a password manager keeps its unlock UI, and this copy
+    // has no worker of its own for it to talk to
+    expect(page.indexOf("/chrome-facade.js")).toBeLessThan(
+      page.indexOf("/chrome-runtime-proxy-shim.js"),
+    );
+    expect(page.indexOf("/chrome-runtime-proxy-shim.js")).toBeLessThan(page.indexOf("/popup.js"));
+
+    expect(page).toContain(
+      `content="default-src 'none'; script-src 'self'; connect-src extension-bridge:"`,
+    );
+  });
+
+  test("the worker copy's pages are derived exactly as the ordinary copy's", async () => {
+    const { derivedDir } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      sharedInstance: { role: "worker", relayScriptPath },
+    });
+
+    const page = await readFile(path.join(derivedDir, "popup.html"), "utf8");
+
+    expect(page).not.toContain("chrome-runtime-proxy-shim.js");
+    expect(page).toContain(`content="default-src 'none'; script-src 'self'"`);
   });
 
   test("the two copies exist side by side, from one source, as one extension id", async () => {

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -3,7 +3,7 @@ import { cp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { EXTENSION_BRIDGE_SCHEME, EXTENSION_BRIDGE_TOKEN_GLOBAL } from "../bridge/protocol";
 import { getExtensionIdFromManifestKey } from "./extension-id";
-import { injectFacadeScript } from "./html";
+import { allowPageConnectSource, injectPageScripts } from "./html";
 import {
   deriveManifest,
   type ExtensionManifest,
@@ -31,7 +31,7 @@ const RUNTIME_PROXY_RELAY_FILE_NAME = "chrome-runtime-proxy-relay.js";
 const CONTENT_SCRIPT_ONLY_DIR_SUFFIX = "-content-scripts";
 
 /** Bump whenever what is written into a derived copy changes. */
-const DERIVE_VERSION = 6;
+const DERIVE_VERSION = 7;
 
 /**
  * The copy's part in one shared extension instance serving every session (see
@@ -115,7 +115,24 @@ async function directoryExists(dirPath: string) {
 /** Chromium serves `Popup.HTM` as a page just as well, so the net is this wide. */
 const PAGE_FILE_EXTENSIONS = new Set([".html", ".htm"]);
 
-async function injectFacadeIntoPages(derivedDir: string) {
+/**
+ * Writes the loader's scripts into every page of the copy. A content-script-only
+ * copy has no worker of its own to receive what its pages send, so the proxy's
+ * shim goes in behind the facade and its pages are let through to the bridge —
+ * both only for that role, so the ordinary copy is derived byte for byte as it
+ * always was.
+ */
+async function derivePages(
+  derivedDir: string,
+  sharedInstance: SharedInstanceDeriveOptions | undefined,
+) {
+  const isContentScriptOnly = sharedInstance?.role === "contentScriptOnly";
+
+  const scriptUrls = [
+    `/${FACADE_FILE_NAME}`,
+    ...(isContentScriptOnly ? [`/${RUNTIME_PROXY_SHIM_FILE_NAME}`] : []),
+  ];
+
   const fileNames = await readdir(derivedDir, { recursive: true });
 
   for (const fileName of fileNames) {
@@ -127,7 +144,11 @@ async function injectFacadeIntoPages(derivedDir: string) {
 
     const page = await readFile(pagePath, "utf8");
 
-    await writeFile(pagePath, injectFacadeScript(page, `/${FACADE_FILE_NAME}`));
+    const bridgeReachablePage = isContentScriptOnly
+      ? allowPageConnectSource(page, `${EXTENSION_BRIDGE_SCHEME}:`)
+      : page;
+
+    await writeFile(pagePath, injectPageScripts(bridgeReachablePage, scriptUrls));
   }
 }
 
@@ -210,7 +231,7 @@ export async function deriveExtension({
       await writeFile(path.join(derivedDir, SERVICE_WORKER_FILE_NAME), serviceWorkerWrapper);
     }
 
-    await injectFacadeIntoPages(derivedDir);
+    await derivePages(derivedDir, sharedInstance);
 
     await writeFile(stampPath, stamp);
   }

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 import { EXTENSION_BRIDGE_SCHEME, EXTENSION_BRIDGE_TOKEN_GLOBAL } from "../bridge/protocol";
 import { getExtensionIdFromManifestKey } from "./extension-id";
 import { injectFacadeScript } from "./html";
-import { deriveManifest, type ExtensionManifest } from "./manifest";
+import {
+  deriveManifest,
+  type ExtensionManifest,
+  type SharedInstanceManifestOptions,
+} from "./manifest";
 
 const MANIFEST_FILE_NAME = "manifest.json";
 
@@ -15,8 +19,29 @@ const FACADE_FILE_NAME = "chrome-facade.js";
 
 const SERVICE_WORKER_FILE_NAME = "chrome-facade-service-worker.js";
 
+const RUNTIME_PROXY_SHIM_FILE_NAME = "chrome-runtime-proxy-shim.js";
+
+const RUNTIME_PROXY_RELAY_FILE_NAME = "chrome-runtime-proxy-relay.js";
+
+/**
+ * What the copy's derived directory is called next to the ordinary copy's, so
+ * the two exist side by side: one launch loads the full copy into the session
+ * that keeps the worker and this one into every other session.
+ */
+const CONTENT_SCRIPT_ONLY_DIR_SUFFIX = "-content-scripts";
+
 /** Bump whenever what is written into a derived copy changes. */
 const DERIVE_VERSION = 6;
+
+/**
+ * The copy's part in one shared extension instance serving every session (see
+ * `SharedInstanceManifestOptions` in `manifest.ts` for what each role changes
+ * in the manifest). Each role's proxy script is bundled on its own, like the
+ * facade, and written into the copy carrying the same bridge token.
+ */
+export type SharedInstanceDeriveOptions =
+  | { role: "worker"; relayScriptPath: string }
+  | { role: "contentScriptOnly"; shimScriptPath: string };
 
 export type DeriveExtensionOptions = {
   /** The unpacked extension the embedder handed over, never written to. */
@@ -35,6 +60,11 @@ export type DeriveExtensionOptions = {
    * has no id to be recognised by and keeps the patterns its author declared.
    */
   getContentScriptMatches?: (extensionId: string) => string[] | undefined;
+  /**
+   * Derives the copy for its part in one shared instance across sessions.
+   * Without it the copy is derived exactly as it always was, byte for byte.
+   */
+  sharedInstance?: SharedInstanceDeriveOptions;
 };
 
 function hash(value: string) {
@@ -122,6 +152,7 @@ export async function deriveExtension({
   facadeScriptPath,
   strippedManifestKeys = [],
   getContentScriptMatches,
+  sharedInstance,
 }: DeriveExtensionOptions) {
   const manifestSource = await readFile(path.join(sourceDir, MANIFEST_FILE_NAME), "utf8");
 
@@ -131,7 +162,11 @@ export async function deriveExtension({
 
   const contentScriptMatches = extensionId ? getContentScriptMatches?.(extensionId) : undefined;
 
-  const derivedDir = path.join(derivedExtensionsDir, hash(sourceDir).slice(0, 16));
+  const derivedDirName = `${hash(sourceDir).slice(0, 16)}${
+    sharedInstance?.role === "contentScriptOnly" ? CONTENT_SCRIPT_ONLY_DIR_SUFFIX : ""
+  }`;
+
+  const derivedDir = path.join(derivedExtensionsDir, derivedDirName);
 
   const stampPath = `${derivedDir}${STAMP_FILE_EXTENSION}`;
 
@@ -139,12 +174,15 @@ export async function deriveExtension({
   // installed extension moving to a new version does and what a developer
   // working in an unpacked one does, and when what the derive makes of it
   // changes
+  // `sharedInstanceRole` is `undefined` — and so absent from the JSON — for the
+  // ordinary copy, which keeps its stamp what it was before roles existed
   const stamp = JSON.stringify({
     deriveVersion: DERIVE_VERSION,
     sourceDir,
     sourceTree: await hashSourceTree(sourceDir),
     strippedManifestKeys,
     contentScriptMatches,
+    sharedInstanceRole: sharedInstance?.role,
   });
 
   // A stamp that matches while its copy is gone would otherwise skip the copy
@@ -163,6 +201,7 @@ export async function deriveExtension({
       bridgeConnectSource: `${EXTENSION_BRIDGE_SCHEME}:`,
       strippedManifestKeys,
       contentScriptMatches,
+      sharedInstance: toSharedInstanceManifestOptions(sharedInstance),
     });
 
     await writeFile(path.join(derivedDir, MANIFEST_FILE_NAME), JSON.stringify(manifest, null, 2));
@@ -179,15 +218,40 @@ export async function deriveExtension({
   // Always, so a rebuilt facade reaches copies that are otherwise up to date
   const bridgeToken = randomUUID();
 
-  await writeFile(
-    path.join(derivedDir, FACADE_FILE_NAME),
-    `globalThis.${EXTENSION_BRIDGE_TOKEN_GLOBAL} = ${JSON.stringify(bridgeToken)};\n${await readFile(
-      facadeScriptPath,
-      "utf8",
-    )}`,
-  );
+  const writeTokenCarryingScript = async (fileName: string, scriptPath: string) =>
+    writeFile(
+      path.join(derivedDir, fileName),
+      `globalThis.${EXTENSION_BRIDGE_TOKEN_GLOBAL} = ${JSON.stringify(bridgeToken)};\n${await readFile(
+        scriptPath,
+        "utf8",
+      )}`,
+    );
+
+  await writeTokenCarryingScript(FACADE_FILE_NAME, facadeScriptPath);
+
+  // The proxy scripts run where the facade never loads — the shim in content
+  // scripts' isolated worlds — so each carries the token itself, the same way
+  if (sharedInstance?.role === "worker") {
+    await writeTokenCarryingScript(RUNTIME_PROXY_RELAY_FILE_NAME, sharedInstance.relayScriptPath);
+  }
+
+  if (sharedInstance?.role === "contentScriptOnly") {
+    await writeTokenCarryingScript(RUNTIME_PROXY_SHIM_FILE_NAME, sharedInstance.shimScriptPath);
+  }
 
   return { derivedDir, bridgeToken, extensionId };
+}
+
+function toSharedInstanceManifestOptions(
+  sharedInstance: SharedInstanceDeriveOptions | undefined,
+): SharedInstanceManifestOptions | undefined {
+  if (!sharedInstance) {
+    return undefined;
+  }
+
+  return sharedInstance.role === "worker"
+    ? { role: "worker", relayFileName: RUNTIME_PROXY_RELAY_FILE_NAME }
+    : { role: "contentScriptOnly", shimFileName: RUNTIME_PROXY_SHIM_FILE_NAME };
 }
 
 export type PruneDerivedExtensionsOptions = {

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -31,7 +31,7 @@ const RUNTIME_PROXY_RELAY_FILE_NAME = "chrome-runtime-proxy-relay.js";
 const CONTENT_SCRIPT_ONLY_DIR_SUFFIX = "-content-scripts";
 
 /** Bump whenever what is written into a derived copy changes. */
-const DERIVE_VERSION = 7;
+const DERIVE_VERSION = 8;
 
 /**
  * The copy's part in one shared extension instance serving every session (see
@@ -62,7 +62,9 @@ export type DeriveExtensionOptions = {
   getContentScriptMatches?: (extensionId: string) => string[] | undefined;
   /**
    * Derives the copy for its part in one shared instance across sessions.
-   * Without it the copy is derived exactly as it always was, byte for byte.
+   * Without it the copy carries no proxy script and keeps its worker — the
+   * facade and the page policy that lets its calls through are the transport's
+   * and go into every copy alike.
    */
   sharedInstance?: SharedInstanceDeriveOptions;
 };
@@ -116,11 +118,14 @@ async function directoryExists(dirPath: string) {
 const PAGE_FILE_EXTENSIONS = new Set([".html", ".htm"]);
 
 /**
- * Writes the loader's scripts into every page of the copy. A content-script-only
- * copy has no worker of its own to receive what its pages send, so the proxy's
- * shim goes in behind the facade and its pages are let through to the bridge —
- * both only for that role, so the ordinary copy is derived byte for byte as it
- * always was.
+ * Writes the loader's scripts into every page of the copy, and lets every page
+ * through to the bridge. The facade calls the bridge from pages whatever the
+ * copy's role — `connectNative` and the webNavigation queries go over it — and
+ * a page's own `<meta>` policy governs alongside the manifest's widened one
+ * with the stricter deciding, so a page declaring `default-src 'none'` — which
+ * is what 1Password's popup declares — would refuse those calls however wide
+ * the manifest was made. The shim rides only in the content-script-only copy,
+ * which has no worker of its own to receive what its pages send.
  */
 async function derivePages(
   derivedDir: string,
@@ -144,9 +149,7 @@ async function derivePages(
 
     const page = await readFile(pagePath, "utf8");
 
-    const bridgeReachablePage = isContentScriptOnly
-      ? allowPageConnectSource(page, `${EXTENSION_BRIDGE_SCHEME}:`)
-      : page;
+    const bridgeReachablePage = allowPageConnectSource(page, `${EXTENSION_BRIDGE_SCHEME}:`);
 
     await writeFile(pagePath, injectPageScripts(bridgeReachablePage, scriptUrls));
   }

--- a/packages/electron-extensions/derive/manifest.test.ts
+++ b/packages/electron-extensions/derive/manifest.test.ts
@@ -297,6 +297,124 @@ describe("deriveManifest", () => {
   });
 });
 
+describe("deriveManifest for a shared instance", () => {
+  const workerOptions = { role: "worker", relayFileName: "chrome-runtime-proxy-relay.js" } as const;
+
+  const contentScriptOnlyOptions = {
+    role: "contentScriptOnly",
+    shimFileName: "chrome-runtime-proxy-shim.js",
+  } as const;
+
+  test("the worker copy's wrapper imports the relay client between facade and background", () => {
+    const { manifest, serviceWorkerWrapper } = deriveManifest(
+      { background: { service_worker: "background.js", type: "module" } },
+      { ...fileNames, sharedInstance: workerOptions },
+    );
+
+    expect(manifest.background?.service_worker).toBe("chrome-facade-service-worker.js");
+    expect(serviceWorkerWrapper).toBe(
+      "// Generated when the extension was derived, in place of its own service worker.\n" +
+        'import "./chrome-facade.js";\nimport "./chrome-runtime-proxy-relay.js";\nimport "./background.js";\n',
+    );
+  });
+
+  test("the worker copy's wrapper uses importScripts for a non-module worker", () => {
+    const { serviceWorkerWrapper } = deriveManifest(
+      { background: { service_worker: "background.js" } },
+      { ...fileNames, sharedInstance: workerOptions },
+    );
+
+    expect(serviceWorkerWrapper).toContain(
+      'importScripts("/chrome-facade.js", "/chrome-runtime-proxy-relay.js", "/background.js");',
+    );
+  });
+
+  test("the content-script-only copy loses its background key entirely", () => {
+    const { manifest, serviceWorkerWrapper } = deriveManifest(
+      {
+        background: { service_worker: "background.js", type: "module" },
+        content_scripts: [{ matches: ["https://*/*"], js: ["content.js"] }],
+      },
+      { ...fileNames, sharedInstance: contentScriptOnlyOptions },
+    );
+
+    expect("background" in manifest).toBe(false);
+    expect(serviceWorkerWrapper).toBeNull();
+  });
+
+  test("the shim runs first in every content script entry that has scripts", () => {
+    const { manifest } = deriveManifest(
+      {
+        background: { service_worker: "background.js" },
+        content_scripts: [
+          { matches: ["https://*/*"], js: ["a.js", "b.js"] },
+          { matches: ["https://*/*"], css: ["styles.css"] },
+        ],
+      },
+      { ...fileNames, sharedInstance: contentScriptOnlyOptions },
+    );
+
+    expect(manifest.content_scripts).toEqual([
+      { matches: ["https://*/*"], js: ["chrome-runtime-proxy-shim.js", "a.js", "b.js"] },
+      { matches: ["https://*/*"], css: ["styles.css"] },
+    ]);
+  });
+
+  test("the shim is prepended after the clamp narrows the matches", () => {
+    const { manifest } = deriveManifest(
+      { content_scripts: [{ matches: ["https://*/*"], js: ["content.js"] }] },
+      {
+        ...fileNames,
+        contentScriptMatches: ["https://accounts.google.com/*"],
+        sharedInstance: contentScriptOnlyOptions,
+      },
+    );
+
+    expect(manifest.content_scripts).toEqual([
+      {
+        matches: ["https://accounts.google.com/*"],
+        js: ["chrome-runtime-proxy-shim.js", "content.js"],
+      },
+    ]);
+  });
+
+  test("refuses a pattern making the token-carrying shim fetchable by pages", () => {
+    expect(() =>
+      deriveManifest(
+        {
+          web_accessible_resources: [
+            { resources: ["chrome-runtime-proxy-shim.js"], matches: ["<all_urls>"] },
+          ],
+        },
+        { ...fileNames, sharedInstance: contentScriptOnlyOptions },
+      ),
+    ).toThrow(/chrome-runtime-proxy-shim\.js/);
+  });
+
+  test("refuses a pattern covering the worker copy's relay client", () => {
+    expect(() =>
+      deriveManifest(
+        {
+          background: { service_worker: "background.js" },
+          web_accessible_resources: [{ resources: ["*.js"], matches: ["<all_urls>"] }],
+        },
+        { ...fileNames, sharedInstance: workerOptions },
+      ),
+    ).toThrow();
+  });
+
+  test("derives without a role exactly as it does without the option", () => {
+    const manifest = {
+      background: { service_worker: "background.js", type: "module" },
+      content_scripts: [{ matches: ["https://*/*"], js: ["content.js"] }],
+    };
+
+    expect(deriveManifest(manifest, { ...fileNames, sharedInstance: undefined })).toEqual(
+      deriveManifest(manifest, fileNames),
+    );
+  });
+});
+
 describe("allowConnectSource", () => {
   const source = "extension-native-messaging:";
 

--- a/packages/electron-extensions/derive/manifest.ts
+++ b/packages/electron-extensions/derive/manifest.ts
@@ -35,15 +35,20 @@ function createServiceWorkerWrapper(
   facadeFileName: string,
   backgroundFileName: string,
   isModule: boolean,
+  relayFileName?: string,
 ) {
   const header =
     "// Generated when the extension was derived, in place of its own service worker.\n";
 
+  const wrappedFileNames = [facadeFileName, relayFileName, backgroundFileName].filter(
+    (fileName): fileName is string => fileName !== undefined,
+  );
+
   if (isModule) {
-    return `${header}import "./${facadeFileName}";\nimport "./${backgroundFileName}";\n`;
+    return `${header}${wrappedFileNames.map((fileName) => `import "./${fileName}";\n`).join("")}`;
   }
 
-  return `${header}importScripts("/${facadeFileName}", "/${backgroundFileName}");\n`;
+  return `${header}importScripts(${wrappedFileNames.map((fileName) => `"/${fileName}"`).join(", ")});\n`;
 }
 
 /**
@@ -174,6 +179,36 @@ function deriveContentSecurityPolicy(
 }
 
 /**
+ * How a derived copy takes part in one shared extension instance across
+ * sessions. The `worker` copy keeps the extension whole and additionally runs
+ * the runtime proxy's relay client next to its service worker; the
+ * `contentScriptOnly` copy loses its `background` key entirely — Electron still
+ * injects its content scripts (measured 2026-08-25) — and gets the proxy's shim
+ * prepended to every one of them, so its `chrome.runtime` messaging reaches the
+ * one worker instead of a receiving end that does not exist.
+ */
+export type SharedInstanceManifestOptions =
+  | { role: "worker"; relayFileName: string }
+  | { role: "contentScriptOnly"; shimFileName: string };
+
+/**
+ * Runs the shim ahead of the extension's own scripts in every content script
+ * entry, in the same isolated world, which is what lets it shadow
+ * `chrome.runtime.sendMessage` and `connect` before any extension code reads
+ * them. Entries without scripts — CSS-only ones — have nothing to shadow.
+ */
+function prependContentScriptShim(
+  contentScripts: ExtensionManifest["content_scripts"],
+  shimFileName: string,
+) {
+  return contentScripts?.map((contentScript) =>
+    Array.isArray(contentScript.js)
+      ? { ...contentScript, js: [shimFileName, ...contentScript.js] }
+      : contentScript,
+  );
+}
+
+/**
  * Narrows where the extension's content scripts run. Electron has no per-site
  * extension controls, so the manifest is the only lever: an extension declaring
  * `<all_urls>` injects into every frame of every view otherwise.
@@ -235,6 +270,7 @@ export function deriveManifest(
     bridgeConnectSource,
     strippedManifestKeys = [],
     contentScriptMatches,
+    sharedInstance,
   }: {
     facadeFileName: string;
     serviceWorkerFileName: string;
@@ -246,13 +282,26 @@ export function deriveManifest(
      * extension's content scripts run wherever its author declared.
      */
     contentScriptMatches?: string[];
+    /**
+     * The copy's part in one shared instance across sessions, or `undefined`
+     * for the ordinary copy every session gets its own instance of.
+     */
+    sharedInstance?: SharedInstanceManifestOptions;
   },
 ): DerivedManifest {
+  const clampedContentScripts = deriveContentScripts(
+    manifest.content_scripts,
+    contentScriptMatches,
+  );
+
   const derivedManifest: ExtensionManifest = {
     ...manifest,
     permissions: derivePermissions(manifest.permissions),
     content_security_policy: deriveContentSecurityPolicy(manifest, bridgeConnectSource),
-    content_scripts: deriveContentScripts(manifest.content_scripts, contentScriptMatches),
+    content_scripts:
+      sharedInstance?.role === "contentScriptOnly"
+        ? prependContentScriptShim(clampedContentScripts, sharedInstance.shimFileName)
+        : clampedContentScripts,
   };
 
   for (const droppedManifestKey of DROPPED_MANIFEST_KEYS) {
@@ -268,7 +317,16 @@ export function deriveManifest(
   // extension's `web_accessible_resources` comes near the facade, but an update
   // widening a pattern to `*.js` would hand the token to every page in the
   // session — refusing to derive is what keeps that an outage instead of a leak
-  for (const derivedFileName of [facadeFileName, serviceWorkerFileName]) {
+  const sharedInstanceFileName =
+    sharedInstance?.role === "contentScriptOnly"
+      ? sharedInstance.shimFileName
+      : sharedInstance?.relayFileName;
+
+  for (const derivedFileName of [facadeFileName, serviceWorkerFileName, sharedInstanceFileName]) {
+    if (derivedFileName === undefined) {
+      continue;
+    }
+
     const exposingPattern = findWebAccessiblePattern(
       derivedManifest.web_accessible_resources,
       derivedFileName,
@@ -279,6 +337,16 @@ export function deriveManifest(
         `web_accessible_resources pattern "${exposingPattern}" makes "${derivedFileName}" fetchable by web pages`,
       );
     }
+  }
+
+  // The whole `background` key goes, not just the worker: a copy meant to run
+  // no worker must not leave Chromium anything to start. `strippedManifestKeys`
+  // cannot express this, since the wrapper branch below re-adds `background`
+  // after the strip — which is also why this is its own explicit option.
+  if (sharedInstance?.role === "contentScriptOnly") {
+    delete derivedManifest.background;
+
+    return { manifest: derivedManifest, serviceWorkerWrapper: null };
   }
 
   const backgroundFileName = manifest.background?.service_worker?.replace(/^\//, "");
@@ -296,6 +364,7 @@ export function deriveManifest(
       facadeFileName,
       backgroundFileName,
       manifest.background?.type === "module",
+      sharedInstance?.role === "worker" ? sharedInstance.relayFileName : undefined,
     ),
   };
 }

--- a/packages/electron-extensions/derive/manifest.ts
+++ b/packages/electron-extensions/derive/manifest.ts
@@ -185,7 +185,9 @@ function deriveContentSecurityPolicy(
  * `contentScriptOnly` copy loses its `background` key entirely — Electron still
  * injects its content scripts (measured 2026-08-25) — and gets the proxy's shim
  * prepended to every one of them, so its `chrome.runtime` messaging reaches the
- * one worker instead of a receiving end that does not exist.
+ * one worker instead of a receiving end that does not exist. Its extension
+ * pages are shimmed too, which is the derive's own job rather than the
+ * manifest's.
  */
 export type SharedInstanceManifestOptions =
   | { role: "worker"; relayFileName: string }

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -122,6 +122,9 @@ function createSession({
       sessionEvents.push(`clearStorageData ${origin} ${storages?.join()}`);
     },
     getStoragePath: () => storagePath,
+    webRequest: {
+      onBeforeSendHeaders: () => undefined,
+    },
     serviceWorkers: {
       on: (
         _eventName: string,

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -8,7 +8,7 @@ import {
   readExtensionActionIcon,
 } from "./action";
 import { ExtensionBridge } from "./bridge/bridge";
-import { deriveExtension } from "./derive";
+import { deriveExtension, type SharedInstanceDeriveOptions } from "./derive";
 import type { ExtensionsLogger } from "./logger";
 import {
   NativeMessaging,
@@ -38,6 +38,23 @@ const CONSOLE_ERROR_LEVEL = 3;
 export type ActionsChangedListener = (session: Session, actions: ExtensionAction[]) => void;
 
 export type ExtensionDirs = string[] | (() => Promise<string[]> | string[]);
+
+/**
+ * One extension instance serving every session, in place of the independent
+ * instance per session everything above describes. The loader stays out of
+ * how: it hands over its bridge once, asks what part each session plays as the
+ * session is set up — the answer is the derive option shaping that session's
+ * copy — and reports each session's teardown. `runtime-proxy/` holds the one
+ * implementation, and an embedder that never passes one runs exactly as
+ * before.
+ */
+export type SharedExtensionInstance = {
+  /** Called once, from the loader's constructor. */
+  install(context: { bridge: ExtensionBridge; logger?: ExtensionsLogger }): void;
+  /** Called per session before its extensions derive. */
+  adoptSession(session: Session): SharedInstanceDeriveOptions;
+  teardownSession(session: Session): void;
+};
 
 export type ExtensionsOptions = {
   /**
@@ -70,6 +87,12 @@ export type ExtensionsOptions = {
    * host that lists the extension in its own `allowed_origins` is reachable.
    */
   isNativeMessagingHostAllowed?: NativeMessagingHostPolicy;
+  /**
+   * Lets one extension instance serve every session
+   * (`createSharedExtensionInstance` in `runtime-proxy/`). Without it every
+   * session runs its own.
+   */
+  sharedInstance?: SharedExtensionInstance;
   logger?: ExtensionsLogger;
 };
 
@@ -94,6 +117,8 @@ export class Extensions {
   private strippedManifestKeys: string[] | undefined;
 
   private getContentScriptMatches: ExtensionsOptions["getContentScriptMatches"];
+
+  private sharedInstance: SharedExtensionInstance | undefined;
 
   private logger: ExtensionsLogger | undefined;
 
@@ -123,6 +148,7 @@ export class Extensions {
     strippedManifestKeys,
     getContentScriptMatches,
     isNativeMessagingHostAllowed,
+    sharedInstance,
     logger,
   }: ExtensionsOptions) {
     this.extensionDirs = extensionDirs;
@@ -134,6 +160,8 @@ export class Extensions {
     this.strippedManifestKeys = strippedManifestKeys;
 
     this.getContentScriptMatches = getContentScriptMatches;
+
+    this.sharedInstance = sharedInstance;
 
     this.logger = logger;
 
@@ -149,6 +177,8 @@ export class Extensions {
     this.webNavigation = new WebNavigation();
 
     this.webNavigation.registerRoutes(this.bridge);
+
+    this.sharedInstance?.install({ bridge: this.bridge, logger });
   }
 
   /**
@@ -156,8 +186,13 @@ export class Extensions {
    * they shared the source directory: one copy on disk, one instance per
    * session.
    */
-  private deriveExtension(sourceDir: string) {
-    let derivedExtension = this.derivedExtensions.get(sourceDir);
+  private deriveExtension(sourceDir: string, sharedInstanceDerive?: SharedInstanceDeriveOptions) {
+    // One derived copy per role, since a launch with a shared instance loads
+    // the worker copy into one session and the content-script-only copy into
+    // the rest, both from the one source
+    const derivedExtensionKey = `${sharedInstanceDerive?.role ?? "default"}\0${sourceDir}`;
+
+    let derivedExtension = this.derivedExtensions.get(derivedExtensionKey);
 
     if (!derivedExtension) {
       derivedExtension = deriveExtension({
@@ -166,9 +201,10 @@ export class Extensions {
         facadeScriptPath: this.facadeScriptPath,
         strippedManifestKeys: this.strippedManifestKeys,
         getContentScriptMatches: this.getContentScriptMatches,
+        sharedInstance: sharedInstanceDerive,
       });
 
-      this.derivedExtensions.set(sourceDir, derivedExtension);
+      this.derivedExtensions.set(derivedExtensionKey, derivedExtension);
 
       // A failure must not be the answer for every later session: dropped from
       // the memo, the next setup derives again and can succeed once whatever
@@ -176,8 +212,8 @@ export class Extensions {
       const failedDerivedExtension = derivedExtension;
 
       derivedExtension.catch(() => {
-        if (this.derivedExtensions.get(sourceDir) === failedDerivedExtension) {
-          this.derivedExtensions.delete(sourceDir);
+        if (this.derivedExtensions.get(derivedExtensionKey) === failedDerivedExtension) {
+          this.derivedExtensions.delete(derivedExtensionKey);
         }
       });
     }
@@ -209,9 +245,14 @@ export class Extensions {
 
     this.pipeServiceWorkerConsole(session);
 
+    const sharedInstanceDerive = this.sharedInstance?.adoptSession(session);
+
     for (const extensionDir of extensionDirs) {
       try {
-        const { derivedDir, bridgeToken, extensionId } = await this.deriveExtension(extensionDir);
+        const { derivedDir, bridgeToken, extensionId } = await this.deriveExtension(
+          extensionDir,
+          sharedInstanceDerive,
+        );
 
         await this.dropServiceWorkerRegistration(session, extensionId);
 
@@ -321,6 +362,8 @@ export class Extensions {
     this.bridge.teardownSession(session);
 
     this.nativeMessaging.teardownSession(session);
+
+    this.sharedInstance?.teardownSession(session);
 
     const consoleListener = this.serviceWorkerConsoleListeners.get(session);
 

--- a/packages/electron-extensions/facade/api/native-messaging.ts
+++ b/packages/electron-extensions/facade/api/native-messaging.ts
@@ -6,6 +6,7 @@ import { NativeMessageDecoder } from "../../native-messaging/framing";
 import { postBridge } from "../lib/bridge";
 import type { ChromeNamespace } from "../lib/chrome";
 import { createEvent } from "../lib/event";
+import { getLastErrorMessage, withLastError } from "../lib/last-error";
 
 const DISCONNECTED_PORT_ERROR = "Attempting to use a disconnected port object";
 
@@ -18,30 +19,6 @@ type NativeMessagingPort = {
   onMessage: ReturnType<typeof createEvent>;
   onDisconnect: ReturnType<typeof createEvent>;
 };
-
-/**
- * `chrome.runtime.lastError` the way Chrome exposes it: set for the duration of
- * the callback that reads it, gone again afterwards.
- */
-function withLastError(runtime: ChromeNamespace, error: string | undefined, run: () => void) {
-  if (error === undefined) {
-    run();
-
-    return;
-  }
-
-  runtime.lastError = { message: error };
-
-  try {
-    run();
-  } finally {
-    delete runtime.lastError;
-  }
-}
-
-function getLastErrorMessage(runtime: ChromeNamespace) {
-  return (runtime.lastError as { message?: string } | undefined)?.message;
-}
 
 function createPort(runtime: ChromeNamespace, hostName: string): NativeMessagingPort {
   const portId = crypto.randomUUID();

--- a/packages/electron-extensions/facade/lib/last-error.ts
+++ b/packages/electron-extensions/facade/lib/last-error.ts
@@ -1,0 +1,29 @@
+import type { ChromeNamespace } from "./chrome";
+
+/**
+ * `chrome.runtime.lastError` the way Chrome exposes it: set for the duration of
+ * the callback that reads it, gone again afterwards.
+ */
+export function withLastError(
+  runtime: ChromeNamespace,
+  error: string | undefined,
+  run: () => void,
+) {
+  if (error === undefined) {
+    run();
+
+    return;
+  }
+
+  runtime.lastError = { message: error };
+
+  try {
+    run();
+  } finally {
+    delete runtime.lastError;
+  }
+}
+
+export function getLastErrorMessage(runtime: ChromeNamespace) {
+  return (runtime.lastError as { message?: string } | undefined)?.message;
+}

--- a/packages/electron-extensions/index.ts
+++ b/packages/electron-extensions/index.ts
@@ -6,7 +6,12 @@ export { pruneDerivedExtensions } from "./derive";
 export type { PruneDerivedExtensionsOptions } from "./derive";
 export { isExtensionId } from "./derive/extension-id";
 export { Extensions } from "./extensions";
-export type { ActionsChangedListener, ExtensionDirs, ExtensionsOptions } from "./extensions";
+export type {
+  ActionsChangedListener,
+  ExtensionDirs,
+  ExtensionsOptions,
+  SharedExtensionInstance,
+} from "./extensions";
 export {
   buildCrxDownloadUrl,
   buildUpdateCheckUrl,
@@ -34,4 +39,6 @@ export type {
 } from "./install";
 export type { ExtensionsLogger } from "./logger";
 export type { NativeMessagingHostPolicy } from "./native-messaging/native-messaging";
+export { createSharedExtensionInstance } from "./runtime-proxy";
+export type { CreateSharedExtensionInstanceOptions } from "./runtime-proxy";
 export { findExtensionDirs } from "./scan";

--- a/packages/electron-extensions/native-messaging/native-messaging.test.ts
+++ b/packages/electron-extensions/native-messaging/native-messaging.test.ts
@@ -65,6 +65,9 @@ beforeEach(async () => {
         requestHandler = undefined;
       },
     },
+    webRequest: {
+      onBeforeSendHeaders: () => undefined,
+    },
   } as unknown as Session;
 });
 

--- a/packages/electron-extensions/runtime-proxy/bridge-protocol.ts
+++ b/packages/electron-extensions/runtime-proxy/bridge-protocol.ts
@@ -3,13 +3,17 @@
  * shared by the content-script shim, the worker-side relay client, and the
  * main-process relay.
  *
- * The proxy carries `chrome.runtime` messaging from content scripts in
- * worker-less sessions to the one session that keeps the extension's service
- * worker. Content-script calls go up as ordinary bridge POSTs; everything
- * flowing the other way rides a streaming response body — port frames to a
- * content script, jobs to the worker — in the same length-prefixed JSON frames
- * native messaging uses (`native-messaging/framing.ts`).
+ * The proxy carries `chrome.runtime` messaging from the contexts of a
+ * worker-less session — its content scripts and its extension pages, the action
+ * popup above all — to the one session that keeps the extension's service
+ * worker. Their calls go up as ordinary bridge POSTs; everything flowing the
+ * other way rides a streaming response body — port frames to the caller, jobs
+ * to the worker — in the same length-prefixed JSON frames native messaging uses
+ * (`native-messaging/framing.ts`).
  */
+
+/** What every extension URL starts with, from a worker scope to a page's own. */
+export const EXTENSION_SCHEME_PREFIX = "chrome-extension://";
 
 export const RUNTIME_PROXY_PATHS = {
   /** Content-script side, called by the shim. */
@@ -38,11 +42,13 @@ export const RECEIVING_END_ERROR = "Could not establish connection. Receiving en
 export const PORT_CLOSED_ERROR = "The message port closed before a response was received.";
 
 /**
- * What a content script can truthfully say about itself: a bridge request
+ * What a shimmed context can truthfully say about itself: a bridge request
  * carries no sender at all — no `Origin` header, nothing — so the shim reports
  * where it runs and the main process checks the claim against the session's
  * real frame tree before building the sender the worker sees. The bridge token
- * has already proven the caller is the extension's own isolated world.
+ * has already proven the caller is the extension's own — its isolated world, or
+ * one of its pages. Together the two fields say which: a top-level document on
+ * the extension's own scheme is an extension page, and no tab.
  */
 export type RuntimeProxySenderReport = {
   url: string;
@@ -109,8 +115,9 @@ export type RuntimeProxyTab = {
 
 /**
  * The `MessageSender` a relayed message hands the worker's listeners. `tab` and
- * `frameId` are missing when the reported frame could not be found in the
- * session — it navigated away while the message was in flight.
+ * `frameId` are missing when the message came from an extension page, which is
+ * no tab, and when the reported frame could not be found in the session — it
+ * navigated away while the message was in flight.
  */
 export type RuntimeProxySender = {
   id: string;

--- a/packages/electron-extensions/runtime-proxy/bridge-protocol.ts
+++ b/packages/electron-extensions/runtime-proxy/bridge-protocol.ts
@@ -114,15 +114,18 @@ export type RuntimeProxyTab = {
 };
 
 /**
- * The `MessageSender` a relayed message hands the worker's listeners. `tab` and
- * `frameId` are missing when the message came from an extension page, which is
- * no tab, and when the reported frame could not be found in the session — it
- * navigated away while the message was in flight.
+ * The `MessageSender` a relayed message hands the worker's listeners. Only `id`
+ * is always there: everything else is held back unless a live frame of the
+ * session was found at the reported URL, so a report no frame backs — the page
+ * navigated away while the message was in flight, or the report was never true
+ * — arrives carrying nothing but the extension's own id. `tab` and `frameId`
+ * are missing on top of that when the message came from an extension page,
+ * which is no tab.
  */
 export type RuntimeProxySender = {
   id: string;
-  url: string;
-  origin: string;
+  url?: string;
+  origin?: string;
   frameId?: number;
   tab?: RuntimeProxyTab;
 };

--- a/packages/electron-extensions/runtime-proxy/bridge-protocol.ts
+++ b/packages/electron-extensions/runtime-proxy/bridge-protocol.ts
@@ -42,13 +42,14 @@ export const RECEIVING_END_ERROR = "Could not establish connection. Receiving en
 export const PORT_CLOSED_ERROR = "The message port closed before a response was received.";
 
 /**
- * What a shimmed context can truthfully say about itself: a bridge request
- * carries no sender at all — no `Origin` header, nothing — so the shim reports
- * where it runs and the main process checks the claim against the session's
- * real frame tree before building the sender the worker sees. The bridge token
- * has already proven the caller is the extension's own — its isolated world, or
- * one of its pages. Together the two fields say which: a top-level document on
- * the extension's own scheme is an extension page, and no tab.
+ * What a shimmed context can truthfully say about itself: a bridge request's
+ * body carries no sender of its own — no `Origin` header, nothing — so the shim
+ * reports where it runs and the main process holds the claim against the frame
+ * Chromium recorded as the request's caller (`bridge/bridge.ts`) before
+ * building the sender the worker sees. The bridge token has already proven the
+ * caller is the extension's own — its isolated world, or one of its pages.
+ * Together the two fields say which: a top-level document on the extension's
+ * own scheme is an extension page, and no tab.
  */
 export type RuntimeProxySenderReport = {
   url: string;
@@ -115,12 +116,12 @@ export type RuntimeProxyTab = {
 
 /**
  * The `MessageSender` a relayed message hands the worker's listeners. Only `id`
- * is always there: everything else is held back unless a live frame of the
- * session was found at the reported URL, so a report no frame backs — the page
- * navigated away while the message was in flight, or the report was never true
- * — arrives carrying nothing but the extension's own id. `tab` and `frameId`
- * are missing on top of that when the message came from an extension page,
- * which is no tab.
+ * is always there: everything else is held back unless the frame Chromium
+ * recorded as the request's caller backs the report, so a report the caller's
+ * own frame does not back — the page navigated away while the message was in
+ * flight, or the report was never true — arrives carrying nothing but the
+ * extension's own id. `tab` and `frameId` are missing on top of that when the
+ * message came from an extension page, which is no tab.
  */
 export type RuntimeProxySender = {
   id: string;

--- a/packages/electron-extensions/runtime-proxy/bridge-protocol.ts
+++ b/packages/electron-extensions/runtime-proxy/bridge-protocol.ts
@@ -1,0 +1,151 @@
+/**
+ * What the runtime proxy says over the extension bridge (`bridge/protocol.ts`),
+ * shared by the content-script shim, the worker-side relay client, and the
+ * main-process relay.
+ *
+ * The proxy carries `chrome.runtime` messaging from content scripts in
+ * worker-less sessions to the one session that keeps the extension's service
+ * worker. Content-script calls go up as ordinary bridge POSTs; everything
+ * flowing the other way rides a streaming response body — port frames to a
+ * content script, jobs to the worker — in the same length-prefixed JSON frames
+ * native messaging uses (`native-messaging/framing.ts`).
+ */
+
+export const RUNTIME_PROXY_PATHS = {
+  /** Content-script side, called by the shim. */
+  sendMessage: "/runtime-proxy/send-message",
+  connect: "/runtime-proxy/connect",
+  portPost: "/runtime-proxy/port-post",
+  portDisconnect: "/runtime-proxy/port-disconnect",
+  /** Worker side, called by the relay client. */
+  workerJobs: "/runtime-proxy/worker-jobs",
+  workerAck: "/runtime-proxy/worker-ack",
+  workerReply: "/runtime-proxy/worker-reply",
+  workerPortPost: "/runtime-proxy/worker-port-post",
+  workerPortDisconnect: "/runtime-proxy/worker-port-disconnect",
+} as const;
+
+/**
+ * Far past any `chrome.runtime` message's business, but native messaging's
+ * 1 MB cap is one Chrome does not apply to runtime messaging, so the proxy's
+ * streams get a cap of their own rather than inheriting that one.
+ */
+export const MAX_RUNTIME_PROXY_FRAME_BYTES = 64 * 1024 * 1024;
+
+/** Chrome's own words, so extensions match on what they already handle. */
+export const RECEIVING_END_ERROR = "Could not establish connection. Receiving end does not exist.";
+
+export const PORT_CLOSED_ERROR = "The message port closed before a response was received.";
+
+/**
+ * What a content script can truthfully say about itself: a bridge request
+ * carries no sender at all — no `Origin` header, nothing — so the shim reports
+ * where it runs and the main process checks the claim against the session's
+ * real frame tree before building the sender the worker sees. The bridge token
+ * has already proven the caller is the extension's own isolated world.
+ */
+export type RuntimeProxySenderReport = {
+  url: string;
+  isTopFrame: boolean;
+};
+
+export type RuntimeProxySendMessageRequest = {
+  message: unknown;
+  sender: RuntimeProxySenderReport;
+};
+
+/**
+ * How a relayed `sendMessage` ended, mapped by the shim onto Chrome's own
+ * behavior: a reply, "receiving end does not exist" when nothing listens, and
+ * "message port closed" when a listener took the message and never answered.
+ */
+export type RuntimeProxySendMessageResult =
+  | { status: "replied"; reply?: unknown }
+  | { status: "noListener" }
+  | { status: "closed" };
+
+export type RuntimeProxyConnectRequest = {
+  /**
+   * The shim's to choose, like a native messaging port id, so it can post the
+   * moment `connect` returns. The relay still owns what the id may reach: a
+   * port answers only to the session and extension that opened it.
+   */
+  portId: string;
+  name?: string;
+  sender: RuntimeProxySenderReport;
+};
+
+export type RuntimeProxyConnectResult = { status: "connected" } | { status: "noListener" };
+
+export type RuntimeProxyPortPostRequest = {
+  portId: string;
+  message: unknown;
+};
+
+export type RuntimeProxyPortDisconnectRequest = {
+  portId: string;
+};
+
+/**
+ * Frames on a connect response body, streamed to the shim's port. A stream that
+ * ends without a disconnect frame means the bridge itself went away.
+ */
+export type RuntimeProxyPortFrame =
+  | { type: "message"; message: unknown }
+  | { type: "disconnect"; error?: string };
+
+/** `chrome.tabs.Tab`, as much of it as the main process can honestly build. */
+export type RuntimeProxyTab = {
+  id: number;
+  url: string;
+  title: string;
+  windowId: number;
+  index: number;
+  active: boolean;
+  highlighted: boolean;
+  pinned: boolean;
+  incognito: boolean;
+};
+
+/**
+ * The `MessageSender` a relayed message hands the worker's listeners. `tab` and
+ * `frameId` are missing when the reported frame could not be found in the
+ * session — it navigated away while the message was in flight.
+ */
+export type RuntimeProxySender = {
+  id: string;
+  url: string;
+  origin: string;
+  frameId?: number;
+  tab?: RuntimeProxyTab;
+};
+
+/**
+ * Frames on the worker-jobs response body. Every job is acked by id the moment
+ * the relay client takes it (`workerAck`), which is what tells a job handed to
+ * a stream just before the worker stopped apart from one the worker has:
+ * un-acked jobs are delivered again on the next stream, acked ones are not.
+ */
+export type RuntimeProxyJob =
+  | { type: "sendMessage"; jobId: string; message: unknown; sender: RuntimeProxySender }
+  | { type: "connect"; jobId: string; portId: string; name?: string; sender: RuntimeProxySender }
+  | { type: "portMessage"; jobId: string; portId: string; message: unknown }
+  | { type: "portDisconnect"; jobId: string; portId: string };
+
+export type RuntimeProxyWorkerAckRequest = {
+  jobId: string;
+};
+
+export type RuntimeProxyWorkerReplyRequest = {
+  jobId: string;
+  result: RuntimeProxySendMessageResult | RuntimeProxyConnectResult;
+};
+
+export type RuntimeProxyWorkerPortPostRequest = {
+  portId: string;
+  message: unknown;
+};
+
+export type RuntimeProxyWorkerPortDisconnectRequest = {
+  portId: string;
+};

--- a/packages/electron-extensions/runtime-proxy/index.ts
+++ b/packages/electron-extensions/runtime-proxy/index.ts
@@ -1,7 +1,7 @@
 import type { Session } from "electron";
 import type { SharedExtensionInstance } from "../extensions";
 import { RuntimeProxy } from "./runtime-proxy";
-import type { RuntimeProxyTabsProvider } from "./sender";
+import type { GetWebContentsFromFrame } from "./sender";
 
 export type CreateSharedExtensionInstanceOptions = {
   /**
@@ -15,8 +15,8 @@ export type CreateSharedExtensionInstanceOptions = {
    * copy and imported by its service worker wrapper.
    */
   relayScriptPath: string;
-  /** How a session's tabs are enumerated for sender reconstruction. */
-  getTabWebContents?: RuntimeProxyTabsProvider;
+  /** How a caller frame resolves to its hosting tab for sender reconstruction. */
+  getWebContentsFromFrame?: GetWebContentsFromFrame;
 };
 
 /**
@@ -37,7 +37,7 @@ export type CreateSharedExtensionInstanceOptions = {
 export function createSharedExtensionInstance({
   shimScriptPath,
   relayScriptPath,
-  getTabWebContents,
+  getWebContentsFromFrame,
 }: CreateSharedExtensionInstanceOptions): SharedExtensionInstance {
   let proxy: RuntimeProxy | undefined;
 
@@ -45,7 +45,7 @@ export function createSharedExtensionInstance({
 
   return {
     install({ bridge, logger }) {
-      proxy = new RuntimeProxy({ logger, getTabWebContents });
+      proxy = new RuntimeProxy({ logger, getWebContentsFromFrame });
 
       proxy.registerRoutes(bridge);
     },

--- a/packages/electron-extensions/runtime-proxy/index.ts
+++ b/packages/electron-extensions/runtime-proxy/index.ts
@@ -5,8 +5,9 @@ import type { RuntimeProxyTabsProvider } from "./sender";
 
 export type CreateSharedExtensionInstanceOptions = {
   /**
-   * The bundled content-script shim, written into every content-script-only
-   * copy and prepended to each of its `content_scripts` entries.
+   * The bundled shim, written into every content-script-only copy, prepended to
+   * each of its `content_scripts` entries and injected into each of its
+   * extension pages.
    */
   shimScriptPath: string;
   /**
@@ -23,9 +24,11 @@ export type CreateSharedExtensionInstanceOptions = {
  * instance per session: the first session set up keeps the whole extension —
  * the one service worker, the one `chrome.storage` — and every later session
  * gets a content-script-only copy whose `chrome.runtime` messaging the
- * `RuntimeProxy` relays to that worker and back. The prize is one sign-in to a
- * password manager instead of one per account; one worker at any session count
- * instead of one per session comes with it.
+ * `RuntimeProxy` relays to that worker and back — from its content scripts and
+ * from its extension pages, which is where a password manager keeps its unlock
+ * UI. The prize is one sign-in to a password manager instead of one per
+ * account; one worker at any session count instead of one per session comes
+ * with it.
  *
  * The whole feature hangs off the one `sharedInstance` option this creates a
  * value for. An embedder that never passes it runs exactly as before, and

--- a/packages/electron-extensions/runtime-proxy/index.ts
+++ b/packages/electron-extensions/runtime-proxy/index.ts
@@ -1,0 +1,76 @@
+import type { Session } from "electron";
+import type { SharedExtensionInstance } from "../extensions";
+import { RuntimeProxy } from "./runtime-proxy";
+import type { RuntimeProxyTabsProvider } from "./sender";
+
+export type CreateSharedExtensionInstanceOptions = {
+  /**
+   * The bundled content-script shim, written into every content-script-only
+   * copy and prepended to each of its `content_scripts` entries.
+   */
+  shimScriptPath: string;
+  /**
+   * The bundled worker-side relay client, written into the worker session's
+   * copy and imported by its service worker wrapper.
+   */
+  relayScriptPath: string;
+  /** How a session's tabs are enumerated for sender reconstruction. */
+  getTabWebContents?: RuntimeProxyTabsProvider;
+};
+
+/**
+ * One shared extension instance serving every session, in place of one full
+ * instance per session: the first session set up keeps the whole extension —
+ * the one service worker, the one `chrome.storage` — and every later session
+ * gets a content-script-only copy whose `chrome.runtime` messaging the
+ * `RuntimeProxy` relays to that worker and back. The prize is one sign-in to a
+ * password manager instead of one per account; one worker at any session count
+ * instead of one per session comes with it.
+ *
+ * The whole feature hangs off the one `sharedInstance` option this creates a
+ * value for. An embedder that never passes it runs exactly as before, and
+ * removing the feature is removing that option and this directory.
+ */
+export function createSharedExtensionInstance({
+  shimScriptPath,
+  relayScriptPath,
+  getTabWebContents,
+}: CreateSharedExtensionInstanceOptions): SharedExtensionInstance {
+  let proxy: RuntimeProxy | undefined;
+
+  let workerSession: Session | undefined;
+
+  return {
+    install({ bridge, logger }) {
+      proxy = new RuntimeProxy({ logger, getTabWebContents });
+
+      proxy.registerRoutes(bridge);
+    },
+
+    adoptSession(session) {
+      // The first session set up keeps the worker. Which session that is is
+      // deliberately not a setting: any one worker serves every session alike,
+      // and the first one exists whenever any session does.
+      if (!workerSession) {
+        workerSession = session;
+
+        proxy?.setWorkerSession(session);
+      }
+
+      return workerSession === session
+        ? { role: "worker", relayScriptPath }
+        : { role: "contentScriptOnly", shimScriptPath };
+    },
+
+    teardownSession(session) {
+      // A torn-down worker session orphans the content-script-only sessions
+      // until the next session adopts the worker role on a fresh instance;
+      // the proxy answers them "receiving end does not exist" in between
+      if (session === workerSession) {
+        workerSession = undefined;
+      }
+
+      proxy?.teardownSession(session);
+    },
+  };
+}

--- a/packages/electron-extensions/runtime-proxy/relay-client.test.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.test.ts
@@ -1,0 +1,452 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { EXTENSION_BRIDGE_ORIGIN } from "../bridge/protocol";
+import type { ChromeEventListener, ChromeNamespace } from "../facade/lib/chrome";
+import { encodeNativeMessage } from "../native-messaging/framing";
+import {
+  RUNTIME_PROXY_PATHS,
+  type RuntimeProxyJob,
+  type RuntimeProxySender,
+} from "./bridge-protocol";
+import { createRelayClient } from "./relay-client";
+
+const EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
+
+const SENDER: RuntimeProxySender = {
+  id: EXTENSION_ID,
+  url: "https://accounts.google.com/",
+  origin: "https://accounts.google.com",
+};
+
+const originalFetch = globalThis.fetch;
+
+const startedClients: { stop: () => void }[] = [];
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+
+  for (const client of startedClients.splice(0)) {
+    client.stop();
+  }
+});
+
+async function waitFor(condition: () => boolean, what: string) {
+  const deadline = Date.now() + 1000;
+
+  while (!condition()) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for ${what}`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}
+
+type RecordedPost = { pathName: string; body: Record<string, unknown> };
+
+function stubBridge() {
+  const posts: RecordedPost[] = [];
+
+  const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
+
+  globalThis.fetch = (async (url: string, init: RequestInit) => {
+    const pathName = url.slice(EXTENSION_BRIDGE_ORIGIN.length);
+
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+
+    posts.push({ pathName, body });
+
+    if (pathName === RUNTIME_PROXY_PATHS.workerJobs) {
+      const stream = new ReadableStream<Uint8Array>({
+        start: (controller) => {
+          streamControllers.push(controller);
+        },
+      });
+
+      return new Response(stream, { status: 200 });
+    }
+
+    return new Response(null, { status: 204 });
+  }) as unknown as typeof fetch;
+
+  return {
+    posts,
+    postsTo: (pathName: string) => posts.filter((post) => post.pathName === pathName),
+    waitForStream: async (streamCount = 1) => {
+      await waitFor(() => streamControllers.length >= streamCount, `${streamCount} job streams`);
+
+      return streamControllers[streamCount - 1] as ReadableStreamDefaultController<Uint8Array>;
+    },
+    pushJob: (job: RuntimeProxyJob) => {
+      streamControllers.at(-1)?.enqueue(encodeNativeMessage(job));
+    },
+  };
+}
+
+function createNativeEvent() {
+  const listeners: ChromeEventListener[] = [];
+
+  return {
+    listeners,
+    addListener: (listener: ChromeEventListener) => {
+      listeners.push(listener);
+    },
+    removeListener: (listener: ChromeEventListener) => {
+      listeners.splice(listeners.indexOf(listener), 1);
+    },
+  };
+}
+
+function createWorkerChrome() {
+  const nativeOnMessage = createNativeEvent();
+
+  const nativeOnConnect = createNativeEvent();
+
+  const chrome: ChromeNamespace = {
+    runtime: { id: EXTENSION_ID, onMessage: nativeOnMessage, onConnect: nativeOnConnect },
+  };
+
+  return { chrome, nativeOnMessage, nativeOnConnect };
+}
+
+type WrappedEvent = {
+  addListener: (listener: ChromeEventListener) => void;
+  removeListener: (listener: ChromeEventListener) => void;
+  hasListener: (listener: ChromeEventListener) => boolean;
+  hasListeners: () => boolean;
+};
+
+function startClient(chromeObjects: ChromeNamespace[]) {
+  const client = createRelayClient({ retryDelayMs: 5 });
+
+  for (const chrome of chromeObjects) {
+    client.wrapRuntime(chrome);
+  }
+
+  client.start();
+
+  startedClients.push(client);
+
+  return client;
+}
+
+describe("createRelayClient", () => {
+  test("wraps the events and keeps registering listeners natively", () => {
+    const { chrome, nativeOnMessage } = createWorkerChrome();
+
+    const client = createRelayClient();
+
+    client.wrapRuntime(chrome);
+
+    const runtime = chrome.runtime as ChromeNamespace;
+
+    const onMessage = runtime.onMessage as WrappedEvent;
+
+    const listener = () => undefined;
+
+    onMessage.addListener(listener);
+
+    expect(nativeOnMessage.listeners).toEqual([listener]);
+    expect(onMessage.hasListener(listener)).toBe(true);
+    expect(onMessage.hasListeners()).toBe(true);
+
+    onMessage.removeListener(listener);
+
+    expect(nativeOnMessage.listeners).toEqual([]);
+    expect(onMessage.hasListeners()).toBe(false);
+  });
+
+  test("chrome and browser share one set of mirrored listeners", async () => {
+    const stub = stubBridge();
+
+    const { chrome } = createWorkerChrome();
+
+    const browser: ChromeNamespace = {
+      runtime: { id: EXTENSION_ID, onMessage: createNativeEvent(), onConnect: createNativeEvent() },
+    };
+
+    startClient([chrome, browser]);
+
+    const heard: unknown[] = [];
+
+    ((browser.runtime as ChromeNamespace).onMessage as WrappedEvent).addListener((message) => {
+      heard.push(message);
+    });
+
+    await stub.waitForStream();
+
+    stub.pushJob({ type: "sendMessage", jobId: "job-1", message: "via browser", sender: SENDER });
+
+    await waitFor(() => heard.length === 1, "the browser-registered listener");
+  });
+
+  test("acks a job before answering it, and answers with the first response", async () => {
+    const stub = stubBridge();
+
+    const { chrome } = createWorkerChrome();
+
+    startClient([chrome]);
+
+    const runtime = chrome.runtime as ChromeNamespace;
+
+    (runtime.onMessage as WrappedEvent).addListener((_message, _sender, sendResponse) => {
+      (sendResponse as (response: unknown) => void)({ unlocked: true });
+    });
+
+    await stub.waitForStream();
+
+    stub.pushJob({
+      type: "sendMessage",
+      jobId: "job-1",
+      message: { kind: "unlock" },
+      sender: SENDER,
+    });
+
+    await waitFor(() => stub.postsTo(RUNTIME_PROXY_PATHS.workerReply).length === 1, "the reply");
+
+    expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerAck)).toEqual([
+      { pathName: RUNTIME_PROXY_PATHS.workerAck, body: { jobId: "job-1" } },
+    ]);
+
+    expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerReply)[0]?.body).toEqual({
+      jobId: "job-1",
+      result: { status: "replied", reply: { unlocked: true } },
+    });
+  });
+
+  test("a listener returning true keeps the channel open for a later response", async () => {
+    const stub = stubBridge();
+
+    const { chrome } = createWorkerChrome();
+
+    startClient([chrome]);
+
+    let respondLater: ((response: unknown) => void) | undefined;
+
+    ((chrome.runtime as ChromeNamespace).onMessage as WrappedEvent).addListener(
+      (_message, _sender, sendResponse) => {
+        respondLater = sendResponse as (response: unknown) => void;
+
+        return true;
+      },
+    );
+
+    await stub.waitForStream();
+
+    stub.pushJob({ type: "sendMessage", jobId: "job-1", message: "wait", sender: SENDER });
+
+    await waitFor(() => respondLater !== undefined, "the listener");
+
+    expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerReply)).toEqual([]);
+
+    respondLater?.("took a while");
+
+    await waitFor(() => stub.postsTo(RUNTIME_PROXY_PATHS.workerReply).length === 1, "the reply");
+
+    expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerReply)[0]?.body).toEqual({
+      jobId: "job-1",
+      result: { status: "replied", reply: "took a while" },
+    });
+  });
+
+  test("answers noListener with nothing registered, and closed when nobody responds", async () => {
+    const stub = stubBridge();
+
+    const { chrome } = createWorkerChrome();
+
+    startClient([chrome]);
+
+    await stub.waitForStream();
+
+    stub.pushJob({ type: "sendMessage", jobId: "job-1", message: "anyone?", sender: SENDER });
+
+    await waitFor(() => stub.postsTo(RUNTIME_PROXY_PATHS.workerReply).length === 1, "the reply");
+
+    expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerReply)[0]?.body).toEqual({
+      jobId: "job-1",
+      result: { status: "noListener" },
+    });
+
+    ((chrome.runtime as ChromeNamespace).onMessage as WrappedEvent).addListener(() => undefined);
+
+    stub.pushJob({ type: "sendMessage", jobId: "job-2", message: "still there?", sender: SENDER });
+
+    await waitFor(
+      () => stub.postsTo(RUNTIME_PROXY_PATHS.workerReply).length === 2,
+      "the second reply",
+    );
+
+    expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerReply)[1]?.body).toEqual({
+      jobId: "job-2",
+      result: { status: "closed" },
+    });
+  });
+
+  test("builds a port for a connect job and carries it both ways", async () => {
+    const stub = stubBridge();
+
+    const { chrome } = createWorkerChrome();
+
+    startClient([chrome]);
+
+    const runtime = chrome.runtime as ChromeNamespace;
+
+    type WorkerPort = {
+      name: string;
+      sender: RuntimeProxySender;
+      postMessage: (message: unknown) => void;
+      disconnect: () => void;
+      onMessage: WrappedEvent;
+      onDisconnect: WrappedEvent;
+    };
+
+    let port: WorkerPort | undefined;
+
+    (runtime.onConnect as WrappedEvent).addListener((connectedPort) => {
+      port = connectedPort as WorkerPort;
+    });
+
+    await stub.waitForStream();
+
+    stub.pushJob({
+      type: "connect",
+      jobId: "job-1",
+      portId: "port-1",
+      name: "relay",
+      sender: SENDER,
+    });
+
+    await waitFor(() => port !== undefined, "the port");
+
+    expect(port?.name).toBe("relay");
+    expect(port?.sender).toEqual(SENDER);
+
+    expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerReply)[0]?.body).toEqual({
+      jobId: "job-1",
+      result: { status: "connected" },
+    });
+
+    // Worker to content script, in the order it was written
+    port?.postMessage("first");
+
+    port?.postMessage("second");
+
+    await waitFor(() => stub.postsTo(RUNTIME_PROXY_PATHS.workerPortPost).length === 2, "the posts");
+
+    expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerPortPost).map(({ body }) => body)).toEqual([
+      { portId: "port-1", message: "first" },
+      { portId: "port-1", message: "second" },
+    ]);
+
+    // Content script to worker
+    const heard: unknown[] = [];
+
+    port?.onMessage.addListener((message) => {
+      heard.push(message);
+    });
+
+    stub.pushJob({ type: "portMessage", jobId: "job-2", portId: "port-1", message: "fill" });
+
+    await waitFor(() => heard.length === 1, "the port message");
+
+    expect(heard).toEqual(["fill"]);
+
+    // The far side hangs up
+    let disconnectHeard = false;
+
+    port?.onDisconnect.addListener(() => {
+      disconnectHeard = true;
+    });
+
+    stub.pushJob({ type: "portDisconnect", jobId: "job-3", portId: "port-1" });
+
+    await waitFor(() => disconnectHeard, "the disconnect");
+
+    expect(() => port?.postMessage("too late")).toThrow(
+      "Attempting to use a disconnected port object",
+    );
+  });
+
+  test("answers a connect nothing listens to with noListener", async () => {
+    const stub = stubBridge();
+
+    const { chrome } = createWorkerChrome();
+
+    startClient([chrome]);
+
+    await stub.waitForStream();
+
+    stub.pushJob({ type: "connect", jobId: "job-1", portId: "port-1", name: "x", sender: SENDER });
+
+    await waitFor(() => stub.postsTo(RUNTIME_PROXY_PATHS.workerReply).length === 1, "the reply");
+
+    expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerReply)[0]?.body).toEqual({
+      jobId: "job-1",
+      result: { status: "noListener" },
+    });
+  });
+
+  test("disconnecting from the worker side tells the relay", async () => {
+    const stub = stubBridge();
+
+    const { chrome } = createWorkerChrome();
+
+    startClient([chrome]);
+
+    let port: { disconnect: () => void } | undefined;
+
+    ((chrome.runtime as ChromeNamespace).onConnect as WrappedEvent).addListener((connectedPort) => {
+      port = connectedPort as { disconnect: () => void };
+    });
+
+    await stub.waitForStream();
+
+    stub.pushJob({
+      type: "connect",
+      jobId: "job-1",
+      portId: "port-1",
+      name: "relay",
+      sender: SENDER,
+    });
+
+    await waitFor(() => port !== undefined, "the port");
+
+    port?.disconnect();
+
+    await waitFor(
+      () => stub.postsTo(RUNTIME_PROXY_PATHS.workerPortDisconnect).length === 1,
+      "the disconnect post",
+    );
+
+    expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerPortDisconnect)[0]?.body).toEqual({
+      portId: "port-1",
+    });
+  });
+
+  test("parks a fresh job stream when the previous one ends", async () => {
+    const stub = stubBridge();
+
+    const { chrome } = createWorkerChrome();
+
+    startClient([chrome]);
+
+    const firstController = await stub.waitForStream();
+
+    firstController.close();
+
+    await stub.waitForStream(2);
+
+    const heard: unknown[] = [];
+
+    ((chrome.runtime as ChromeNamespace).onMessage as WrappedEvent).addListener(
+      (message, _sender, sendResponse) => {
+        heard.push(message);
+
+        (sendResponse as (response: unknown) => void)("still here");
+      },
+    );
+
+    stub.pushJob({ type: "sendMessage", jobId: "job-1", message: "after restart", sender: SENDER });
+
+    await waitFor(() => heard.length === 1, "the redelivered job");
+  });
+});

--- a/packages/electron-extensions/runtime-proxy/relay-client.test.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.test.ts
@@ -213,6 +213,85 @@ describe("createRelayClient", () => {
     });
   });
 
+  /*
+   * The relay redelivers anything it holds no ack for, and an ack can go
+   * missing on its own since a failed POST is swallowed. A redelivered job that
+   * ran here already must not run again: for anything that changes state —
+   * unlocking a vault, saving an item — a second dispatch is a double apply
+   * rather than a retry.
+   */
+  test("a redelivered job is acked again but never dispatched twice", async () => {
+    const stub = stubBridge();
+
+    const { chrome } = createWorkerChrome();
+
+    startClient([chrome]);
+
+    const heard: unknown[] = [];
+
+    ((chrome.runtime as ChromeNamespace).onMessage as WrappedEvent).addListener(
+      (message, _sender, sendResponse) => {
+        heard.push(message);
+
+        (sendResponse as (response: unknown) => void)({ unlocked: true });
+      },
+    );
+
+    await stub.waitForStream();
+
+    const job = {
+      type: "sendMessage" as const,
+      jobId: "job-1",
+      message: { kind: "unlock" },
+      sender: SENDER,
+    };
+
+    stub.pushJob(job);
+
+    await waitFor(() => stub.postsTo(RUNTIME_PROXY_PATHS.workerReply).length === 1, "the reply");
+
+    stub.pushJob(job);
+
+    await waitFor(() => stub.postsTo(RUNTIME_PROXY_PATHS.workerAck).length === 2, "the second ack");
+
+    expect(heard).toEqual([{ kind: "unlock" }]);
+    expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerReply)).toHaveLength(1);
+  });
+
+  test("a redelivered connect does not open the port a second time", async () => {
+    const stub = stubBridge();
+
+    const { chrome } = createWorkerChrome();
+
+    startClient([chrome]);
+
+    const connected: unknown[] = [];
+
+    ((chrome.runtime as ChromeNamespace).onConnect as WrappedEvent).addListener((port) => {
+      connected.push(port);
+    });
+
+    await stub.waitForStream();
+
+    const job = {
+      type: "connect" as const,
+      jobId: "job-1",
+      portId: "port-1",
+      name: "relay",
+      sender: SENDER,
+    };
+
+    stub.pushJob(job);
+
+    await waitFor(() => connected.length === 1, "the port");
+
+    stub.pushJob(job);
+
+    await waitFor(() => stub.postsTo(RUNTIME_PROXY_PATHS.workerAck).length === 2, "the second ack");
+
+    expect(connected).toHaveLength(1);
+  });
+
   test("a listener returning true keeps the channel open for a later response", async () => {
     const stub = stubBridge();
 

--- a/packages/electron-extensions/runtime-proxy/relay-client.test.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.test.ts
@@ -115,8 +115,8 @@ type WrappedEvent = {
   hasListeners: () => boolean;
 };
 
-function startClient(chromeObjects: ChromeNamespace[]) {
-  const client = createRelayClient({ retryDelayMs: 5 });
+function startClient(chromeObjects: ChromeNamespace[], maxRememberedJobIds?: number) {
+  const client = createRelayClient({ retryDelayMs: 5, maxRememberedJobIds });
 
   for (const chrome of chromeObjects) {
     client.wrapRuntime(chrome);
@@ -256,6 +256,63 @@ describe("createRelayClient", () => {
 
     expect(heard).toEqual([{ kind: "unlock" }]);
     expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerReply)).toHaveLength(1);
+  });
+
+  /*
+   * The set of handled ids is bounded, so a worker that lives for hours cannot
+   * grow one without limit. Eviction is oldest-first, and a job old enough to
+   * be forgotten runs again: at-least-once is the guarantee that survives, and
+   * running a very old job twice beats never running a new one.
+   */
+  test("the handled-job memory is bounded, and forgets oldest first", async () => {
+    const stub = stubBridge();
+
+    const { chrome } = createWorkerChrome();
+
+    startClient([chrome], 2);
+
+    const heard: unknown[] = [];
+
+    ((chrome.runtime as ChromeNamespace).onMessage as WrappedEvent).addListener(
+      (message, _sender, sendResponse) => {
+        heard.push(message);
+
+        (sendResponse as (response: unknown) => void)({ unlocked: true });
+      },
+    );
+
+    await stub.waitForStream();
+
+    const jobAt = (index: number) => ({
+      type: "sendMessage" as const,
+      jobId: `job-${index}`,
+      message: { index },
+      sender: SENDER,
+    });
+
+    // Three against a bound of two, so the first id is the one evicted
+    for (const index of [1, 2, 3]) {
+      stub.pushJob(jobAt(index));
+    }
+
+    await waitFor(
+      () => stub.postsTo(RUNTIME_PROXY_PATHS.workerReply).length === 3,
+      "three replies",
+    );
+
+    // Still remembered, so it is acked and not run again
+    stub.pushJob(jobAt(3));
+
+    await waitFor(() => stub.postsTo(RUNTIME_PROXY_PATHS.workerAck).length === 4, "the fourth ack");
+
+    expect(heard).toEqual([{ index: 1 }, { index: 2 }, { index: 3 }]);
+
+    // Forgotten, so it runs a second time
+    stub.pushJob(jobAt(1));
+
+    await waitFor(() => stub.postsTo(RUNTIME_PROXY_PATHS.workerReply).length === 4, "the rerun");
+
+    expect(heard).toEqual([{ index: 1 }, { index: 2 }, { index: 3 }, { index: 1 }]);
   });
 
   test("a redelivered connect does not open the port a second time", async () => {

--- a/packages/electron-extensions/runtime-proxy/relay-client.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.ts
@@ -1,0 +1,336 @@
+import { postBridge } from "../facade/lib/bridge";
+import type { ChromeEventListener, ChromeNamespace } from "../facade/lib/chrome";
+import { createEvent } from "../facade/lib/event";
+import { NativeMessageDecoder } from "../native-messaging/framing";
+import {
+  MAX_RUNTIME_PROXY_FRAME_BYTES,
+  RUNTIME_PROXY_PATHS,
+  type RuntimeProxyConnectResult,
+  type RuntimeProxyJob,
+  type RuntimeProxySender,
+  type RuntimeProxySendMessageResult,
+} from "./bridge-protocol";
+
+const DISCONNECTED_PORT_ERROR = "Attempting to use a disconnected port object";
+
+const DEFAULT_RETRY_DELAY_MS = 1000;
+
+type WorkerPort = {
+  externalPort: Record<string, unknown>;
+  emitMessage: (message: unknown) => void;
+  emitDisconnect: () => void;
+};
+
+export type CreateRelayClientOptions = {
+  /** How long a failed job stream waits before it is opened again. */
+  retryDelayMs?: number;
+};
+
+/**
+ * The worker-side half of the runtime proxy, run next to the extension's own
+ * service worker in the one session that keeps it.
+ *
+ * It wraps `chrome.runtime.onMessage` and `onConnect` so it knows the listeners
+ * the extension registered — native in-session dispatch keeps working, since
+ * every listener is registered natively too — and keeps a job stream parked at
+ * the bridge, through which the relay hands over what content scripts in the
+ * other sessions sent. Each job is acked by id the moment it arrives, so a job
+ * the worker died holding is told apart from one that never arrived, and
+ * replies go back as bridge calls of their own. The parked stream does not pin
+ * the worker: idle-stop happens as ever, and the relay wakes the worker when
+ * the next job needs it.
+ */
+export function createRelayClient({
+  retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+}: CreateRelayClientOptions = {}) {
+  const messageListeners = new Set<ChromeEventListener>();
+
+  const connectListeners = new Set<ChromeEventListener>();
+
+  const ports = new Map<string, WorkerPort>();
+
+  let isStopped = false;
+
+  const postToBridge = (pathName: string, body: Record<string, unknown>) =>
+    postBridge(pathName, body).catch(() => undefined);
+
+  /**
+   * Wraps a native event with one that also mirrors its listeners here. The
+   * native event keeps every listener too, so in-session messaging — the
+   * worker's own popup, above all — dispatches exactly as before.
+   */
+  const mirrorEvent = (
+    runtime: ChromeNamespace,
+    eventName: string,
+    mirroredListeners: Set<ChromeEventListener>,
+  ) => {
+    const nativeEvent = runtime[eventName] as
+      | {
+          addListener?: (listener: ChromeEventListener, ...eventOptions: unknown[]) => void;
+          removeListener?: (listener: ChromeEventListener) => void;
+          hasListener?: (listener: ChromeEventListener) => boolean;
+          hasListeners?: () => boolean;
+        }
+      | undefined;
+
+    const wrappedEvent = {
+      addListener(listener: ChromeEventListener, ...eventOptions: unknown[]) {
+        mirroredListeners.add(listener);
+
+        nativeEvent?.addListener?.(listener, ...eventOptions);
+      },
+      removeListener(listener: ChromeEventListener) {
+        mirroredListeners.delete(listener);
+
+        nativeEvent?.removeListener?.(listener);
+      },
+      hasListener(listener: ChromeEventListener) {
+        return mirroredListeners.has(listener);
+      },
+      hasListeners() {
+        return mirroredListeners.size > 0;
+      },
+    };
+
+    runtime[eventName] = wrappedEvent;
+
+    if (runtime[eventName] !== wrappedEvent) {
+      console.error(`[runtime-proxy-relay] could not wrap runtime.${eventName}`);
+    }
+  };
+
+  /**
+   * Chrome's dispatch, reproduced: every listener hears the message, the first
+   * `sendResponse` wins, and a listener returning `true` keeps the channel
+   * open for an answer that comes later. No listener at all is the "receiving
+   * end does not exist" case, and listeners that all decline to answer close
+   * the channel the way Chrome's message port closes.
+   */
+  const dispatchMessage = (
+    message: unknown,
+    sender: RuntimeProxySender,
+  ): Promise<RuntimeProxySendMessageResult> => {
+    if (messageListeners.size === 0) {
+      return Promise.resolve({ status: "noListener" });
+    }
+
+    return new Promise((resolve) => {
+      let isDone = false;
+
+      let expectsAsyncResponse = false;
+
+      const sendResponse = (response?: unknown) => {
+        if (isDone) {
+          return;
+        }
+
+        isDone = true;
+
+        resolve({ status: "replied", reply: response });
+      };
+
+      for (const listener of messageListeners) {
+        try {
+          if (listener(message, sender, sendResponse) === true) {
+            expectsAsyncResponse = true;
+          }
+        } catch (error) {
+          console.error("[runtime-proxy-relay] onMessage listener threw", error);
+        }
+      }
+
+      if (!isDone && !expectsAsyncResponse) {
+        isDone = true;
+
+        resolve({ status: "closed" });
+      }
+    });
+  };
+
+  const createWorkerPort = (
+    portId: string,
+    name: string | undefined,
+    sender: RuntimeProxySender,
+  ): WorkerPort => {
+    const onMessage = createEvent();
+
+    const onDisconnect = createEvent();
+
+    let isDisconnected = false;
+
+    let sendChain: Promise<unknown> = Promise.resolve();
+
+    const externalPort: Record<string, unknown> = {
+      name: name ?? "",
+      sender,
+      onMessage,
+      onDisconnect,
+      postMessage(message: unknown) {
+        if (isDisconnected) {
+          throw new Error(DISCONNECTED_PORT_ERROR);
+        }
+
+        // Chained so two posts arrive in the order they were written
+        sendChain = sendChain
+          .then(() => postBridge(RUNTIME_PROXY_PATHS.workerPortPost, { portId, message }))
+          .catch(() => undefined);
+      },
+      disconnect() {
+        if (isDisconnected) {
+          return;
+        }
+
+        isDisconnected = true;
+
+        ports.delete(portId);
+
+        void postToBridge(RUNTIME_PROXY_PATHS.workerPortDisconnect, { portId });
+      },
+    };
+
+    return {
+      externalPort,
+      emitMessage(message: unknown) {
+        onMessage.emit(message, externalPort);
+      },
+      emitDisconnect() {
+        if (isDisconnected) {
+          return;
+        }
+
+        isDisconnected = true;
+
+        onDisconnect.emit(externalPort);
+      },
+    };
+  };
+
+  const postReply = (
+    jobId: string,
+    result: RuntimeProxySendMessageResult | RuntimeProxyConnectResult,
+  ) => postToBridge(RUNTIME_PROXY_PATHS.workerReply, { jobId, result });
+
+  const handleJob = (job: RuntimeProxyJob) => {
+    if (typeof job?.jobId !== "string") {
+      return;
+    }
+
+    // Acked first: the relay redelivers a job the worker died before taking,
+    // and the ack is what says this one was taken
+    void postToBridge(RUNTIME_PROXY_PATHS.workerAck, { jobId: job.jobId });
+
+    switch (job.type) {
+      case "sendMessage": {
+        void dispatchMessage(job.message, job.sender).then((result) =>
+          postReply(job.jobId, result),
+        );
+
+        break;
+      }
+
+      case "connect": {
+        if (connectListeners.size === 0) {
+          void postReply(job.jobId, { status: "noListener" });
+
+          break;
+        }
+
+        const port = createWorkerPort(job.portId, job.name, job.sender);
+
+        ports.set(job.portId, port);
+
+        void postReply(job.jobId, { status: "connected" });
+
+        for (const listener of connectListeners) {
+          try {
+            listener(port.externalPort);
+          } catch (error) {
+            console.error("[runtime-proxy-relay] onConnect listener threw", error);
+          }
+        }
+
+        break;
+      }
+
+      case "portMessage": {
+        ports.get(job.portId)?.emitMessage(job.message);
+
+        break;
+      }
+
+      case "portDisconnect": {
+        const port = ports.get(job.portId);
+
+        if (port) {
+          ports.delete(job.portId);
+
+          port.emitDisconnect();
+        }
+
+        break;
+      }
+    }
+  };
+
+  const runJobStream = async () => {
+    while (!isStopped) {
+      try {
+        const response = await postBridge(RUNTIME_PROXY_PATHS.workerJobs, {});
+
+        if (!response.ok || !response.body) {
+          throw new Error(`The runtime proxy bridge answered ${response.status}`);
+        }
+
+        const reader = response.body.getReader();
+
+        const decoder = new NativeMessageDecoder(MAX_RUNTIME_PROXY_FRAME_BYTES);
+
+        for (;;) {
+          const { value, done } = await reader.read();
+
+          if (done) {
+            break;
+          }
+
+          for (const job of decoder.push(value) as RuntimeProxyJob[]) {
+            handleJob(job);
+          }
+        }
+      } catch (error) {
+        console.error("[runtime-proxy-relay] job stream failed", error);
+      }
+
+      if (!isStopped) {
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+      }
+    }
+  };
+
+  return {
+    /**
+     * Wraps `runtime.onMessage` and `runtime.onConnect` of one extension API
+     * object. Called for both `chrome` and `browser` — Electron builds them as
+     * two objects — with the mirrored listeners shared between them.
+     */
+    wrapRuntime(extensionApi: ChromeNamespace) {
+      const runtime = extensionApi.runtime as ChromeNamespace | undefined;
+
+      if (!runtime) {
+        return;
+      }
+
+      mirrorEvent(runtime, "onMessage", messageListeners);
+
+      mirrorEvent(runtime, "onConnect", connectListeners);
+    },
+
+    /** Parks the job stream at the bridge, and keeps it parked. */
+    start() {
+      void runJobStream();
+    },
+
+    stop() {
+      isStopped = true;
+    },
+  };
+}

--- a/packages/electron-extensions/runtime-proxy/relay-client.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.ts
@@ -15,6 +15,13 @@ const DISCONNECTED_PORT_ERROR = "Attempting to use a disconnected port object";
 
 const DEFAULT_RETRY_DELAY_MS = 1000;
 
+/**
+ * How many job ids the client remembers to recognise a redelivery by. Far more
+ * than a stream flap can put in flight at once, and bounded so a worker that
+ * runs for hours does not grow a set for as long as it lives.
+ */
+const MAX_REMEMBERED_JOB_IDS = 1000;
+
 type WorkerPort = {
   externalPort: Record<string, unknown>;
   emitMessage: (message: unknown) => void;
@@ -48,6 +55,8 @@ export function createRelayClient({
   const connectListeners = new Set<ChromeEventListener>();
 
   const ports = new Map<string, WorkerPort>();
+
+  const handledJobIds = new Set<string>();
 
   let isStopped = false;
 
@@ -210,14 +219,44 @@ export function createRelayClient({
     result: RuntimeProxySendMessageResult | RuntimeProxyConnectResult,
   ) => postToBridge(RUNTIME_PROXY_PATHS.workerReply, { jobId, result });
 
+  /**
+   * Whether this job is new here. The relay redelivers anything it has no ack
+   * for, and an ack can go missing on its own — `postToBridge` swallows a
+   * failed POST — so a job this worker already ran can come back. Dispatching
+   * it again would run the extension's listeners a second time, which for
+   * anything that changes state is a double apply rather than a retry.
+   */
+  const isFirstDelivery = (jobId: string) => {
+    if (handledJobIds.has(jobId)) {
+      return false;
+    }
+
+    handledJobIds.add(jobId);
+
+    if (handledJobIds.size > MAX_REMEMBERED_JOB_IDS) {
+      const oldestJobId = handledJobIds.values().next().value;
+
+      if (oldestJobId !== undefined) {
+        handledJobIds.delete(oldestJobId);
+      }
+    }
+
+    return true;
+  };
+
   const handleJob = (job: RuntimeProxyJob) => {
     if (typeof job?.jobId !== "string") {
       return;
     }
 
     // Acked first: the relay redelivers a job the worker died before taking,
-    // and the ack is what says this one was taken
+    // and the ack is what says this one was taken. A redelivery is acked again
+    // rather than ignored, since a lost ack is the reason it came back.
     void postToBridge(RUNTIME_PROXY_PATHS.workerAck, { jobId: job.jobId });
+
+    if (!isFirstDelivery(job.jobId)) {
+      return;
+    }
 
     switch (job.type) {
       case "sendMessage": {

--- a/packages/electron-extensions/runtime-proxy/relay-client.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.ts
@@ -31,6 +31,8 @@ type WorkerPort = {
 export type CreateRelayClientOptions = {
   /** How long a failed job stream waits before it is opened again. */
   retryDelayMs?: number;
+  /** How many handled job ids to remember before forgetting the oldest. */
+  maxRememberedJobIds?: number;
 };
 
 /**
@@ -49,6 +51,7 @@ export type CreateRelayClientOptions = {
  */
 export function createRelayClient({
   retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+  maxRememberedJobIds = MAX_REMEMBERED_JOB_IDS,
 }: CreateRelayClientOptions = {}) {
   const messageListeners = new Set<ChromeEventListener>();
 
@@ -233,7 +236,7 @@ export function createRelayClient({
 
     handledJobIds.add(jobId);
 
-    if (handledJobIds.size > MAX_REMEMBERED_JOB_IDS) {
+    if (handledJobIds.size > maxRememberedJobIds) {
       const oldestJobId = handledJobIds.values().next().value;
 
       if (oldestJobId !== undefined) {

--- a/packages/electron-extensions/runtime-proxy/relay-entry.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-entry.ts
@@ -1,0 +1,23 @@
+import type { ChromeNamespace } from "../facade/lib/chrome";
+import { createRelayClient } from "./relay-client";
+
+/**
+ * Entry point of the runtime proxy's worker-side relay client. It is bundled
+ * on its own and imported by the derived service worker wrapper between the
+ * facade and the extension's own background script, so its wrapped `onMessage`
+ * and `onConnect` are what the extension registers its listeners on. One
+ * client serves both `chrome` and `browser`, sharing one set of listeners.
+ */
+const workerGlobals = globalThis as unknown as Record<string, ChromeNamespace | undefined>;
+
+const relayClient = createRelayClient();
+
+for (const globalName of ["chrome", "browser"]) {
+  const extensionApi = workerGlobals[globalName];
+
+  if (extensionApi) {
+    relayClient.wrapRuntime(extensionApi);
+  }
+}
+
+relayClient.start();

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
@@ -1,0 +1,672 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { Session, WebContents, WebFrameMain } from "electron";
+import { ExtensionBridge } from "../bridge/bridge";
+import { EXTENSION_BRIDGE_ORIGIN } from "../bridge/protocol";
+import { NativeMessageDecoder } from "../native-messaging/framing";
+import {
+  PORT_CLOSED_ERROR,
+  RECEIVING_END_ERROR,
+  RUNTIME_PROXY_PATHS,
+  type RuntimeProxyJob,
+  type RuntimeProxyPortFrame,
+} from "./bridge-protocol";
+import { RuntimeProxy, type RuntimeProxyOptions } from "./runtime-proxy";
+
+const EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
+
+const EXTENSION_SCOPE = `chrome-extension://${EXTENSION_ID}/`;
+
+const WORKER_TOKEN = "worker-token";
+
+const SHIM_TOKEN = "shim-token";
+
+const PAGE_URL = "https://accounts.google.com/signin";
+
+const SENDER_REPORT = { url: PAGE_URL, isTopFrame: true };
+
+async function waitFor(condition: () => boolean, what: string) {
+  const deadline = Date.now() + 1000;
+
+  while (!condition()) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for ${what}`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}
+
+type StatusListener = (details: { versionId: number; runningStatus: string }) => void;
+
+function createFakeSession() {
+  let requestHandler: ((request: GlobalRequest) => Promise<Response>) | undefined;
+
+  const statusListeners = new Set<StatusListener>();
+
+  const scopesByVersionId = new Map<number, string>();
+
+  const workerStarts: string[] = [];
+
+  let failWorkerStart = false;
+
+  const session = {
+    protocol: {
+      handle: (_scheme: string, handler: (request: GlobalRequest) => Promise<Response>) => {
+        requestHandler = handler;
+      },
+      unhandle: () => {
+        requestHandler = undefined;
+      },
+    },
+    serviceWorkers: {
+      on: (_event: string, listener: StatusListener) => {
+        statusListeners.add(listener);
+      },
+      removeListener: (_event: string, listener: StatusListener) => {
+        statusListeners.delete(listener);
+      },
+      getInfoFromVersionID: (versionId: number) => {
+        const scope = scopesByVersionId.get(versionId);
+
+        if (scope === undefined) {
+          throw new Error("Service worker is not running");
+        }
+
+        return { scope };
+      },
+      startWorkerForScope: (scope: string) => {
+        workerStarts.push(scope);
+
+        return failWorkerStart
+          ? Promise.reject(new Error("Failed to start service worker"))
+          : Promise.resolve({});
+      },
+    },
+  } as unknown as Session;
+
+  return {
+    session,
+    workerStarts,
+    setFailWorkerStart: (fail: boolean) => {
+      failWorkerStart = fail;
+    },
+    /** Registers the version's scope and reports the worker running. */
+    reportWorkerRunning: (versionId: number, scope = EXTENSION_SCOPE) => {
+      scopesByVersionId.set(versionId, scope);
+
+      for (const listener of statusListeners) {
+        listener({ versionId, runningStatus: "running" });
+      }
+    },
+    reportWorkerStopping: (versionId: number) => {
+      for (const listener of statusListeners) {
+        listener({ versionId, runningStatus: "stopping" });
+      }
+    },
+    request: (pathName: string, body: Record<string, unknown>) =>
+      requestHandler?.(
+        new Request(`${EXTENSION_BRIDGE_ORIGIN}${pathName}`, {
+          method: "POST",
+          body: JSON.stringify(body),
+        }) as GlobalRequest,
+      ) as Promise<Response>,
+  };
+}
+
+function createPageContents() {
+  const frame = {
+    url: PAGE_URL,
+    frameTreeNodeId: 12,
+    parent: null,
+    isDestroyed: () => false,
+  };
+
+  return {
+    id: 7,
+    isDestroyed: () => false,
+    getURL: () => PAGE_URL,
+    getTitle: () => "Sign in",
+    mainFrame: { framesInSubtree: [frame] } as unknown as WebFrameMain,
+  } as unknown as WebContents;
+}
+
+function createHarness(proxyOptions: RuntimeProxyOptions = {}) {
+  const workerSession = createFakeSession();
+
+  const shimSession = createFakeSession();
+
+  const bridge = new ExtensionBridge();
+
+  bridge.setupSession(workerSession.session, {
+    getExtensionId: (bridgeToken) => (bridgeToken === WORKER_TOKEN ? EXTENSION_ID : undefined),
+  });
+
+  bridge.setupSession(shimSession.session, {
+    getExtensionId: (bridgeToken) => (bridgeToken === SHIM_TOKEN ? EXTENSION_ID : undefined),
+  });
+
+  const proxy = new RuntimeProxy({
+    getTabWebContents: () => [createPageContents()],
+    ...proxyOptions,
+  });
+
+  proxy.registerRoutes(bridge);
+
+  proxy.setWorkerSession(workerSession.session);
+
+  /** Parks a worker job stream the way the relay client does, collecting jobs. */
+  const openWorkerStream = async () => {
+    const response = await workerSession.request(RUNTIME_PROXY_PATHS.workerJobs, {
+      token: WORKER_TOKEN,
+    });
+
+    expect(response.status).toBe(200);
+
+    const jobs: RuntimeProxyJob[] = [];
+
+    let isEnded = false;
+
+    const reader = response.body?.getReader();
+
+    void (async () => {
+      const decoder = new NativeMessageDecoder();
+
+      for (;;) {
+        const result = await reader?.read();
+
+        if (!result || result.done) {
+          isEnded = true;
+
+          return;
+        }
+
+        for (const job of decoder.push(result.value) as RuntimeProxyJob[]) {
+          jobs.push(job);
+        }
+      }
+    })();
+
+    return {
+      jobs,
+      isEnded: () => isEnded,
+      waitForJobs: async (jobCount: number) => {
+        await waitFor(() => jobs.length >= jobCount, `${jobCount} jobs`);
+
+        return jobs;
+      },
+    };
+  };
+
+  const ackJob = (jobId: string) =>
+    workerSession.request(RUNTIME_PROXY_PATHS.workerAck, { token: WORKER_TOKEN, jobId });
+
+  const replyToJob = (jobId: string, result: Record<string, unknown>) =>
+    workerSession.request(RUNTIME_PROXY_PATHS.workerReply, { token: WORKER_TOKEN, jobId, result });
+
+  const sendShimMessage = (message: unknown) =>
+    shimSession.request(RUNTIME_PROXY_PATHS.sendMessage, {
+      token: SHIM_TOKEN,
+      message,
+      sender: SENDER_REPORT,
+    });
+
+  /** Opens a shim port and collects the frames streamed back to it. */
+  const connectShimPort = async (portId: string, name = "relay") => {
+    const response = await shimSession.request(RUNTIME_PROXY_PATHS.connect, {
+      token: SHIM_TOKEN,
+      portId,
+      name,
+      sender: SENDER_REPORT,
+    });
+
+    expect(response.status).toBe(200);
+
+    const frames: RuntimeProxyPortFrame[] = [];
+
+    const reader = response.body?.getReader();
+
+    void (async () => {
+      const decoder = new NativeMessageDecoder();
+
+      for (;;) {
+        const result = await reader?.read();
+
+        if (!result || result.done) {
+          return;
+        }
+
+        for (const frame of decoder.push(result.value) as RuntimeProxyPortFrame[]) {
+          frames.push(frame);
+        }
+      }
+    })();
+
+    return {
+      frames,
+      waitForFrames: async (frameCount: number) => {
+        await waitFor(() => frames.length >= frameCount, `${frameCount} port frames`);
+
+        return frames;
+      },
+    };
+  };
+
+  return {
+    proxy,
+    workerSession,
+    shimSession,
+    openWorkerStream,
+    ackJob,
+    replyToJob,
+    sendShimMessage,
+    connectShimPort,
+  };
+}
+
+describe("RuntimeProxy", () => {
+  test("Electron still ships the experimental APIs the proxy stands on", async () => {
+    // `startWorkerForScope` and `running-status-changed` are marked
+    // experimental on Electron 43. This pin fails the moment an upgrade drops
+    // either, before a runtime ever does.
+    const electronTypes = await readFile(
+      path.join(path.dirname(require.resolve("electron")), "electron.d.ts"),
+      "utf8",
+    );
+
+    expect(electronTypes).toContain("startWorkerForScope(scope: string)");
+    expect(electronTypes).toContain("'running-status-changed'");
+  });
+
+  test("relays a message to the parked stream and its reply back, sender rebuilt", async () => {
+    const harness = createHarness();
+
+    const workerStream = await harness.openWorkerStream();
+
+    const shimResponse = harness.sendShimMessage({ kind: "unlock" });
+
+    const [job] = await workerStream.waitForJobs(1);
+
+    if (job?.type !== "sendMessage") {
+      throw new Error("Expected a sendMessage job");
+    }
+
+    expect(job.message).toEqual({ kind: "unlock" });
+    expect(job.sender.id).toBe(EXTENSION_ID);
+    expect(job.sender.url).toBe(PAGE_URL);
+    expect(job.sender.frameId).toBe(0);
+    expect(job.sender.tab?.id).toBe(7);
+    expect(job.sender.tab?.title).toBe("Sign in");
+
+    await harness.ackJob(job.jobId);
+
+    await harness.replyToJob(job.jobId, { status: "replied", reply: { unlocked: true } });
+
+    const response = await shimResponse;
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: "replied", reply: { unlocked: true } });
+  });
+
+  test("wakes a stopped worker and hands the job to the stream that follows", async () => {
+    const harness = createHarness();
+
+    const shimResponse = harness.sendShimMessage("wake up");
+
+    await waitFor(() => harness.workerSession.workerStarts.length === 1, "the wake");
+
+    expect(harness.workerSession.workerStarts).toEqual([EXTENSION_SCOPE]);
+
+    const workerStream = await harness.openWorkerStream();
+
+    const [job] = await workerStream.waitForJobs(1);
+
+    if (job?.type !== "sendMessage") {
+      throw new Error("Expected a sendMessage job");
+    }
+
+    await harness.ackJob(job.jobId);
+
+    await harness.replyToJob(job.jobId, { status: "replied", reply: "awake" });
+
+    expect(await (await shimResponse).json()).toEqual({ status: "replied", reply: "awake" });
+  });
+
+  test("passes the worker's noListener answer through to the shim", async () => {
+    const harness = createHarness();
+
+    const workerStream = await harness.openWorkerStream();
+
+    const shimResponse = harness.sendShimMessage("anyone there?");
+
+    const [job] = await workerStream.waitForJobs(1);
+
+    if (job?.type !== "sendMessage") {
+      throw new Error("Expected a sendMessage job");
+    }
+
+    await harness.ackJob(job.jobId);
+
+    await harness.replyToJob(job.jobId, { status: "noListener" });
+
+    expect(await (await shimResponse).json()).toEqual({ status: "noListener" });
+  });
+
+  test("a worker stop redelivers the un-acked and fails the acked", async () => {
+    const harness = createHarness();
+
+    harness.workerSession.reportWorkerRunning(1);
+
+    const firstStream = await harness.openWorkerStream();
+
+    const unackedResponse = harness.sendShimMessage("never acked");
+
+    const ackedResponse = harness.sendShimMessage("acked, never answered");
+
+    const [firstJob, secondJob] = await firstStream.waitForJobs(2);
+
+    if (firstJob?.type !== "sendMessage" || secondJob?.type !== "sendMessage") {
+      throw new Error("Expected two sendMessage jobs");
+    }
+
+    await harness.ackJob(secondJob.jobId);
+
+    harness.workerSession.reportWorkerStopping(1);
+
+    // The acked job died with the worker that took it: Chrome's closed port
+    expect(await (await ackedResponse).json()).toEqual({ status: "closed" });
+
+    await waitFor(() => firstStream.isEnded(), "the parked stream to be invalidated");
+
+    // The un-acked job is handed again to the next stream, same job id
+    await waitFor(() => harness.workerSession.workerStarts.length >= 1, "the re-wake");
+
+    const secondStream = await harness.openWorkerStream();
+
+    const [redeliveredJob] = await secondStream.waitForJobs(1);
+
+    if (redeliveredJob?.type !== "sendMessage") {
+      throw new Error("Expected the redelivered sendMessage job");
+    }
+
+    expect(redeliveredJob.jobId).toBe(firstJob.jobId);
+    expect(redeliveredJob.message).toBe("never acked");
+
+    await harness.ackJob(redeliveredJob.jobId);
+
+    await harness.replyToJob(redeliveredJob.jobId, { status: "replied", reply: "finally" });
+
+    expect(await (await unackedResponse).json()).toEqual({ status: "replied", reply: "finally" });
+  });
+
+  test("a job past its delivery attempts fails instead of chasing the worker", async () => {
+    const harness = createHarness({ maxDeliveryAttempts: 1 });
+
+    harness.workerSession.reportWorkerRunning(1);
+
+    const workerStream = await harness.openWorkerStream();
+
+    const shimResponse = harness.sendShimMessage("lost");
+
+    await workerStream.waitForJobs(1);
+
+    harness.workerSession.reportWorkerStopping(1);
+
+    expect(await (await shimResponse).json()).toEqual({ status: "noListener" });
+  });
+
+  test("a failed wake answers every queued job", async () => {
+    const harness = createHarness();
+
+    harness.workerSession.setFailWorkerStart(true);
+
+    const shimResponse = harness.sendShimMessage("no worker to wake");
+
+    expect(await (await shimResponse).json()).toEqual({ status: "noListener" });
+  });
+
+  test("a wake nothing follows times out instead of parking the job forever", async () => {
+    const harness = createHarness({ wakeTimeoutMs: 20 });
+
+    const shimResponse = harness.sendShimMessage("stuck");
+
+    expect(await (await shimResponse).json()).toEqual({ status: "noListener" });
+  });
+
+  test("carries a port both ways: connect, messages, and disconnects", async () => {
+    const harness = createHarness();
+
+    const workerStream = await harness.openWorkerStream();
+
+    const shimPort = await harness.connectShimPort("port-1");
+
+    const [connectJob] = await workerStream.waitForJobs(1);
+
+    if (connectJob?.type !== "connect") {
+      throw new Error("Expected a connect job");
+    }
+
+    expect(connectJob.portId).toBe("port-1");
+    expect(connectJob.name).toBe("relay");
+    expect(connectJob.sender.tab?.id).toBe(7);
+
+    await harness.ackJob(connectJob.jobId);
+
+    await harness.replyToJob(connectJob.jobId, { status: "connected" });
+
+    // Worker to content script
+    await harness.workerSession.request(RUNTIME_PROXY_PATHS.workerPortPost, {
+      token: WORKER_TOKEN,
+      portId: "port-1",
+      message: { locked: false },
+    });
+
+    expect(await shimPort.waitForFrames(1)).toEqual([
+      { type: "message", message: { locked: false } },
+    ]);
+
+    // Content script to worker
+    await harness.shimSession.request(RUNTIME_PROXY_PATHS.portPost, {
+      token: SHIM_TOKEN,
+      portId: "port-1",
+      message: "fill",
+    });
+
+    const [, portMessageJob] = await workerStream.waitForJobs(2);
+
+    expect(portMessageJob).toMatchObject({
+      type: "portMessage",
+      portId: "port-1",
+      message: "fill",
+    });
+
+    // The worker hangs up; the shim hears a clean disconnect
+    await harness.workerSession.request(RUNTIME_PROXY_PATHS.workerPortDisconnect, {
+      token: WORKER_TOKEN,
+      portId: "port-1",
+    });
+
+    expect((await shimPort.waitForFrames(2))[1]).toEqual({ type: "disconnect", error: undefined });
+  });
+
+  test("the shim disconnecting tells the worker", async () => {
+    const harness = createHarness();
+
+    const workerStream = await harness.openWorkerStream();
+
+    await harness.connectShimPort("port-2");
+
+    const [connectJob] = await workerStream.waitForJobs(1);
+
+    if (connectJob?.type !== "connect") {
+      throw new Error("Expected a connect job");
+    }
+
+    await harness.ackJob(connectJob.jobId);
+
+    await harness.replyToJob(connectJob.jobId, { status: "connected" });
+
+    await harness.shimSession.request(RUNTIME_PROXY_PATHS.portDisconnect, {
+      token: SHIM_TOKEN,
+      portId: "port-2",
+    });
+
+    const [, disconnectJob] = await workerStream.waitForJobs(2);
+
+    expect(disconnectJob).toMatchObject({ type: "portDisconnect", portId: "port-2" });
+  });
+
+  test("a connect nothing listens to disconnects with the receiving-end error", async () => {
+    const harness = createHarness();
+
+    const workerStream = await harness.openWorkerStream();
+
+    const shimPort = await harness.connectShimPort("port-3");
+
+    const [connectJob] = await workerStream.waitForJobs(1);
+
+    if (connectJob?.type !== "connect") {
+      throw new Error("Expected a connect job");
+    }
+
+    await harness.ackJob(connectJob.jobId);
+
+    await harness.replyToJob(connectJob.jobId, { status: "noListener" });
+
+    expect(await shimPort.waitForFrames(1)).toEqual([
+      { type: "disconnect", error: RECEIVING_END_ERROR },
+    ]);
+  });
+
+  test("a worker stop disconnects the established ports", async () => {
+    const harness = createHarness();
+
+    harness.workerSession.reportWorkerRunning(1);
+
+    const workerStream = await harness.openWorkerStream();
+
+    const shimPort = await harness.connectShimPort("port-4");
+
+    const [connectJob] = await workerStream.waitForJobs(1);
+
+    if (connectJob?.type !== "connect") {
+      throw new Error("Expected a connect job");
+    }
+
+    await harness.ackJob(connectJob.jobId);
+
+    await harness.replyToJob(connectJob.jobId, { status: "connected" });
+
+    harness.workerSession.reportWorkerStopping(1);
+
+    expect(await shimPort.waitForFrames(1)).toEqual([{ type: "disconnect", error: undefined }]);
+  });
+
+  test("a torn-down shim session closes its ports and tells the worker", async () => {
+    const harness = createHarness();
+
+    const workerStream = await harness.openWorkerStream();
+
+    await harness.connectShimPort("port-5");
+
+    const [connectJob] = await workerStream.waitForJobs(1);
+
+    if (connectJob?.type !== "connect") {
+      throw new Error("Expected a connect job");
+    }
+
+    await harness.ackJob(connectJob.jobId);
+
+    await harness.replyToJob(connectJob.jobId, { status: "connected" });
+
+    harness.proxy.teardownSession(harness.shimSession.session);
+
+    const [, disconnectJob] = await workerStream.waitForJobs(2);
+
+    expect(disconnectJob).toMatchObject({ type: "portDisconnect", portId: "port-5" });
+  });
+
+  test("refuses the worker routes from any other session", async () => {
+    const harness = createHarness();
+
+    expect(
+      (await harness.shimSession.request(RUNTIME_PROXY_PATHS.workerJobs, { token: SHIM_TOKEN }))
+        .status,
+    ).toBe(403);
+
+    expect(
+      (
+        await harness.shimSession.request(RUNTIME_PROXY_PATHS.workerAck, {
+          token: SHIM_TOKEN,
+          jobId: "guessed",
+        })
+      ).status,
+    ).toBe(403);
+
+    expect(
+      (
+        await harness.shimSession.request(RUNTIME_PROXY_PATHS.workerReply, {
+          token: SHIM_TOKEN,
+          jobId: "guessed",
+          result: { status: "replied", reply: "spoofed" },
+        })
+      ).status,
+    ).toBe(403);
+  });
+
+  test("refuses the shim routes from the worker session, whose messaging is native", async () => {
+    const harness = createHarness();
+
+    expect(
+      (
+        await harness.workerSession.request(RUNTIME_PROXY_PATHS.sendMessage, {
+          token: WORKER_TOKEN,
+          message: "loop",
+          sender: SENDER_REPORT,
+        })
+      ).status,
+    ).toBe(400);
+  });
+
+  test("a fresh worker stream takes over from the stale one", async () => {
+    const harness = createHarness();
+
+    const staleStream = await harness.openWorkerStream();
+
+    const freshStream = await harness.openWorkerStream();
+
+    await waitFor(() => staleStream.isEnded(), "the stale stream to end");
+
+    const shimResponse = harness.sendShimMessage("to the fresh stream");
+
+    const [job] = await freshStream.waitForJobs(1);
+
+    if (job?.type !== "sendMessage") {
+      throw new Error("Expected a sendMessage job");
+    }
+
+    await harness.ackJob(job.jobId);
+
+    await harness.replyToJob(job.jobId, { status: "replied", reply: "heard" });
+
+    expect(await (await shimResponse).json()).toEqual({ status: "replied", reply: "heard" });
+  });
+
+  test("the worker session going away answers shims like a missing receiving end", async () => {
+    const harness = createHarness();
+
+    harness.proxy.teardownSession(harness.workerSession.session);
+
+    const shimResponse = await harness.sendShimMessage("anyone?");
+
+    expect(await shimResponse.json()).toEqual({ status: "noListener" });
+  });
+});
+
+// The shim maps the relay's failure statuses onto Chrome's error strings; the
+// exact words are contractual, so a drift fails here rather than in 1Password
+test("the failure statuses map to Chrome's own words", () => {
+  expect(RECEIVING_END_ERROR).toBe("Could not establish connection. Receiving end does not exist.");
+  expect(PORT_CLOSED_ERROR).toBe("The message port closed before a response was received.");
+});

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
@@ -400,6 +400,63 @@ describe("RuntimeProxy", () => {
     expect(await (await unackedResponse).json()).toEqual({ status: "replied", reply: "finally" });
   });
 
+  /*
+   * A worker that crashes, is killed, or is taken by the out-of-memory killer
+   * may never make its session report it stopped, and the request's own abort
+   * signal never fires — so without a backstop the job stays in flight and the
+   * shim's `sendMessage`, whose response is held open until the job settles,
+   * neither resolves nor rejects.
+   */
+  test("a worker that dies without a word ends its acked job as a closed port", async () => {
+    const harness = createHarness({ inFlightTimeoutMs: 20 });
+
+    const workerStream = await harness.openWorkerStream();
+
+    const shimResponse = harness.sendShimMessage({ kind: "unlock" });
+
+    const [job] = await workerStream.waitForJobs(1);
+
+    await harness.ackJob(job?.jobId as string);
+
+    // Nothing more from the worker: no reply, and no stopping event either
+    const response = await shimResponse;
+
+    expect(await response.json()).toEqual({ status: "closed" });
+  });
+
+  test("a job the worker never acked ends as a missing receiving end", async () => {
+    const harness = createHarness({ inFlightTimeoutMs: 20 });
+
+    const workerStream = await harness.openWorkerStream();
+
+    const shimResponse = harness.sendShimMessage({ kind: "unlock" });
+
+    await workerStream.waitForJobs(1);
+
+    const response = await shimResponse;
+
+    expect(await response.json()).toEqual({ status: "noListener" });
+  });
+
+  test("a worker that answers in time is not cut off by the backstop", async () => {
+    const harness = createHarness({ inFlightTimeoutMs: 50 });
+
+    const workerStream = await harness.openWorkerStream();
+
+    const shimResponse = harness.sendShimMessage({ kind: "unlock" });
+
+    const [job] = await workerStream.waitForJobs(1);
+
+    await harness.ackJob(job?.jobId as string);
+
+    await harness.replyToJob(job?.jobId as string, { status: "replied", reply: "unlocked" });
+
+    expect(await (await shimResponse).json()).toEqual({ status: "replied", reply: "unlocked" });
+
+    // Long enough that a timer left running would have fired by now
+    await new Promise((resolve) => setTimeout(resolve, 80));
+  });
+
   test("a job past its delivery attempts fails instead of chasing the worker", async () => {
     const harness = createHarness({ maxDeliveryAttempts: 1 });
 

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
@@ -452,9 +452,6 @@ describe("RuntimeProxy", () => {
     await harness.replyToJob(job?.jobId as string, { status: "replied", reply: "unlocked" });
 
     expect(await (await shimResponse).json()).toEqual({ status: "replied", reply: "unlocked" });
-
-    // Long enough that a timer left running would have fired by now
-    await new Promise((resolve) => setTimeout(resolve, 80));
   });
 
   test("a job past its delivery attempts fails instead of chasing the worker", async () => {

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import type { Session, WebContents, WebFrameMain } from "electron";
+import type {
+  OnBeforeSendHeadersListenerDetails,
+  Session,
+  WebContents,
+  WebFrameMain,
+} from "electron";
 import { ExtensionBridge } from "../bridge/bridge";
 import { EXTENSION_BRIDGE_ORIGIN } from "../bridge/protocol";
 import { NativeMessageDecoder } from "../native-messaging/framing";
@@ -40,8 +45,15 @@ async function waitFor(condition: () => boolean, what: string) {
 
 type StatusListener = (details: { versionId: number; runningStatus: string }) => void;
 
+type BeforeSendHeadersListener = (
+  details: OnBeforeSendHeadersListenerDetails,
+  callback: (response: { requestHeaders?: Record<string, string> }) => void,
+) => void;
+
 function createFakeSession() {
   let requestHandler: ((request: GlobalRequest) => Promise<Response>) | undefined;
+
+  let beforeSendHeadersListener: BeforeSendHeadersListener | null = null;
 
   const statusListeners = new Set<StatusListener>();
 
@@ -58,6 +70,17 @@ function createFakeSession() {
       },
       unhandle: () => {
         requestHandler = undefined;
+      },
+    },
+    webRequest: {
+      onBeforeSendHeaders: (
+        filterOrListener: unknown,
+        maybeListener?: BeforeSendHeadersListener | null,
+      ) => {
+        beforeSendHeadersListener =
+          maybeListener === undefined
+            ? (filterOrListener as BeforeSendHeadersListener | null)
+            : maybeListener;
       },
     },
     serviceWorkers: {
@@ -105,31 +128,55 @@ function createFakeSession() {
         listener({ versionId, runningStatus: "stopping" });
       }
     },
-    request: (pathName: string, body: Record<string, unknown>) =>
-      requestHandler?.(
-        new Request(`${EXTENSION_BRIDGE_ORIGIN}${pathName}`, {
+    /**
+     * Sends a request the way Electron carries one: the bridge's headers
+     * listener runs first — recording `callerFrame` when the request has one,
+     * the way Chromium names a fetch's initiator — and the handler receives
+     * the request with whatever the listener stamped on it.
+     */
+    request: (pathName: string, body: Record<string, unknown>, callerFrame?: WebFrameMain) => {
+      const url = `${EXTENSION_BRIDGE_ORIGIN}${pathName}`;
+
+      let requestHeaders: Record<string, string> = {};
+
+      beforeSendHeadersListener?.(
+        { url, frame: callerFrame ?? null, requestHeaders } as OnBeforeSendHeadersListenerDetails,
+        ({ requestHeaders: stampedHeaders }) => {
+          if (stampedHeaders) {
+            requestHeaders = stampedHeaders;
+          }
+        },
+      );
+
+      return requestHandler?.(
+        new Request(url, {
           method: "POST",
+          headers: requestHeaders,
           body: JSON.stringify(body),
         }) as GlobalRequest,
-      ) as Promise<Response>,
+      ) as Promise<Response>;
+    },
   };
 }
 
-function createPageContents() {
+/** A page of the shim's session, its frame and the tab hosting it. */
+function createPage(shimSession: Session, contentsId = 7, url = PAGE_URL) {
   const frame = {
-    url: PAGE_URL,
+    url,
     frameTreeNodeId: 12,
     parent: null,
     isDestroyed: () => false,
-  };
+  } as unknown as WebFrameMain;
 
-  return {
-    id: 7,
+  const contents = {
+    id: contentsId,
+    session: shimSession,
     isDestroyed: () => false,
-    getURL: () => PAGE_URL,
+    getURL: () => url,
     getTitle: () => "Sign in",
-    mainFrame: { framesInSubtree: [frame] } as unknown as WebFrameMain,
   } as unknown as WebContents;
+
+  return { frame, contents };
 }
 
 function createHarness(proxyOptions: RuntimeProxyOptions = {}) {
@@ -147,8 +194,17 @@ function createHarness(proxyOptions: RuntimeProxyOptions = {}) {
     getExtensionId: (bridgeToken) => (bridgeToken === SHIM_TOKEN ? EXTENSION_ID : undefined),
   });
 
+  const page = createPage(shimSession.session);
+
+  const secondPage = createPage(shimSession.session, 8);
+
+  const contentsByFrame = new Map([
+    [page.frame, page.contents],
+    [secondPage.frame, secondPage.contents],
+  ]);
+
   const proxy = new RuntimeProxy({
-    getTabWebContents: () => [createPageContents()],
+    getWebContentsFromFrame: (frame) => contentsByFrame.get(frame),
     ...proxyOptions,
   });
 
@@ -205,21 +261,30 @@ function createHarness(proxyOptions: RuntimeProxyOptions = {}) {
   const replyToJob = (jobId: string, result: Record<string, unknown>) =>
     workerSession.request(RUNTIME_PROXY_PATHS.workerReply, { token: WORKER_TOKEN, jobId, result });
 
-  const sendShimMessage = (message: unknown) =>
-    shimSession.request(RUNTIME_PROXY_PATHS.sendMessage, {
-      token: SHIM_TOKEN,
-      message,
-      sender: SENDER_REPORT,
-    });
+  /** `null` sends the way a frameless caller would; omitted, the page calls. */
+  const sendShimMessage = (message: unknown, callerFrame: WebFrameMain | null = page.frame) =>
+    shimSession.request(
+      RUNTIME_PROXY_PATHS.sendMessage,
+      {
+        token: SHIM_TOKEN,
+        message,
+        sender: SENDER_REPORT,
+      },
+      callerFrame ?? undefined,
+    );
 
   /** Opens a shim port and collects the frames streamed back to it. */
   const connectShimPort = async (portId: string, name = "relay") => {
-    const response = await shimSession.request(RUNTIME_PROXY_PATHS.connect, {
-      token: SHIM_TOKEN,
-      portId,
-      name,
-      sender: SENDER_REPORT,
-    });
+    const response = await shimSession.request(
+      RUNTIME_PROXY_PATHS.connect,
+      {
+        token: SHIM_TOKEN,
+        portId,
+        name,
+        sender: SENDER_REPORT,
+      },
+      page.frame,
+    );
 
     expect(response.status).toBe(200);
 
@@ -257,6 +322,8 @@ function createHarness(proxyOptions: RuntimeProxyOptions = {}) {
     proxy,
     workerSession,
     shimSession,
+    page,
+    secondPage,
     openWorkerStream,
     ackJob,
     replyToJob,
@@ -307,6 +374,53 @@ describe("RuntimeProxy", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ status: "replied", reply: { unlocked: true } });
+  });
+
+  test("two tabs on one URL: the sender is the tab that called, not the first match", async () => {
+    const harness = createHarness();
+
+    const workerStream = await harness.openWorkerStream();
+
+    // Both pages sit at PAGE_URL; the message goes out from the second one
+    const shimResponse = harness.sendShimMessage("which tab am I?", harness.secondPage.frame);
+
+    const [job] = await workerStream.waitForJobs(1);
+
+    if (job?.type !== "sendMessage") {
+      throw new Error("Expected a sendMessage job");
+    }
+
+    expect(job.sender.tab?.id).toBe(8);
+
+    await harness.ackJob(job.jobId);
+
+    await harness.replyToJob(job.jobId, { status: "replied" });
+
+    await shimResponse;
+  });
+
+  test("a report the caller's own frame does not back delivers the id alone", async () => {
+    const harness = createHarness();
+
+    const workerStream = await harness.openWorkerStream();
+
+    // The stamped caller is a service worker's frameless request, so nothing
+    // the report claims has backing
+    const shimResponse = harness.sendShimMessage("trust me", null);
+
+    const [job] = await workerStream.waitForJobs(1);
+
+    if (job?.type !== "sendMessage") {
+      throw new Error("Expected a sendMessage job");
+    }
+
+    expect(job.sender).toEqual({ id: EXTENSION_ID });
+
+    await harness.ackJob(job.jobId);
+
+    await harness.replyToJob(job.jobId, { status: "replied" });
+
+    await shimResponse;
   });
 
   test("wakes a stopped worker and hands the job to the stream that follows", async () => {

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
@@ -584,14 +584,44 @@ describe("RuntimeProxy", () => {
     expect(await (await shimResponse).json()).toEqual({ status: "noListener" });
   });
 
-  test("a failed wake answers every queued job", async () => {
+  test("a wake that fails before the first registration hands its jobs to the worker that arrives", async () => {
     const harness = createHarness();
 
+    // Chromium rejects `startWorkerForScope` while the scope has no stored
+    // registration — the app's first moments, before the worker session has
+    // finished loading its copy of the extension
     harness.workerSession.setFailWorkerStart(true);
+
+    const shimResponse = harness.sendShimMessage("sent before the worker registered");
+
+    await waitFor(() => harness.workerSession.workerStarts.length === 1, "the wake attempt");
+
+    // The freshly registered worker parks its stream, exactly as the relay
+    // client does on its first start, and the job is waiting for it
+    const workerStream = await harness.openWorkerStream();
+
+    const [job] = await workerStream.waitForJobs(1);
+
+    await harness.ackJob(job?.jobId as string);
+
+    await harness.replyToJob(job?.jobId as string, { status: "replied", reply: "made it" });
+
+    expect(await (await shimResponse).json()).toEqual({ status: "replied", reply: "made it" });
+  });
+
+  test("a failed wake nothing follows still answers every queued job, one timeout later", async () => {
+    const harness = createHarness({ wakeTimeoutMs: 20 });
+
+    harness.workerSession.setFailWorkerStart(true);
+
+    const startedAt = Date.now();
 
     const shimResponse = harness.sendShimMessage("no worker to wake");
 
     expect(await (await shimResponse).json()).toEqual({ status: "noListener" });
+
+    // The bounded wait, not the instant refusal that raced real launches
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(15);
   });
 
   test("a wake nothing follows times out instead of parking the job forever", async () => {

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
@@ -4,6 +4,7 @@ import type { ExtensionBridge } from "../bridge/bridge";
 import type { ExtensionsLogger } from "../logger";
 import { encodeNativeMessage } from "../native-messaging/framing";
 import {
+  EXTENSION_SCHEME_PREFIX,
   PORT_CLOSED_ERROR,
   RECEIVING_END_ERROR,
   RUNTIME_PROXY_PATHS,
@@ -22,8 +23,6 @@ import {
   type RuntimeProxyWorkerReplyRequest,
 } from "./bridge-protocol";
 import { parseSenderReport, reconstructSender, type RuntimeProxyTabsProvider } from "./sender";
-
-const EXTENSION_SCHEME_PREFIX = "chrome-extension://";
 
 type RelayJobBase = {
   jobId: string;
@@ -103,8 +102,8 @@ const DEFAULT_MAX_DELIVERY_ATTEMPTS = 3;
 
 /**
  * The main-process relay carrying `chrome.runtime` messaging between
- * content-script-only sessions and the one session that keeps an extension's
- * service worker.
+ * content-script-only sessions — their content scripts and their extension
+ * pages alike — and the one session that keeps an extension's service worker.
  *
  * The shim's calls arrive as bridge requests; jobs flow to the worker on a
  * streaming response its relay client keeps parked, and replies come back as

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
@@ -1,0 +1,874 @@
+import { randomUUID } from "node:crypto";
+import type { Session } from "electron";
+import type { ExtensionBridge } from "../bridge/bridge";
+import type { ExtensionsLogger } from "../logger";
+import { encodeNativeMessage } from "../native-messaging/framing";
+import {
+  PORT_CLOSED_ERROR,
+  RECEIVING_END_ERROR,
+  RUNTIME_PROXY_PATHS,
+  type RuntimeProxyConnectRequest,
+  type RuntimeProxyConnectResult,
+  type RuntimeProxyJob,
+  type RuntimeProxyPortDisconnectRequest,
+  type RuntimeProxyPortFrame,
+  type RuntimeProxyPortPostRequest,
+  type RuntimeProxySender,
+  type RuntimeProxySendMessageRequest,
+  type RuntimeProxySendMessageResult,
+  type RuntimeProxyWorkerAckRequest,
+  type RuntimeProxyWorkerPortDisconnectRequest,
+  type RuntimeProxyWorkerPortPostRequest,
+  type RuntimeProxyWorkerReplyRequest,
+} from "./bridge-protocol";
+import { parseSenderReport, reconstructSender, type RuntimeProxyTabsProvider } from "./sender";
+
+const EXTENSION_SCHEME_PREFIX = "chrome-extension://";
+
+type RelayJobBase = {
+  jobId: string;
+  extensionId: string;
+  /** The session whose shim asked, for tearing its jobs down with it. */
+  shimSession: Session;
+  /** How often the job has been handed to a stream, bounding redelivery. */
+  attempts: number;
+  state: "queued" | "handed" | "acked";
+};
+
+type SendMessageJob = RelayJobBase & {
+  kind: "sendMessage";
+  message: unknown;
+  sender: RuntimeProxySender;
+  settle: (result: RuntimeProxySendMessageResult) => void;
+  isSettled: boolean;
+};
+
+type ConnectJob = RelayJobBase & {
+  kind: "connect";
+  portId: string;
+  name: string | undefined;
+  sender: RuntimeProxySender;
+};
+
+type PortMessageJob = RelayJobBase & {
+  kind: "portMessage";
+  portId: string;
+  message: unknown;
+};
+
+type PortDisconnectJob = RelayJobBase & {
+  kind: "portDisconnect";
+  portId: string;
+};
+
+type RelayJob = SendMessageJob | ConnectJob | PortMessageJob | PortDisconnectJob;
+
+type WorkerStream = {
+  extensionId: string;
+  controller: ReadableStreamDefaultController<Uint8Array>;
+  isClosed: boolean;
+};
+
+type ProxyPort = {
+  id: string;
+  extensionId: string;
+  shimSession: Session;
+  controller: ReadableStreamDefaultController<Uint8Array>;
+  isClosed: boolean;
+};
+
+type Wake = {
+  timer: ReturnType<typeof setTimeout> | undefined;
+};
+
+export type RuntimeProxyOptions = {
+  logger?: ExtensionsLogger;
+  /** How a session's tabs are enumerated for sender reconstruction. */
+  getTabWebContents?: RuntimeProxyTabsProvider;
+  /**
+   * How long jobs queued behind a worker wake wait for the woken worker's job
+   * stream before they fail the way a missing receiving end does.
+   */
+  wakeTimeoutMs?: number;
+  /**
+   * How often an un-acked job is handed to a fresh stream before it fails
+   * rather than chase a worker that takes jobs without ever acking them.
+   */
+  maxDeliveryAttempts?: number;
+};
+
+const DEFAULT_WAKE_TIMEOUT_MS = 10_000;
+
+const DEFAULT_MAX_DELIVERY_ATTEMPTS = 3;
+
+/**
+ * The main-process relay carrying `chrome.runtime` messaging between
+ * content-script-only sessions and the one session that keeps an extension's
+ * service worker.
+ *
+ * The shim's calls arrive as bridge requests; jobs flow to the worker on a
+ * streaming response its relay client keeps parked, and replies come back as
+ * bridge requests of the worker's own. Delivery is bookkept rather than
+ * assumed, because a `protocol.handle` request's abort signal never fires when
+ * the worker behind it is killed (measured 2026-08-25): a parked stream from a
+ * dead worker looks live forever, so streams are invalidated from the session's
+ * `running-status-changed` events, every handed job is acked by id, and an
+ * un-acked job is handed again to the next stream while an acked one that lost
+ * its worker fails the way Chrome's closed message port does. A stopped worker
+ * is woken with `startWorkerForScope` the moment a job needs it.
+ */
+export class RuntimeProxy {
+  private logger: ExtensionsLogger | undefined;
+
+  private getTabWebContents: RuntimeProxyTabsProvider | undefined;
+
+  private wakeTimeoutMs: number;
+
+  private maxDeliveryAttempts: number;
+
+  private workerSession: Session | undefined;
+
+  private removeWorkerSessionListener: (() => void) | undefined;
+
+  /** Scopes seen starting, the only way to name a worker once it is stopping. */
+  private scopesByVersionId = new Map<number, string>();
+
+  private workerStreams = new Map<string, WorkerStream>();
+
+  private queuedJobs = new Map<string, RelayJob[]>();
+
+  private inFlightJobs = new Map<string, RelayJob>();
+
+  private ports = new Map<string, ProxyPort>();
+
+  private wakes = new Map<string, Wake>();
+
+  constructor({
+    logger,
+    getTabWebContents,
+    wakeTimeoutMs = DEFAULT_WAKE_TIMEOUT_MS,
+    maxDeliveryAttempts = DEFAULT_MAX_DELIVERY_ATTEMPTS,
+  }: RuntimeProxyOptions = {}) {
+    this.logger = logger;
+
+    this.getTabWebContents = getTabWebContents;
+
+    this.wakeTimeoutMs = wakeTimeoutMs;
+
+    this.maxDeliveryAttempts = maxDeliveryAttempts;
+  }
+
+  registerRoutes(bridge: ExtensionBridge) {
+    bridge.handle(RUNTIME_PROXY_PATHS.sendMessage, ({ session, extensionId, body, headers }) =>
+      this.handleSendMessage(session, extensionId, body, headers),
+    );
+
+    bridge.handle(RUNTIME_PROXY_PATHS.connect, ({ session, extensionId, body, headers }) =>
+      this.handleConnect(session, extensionId, body, headers),
+    );
+
+    bridge.handle(RUNTIME_PROXY_PATHS.portPost, ({ session, extensionId, body, headers }) => {
+      const { portId, message } = body as unknown as RuntimeProxyPortPostRequest;
+
+      const port = this.getShimPort(session, extensionId, portId);
+
+      if (port) {
+        this.enqueueJob(
+          this.createJob(port.shimSession, extensionId, "portMessage", { portId, message }),
+        );
+      }
+
+      return new Response(null, { status: 204, headers });
+    });
+
+    bridge.handle(RUNTIME_PROXY_PATHS.portDisconnect, ({ session, extensionId, body, headers }) => {
+      const { portId } = body as unknown as RuntimeProxyPortDisconnectRequest;
+
+      const port = this.getShimPort(session, extensionId, portId);
+
+      if (port) {
+        this.closeShimPort(port, { notifyWorker: true });
+      }
+
+      return new Response(null, { status: 204, headers });
+    });
+
+    bridge.handle(RUNTIME_PROXY_PATHS.workerJobs, ({ session, extensionId, headers }) =>
+      this.handleWorkerJobs(session, extensionId, headers),
+    );
+
+    bridge.handle(RUNTIME_PROXY_PATHS.workerAck, ({ session, body, headers }) => {
+      if (session === this.workerSession) {
+        this.handleWorkerAck((body as unknown as RuntimeProxyWorkerAckRequest).jobId);
+      }
+
+      return new Response(null, { status: session === this.workerSession ? 204 : 403, headers });
+    });
+
+    bridge.handle(RUNTIME_PROXY_PATHS.workerReply, ({ session, body, headers }) => {
+      if (session === this.workerSession) {
+        this.handleWorkerReply(body as unknown as RuntimeProxyWorkerReplyRequest);
+      }
+
+      return new Response(null, { status: session === this.workerSession ? 204 : 403, headers });
+    });
+
+    bridge.handle(RUNTIME_PROXY_PATHS.workerPortPost, ({ session, extensionId, body, headers }) => {
+      const { portId, message } = body as unknown as RuntimeProxyWorkerPortPostRequest;
+
+      if (session === this.workerSession) {
+        const port = this.ports.get(portId);
+
+        if (port && !port.isClosed && port.extensionId === extensionId) {
+          this.sendPortFrame(port, { type: "message", message });
+        }
+      }
+
+      return new Response(null, { status: session === this.workerSession ? 204 : 403, headers });
+    });
+
+    bridge.handle(
+      RUNTIME_PROXY_PATHS.workerPortDisconnect,
+      ({ session, extensionId, body, headers }) => {
+        const { portId } = body as unknown as RuntimeProxyWorkerPortDisconnectRequest;
+
+        if (session === this.workerSession) {
+          const port = this.ports.get(portId);
+
+          if (port && port.extensionId === extensionId) {
+            // The worker hung up on purpose, which Chrome reports without error
+            this.closeShimPort(port, { notifyWorker: false });
+          }
+        }
+
+        return new Response(null, { status: session === this.workerSession ? 204 : 403, headers });
+      },
+    );
+  }
+
+  /**
+   * The session that keeps the workers. Its `running-status-changed` events are
+   * what invalidate parked job streams, since nothing else says a worker died.
+   */
+  setWorkerSession(session: Session) {
+    this.removeWorkerSessionListener?.();
+
+    this.workerSession = session;
+
+    const statusListener = (details: { versionId: number; runningStatus: string }) => {
+      this.handleRunningStatusChanged(details.versionId, details.runningStatus);
+    };
+
+    session.serviceWorkers.on("running-status-changed", statusListener);
+
+    this.removeWorkerSessionListener = () => {
+      session.serviceWorkers.removeListener("running-status-changed", statusListener);
+
+      this.removeWorkerSessionListener = undefined;
+    };
+  }
+
+  teardownSession(session: Session) {
+    if (session === this.workerSession) {
+      this.removeWorkerSessionListener?.();
+
+      this.workerSession = undefined;
+
+      for (const extensionId of this.workerStreams.keys()) {
+        this.invalidateWorkerStream(extensionId);
+      }
+
+      for (const extensionId of this.queuedJobs.keys()) {
+        this.failQueuedJobs(extensionId, "noListener");
+      }
+
+      return;
+    }
+
+    for (const port of this.ports.values()) {
+      if (port.shimSession === session) {
+        this.closeShimPort(port, { notifyWorker: true });
+      }
+    }
+
+    for (const [extensionId, queue] of this.queuedJobs) {
+      const keptJobs = queue.filter((job) => job.shimSession !== session);
+
+      for (const job of queue) {
+        if (job.shimSession === session) {
+          this.failJob(job, "closed");
+        }
+      }
+
+      this.queuedJobs.set(extensionId, keptJobs);
+    }
+  }
+
+  private async handleSendMessage(
+    session: Session,
+    extensionId: string,
+    body: Record<string, unknown>,
+    headers: Record<string, string>,
+  ) {
+    const request = body as unknown as RuntimeProxySendMessageRequest;
+
+    const report = parseSenderReport(request.sender);
+
+    if (!report || session === this.workerSession) {
+      return new Response(null, { status: 400, headers });
+    }
+
+    const result = await new Promise<RuntimeProxySendMessageResult>((resolve) => {
+      const job = this.createJob(session, extensionId, "sendMessage", {
+        message: request.message,
+        sender: this.reconstructSender(session, extensionId, report),
+        settle: resolve,
+        isSettled: false,
+      });
+
+      this.enqueueJob(job);
+    });
+
+    return Response.json(result, { headers });
+  }
+
+  private handleConnect(
+    session: Session,
+    extensionId: string,
+    body: Record<string, unknown>,
+    headers: Record<string, string>,
+  ) {
+    const request = body as unknown as RuntimeProxyConnectRequest;
+
+    const report = parseSenderReport(request.sender);
+
+    if (
+      !report ||
+      typeof request.portId !== "string" ||
+      this.ports.has(request.portId) ||
+      session === this.workerSession
+    ) {
+      return new Response(null, { status: 400, headers });
+    }
+
+    let port: ProxyPort | undefined;
+
+    const stream = new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        port = {
+          id: request.portId,
+          extensionId,
+          shimSession: session,
+          controller,
+          isClosed: false,
+        };
+
+        this.ports.set(port.id, port);
+      },
+      cancel: () => {
+        // The content script's context went away with its page
+        if (port) {
+          this.closeShimPort(port, { notifyWorker: true });
+        }
+      },
+    });
+
+    this.enqueueJob(
+      this.createJob(session, extensionId, "connect", {
+        portId: request.portId,
+        name: typeof request.name === "string" ? request.name : undefined,
+        sender: this.reconstructSender(session, extensionId, report),
+      }),
+    );
+
+    return new Response(stream, {
+      headers: { ...headers, "content-type": "application/octet-stream" },
+    });
+  }
+
+  private handleWorkerJobs(session: Session, extensionId: string, headers: Record<string, string>) {
+    if (!this.workerSession || session !== this.workerSession) {
+      return new Response(null, { status: 403, headers });
+    }
+
+    // Whatever stream was parked belongs to a worker that is gone — a fresh
+    // worker opens a fresh stream — so its jobs and ports are settled first
+    if (this.workerStreams.has(extensionId)) {
+      this.invalidateWorkerStream(extensionId);
+    }
+
+    const stream = new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        this.workerStreams.set(extensionId, { extensionId, controller, isClosed: false });
+      },
+    });
+
+    this.clearWake(extensionId);
+
+    this.flushQueuedJobs(extensionId);
+
+    return new Response(stream, {
+      headers: { ...headers, "content-type": "application/octet-stream" },
+    });
+  }
+
+  private handleWorkerAck(jobId: string) {
+    const job = this.inFlightJobs.get(typeof jobId === "string" ? jobId : "");
+
+    if (!job || job.state !== "handed") {
+      return;
+    }
+
+    job.state = "acked";
+
+    // Nothing more comes back for these; the ack is the end of their story
+    if (job.kind === "portMessage" || job.kind === "portDisconnect") {
+      this.inFlightJobs.delete(job.jobId);
+    }
+  }
+
+  private handleWorkerReply({ jobId, result }: RuntimeProxyWorkerReplyRequest) {
+    const job = this.inFlightJobs.get(typeof jobId === "string" ? jobId : "");
+
+    if (!job) {
+      return;
+    }
+
+    this.inFlightJobs.delete(job.jobId);
+
+    if (job.kind === "sendMessage") {
+      const sendMessageResult = result as RuntimeProxySendMessageResult;
+
+      this.settleSendMessage(
+        job,
+        sendMessageResult?.status === "replied" || sendMessageResult?.status === "noListener"
+          ? sendMessageResult
+          : { status: "closed" },
+      );
+
+      return;
+    }
+
+    if (job.kind === "connect") {
+      const connectResult = result as RuntimeProxyConnectResult;
+
+      if (connectResult?.status !== "connected") {
+        const port = this.ports.get(job.portId);
+
+        if (port) {
+          this.closeShimPort(port, { notifyWorker: false, error: RECEIVING_END_ERROR });
+        }
+      }
+    }
+  }
+
+  private handleRunningStatusChanged(versionId: number, runningStatus: string) {
+    if (!this.workerSession) {
+      return;
+    }
+
+    if (runningStatus === "starting" || runningStatus === "running") {
+      try {
+        const { scope } = this.workerSession.serviceWorkers.getInfoFromVersionID(versionId);
+
+        this.scopesByVersionId.set(versionId, scope);
+      } catch {
+        // A worker gone again before it was asked about names no stream
+      }
+
+      return;
+    }
+
+    if (runningStatus !== "stopping" && runningStatus !== "stopped") {
+      return;
+    }
+
+    const scope = this.scopesByVersionId.get(versionId);
+
+    if (runningStatus === "stopped") {
+      this.scopesByVersionId.delete(versionId);
+    }
+
+    if (scope?.startsWith(EXTENSION_SCHEME_PREFIX)) {
+      const extensionId = scope.slice(EXTENSION_SCHEME_PREFIX.length).replace(/\/.*$/, "");
+
+      this.invalidateWorkerStream(extensionId);
+
+      return;
+    }
+
+    // A stop that cannot be pinned to a scope invalidates every stream: a live
+    // worker's relay client parks a fresh one right away, and jobs are redelivered
+    for (const extensionId of this.workerStreams.keys()) {
+      this.invalidateWorkerStream(extensionId);
+    }
+  }
+
+  /**
+   * Settles everything the stream owed. Un-acked jobs may never have reached
+   * the worker and are handed to the next stream; acked ones died with the
+   * worker that took them, which for a message awaiting its reply is Chrome's
+   * closed message port. The worker's ports died with it too, except ports
+   * whose connect is queued again and so will be opened anew.
+   */
+  private invalidateWorkerStream(extensionId: string) {
+    const stream = this.workerStreams.get(extensionId);
+
+    if (stream) {
+      this.workerStreams.delete(extensionId);
+
+      stream.isClosed = true;
+
+      try {
+        stream.controller.close();
+      } catch {
+        // The stream is already gone when the worker's side canceled it
+      }
+    }
+
+    for (const job of this.inFlightJobs.values()) {
+      if (job.extensionId !== extensionId) {
+        continue;
+      }
+
+      this.inFlightJobs.delete(job.jobId);
+
+      if (job.state === "acked") {
+        this.failJob(job, "closed");
+
+        continue;
+      }
+
+      if (job.attempts >= this.maxDeliveryAttempts) {
+        this.failJob(job, "noListener");
+
+        continue;
+      }
+
+      job.state = "queued";
+
+      this.queue(extensionId).push(job);
+    }
+
+    const requeuedConnectPortIds = new Set(
+      this.queue(extensionId)
+        .filter((job) => job.kind === "connect")
+        .map((job) => (job as ConnectJob).portId),
+    );
+
+    for (const port of this.ports.values()) {
+      if (port.extensionId === extensionId && !requeuedConnectPortIds.has(port.id)) {
+        this.closeShimPort(port, { notifyWorker: false });
+      }
+    }
+
+    if (this.queue(extensionId).length > 0) {
+      this.ensureDelivery(extensionId);
+    }
+  }
+
+  private createJob<Kind extends RelayJob["kind"]>(
+    shimSession: Session,
+    extensionId: string,
+    kind: Kind,
+    jobFields: Omit<Extract<RelayJob, { kind: Kind }>, keyof RelayJobBase | "kind">,
+  ) {
+    return {
+      jobId: randomUUID(),
+      extensionId,
+      shimSession,
+      attempts: 0,
+      state: "queued",
+      kind,
+      ...jobFields,
+    } as unknown as Extract<RelayJob, { kind: Kind }>;
+  }
+
+  private queue(extensionId: string) {
+    let queue = this.queuedJobs.get(extensionId);
+
+    if (!queue) {
+      queue = [];
+
+      this.queuedJobs.set(extensionId, queue);
+    }
+
+    return queue;
+  }
+
+  private enqueueJob(job: RelayJob) {
+    if (!this.workerSession) {
+      this.failJob(job, "noListener");
+
+      return;
+    }
+
+    this.queue(job.extensionId).push(job);
+
+    this.ensureDelivery(job.extensionId);
+  }
+
+  private ensureDelivery(extensionId: string) {
+    if (this.workerStreams.has(extensionId)) {
+      this.flushQueuedJobs(extensionId);
+
+      return;
+    }
+
+    this.wakeWorker(extensionId);
+  }
+
+  private flushQueuedJobs(extensionId: string) {
+    const stream = this.workerStreams.get(extensionId);
+
+    if (!stream || stream.isClosed) {
+      return;
+    }
+
+    const queue = this.queue(extensionId);
+
+    for (const job of queue.splice(0)) {
+      job.state = "handed";
+
+      job.attempts += 1;
+
+      this.inFlightJobs.set(job.jobId, job);
+
+      try {
+        stream.controller.enqueue(encodeNativeMessage(this.toJobFrame(job)));
+      } catch {
+        // The stream stopped taking frames under us; its worker is gone
+        this.invalidateWorkerStream(extensionId);
+
+        return;
+      }
+    }
+  }
+
+  /**
+   * `startWorkerForScope` starts the extension's worker or does nothing when it
+   * is already running — a running worker without a parked stream just hasn't
+   * reconnected yet. Either way the queued jobs wait for a stream, bounded by
+   * the wake timeout. The API is experimental on Electron 43, which is why the
+   * tests pin its presence.
+   */
+  private wakeWorker(extensionId: string) {
+    if (this.wakes.has(extensionId)) {
+      return;
+    }
+
+    const workerSession = this.workerSession;
+
+    if (!workerSession) {
+      this.failQueuedJobs(extensionId, "noListener");
+
+      return;
+    }
+
+    const wake: Wake = { timer: undefined };
+
+    this.wakes.set(extensionId, wake);
+
+    Promise.resolve()
+      .then(() =>
+        workerSession.serviceWorkers.startWorkerForScope(
+          `${EXTENSION_SCHEME_PREFIX}${extensionId}/`,
+        ),
+      )
+      .then(() => {
+        if (this.wakes.get(extensionId) !== wake) {
+          return;
+        }
+
+        wake.timer = setTimeout(() => {
+          this.wakes.delete(extensionId);
+
+          this.failQueuedJobs(extensionId, "noListener");
+        }, this.wakeTimeoutMs);
+      })
+      .catch((error: unknown) => {
+        if (this.wakes.get(extensionId) !== wake) {
+          return;
+        }
+
+        this.wakes.delete(extensionId);
+
+        this.logger?.error("Failed to wake extension service worker", { extensionId, error });
+
+        this.failQueuedJobs(extensionId, "noListener");
+      });
+  }
+
+  private clearWake(extensionId: string) {
+    const wake = this.wakes.get(extensionId);
+
+    if (!wake) {
+      return;
+    }
+
+    this.wakes.delete(extensionId);
+
+    if (wake.timer !== undefined) {
+      clearTimeout(wake.timer);
+    }
+  }
+
+  private failQueuedJobs(extensionId: string, failure: "noListener" | "closed") {
+    for (const job of this.queue(extensionId).splice(0)) {
+      this.failJob(job, failure);
+    }
+  }
+
+  private failJob(job: RelayJob, failure: "noListener" | "closed") {
+    if (job.kind === "sendMessage") {
+      this.settleSendMessage(job, { status: failure });
+
+      return;
+    }
+
+    const port = this.ports.get(job.portId);
+
+    if (!port) {
+      return;
+    }
+
+    if (job.kind === "connect") {
+      this.closeShimPort(port, {
+        notifyWorker: false,
+        error: failure === "noListener" ? RECEIVING_END_ERROR : PORT_CLOSED_ERROR,
+      });
+
+      return;
+    }
+
+    // An undeliverable port job means the port's far end is gone for good
+    this.closeShimPort(port, { notifyWorker: false });
+  }
+
+  private settleSendMessage(job: SendMessageJob, result: RuntimeProxySendMessageResult) {
+    if (job.isSettled) {
+      return;
+    }
+
+    job.isSettled = true;
+
+    this.inFlightJobs.delete(job.jobId);
+
+    job.settle(result);
+  }
+
+  private getShimPort(session: Session, extensionId: string, portId: unknown) {
+    if (typeof portId !== "string") {
+      return undefined;
+    }
+
+    const port = this.ports.get(portId);
+
+    if (
+      !port ||
+      port.isClosed ||
+      port.shimSession !== session ||
+      port.extensionId !== extensionId
+    ) {
+      return undefined;
+    }
+
+    return port;
+  }
+
+  private closeShimPort(
+    port: ProxyPort,
+    { notifyWorker, error }: { notifyWorker: boolean; error?: string },
+  ) {
+    if (port.isClosed) {
+      return;
+    }
+
+    port.isClosed = true;
+
+    this.ports.delete(port.id);
+
+    // Jobs still queued for this port have nowhere to land any more. When the
+    // connect itself is among them the worker never learned the port existed,
+    // and there is nothing to tell it either.
+    const queue = this.queue(port.extensionId);
+
+    const keptJobs: RelayJob[] = [];
+
+    let wasConnectQueued = false;
+
+    for (const job of queue) {
+      if (job.kind !== "connect" && job.kind !== "portMessage" && job.kind !== "portDisconnect") {
+        keptJobs.push(job);
+
+        continue;
+      }
+
+      if (job.portId !== port.id) {
+        keptJobs.push(job);
+
+        continue;
+      }
+
+      if (job.kind === "connect") {
+        wasConnectQueued = true;
+      }
+    }
+
+    queue.splice(0, queue.length, ...keptJobs);
+
+    this.sendPortFrame(port, { type: "disconnect", error });
+
+    try {
+      port.controller.close();
+    } catch {
+      // The stream is already gone when the shim's side canceled it
+    }
+
+    if (notifyWorker && !wasConnectQueued) {
+      this.enqueueJob(
+        this.createJob(port.shimSession, port.extensionId, "portDisconnect", { portId: port.id }),
+      );
+    }
+  }
+
+  private sendPortFrame(port: ProxyPort, frame: RuntimeProxyPortFrame) {
+    try {
+      port.controller.enqueue(encodeNativeMessage(frame));
+    } catch {
+      // The stream no longer accepts frames when the shim's side canceled it
+    }
+  }
+
+  private reconstructSender(
+    session: Session,
+    extensionId: string,
+    report: { url: string; isTopFrame: boolean },
+  ) {
+    return reconstructSender({
+      session,
+      extensionId,
+      report,
+      getTabWebContents: this.getTabWebContents,
+    });
+  }
+
+  private toJobFrame(job: RelayJob): RuntimeProxyJob {
+    switch (job.kind) {
+      case "sendMessage":
+        return { type: "sendMessage", jobId: job.jobId, message: job.message, sender: job.sender };
+      case "connect":
+        return {
+          type: "connect",
+          jobId: job.jobId,
+          portId: job.portId,
+          name: job.name,
+          sender: job.sender,
+        };
+      case "portMessage":
+        return { type: "portMessage", jobId: job.jobId, portId: job.portId, message: job.message };
+      case "portDisconnect":
+        return { type: "portDisconnect", jobId: job.jobId, portId: job.portId };
+    }
+  }
+}

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
@@ -721,11 +721,33 @@ export class RuntimeProxy {
           return;
         }
 
-        this.wakes.delete(extensionId);
+        /*
+         * A rejection is Chromium finding no registration for the scope, and
+         * at a cold launch that is a window rather than a verdict: the worker
+         * session is still loading its copy of the extension, and
+         * `startWorkerForScope` fails with "not found" until the first
+         * registration is stored. Another session's content scripts inject at
+         * document_start and can message inside that window on every launch,
+         * so the queued jobs wait for the stream the starting worker will
+         * park, bounded by the same wake timeout as the resolve path, instead
+         * of failing instantly as a receiving end that "does not exist". A
+         * scope no worker ever registers for still fails the same way, one
+         * timeout later — which is also closer to Chrome, where a message
+         * never races the extension's own startup.
+         */
+        this.logger?.info(
+          "Waking the extension service worker failed; waiting for it to register",
+          {
+            extensionId,
+            error,
+          },
+        );
 
-        this.logger?.error("Failed to wake extension service worker", { extensionId, error });
+        wake.timer = setTimeout(() => {
+          this.wakes.delete(extensionId);
 
-        this.failQueuedJobs(extensionId, "noListener");
+          this.failQueuedJobs(extensionId, "noListener");
+        }, this.wakeTimeoutMs);
       });
   }
 

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
@@ -752,6 +752,13 @@ export class RuntimeProxy {
    */
   private startInFlightTimer(job: RelayJob) {
     job.timer = setTimeout(() => {
+      /*
+       * A timer that outlives its job is inert: the job it closes over is gone
+       * from the map, or a re-handing replaced it with another object under the
+       * same id. `removeInFlightJob` clears the handle as well, so the two
+       * guard the same thing twice over — which is also why no test here can
+       * observe the clearing, and why there isn't one pretending to.
+       */
       if (this.inFlightJobs.get(job.jobId) !== job) {
         return;
       }

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
@@ -32,6 +32,8 @@ type RelayJobBase = {
   /** How often the job has been handed to a stream, bounding redelivery. */
   attempts: number;
   state: "queued" | "handed" | "acked";
+  /** Runs while the job is in flight, so a worker that dies quietly ends it. */
+  timer: ReturnType<typeof setTimeout> | undefined;
 };
 
 type SendMessageJob = RelayJobBase & {
@@ -94,11 +96,26 @@ export type RuntimeProxyOptions = {
    * rather than chase a worker that takes jobs without ever acking them.
    */
   maxDeliveryAttempts?: number;
+  /**
+   * How long a job handed to the worker may go unanswered before it fails the
+   * way Chrome's closed message port does.
+   */
+  inFlightTimeoutMs?: number;
 };
 
 const DEFAULT_WAKE_TIMEOUT_MS = 10_000;
 
 const DEFAULT_MAX_DELIVERY_ATTEMPTS = 3;
+
+/**
+ * Five minutes, which is a backstop rather than a latency budget. Chrome puts
+ * no deadline on a `sendMessage` reply and neither should this: 1Password's
+ * biometric unlock answers only once the desktop app has prompted the user and
+ * been satisfied, and a timeout tight enough to feel responsive would be the
+ * thing that broke it. What this bounds is the wedge — a worker that dies
+ * without the session ever reporting it stopped.
+ */
+const DEFAULT_IN_FLIGHT_TIMEOUT_MS = 5 * 60_000;
 
 /**
  * The main-process relay carrying `chrome.runtime` messaging between
@@ -125,6 +142,8 @@ export class RuntimeProxy {
 
   private maxDeliveryAttempts: number;
 
+  private inFlightTimeoutMs: number;
+
   private workerSession: Session | undefined;
 
   private removeWorkerSessionListener: (() => void) | undefined;
@@ -147,6 +166,7 @@ export class RuntimeProxy {
     getTabWebContents,
     wakeTimeoutMs = DEFAULT_WAKE_TIMEOUT_MS,
     maxDeliveryAttempts = DEFAULT_MAX_DELIVERY_ATTEMPTS,
+    inFlightTimeoutMs = DEFAULT_IN_FLIGHT_TIMEOUT_MS,
   }: RuntimeProxyOptions = {}) {
     this.logger = logger;
 
@@ -155,6 +175,8 @@ export class RuntimeProxy {
     this.wakeTimeoutMs = wakeTimeoutMs;
 
     this.maxDeliveryAttempts = maxDeliveryAttempts;
+
+    this.inFlightTimeoutMs = inFlightTimeoutMs;
   }
 
   registerRoutes(bridge: ExtensionBridge) {
@@ -422,7 +444,7 @@ export class RuntimeProxy {
 
     // Nothing more comes back for these; the ack is the end of their story
     if (job.kind === "portMessage" || job.kind === "portDisconnect") {
-      this.inFlightJobs.delete(job.jobId);
+      this.removeInFlightJob(job);
     }
   }
 
@@ -433,7 +455,7 @@ export class RuntimeProxy {
       return;
     }
 
-    this.inFlightJobs.delete(job.jobId);
+    this.removeInFlightJob(job);
 
     if (job.kind === "sendMessage") {
       const sendMessageResult = result as RuntimeProxySendMessageResult;
@@ -530,7 +552,7 @@ export class RuntimeProxy {
         continue;
       }
 
-      this.inFlightJobs.delete(job.jobId);
+      this.removeInFlightJob(job);
 
       if (job.state === "acked") {
         this.failJob(job, "closed");
@@ -578,6 +600,7 @@ export class RuntimeProxy {
       shimSession,
       attempts: 0,
       state: "queued",
+      timer: undefined,
       kind,
       ...jobFields,
     } as unknown as Extract<RelayJob, { kind: Kind }>;
@@ -632,6 +655,8 @@ export class RuntimeProxy {
       job.attempts += 1;
 
       this.inFlightJobs.set(job.jobId, job);
+
+      this.startInFlightTimer(job);
 
       try {
         stream.controller.enqueue(encodeNativeMessage(this.toJobFrame(job)));
@@ -712,6 +737,46 @@ export class RuntimeProxy {
     }
   }
 
+  /**
+   * The only death signal a worker gives is its session's
+   * `running-status-changed`, and a worker that crashes, is killed, or is taken
+   * by the out-of-memory killer may never produce one — the request's own abort
+   * signal certainly does not. Without this a job handed to that worker stays
+   * in flight for good, and since `handleSendMessage` holds its response open
+   * until the job settles, the content script's `sendMessage` never resolves
+   * and never rejects, where Chrome would long since have errored.
+   *
+   * A job the worker acked and died holding is Chrome's closed message port,
+   * the same as losing the stream; one it never acked is treated as the missing
+   * receiving end it looks like from here.
+   */
+  private startInFlightTimer(job: RelayJob) {
+    job.timer = setTimeout(() => {
+      if (this.inFlightJobs.get(job.jobId) !== job) {
+        return;
+      }
+
+      this.removeInFlightJob(job);
+
+      this.logger?.error("Extension service worker never answered a relayed job", {
+        extensionId: job.extensionId,
+        kind: job.kind,
+      });
+
+      this.failJob(job, job.state === "acked" ? "closed" : "noListener");
+    }, this.inFlightTimeoutMs);
+  }
+
+  private removeInFlightJob(job: RelayJob) {
+    this.inFlightJobs.delete(job.jobId);
+
+    if (job.timer !== undefined) {
+      clearTimeout(job.timer);
+
+      job.timer = undefined;
+    }
+  }
+
   private failQueuedJobs(extensionId: string, failure: "noListener" | "closed") {
     for (const job of this.queue(extensionId).splice(0)) {
       this.failJob(job, failure);
@@ -751,7 +816,7 @@ export class RuntimeProxy {
 
     job.isSettled = true;
 
-    this.inFlightJobs.delete(job.jobId);
+    this.removeInFlightJob(job);
 
     job.settle(result);
   }

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { Session } from "electron";
+import type { Session, WebFrameMain } from "electron";
 import type { ExtensionBridge } from "../bridge/bridge";
 import type { ExtensionsLogger } from "../logger";
 import { encodeNativeMessage } from "../native-messaging/framing";
@@ -22,7 +22,7 @@ import {
   type RuntimeProxyWorkerPortPostRequest,
   type RuntimeProxyWorkerReplyRequest,
 } from "./bridge-protocol";
-import { parseSenderReport, reconstructSender, type RuntimeProxyTabsProvider } from "./sender";
+import { type GetWebContentsFromFrame, parseSenderReport, reconstructSender } from "./sender";
 
 type RelayJobBase = {
   jobId: string;
@@ -84,8 +84,8 @@ type Wake = {
 
 export type RuntimeProxyOptions = {
   logger?: ExtensionsLogger;
-  /** How a session's tabs are enumerated for sender reconstruction. */
-  getTabWebContents?: RuntimeProxyTabsProvider;
+  /** How a caller frame resolves to its hosting tab for sender reconstruction. */
+  getWebContentsFromFrame?: GetWebContentsFromFrame;
   /**
    * How long jobs queued behind a worker wake wait for the woken worker's job
    * stream before they fail the way a missing receiving end does.
@@ -136,7 +136,7 @@ const DEFAULT_IN_FLIGHT_TIMEOUT_MS = 5 * 60_000;
 export class RuntimeProxy {
   private logger: ExtensionsLogger | undefined;
 
-  private getTabWebContents: RuntimeProxyTabsProvider | undefined;
+  private getWebContentsFromFrame: GetWebContentsFromFrame | undefined;
 
   private wakeTimeoutMs: number;
 
@@ -163,14 +163,14 @@ export class RuntimeProxy {
 
   constructor({
     logger,
-    getTabWebContents,
+    getWebContentsFromFrame,
     wakeTimeoutMs = DEFAULT_WAKE_TIMEOUT_MS,
     maxDeliveryAttempts = DEFAULT_MAX_DELIVERY_ATTEMPTS,
     inFlightTimeoutMs = DEFAULT_IN_FLIGHT_TIMEOUT_MS,
   }: RuntimeProxyOptions = {}) {
     this.logger = logger;
 
-    this.getTabWebContents = getTabWebContents;
+    this.getWebContentsFromFrame = getWebContentsFromFrame;
 
     this.wakeTimeoutMs = wakeTimeoutMs;
 
@@ -180,12 +180,16 @@ export class RuntimeProxy {
   }
 
   registerRoutes(bridge: ExtensionBridge) {
-    bridge.handle(RUNTIME_PROXY_PATHS.sendMessage, ({ session, extensionId, body, headers }) =>
-      this.handleSendMessage(session, extensionId, body, headers),
+    bridge.handle(
+      RUNTIME_PROXY_PATHS.sendMessage,
+      ({ session, extensionId, senderFrame, body, headers }) =>
+        this.handleSendMessage(session, extensionId, senderFrame, body, headers),
     );
 
-    bridge.handle(RUNTIME_PROXY_PATHS.connect, ({ session, extensionId, body, headers }) =>
-      this.handleConnect(session, extensionId, body, headers),
+    bridge.handle(
+      RUNTIME_PROXY_PATHS.connect,
+      ({ session, extensionId, senderFrame, body, headers }) =>
+        this.handleConnect(session, extensionId, senderFrame, body, headers),
     );
 
     bridge.handle(RUNTIME_PROXY_PATHS.portPost, ({ session, extensionId, body, headers }) => {
@@ -328,6 +332,7 @@ export class RuntimeProxy {
   private async handleSendMessage(
     session: Session,
     extensionId: string,
+    senderFrame: WebFrameMain | undefined,
     body: Record<string, unknown>,
     headers: Record<string, string>,
   ) {
@@ -342,7 +347,7 @@ export class RuntimeProxy {
     const result = await new Promise<RuntimeProxySendMessageResult>((resolve) => {
       const job = this.createJob(session, extensionId, "sendMessage", {
         message: request.message,
-        sender: this.reconstructSender(session, extensionId, report),
+        sender: this.reconstructSender(session, extensionId, report, senderFrame),
         settle: resolve,
         isSettled: false,
       });
@@ -356,6 +361,7 @@ export class RuntimeProxy {
   private handleConnect(
     session: Session,
     extensionId: string,
+    senderFrame: WebFrameMain | undefined,
     body: Record<string, unknown>,
     headers: Record<string, string>,
   ) {
@@ -398,7 +404,7 @@ export class RuntimeProxy {
       this.createJob(session, extensionId, "connect", {
         portId: request.portId,
         name: typeof request.name === "string" ? request.name : undefined,
-        sender: this.reconstructSender(session, extensionId, report),
+        sender: this.reconstructSender(session, extensionId, report, senderFrame),
       }),
     );
 
@@ -915,12 +921,14 @@ export class RuntimeProxy {
     session: Session,
     extensionId: string,
     report: { url: string; isTopFrame: boolean },
+    senderFrame: WebFrameMain | undefined,
   ) {
     return reconstructSender({
       session,
       extensionId,
       report,
-      getTabWebContents: this.getTabWebContents,
+      senderFrame,
+      getWebContentsFromFrame: this.getWebContentsFromFrame,
     });
   }
 

--- a/packages/electron-extensions/runtime-proxy/sender.test.ts
+++ b/packages/electron-extensions/runtime-proxy/sender.test.ts
@@ -21,15 +21,26 @@ function createFrame(
   return { url, frameTreeNodeId, parent, isDestroyed: () => false };
 }
 
-function createContents(contentsId: number, title: string, frames: FakeFrame[]) {
+function createContents(
+  contentsId: number,
+  title: string,
+  url: string,
+  contentsSession: Session = session,
+) {
   return {
     id: contentsId,
-    session,
+    session: contentsSession,
     isDestroyed: () => false,
-    getURL: () => frames[0]?.url ?? "",
+    getURL: () => url,
     getTitle: () => title,
-    mainFrame: { framesInSubtree: frames } as unknown as WebFrameMain,
   } as unknown as WebContents;
+}
+
+/** The frame-to-tab mapping Electron owns in production, as a lookup table. */
+function contentsOf(entries: [FakeFrame, WebContents][]) {
+  const contentsByFrame = new Map(entries);
+
+  return (frame: WebFrameMain) => contentsByFrame.get(frame as unknown as FakeFrame);
 }
 
 describe("parseSenderReport", () => {
@@ -47,16 +58,17 @@ describe("parseSenderReport", () => {
 });
 
 describe("reconstructSender", () => {
-  test("builds the sender from the frame backing the report, never from the report", () => {
-    const contents = createContents(7, "Sign in", [
-      createFrame("https://accounts.google.com/signin", 12),
-    ]);
+  test("builds the sender from the caller's frame, never from the report", () => {
+    const frame = createFrame("https://accounts.google.com/signin", 12);
+
+    const contents = createContents(7, "Sign in", "https://accounts.google.com/signin");
 
     const sender = reconstructSender({
       session,
       extensionId: EXTENSION_ID,
       report: { url: "https://accounts.google.com/signin", isTopFrame: true },
-      getTabWebContents: () => [contents],
+      senderFrame: frame as unknown as WebFrameMain,
+      getWebContentsFromFrame: contentsOf([[frame, contents]]),
     });
 
     expect(sender).toEqual({
@@ -78,60 +90,64 @@ describe("reconstructSender", () => {
     });
   });
 
+  test("two tabs on one URL: the tab is the caller's own, not the first match", () => {
+    const pageUrl = "https://mail.google.com/mail/u/0/";
+
+    const firstTabFrame = createFrame(pageUrl, 12);
+
+    const callingTabFrame = createFrame(pageUrl, 34);
+
+    const mapping = contentsOf([
+      [firstTabFrame, createContents(7, "Gmail", pageUrl)],
+      [callingTabFrame, createContents(8, "Gmail", pageUrl)],
+    ]);
+
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: pageUrl, isTopFrame: true },
+      senderFrame: callingTabFrame as unknown as WebFrameMain,
+      getWebContentsFromFrame: mapping,
+    });
+
+    expect(sender.tab?.id).toBe(8);
+  });
+
   test("a subframe answers to its frame tree node id, and the main frame to 0", () => {
     const mainFrame = createFrame("https://accounts.google.com/", 12);
 
     const subFrame = createFrame("https://accounts.google.com/frame", 34, mainFrame);
 
-    const contents = createContents(7, "Sign in", [mainFrame, subFrame]);
+    const contents = createContents(7, "Sign in", "https://accounts.google.com/");
 
     const sender = reconstructSender({
       session,
       extensionId: EXTENSION_ID,
       report: { url: "https://accounts.google.com/frame", isTopFrame: false },
-      getTabWebContents: () => [contents],
+      senderFrame: subFrame as unknown as WebFrameMain,
+      getWebContentsFromFrame: contentsOf([[subFrame, contents]]),
     });
 
     expect(sender.frameId).toBe(34);
     expect(sender.tab?.id).toBe(7);
-  });
-
-  test("tab ids are WebContents ids, so two sessions' tabs never collide", () => {
-    // Electron numbers WebContents across the app; the fake ids just mirror that
-    const firstSessionContents = createContents(3, "First", [createFrame("https://a.test/", 1)]);
-
-    const secondSessionContents = createContents(4, "Second", [createFrame("https://a.test/", 1)]);
-
-    const firstSender = reconstructSender({
-      session,
-      extensionId: EXTENSION_ID,
-      report: { url: "https://a.test/", isTopFrame: true },
-      getTabWebContents: () => [firstSessionContents],
-    });
-
-    const secondSender = reconstructSender({
-      session,
-      extensionId: EXTENSION_ID,
-      report: { url: "https://a.test/", isTopFrame: true },
-      getTabWebContents: () => [secondSessionContents],
-    });
-
-    expect(firstSender.tab?.id).toBe(3);
-    expect(secondSender.tab?.id).toBe(4);
-    expect(firstSender.tab?.id).not.toBe(secondSender.tab?.id);
+    // The tab is the hosting page, not the subframe that spoke
+    expect(sender.tab?.url).toBe("https://accounts.google.com/");
   });
 
   test("a top-level extension page is no tab, the way Chrome's popup is none", () => {
     const popupUrl = `chrome-extension://${EXTENSION_ID}/popup/index.html`;
 
+    const frame = createFrame(popupUrl, 12);
+
     // The popup's own view backs the report; what it does not become is a tab
-    const contents = createContents(7, "1Password", [createFrame(popupUrl, 12)]);
+    const contents = createContents(7, "1Password", popupUrl);
 
     const sender = reconstructSender({
       session,
       extensionId: EXTENSION_ID,
       report: { url: popupUrl, isTopFrame: true },
-      getTabWebContents: () => [contents],
+      senderFrame: frame as unknown as WebFrameMain,
+      getWebContentsFromFrame: contentsOf([[frame, contents]]),
     });
 
     expect(sender).toEqual({
@@ -148,13 +164,14 @@ describe("reconstructSender", () => {
 
     const menuFrame = createFrame(menuUrl, 34, mainFrame);
 
-    const contents = createContents(7, "Sign in", [mainFrame, menuFrame]);
+    const contents = createContents(7, "Sign in", "https://accounts.google.com/");
 
     const sender = reconstructSender({
       session,
       extensionId: EXTENSION_ID,
       report: { url: menuUrl, isTopFrame: false },
-      getTabWebContents: () => [contents],
+      senderFrame: menuFrame as unknown as WebFrameMain,
+      getWebContentsFromFrame: contentsOf([[menuFrame, contents]]),
     });
 
     expect(sender.frameId).toBe(34);
@@ -162,63 +179,121 @@ describe("reconstructSender", () => {
     expect(sender.origin).toBe(`chrome-extension://${EXTENSION_ID}`);
   });
 
-  test("a report no live frame backs is not honored, url and origin included", () => {
-    const contents = createContents(7, "Sign in", [
-      createFrame("https://accounts.google.com/", 12),
-    ]);
+  test("a request the bridge recorded no frame for delivers the id alone", () => {
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: "https://accounts.google.com/", isTopFrame: true },
+      senderFrame: undefined,
+      getWebContentsFromFrame: contentsOf([]),
+    });
+
+    // A report nothing backs buys nothing but the id: an extension checking
+    // `sender.origin` against its own then refuses it
+    expect(sender).toEqual({ id: EXTENSION_ID });
+  });
+
+  test("a report the caller's frame does not back is not honored", () => {
+    const frame = createFrame("https://accounts.google.com/", 12);
+
+    const contents = createContents(7, "Sign in", "https://accounts.google.com/");
 
     const sender = reconstructSender({
       session,
       extensionId: EXTENSION_ID,
-      report: { url: "https://gone.test/", isTopFrame: true },
-      getTabWebContents: () => [contents],
-    });
-
-    // Reporting a URL the session does not have buys nothing but the id: an
-    // extension checking `sender.origin` against its own then refuses it
-    expect(sender).toEqual({ id: EXTENSION_ID });
-  });
-
-  test("an extension page no live frame backs is not honored either", () => {
-    const contents = createContents(7, "Sign in", [
-      createFrame("https://accounts.google.com/", 12),
-    ]);
-
-    const sender = reconstructSender({
-      session,
-      extensionId: EXTENSION_ID,
-      report: { url: `chrome-extension://${EXTENSION_ID}/popup/index.html`, isTopFrame: true },
-      getTabWebContents: () => [contents],
+      report: { url: "https://elsewhere.test/", isTopFrame: true },
+      senderFrame: frame as unknown as WebFrameMain,
+      getWebContentsFromFrame: contentsOf([[frame, contents]]),
     });
 
     expect(sender).toEqual({ id: EXTENSION_ID });
   });
 
-  test("a content script cannot borrow a frame by claiming the wrong side of the top-frame line", () => {
+  test("a caller cannot claim the other side of the top-frame line", () => {
     const mainFrame = createFrame("https://accounts.google.com/", 12);
 
     const subFrame = createFrame("https://accounts.google.com/frame", 34, mainFrame);
 
-    const contents = createContents(7, "Sign in", [mainFrame, subFrame]);
+    const contents = createContents(7, "Sign in", "https://accounts.google.com/");
 
     const sender = reconstructSender({
       session,
       extensionId: EXTENSION_ID,
       report: { url: "https://accounts.google.com/frame", isTopFrame: true },
-      getTabWebContents: () => [contents],
+      senderFrame: subFrame as unknown as WebFrameMain,
+      getWebContentsFromFrame: contentsOf([[subFrame, contents]]),
     });
 
     expect(sender).toEqual({ id: EXTENSION_ID });
   });
 
-  test("an unparseable URL backs nothing, so it yields the id alone", () => {
+  test("a frame destroyed since the request was stamped delivers the id alone", () => {
+    const frame = {
+      url: "https://accounts.google.com/",
+      frameTreeNodeId: 12,
+      parent: null,
+      isDestroyed: () => true,
+    };
+
+    const contents = createContents(7, "Sign in", "https://accounts.google.com/");
+
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: "https://accounts.google.com/", isTopFrame: true },
+      senderFrame: frame as unknown as WebFrameMain,
+      getWebContentsFromFrame: contentsOf([[frame, contents]]),
+    });
+
+    expect(sender).toEqual({ id: EXTENSION_ID });
+  });
+
+  test("a frame no live WebContents hosts delivers the id alone", () => {
+    const frame = createFrame("https://accounts.google.com/", 12);
+
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: "https://accounts.google.com/", isTopFrame: true },
+      senderFrame: frame as unknown as WebFrameMain,
+      getWebContentsFromFrame: contentsOf([]),
+    });
+
+    expect(sender).toEqual({ id: EXTENSION_ID });
+  });
+
+  test("a frame hosted outside the calling session delivers the id alone", () => {
+    const frame = createFrame("https://accounts.google.com/", 12);
+
+    const otherSession = { partition: "persist:account-2" } as unknown as Session;
+
+    const contents = createContents(7, "Sign in", "https://accounts.google.com/", otherSession);
+
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: "https://accounts.google.com/", isTopFrame: true },
+      senderFrame: frame as unknown as WebFrameMain,
+      getWebContentsFromFrame: contentsOf([[frame, contents]]),
+    });
+
+    expect(sender).toEqual({ id: EXTENSION_ID });
+  });
+
+  test("an unparseable URL a frame really has still carries a null origin", () => {
+    const frame = createFrame("not a url", 12);
+
+    const contents = createContents(7, "Odd", "not a url");
+
     const sender = reconstructSender({
       session,
       extensionId: EXTENSION_ID,
       report: { url: "not a url", isTopFrame: true },
-      getTabWebContents: () => [],
+      senderFrame: frame as unknown as WebFrameMain,
+      getWebContentsFromFrame: contentsOf([[frame, contents]]),
     });
 
-    expect(sender).toEqual({ id: EXTENSION_ID });
+    expect(sender.origin).toBe("null");
+    expect(sender.url).toBe("not a url");
   });
 });

--- a/packages/electron-extensions/runtime-proxy/sender.test.ts
+++ b/packages/electron-extensions/runtime-proxy/sender.test.ts
@@ -139,6 +139,47 @@ describe("reconstructSender", () => {
     expect(firstSender.tab?.id).not.toBe(secondSender.tab?.id);
   });
 
+  test("a top-level extension page is no tab, the way Chrome's popup is none", () => {
+    const popupUrl = `chrome-extension://${EXTENSION_ID}/popup/index.html`;
+
+    // The popup's own view lives in the session and would otherwise be found
+    const contents = createContents(7, "1Password", [createFrame(popupUrl, 12)]);
+
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: popupUrl, isTopFrame: true },
+      getTabWebContents: () => [contents],
+    });
+
+    expect(sender).toEqual({
+      id: EXTENSION_ID,
+      url: popupUrl,
+      origin: `chrome-extension://${EXTENSION_ID}`,
+    });
+  });
+
+  test("an extension frame inside a page keeps the tab hosting it", () => {
+    const menuUrl = `chrome-extension://${EXTENSION_ID}/inline/menu/menu.html`;
+
+    const mainFrame = createFrame("https://accounts.google.com/", 12);
+
+    const menuFrame = createFrame(menuUrl, 34, mainFrame);
+
+    const contents = createContents(7, "Sign in", [mainFrame, menuFrame]);
+
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: menuUrl, isTopFrame: false },
+      getTabWebContents: () => [contents],
+    });
+
+    expect(sender.frameId).toBe(34);
+    expect(sender.tab?.id).toBe(7);
+    expect(sender.origin).toBe(`chrome-extension://${EXTENSION_ID}`);
+  });
+
   test("a report no live frame backs still delivers, without tab and frame", () => {
     const contents = createContents(7, "Sign in", [
       createFrame("https://accounts.google.com/", 12),

--- a/packages/electron-extensions/runtime-proxy/sender.test.ts
+++ b/packages/electron-extensions/runtime-proxy/sender.test.ts
@@ -96,24 +96,6 @@ describe("reconstructSender", () => {
     expect(sender.tab?.id).toBe(7);
   });
 
-  test("a report claiming top for a URL only a subframe has matches nothing", () => {
-    const mainFrame = createFrame("https://accounts.google.com/", 12);
-
-    const subFrame = createFrame("https://accounts.google.com/frame", 34, mainFrame);
-
-    const contents = createContents(7, "Sign in", [mainFrame, subFrame]);
-
-    const sender = reconstructSender({
-      session,
-      extensionId: EXTENSION_ID,
-      report: { url: "https://accounts.google.com/frame", isTopFrame: true },
-      getTabWebContents: () => [contents],
-    });
-
-    expect(sender.tab).toBeUndefined();
-    expect(sender.frameId).toBeUndefined();
-  });
-
   test("tab ids are WebContents ids, so two sessions' tabs never collide", () => {
     // Electron numbers WebContents across the app; the fake ids just mirror that
     const firstSessionContents = createContents(3, "First", [createFrame("https://a.test/", 1)]);
@@ -142,7 +124,7 @@ describe("reconstructSender", () => {
   test("a top-level extension page is no tab, the way Chrome's popup is none", () => {
     const popupUrl = `chrome-extension://${EXTENSION_ID}/popup/index.html`;
 
-    // The popup's own view lives in the session and would otherwise be found
+    // The popup's own view backs the report; what it does not become is a tab
     const contents = createContents(7, "1Password", [createFrame(popupUrl, 12)]);
 
     const sender = reconstructSender({
@@ -180,7 +162,7 @@ describe("reconstructSender", () => {
     expect(sender.origin).toBe(`chrome-extension://${EXTENSION_ID}`);
   });
 
-  test("a report no live frame backs still delivers, without tab and frame", () => {
+  test("a report no live frame backs is not honored, url and origin included", () => {
     const contents = createContents(7, "Sign in", [
       createFrame("https://accounts.google.com/", 12),
     ]);
@@ -192,14 +174,44 @@ describe("reconstructSender", () => {
       getTabWebContents: () => [contents],
     });
 
-    expect(sender).toEqual({
-      id: EXTENSION_ID,
-      url: "https://gone.test/",
-      origin: "https://gone.test",
-    });
+    // Reporting a URL the session does not have buys nothing but the id: an
+    // extension checking `sender.origin` against its own then refuses it
+    expect(sender).toEqual({ id: EXTENSION_ID });
   });
 
-  test("an unparseable URL still yields a sender", () => {
+  test("an extension page no live frame backs is not honored either", () => {
+    const contents = createContents(7, "Sign in", [
+      createFrame("https://accounts.google.com/", 12),
+    ]);
+
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: `chrome-extension://${EXTENSION_ID}/popup/index.html`, isTopFrame: true },
+      getTabWebContents: () => [contents],
+    });
+
+    expect(sender).toEqual({ id: EXTENSION_ID });
+  });
+
+  test("a content script cannot borrow a frame by claiming the wrong side of the top-frame line", () => {
+    const mainFrame = createFrame("https://accounts.google.com/", 12);
+
+    const subFrame = createFrame("https://accounts.google.com/frame", 34, mainFrame);
+
+    const contents = createContents(7, "Sign in", [mainFrame, subFrame]);
+
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: "https://accounts.google.com/frame", isTopFrame: true },
+      getTabWebContents: () => [contents],
+    });
+
+    expect(sender).toEqual({ id: EXTENSION_ID });
+  });
+
+  test("an unparseable URL backs nothing, so it yields the id alone", () => {
     const sender = reconstructSender({
       session,
       extensionId: EXTENSION_ID,
@@ -207,6 +219,6 @@ describe("reconstructSender", () => {
       getTabWebContents: () => [],
     });
 
-    expect(sender.origin).toBe("null");
+    expect(sender).toEqual({ id: EXTENSION_ID });
   });
 });

--- a/packages/electron-extensions/runtime-proxy/sender.test.ts
+++ b/packages/electron-extensions/runtime-proxy/sender.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test";
+import type { Session, WebContents, WebFrameMain } from "electron";
+import { parseSenderReport, reconstructSender } from "./sender";
+
+const EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
+
+const session = { partition: "persist:account-1" } as unknown as Session;
+
+type FakeFrame = {
+  url: string;
+  frameTreeNodeId: number;
+  parent: FakeFrame | null;
+  isDestroyed: () => boolean;
+};
+
+function createFrame(
+  url: string,
+  frameTreeNodeId: number,
+  parent: FakeFrame | null = null,
+): FakeFrame {
+  return { url, frameTreeNodeId, parent, isDestroyed: () => false };
+}
+
+function createContents(contentsId: number, title: string, frames: FakeFrame[]) {
+  return {
+    id: contentsId,
+    session,
+    isDestroyed: () => false,
+    getURL: () => frames[0]?.url ?? "",
+    getTitle: () => title,
+    mainFrame: { framesInSubtree: frames } as unknown as WebFrameMain,
+  } as unknown as WebContents;
+}
+
+describe("parseSenderReport", () => {
+  test("takes only the shape the shim sends", () => {
+    expect(parseSenderReport({ url: "https://accounts.google.com/", isTopFrame: true })).toEqual({
+      url: "https://accounts.google.com/",
+      isTopFrame: true,
+    });
+
+    expect(parseSenderReport(undefined)).toBeUndefined();
+    expect(parseSenderReport("https://accounts.google.com/")).toBeUndefined();
+    expect(parseSenderReport({ url: "https://accounts.google.com/" })).toBeUndefined();
+    expect(parseSenderReport({ url: 42, isTopFrame: true })).toBeUndefined();
+  });
+});
+
+describe("reconstructSender", () => {
+  test("builds the sender from the frame backing the report, never from the report", () => {
+    const contents = createContents(7, "Sign in", [
+      createFrame("https://accounts.google.com/signin", 12),
+    ]);
+
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: "https://accounts.google.com/signin", isTopFrame: true },
+      getTabWebContents: () => [contents],
+    });
+
+    expect(sender).toEqual({
+      id: EXTENSION_ID,
+      url: "https://accounts.google.com/signin",
+      origin: "https://accounts.google.com",
+      frameId: 0,
+      tab: {
+        id: 7,
+        url: "https://accounts.google.com/signin",
+        title: "Sign in",
+        windowId: -1,
+        index: -1,
+        active: true,
+        highlighted: true,
+        pinned: false,
+        incognito: false,
+      },
+    });
+  });
+
+  test("a subframe answers to its frame tree node id, and the main frame to 0", () => {
+    const mainFrame = createFrame("https://accounts.google.com/", 12);
+
+    const subFrame = createFrame("https://accounts.google.com/frame", 34, mainFrame);
+
+    const contents = createContents(7, "Sign in", [mainFrame, subFrame]);
+
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: "https://accounts.google.com/frame", isTopFrame: false },
+      getTabWebContents: () => [contents],
+    });
+
+    expect(sender.frameId).toBe(34);
+    expect(sender.tab?.id).toBe(7);
+  });
+
+  test("a report claiming top for a URL only a subframe has matches nothing", () => {
+    const mainFrame = createFrame("https://accounts.google.com/", 12);
+
+    const subFrame = createFrame("https://accounts.google.com/frame", 34, mainFrame);
+
+    const contents = createContents(7, "Sign in", [mainFrame, subFrame]);
+
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: "https://accounts.google.com/frame", isTopFrame: true },
+      getTabWebContents: () => [contents],
+    });
+
+    expect(sender.tab).toBeUndefined();
+    expect(sender.frameId).toBeUndefined();
+  });
+
+  test("tab ids are WebContents ids, so two sessions' tabs never collide", () => {
+    // Electron numbers WebContents across the app; the fake ids just mirror that
+    const firstSessionContents = createContents(3, "First", [createFrame("https://a.test/", 1)]);
+
+    const secondSessionContents = createContents(4, "Second", [createFrame("https://a.test/", 1)]);
+
+    const firstSender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: "https://a.test/", isTopFrame: true },
+      getTabWebContents: () => [firstSessionContents],
+    });
+
+    const secondSender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: "https://a.test/", isTopFrame: true },
+      getTabWebContents: () => [secondSessionContents],
+    });
+
+    expect(firstSender.tab?.id).toBe(3);
+    expect(secondSender.tab?.id).toBe(4);
+    expect(firstSender.tab?.id).not.toBe(secondSender.tab?.id);
+  });
+
+  test("a report no live frame backs still delivers, without tab and frame", () => {
+    const contents = createContents(7, "Sign in", [
+      createFrame("https://accounts.google.com/", 12),
+    ]);
+
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: "https://gone.test/", isTopFrame: true },
+      getTabWebContents: () => [contents],
+    });
+
+    expect(sender).toEqual({
+      id: EXTENSION_ID,
+      url: "https://gone.test/",
+      origin: "https://gone.test",
+    });
+  });
+
+  test("an unparseable URL still yields a sender", () => {
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: "not a url", isTopFrame: true },
+      getTabWebContents: () => [],
+    });
+
+    expect(sender.origin).toBe("null");
+  });
+});

--- a/packages/electron-extensions/runtime-proxy/sender.ts
+++ b/packages/electron-extensions/runtime-proxy/sender.ts
@@ -1,0 +1,124 @@
+import type { Session, WebContents } from "electron";
+import { getExtensionFrameId } from "../web-navigation/web-navigation";
+import type {
+  RuntimeProxySender,
+  RuntimeProxySenderReport,
+  RuntimeProxyTab,
+} from "./bridge-protocol";
+
+/**
+ * How the relay finds the pages that count as tabs in a session,
+ * every live `WebContents` of the session by default.
+ */
+export type RuntimeProxyTabsProvider = (session: Session) => WebContents[];
+
+/**
+ * Resolved at call time: a value import of "electron" cannot even be loaded
+ * outside Electron, which is where this module's tests run.
+ */
+function getSessionWebContents(session: Session) {
+  const { webContents } = require("electron") as typeof import("electron");
+
+  return webContents
+    .getAllWebContents()
+    .filter((contents) => !contents.isDestroyed() && contents.session === session);
+}
+
+export function parseSenderReport(reported: unknown): RuntimeProxySenderReport | undefined {
+  if (typeof reported !== "object" || reported === null) {
+    return undefined;
+  }
+
+  const { url, isTopFrame } = reported as Record<string, unknown>;
+
+  if (typeof url !== "string" || typeof isTopFrame !== "boolean") {
+    return undefined;
+  }
+
+  return { url, isTopFrame };
+}
+
+/**
+ * The tab ids the proxy hands out are `WebContents` ids, which Electron numbers
+ * across the whole app — that is the unified namespace the proxy needs, since
+ * Chromium's own extension tab ids start over per session and two sessions'
+ * tabs would collide the moment one worker serves both. It is also the mapping
+ * the bridge's webNavigation frame queries already answer in, so a sender's
+ * `tab.id` means the same thing everywhere the bridge speaks.
+ */
+function createTabDetails(contents: WebContents): RuntimeProxyTab {
+  return {
+    id: contents.id,
+    url: contents.getURL(),
+    title: contents.getTitle(),
+    // Where the page sits in the embedder's UI isn't the proxy's to know, so
+    // these carry Chrome's own "no such thing" values rather than a guess
+    windowId: -1,
+    index: -1,
+    // The page is speaking, which is the closest this layer has to "in front"
+    active: true,
+    highlighted: true,
+    pinned: false,
+    incognito: false,
+  };
+}
+
+export type ReconstructSenderOptions = {
+  session: Session;
+  extensionId: string;
+  report: RuntimeProxySenderReport;
+  getTabWebContents?: RuntimeProxyTabsProvider;
+};
+
+/**
+ * Builds the `MessageSender` a relayed message hands the worker, which native
+ * in-session messaging gets from Chromium and a bridge request carries nothing
+ * of. The shim's self-report is only trusted as far as it checks out: the
+ * report's URL has to match a live frame in the calling session, and the tab
+ * and frame ids come from that frame, never from the report. A report no frame
+ * backs — the page navigated away mid-flight — still delivers, as a sender
+ * without `tab` and `frameId`.
+ */
+export function reconstructSender({
+  session,
+  extensionId,
+  report,
+  getTabWebContents = getSessionWebContents,
+}: ReconstructSenderOptions): RuntimeProxySender {
+  const sender: RuntimeProxySender = {
+    id: extensionId,
+    url: report.url,
+    origin: getOrigin(report.url),
+  };
+
+  for (const contents of getTabWebContents(session)) {
+    if (contents.isDestroyed()) {
+      continue;
+    }
+
+    const frame = contents.mainFrame.framesInSubtree.find(
+      (candidate) =>
+        !candidate.isDestroyed() &&
+        candidate.url === report.url &&
+        (candidate.parent === null) === report.isTopFrame,
+    );
+
+    if (frame) {
+      return {
+        ...sender,
+        frameId: getExtensionFrameId(frame),
+        tab: createTabDetails(contents),
+      };
+    }
+  }
+
+  return sender;
+}
+
+function getOrigin(url: string) {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return "null";
+  }
+}

--- a/packages/electron-extensions/runtime-proxy/sender.ts
+++ b/packages/electron-extensions/runtime-proxy/sender.ts
@@ -1,9 +1,10 @@
 import type { Session, WebContents } from "electron";
 import { getExtensionFrameId } from "../web-navigation/web-navigation";
-import type {
-  RuntimeProxySender,
-  RuntimeProxySenderReport,
-  RuntimeProxyTab,
+import {
+  EXTENSION_SCHEME_PREFIX,
+  type RuntimeProxySender,
+  type RuntimeProxySenderReport,
+  type RuntimeProxyTab,
 } from "./bridge-protocol";
 
 /**
@@ -78,6 +79,15 @@ export type ReconstructSenderOptions = {
  * and frame ids come from that frame, never from the report. A report no frame
  * backs — the page navigated away mid-flight — still delivers, as a sender
  * without `tab` and `frameId`.
+ *
+ * An extension page reports itself the same way, and a top-level one is no tab:
+ * Chrome gives an action popup's messages a sender of `id`, `url` and `origin`
+ * alone, so that is what the worker sees. An extension page in a subframe is a
+ * different thing — 1Password's inline menu is an iframe of the extension
+ * inside a web page — and keeps the host tab and its frame id, which the frame
+ * lookup finds without being told. Meru renders extension pages only as the
+ * popup; Chrome would hand one opened in a browser tab a `tab`, and there is no
+ * such surface here.
  */
 export function reconstructSender({
   session,
@@ -90,6 +100,10 @@ export function reconstructSender({
     url: report.url,
     origin: getOrigin(report.url),
   };
+
+  if (report.isTopFrame && report.url.startsWith(EXTENSION_SCHEME_PREFIX)) {
+    return sender;
+  }
 
   for (const contents of getTabWebContents(session)) {
     if (contents.isDestroyed()) {
@@ -115,7 +129,20 @@ export function reconstructSender({
   return sender;
 }
 
+/**
+ * `new URL().origin` answers "null" for every scheme it does not know as
+ * special, and outside a browser process `chrome-extension:` is one of those.
+ * Chromium gives an extension URL the origin the extension runs on, which is
+ * what an extension checking `sender.origin` against its own `getURL("")`
+ * expects — 1Password refuses a request from any other origin.
+ */
 function getOrigin(url: string) {
+  if (url.startsWith(EXTENSION_SCHEME_PREFIX)) {
+    const extensionId = url.slice(EXTENSION_SCHEME_PREFIX.length).replace(/[/?#].*$/, "");
+
+    return `${EXTENSION_SCHEME_PREFIX}${extensionId}`;
+  }
+
   try {
     return new URL(url).origin;
   } catch {

--- a/packages/electron-extensions/runtime-proxy/sender.ts
+++ b/packages/electron-extensions/runtime-proxy/sender.ts
@@ -74,20 +74,33 @@ export type ReconstructSenderOptions = {
 /**
  * Builds the `MessageSender` a relayed message hands the worker, which native
  * in-session messaging gets from Chromium and a bridge request carries nothing
- * of. The shim's self-report is only trusted as far as it checks out: the
- * report's URL has to match a live frame in the calling session, and the tab
- * and frame ids come from that frame, never from the report. A report no frame
- * backs — the page navigated away mid-flight — still delivers, as a sender
- * without `tab` and `frameId`.
+ * of.
  *
- * An extension page reports itself the same way, and a top-level one is no tab:
- * Chrome gives an action popup's messages a sender of `id`, `url` and `origin`
- * alone, so that is what the worker sees. An extension page in a subframe is a
- * different thing — 1Password's inline menu is an iframe of the extension
- * inside a web page — and keeps the host tab and its frame id, which the frame
- * lookup finds without being told. Meru renders extension pages only as the
- * popup; Chrome would hand one opened in a browser tab a `tab`, and there is no
- * such surface here.
+ * Nothing the shim reports is passed on unbacked. A live frame of the calling
+ * session has to be at the reported URL, on the reported side of the top-frame
+ * line, and the sender is built from that frame — `url` and `origin` only
+ * because a frame was found to hold them. A report no frame backs delivers as
+ * `id` alone rather than as the URL it asked for: an extension checking
+ * `sender.origin` against its own — which is what 1Password does before it will
+ * answer — then refuses it, which is the right way for an unverifiable claim to
+ * end.
+ *
+ * A top-level extension page is no tab, so it stops there. Chrome gives an
+ * action popup's messages a sender of `id`, `url` and `origin` alone, and that
+ * is what the worker sees — the popup's own view is not reported as a tab
+ * merely because it is a `WebContents` of the session. An extension page in a
+ * subframe is a different thing: 1Password's inline menu is an iframe of the
+ * extension inside a web page, and it keeps the host tab and its frame id.
+ * Meru renders extension pages only as the popup; Chrome would hand one opened
+ * in a browser tab a `tab`, and there is no such surface here.
+ *
+ * What this cannot do is bind a message to the frame that sent it.
+ * `protocol.handle` hands the bridge the session and never the calling frame
+ * (`bridge/bridge.ts`), so one context of the extension in a session can still
+ * report another live frame's URL in that same session and be believed. The
+ * bridge token is what stands between a page and any of this, and it is the
+ * extension's own contexts that hold it; this narrows a forged sender to URLs
+ * the session really has open, and does not eliminate it.
  */
 export function reconstructSender({
   session,
@@ -95,15 +108,7 @@ export function reconstructSender({
   report,
   getTabWebContents = getSessionWebContents,
 }: ReconstructSenderOptions): RuntimeProxySender {
-  const sender: RuntimeProxySender = {
-    id: extensionId,
-    url: report.url,
-    origin: getOrigin(report.url),
-  };
-
-  if (report.isTopFrame && report.url.startsWith(EXTENSION_SCHEME_PREFIX)) {
-    return sender;
-  }
+  const isExtensionPage = report.isTopFrame && report.url.startsWith(EXTENSION_SCHEME_PREFIX);
 
   for (const contents of getTabWebContents(session)) {
     if (contents.isDestroyed()) {
@@ -117,25 +122,25 @@ export function reconstructSender({
         (candidate.parent === null) === report.isTopFrame,
     );
 
-    if (frame) {
-      return {
-        ...sender,
-        frameId: getExtensionFrameId(frame),
-        tab: createTabDetails(contents),
-      };
+    if (!frame) {
+      continue;
     }
+
+    const sender: RuntimeProxySender = {
+      id: extensionId,
+      url: report.url,
+      origin: getOrigin(report.url),
+    };
+
+    return isExtensionPage
+      ? sender
+      : { ...sender, frameId: getExtensionFrameId(frame), tab: createTabDetails(contents) };
   }
 
-  return sender;
+  // The session holds nothing the report describes, so none of it is passed on
+  return { id: extensionId };
 }
 
-/**
- * `new URL().origin` answers "null" for every scheme it does not know as
- * special, and outside a browser process `chrome-extension:` is one of those.
- * Chromium gives an extension URL the origin the extension runs on, which is
- * what an extension checking `sender.origin` against its own `getURL("")`
- * expects — 1Password refuses a request from any other origin.
- */
 function getOrigin(url: string) {
   if (url.startsWith(EXTENSION_SCHEME_PREFIX)) {
     const extensionId = url.slice(EXTENSION_SCHEME_PREFIX.length).replace(/[/?#].*$/, "");

--- a/packages/electron-extensions/runtime-proxy/sender.ts
+++ b/packages/electron-extensions/runtime-proxy/sender.ts
@@ -1,4 +1,4 @@
-import type { Session, WebContents } from "electron";
+import type { Session, WebContents, WebFrameMain } from "electron";
 import { getExtensionFrameId } from "../web-navigation/web-navigation";
 import {
   EXTENSION_SCHEME_PREFIX,
@@ -8,21 +8,19 @@ import {
 } from "./bridge-protocol";
 
 /**
- * How the relay finds the pages that count as tabs in a session,
- * every live `WebContents` of the session by default.
+ * How a verified caller frame resolves to the `WebContents` hosting it,
+ * Electron's own mapping by default.
  */
-export type RuntimeProxyTabsProvider = (session: Session) => WebContents[];
+export type GetWebContentsFromFrame = (frame: WebFrameMain) => WebContents | undefined;
 
 /**
  * Resolved at call time: a value import of "electron" cannot even be loaded
  * outside Electron, which is where this module's tests run.
  */
-function getSessionWebContents(session: Session) {
+function getElectronWebContentsFromFrame(frame: WebFrameMain) {
   const { webContents } = require("electron") as typeof import("electron");
 
-  return webContents
-    .getAllWebContents()
-    .filter((contents) => !contents.isDestroyed() && contents.session === session);
+  return webContents.fromFrame(frame);
 }
 
 export function parseSenderReport(reported: unknown): RuntimeProxySenderReport | undefined {
@@ -68,7 +66,13 @@ export type ReconstructSenderOptions = {
   session: Session;
   extensionId: string;
   report: RuntimeProxySenderReport;
-  getTabWebContents?: RuntimeProxyTabsProvider;
+  /**
+   * The frame Chromium recorded as the bridge request's initiator, from the
+   * caller stamp the bridge put on the request (`bridge/bridge.ts`) — the one
+   * part of the sender the shim has no hand in.
+   */
+  senderFrame: WebFrameMain | undefined;
+  getWebContentsFromFrame?: GetWebContentsFromFrame;
 };
 
 /**
@@ -76,14 +80,17 @@ export type ReconstructSenderOptions = {
  * in-session messaging gets from Chromium and a bridge request carries nothing
  * of.
  *
- * Nothing the shim reports is passed on unbacked. A live frame of the calling
- * session has to be at the reported URL, on the reported side of the top-frame
- * line, and the sender is built from that frame — `url` and `origin` only
- * because a frame was found to hold them. A report no frame backs delivers as
- * `id` alone rather than as the URL it asked for: an extension checking
- * `sender.origin` against its own — which is what 1Password does before it will
- * answer — then refuses it, which is the right way for an unverifiable claim to
- * end.
+ * The sender is built from the frame the bridge recorded as the request's
+ * caller, never from any frame that merely resembles the report: with one URL
+ * open in two tabs of a session, the message is attributed to the tab that
+ * sent it. The shim's self-report still has to match that frame — same URL,
+ * same side of the top-frame line — and a report the caller's own frame does
+ * not back delivers as `id` alone rather than as the URL it asked for: an
+ * extension checking `sender.origin` against its own — which is what 1Password
+ * does before it will answer — then refuses it, which is the right way for an
+ * unverifiable claim to end. A mismatch is a document that navigated between
+ * the shim reading `location.href` and the request being handled, or a report
+ * that was never true, and neither is delivered.
  *
  * A top-level extension page is no tab, so it stops there. Chrome gives an
  * action popup's messages a sender of `id`, `url` and `origin` alone, and that
@@ -93,52 +100,40 @@ export type ReconstructSenderOptions = {
  * extension inside a web page, and it keeps the host tab and its frame id.
  * Meru renders extension pages only as the popup; Chrome would hand one opened
  * in a browser tab a `tab`, and there is no such surface here.
- *
- * What this cannot do is bind a message to the frame that sent it.
- * `protocol.handle` hands the bridge the session and never the calling frame
- * (`bridge/bridge.ts`), so one context of the extension in a session can still
- * report another live frame's URL in that same session and be believed. The
- * bridge token is what stands between a page and any of this, and it is the
- * extension's own contexts that hold it; this narrows a forged sender to URLs
- * the session really has open, and does not eliminate it.
  */
 export function reconstructSender({
   session,
   extensionId,
   report,
-  getTabWebContents = getSessionWebContents,
+  senderFrame,
+  getWebContentsFromFrame = getElectronWebContentsFromFrame,
 }: ReconstructSenderOptions): RuntimeProxySender {
-  const isExtensionPage = report.isTopFrame && report.url.startsWith(EXTENSION_SCHEME_PREFIX);
-
-  for (const contents of getTabWebContents(session)) {
-    if (contents.isDestroyed()) {
-      continue;
-    }
-
-    const frame = contents.mainFrame.framesInSubtree.find(
-      (candidate) =>
-        !candidate.isDestroyed() &&
-        candidate.url === report.url &&
-        (candidate.parent === null) === report.isTopFrame,
-    );
-
-    if (!frame) {
-      continue;
-    }
-
-    const sender: RuntimeProxySender = {
-      id: extensionId,
-      url: report.url,
-      origin: getOrigin(report.url),
-    };
-
-    return isExtensionPage
-      ? sender
-      : { ...sender, frameId: getExtensionFrameId(frame), tab: createTabDetails(contents) };
+  if (!senderFrame || senderFrame.isDestroyed()) {
+    return { id: extensionId };
   }
 
-  // The session holds nothing the report describes, so none of it is passed on
-  return { id: extensionId };
+  if (senderFrame.url !== report.url || (senderFrame.parent === null) !== report.isTopFrame) {
+    return { id: extensionId };
+  }
+
+  const contents = getWebContentsFromFrame(senderFrame);
+
+  if (!contents || contents.isDestroyed() || contents.session !== session) {
+    return { id: extensionId };
+  }
+
+  const sender: RuntimeProxySender = {
+    id: extensionId,
+    url: senderFrame.url,
+    origin: getOrigin(senderFrame.url),
+  };
+
+  const isExtensionPage =
+    senderFrame.parent === null && senderFrame.url.startsWith(EXTENSION_SCHEME_PREFIX);
+
+  return isExtensionPage
+    ? sender
+    : { ...sender, frameId: getExtensionFrameId(senderFrame), tab: createTabDetails(contents) };
 }
 
 function getOrigin(url: string) {

--- a/packages/electron-extensions/runtime-proxy/shim-entry.ts
+++ b/packages/electron-extensions/runtime-proxy/shim-entry.ts
@@ -2,17 +2,19 @@ import type { ChromeNamespace } from "../facade/lib/chrome";
 import { installRuntimeProxyShim } from "./shim";
 
 /**
- * Entry point of the runtime proxy's content-script shim. It is bundled on its
- * own, like the facade, and the derive prepends it to every `content_scripts`
- * entry of a content-script-only copy, so it runs in the extension's isolated
- * world before any of the extension's own scripts. Electron hands content
- * scripts the extension API under both `chrome` and `browser`, so both get the
+ * Entry point of the runtime proxy's shim. It is bundled on its own, like the
+ * facade, and a content-script-only copy runs it in every context of the
+ * extension that can message: the derive prepends it to every `content_scripts`
+ * entry, so it reaches the isolated world before the extension's own scripts,
+ * and writes it into every extension page — the action popup, and the frames an
+ * extension embeds in web pages — ahead of the page's own. Electron hands these
+ * contexts the extension API under both `chrome` and `browser`, so both get the
  * shadowed `runtime` methods.
  */
-const contentScriptGlobals = globalThis as unknown as Record<string, ChromeNamespace | undefined>;
+const contextGlobals = globalThis as unknown as Record<string, ChromeNamespace | undefined>;
 
 for (const globalName of ["chrome", "browser"]) {
-  const extensionApi = contentScriptGlobals[globalName];
+  const extensionApi = contextGlobals[globalName];
 
   if (extensionApi) {
     installRuntimeProxyShim(extensionApi);

--- a/packages/electron-extensions/runtime-proxy/shim-entry.ts
+++ b/packages/electron-extensions/runtime-proxy/shim-entry.ts
@@ -1,0 +1,20 @@
+import type { ChromeNamespace } from "../facade/lib/chrome";
+import { installRuntimeProxyShim } from "./shim";
+
+/**
+ * Entry point of the runtime proxy's content-script shim. It is bundled on its
+ * own, like the facade, and the derive prepends it to every `content_scripts`
+ * entry of a content-script-only copy, so it runs in the extension's isolated
+ * world before any of the extension's own scripts. Electron hands content
+ * scripts the extension API under both `chrome` and `browser`, so both get the
+ * shadowed `runtime` methods.
+ */
+const contentScriptGlobals = globalThis as unknown as Record<string, ChromeNamespace | undefined>;
+
+for (const globalName of ["chrome", "browser"]) {
+  const extensionApi = contentScriptGlobals[globalName];
+
+  if (extensionApi) {
+    installRuntimeProxyShim(extensionApi);
+  }
+}

--- a/packages/electron-extensions/runtime-proxy/shim.test.ts
+++ b/packages/electron-extensions/runtime-proxy/shim.test.ts
@@ -1,0 +1,359 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { EXTENSION_BRIDGE_ORIGIN } from "../bridge/protocol";
+import type { ChromeNamespace } from "../facade/lib/chrome";
+import { encodeNativeMessage } from "../native-messaging/framing";
+import {
+  PORT_CLOSED_ERROR,
+  RECEIVING_END_ERROR,
+  RUNTIME_PROXY_PATHS,
+  type RuntimeProxyPortFrame,
+} from "./bridge-protocol";
+import { installRuntimeProxyShim, parseSendMessageArguments } from "./shim";
+
+const EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
+
+const OTHER_EXTENSION_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+const SENDER_REPORT = { url: "https://accounts.google.com/", isTopFrame: true };
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+type RecordedRequest = { url: string; body: Record<string, unknown> };
+
+function stubFetch(respond: (pathName: string, body: Record<string, unknown>) => Response) {
+  const requests: RecordedRequest[] = [];
+
+  globalThis.fetch = (async (url: string, init: RequestInit) => {
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+
+    requests.push({ url, body });
+
+    return respond(url.slice(EXTENSION_BRIDGE_ORIGIN.length), body);
+  }) as unknown as typeof fetch;
+
+  return requests;
+}
+
+function createShimmedRuntime(nativeMethods: Record<string, unknown> = {}) {
+  const runtime: ChromeNamespace = { id: EXTENSION_ID, ...nativeMethods };
+
+  installRuntimeProxyShim({ runtime }, { getSenderReport: () => SENDER_REPORT });
+
+  return runtime;
+}
+
+type SendMessage = (...callArguments: unknown[]) => Promise<unknown> | undefined;
+
+type Connect = (connectInfo?: unknown) => {
+  name: string;
+  postMessage: (message: unknown) => void;
+  disconnect: () => void;
+  onMessage: { addListener: (listener: (...eventArguments: unknown[]) => void) => void };
+  onDisconnect: { addListener: (listener: (...eventArguments: unknown[]) => void) => void };
+};
+
+describe("parseSendMessageArguments", () => {
+  test("one argument is the message, whatever it looks like", () => {
+    expect(parseSendMessageArguments([{ kind: "unlock" }])).toEqual({
+      message: { kind: "unlock" },
+    });
+
+    // Even a string that reads as an extension id
+    expect(parseSendMessageArguments([EXTENSION_ID])).toEqual({ message: EXTENSION_ID });
+  });
+
+  test("a leading extension id is the target with three arguments, or with two when it reads as one", () => {
+    expect(parseSendMessageArguments([EXTENSION_ID, "hello", {}])).toEqual({
+      targetExtensionId: EXTENSION_ID,
+      message: "hello",
+    });
+
+    expect(parseSendMessageArguments([EXTENSION_ID, "hello"])).toEqual({
+      targetExtensionId: EXTENSION_ID,
+      message: "hello",
+    });
+
+    expect(parseSendMessageArguments(["not an id", { kind: "unlock" }])).toEqual({
+      message: "not an id",
+    });
+  });
+});
+
+describe("shimmed sendMessage", () => {
+  test("posts the message with the sender report and resolves the reply", async () => {
+    const requests = stubFetch(() => Response.json({ status: "replied", reply: { ok: true } }));
+
+    const runtime = createShimmedRuntime();
+
+    const reply = await (runtime.sendMessage as SendMessage)({ kind: "unlock" });
+
+    expect(reply).toEqual({ ok: true });
+
+    expect(requests).toEqual([
+      {
+        url: `${EXTENSION_BRIDGE_ORIGIN}${RUNTIME_PROXY_PATHS.sendMessage}`,
+        body: { message: { kind: "unlock" }, sender: SENDER_REPORT },
+      },
+    ]);
+  });
+
+  test("hands the reply to a callback and sets no lastError", async () => {
+    stubFetch(() => Response.json({ status: "replied", reply: "hi" }));
+
+    const runtime = createShimmedRuntime();
+
+    const { reply, lastErrorDuringCallback } = await new Promise<{
+      reply: unknown;
+      lastErrorDuringCallback: unknown;
+    }>((resolve) => {
+      (runtime.sendMessage as SendMessage)("hello", (callbackReply: unknown) => {
+        resolve({ reply: callbackReply, lastErrorDuringCallback: runtime.lastError });
+      });
+    });
+
+    expect(reply).toBe("hi");
+    expect(lastErrorDuringCallback).toBeUndefined();
+    expect(runtime.lastError).toBeUndefined();
+  });
+
+  test("maps noListener to Chrome's receiving-end rejection", async () => {
+    stubFetch(() => Response.json({ status: "noListener" }));
+
+    const runtime = createShimmedRuntime();
+
+    expect((runtime.sendMessage as SendMessage)("anyone?")).rejects.toThrow(RECEIVING_END_ERROR);
+  });
+
+  test("maps closed to Chrome's message-port error, on lastError for a callback", async () => {
+    stubFetch(() => Response.json({ status: "closed" }));
+
+    const runtime = createShimmedRuntime();
+
+    const lastErrorDuringCallback = await new Promise<unknown>((resolve) => {
+      (runtime.sendMessage as SendMessage)("hello", () => {
+        resolve(runtime.lastError);
+      });
+    });
+
+    expect(lastErrorDuringCallback).toEqual({ message: PORT_CLOSED_ERROR });
+    expect(runtime.lastError).toBeUndefined();
+  });
+
+  test("an unreachable bridge reads like a missing receiving end", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("Failed to fetch");
+    }) as unknown as typeof fetch;
+
+    const runtime = createShimmedRuntime();
+
+    expect((runtime.sendMessage as SendMessage)("hello")).rejects.toThrow(RECEIVING_END_ERROR);
+  });
+
+  test("leaves a message for another extension to the native method", async () => {
+    const nativeCalls: unknown[][] = [];
+
+    stubFetch(() => Response.json({ status: "replied" }));
+
+    const runtime = createShimmedRuntime({
+      sendMessage: (...callArguments: unknown[]) => {
+        nativeCalls.push(callArguments);
+
+        return Promise.resolve("native");
+      },
+    });
+
+    const reply = await (runtime.sendMessage as SendMessage)(OTHER_EXTENSION_ID, "hello", {});
+
+    expect(reply).toBe("native");
+    expect(nativeCalls).toEqual([[OTHER_EXTENSION_ID, "hello", {}]]);
+  });
+});
+
+describe("shimmed connect", () => {
+  function respondWithPortStream(frames: {
+    enqueue?: (controller: ReadableStreamDefaultController<Uint8Array>) => void;
+  }) {
+    return (pathName: string) => {
+      if (pathName !== RUNTIME_PROXY_PATHS.connect) {
+        return new Response(null, { status: 204 });
+      }
+
+      const stream = new ReadableStream<Uint8Array>({
+        start: (controller) => {
+          frames.enqueue?.(controller);
+        },
+      });
+
+      return new Response(stream, { status: 200 });
+    };
+  }
+
+  const encodeFrame = (frame: RuntimeProxyPortFrame) => encodeNativeMessage(frame);
+
+  test("opens the port over the bridge and delivers streamed messages", async () => {
+    const requests = stubFetch(
+      respondWithPortStream({
+        enqueue: (controller) => {
+          controller.enqueue(encodeFrame({ type: "message", message: { locked: false } }));
+        },
+      }),
+    );
+
+    const runtime = createShimmedRuntime();
+
+    const port = (runtime.connect as Connect)({ name: "relay" });
+
+    expect(port.name).toBe("relay");
+
+    const message = await new Promise<unknown>((resolve) => {
+      port.onMessage.addListener((portMessage) => {
+        resolve(portMessage);
+      });
+    });
+
+    expect(message).toEqual({ locked: false });
+
+    expect(requests[0]?.body).toMatchObject({ name: "relay", sender: SENDER_REPORT });
+    expect(typeof requests[0]?.body.portId).toBe("string");
+  });
+
+  test("a message posted before the port opened arrives after the connect", async () => {
+    const requests = stubFetch(respondWithPortStream({}));
+
+    const runtime = createShimmedRuntime();
+
+    const port = (runtime.connect as Connect)();
+
+    port.postMessage("first");
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(requests.map(({ url }) => url.slice(EXTENSION_BRIDGE_ORIGIN.length))).toEqual([
+      RUNTIME_PROXY_PATHS.connect,
+      RUNTIME_PROXY_PATHS.portPost,
+    ]);
+
+    expect(requests[1]?.body).toMatchObject({ message: "first" });
+  });
+
+  test("a disconnect frame fires onDisconnect with the error on lastError", async () => {
+    stubFetch(
+      respondWithPortStream({
+        enqueue: (controller) => {
+          controller.enqueue(encodeFrame({ type: "disconnect", error: RECEIVING_END_ERROR }));
+        },
+      }),
+    );
+
+    const runtime = createShimmedRuntime();
+
+    const port = (runtime.connect as Connect)();
+
+    const lastErrorDuringListener = await new Promise<unknown>((resolve) => {
+      port.onDisconnect.addListener(() => {
+        resolve(runtime.lastError);
+      });
+    });
+
+    expect(lastErrorDuringListener).toEqual({ message: RECEIVING_END_ERROR });
+    expect(runtime.lastError).toBeUndefined();
+  });
+
+  test("a refused connect disconnects like a session with no worker", async () => {
+    stubFetch(() => new Response(null, { status: 403 }));
+
+    const runtime = createShimmedRuntime();
+
+    const port = (runtime.connect as Connect)();
+
+    const lastErrorDuringListener = await new Promise<unknown>((resolve) => {
+      port.onDisconnect.addListener(() => {
+        resolve(runtime.lastError);
+      });
+    });
+
+    expect(lastErrorDuringListener).toEqual({ message: RECEIVING_END_ERROR });
+  });
+
+  test("disconnecting posts the disconnect and stays quiet locally", async () => {
+    const requests = stubFetch(respondWithPortStream({}));
+
+    const runtime = createShimmedRuntime();
+
+    const port = (runtime.connect as Connect)();
+
+    let disconnectHeard = false;
+
+    port.onDisconnect.addListener(() => {
+      disconnectHeard = true;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    port.disconnect();
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(disconnectHeard).toBe(false);
+    expect(
+      requests.some(
+        ({ url }) => url === `${EXTENSION_BRIDGE_ORIGIN}${RUNTIME_PROXY_PATHS.portDisconnect}`,
+      ),
+    ).toBe(true);
+
+    expect(() => port.postMessage("too late")).toThrow(
+      "Attempting to use a disconnected port object",
+    );
+  });
+
+  test("hands a connect aimed at another extension to the native method", () => {
+    stubFetch(() => new Response(null, { status: 204 }));
+
+    const nativeCalls: unknown[][] = [];
+
+    const runtime = createShimmedRuntime({
+      connect: (...callArguments: unknown[]) => {
+        nativeCalls.push(callArguments);
+
+        return { name: "native-port" };
+      },
+    });
+
+    const port = (runtime.connect as Connect)(OTHER_EXTENSION_ID as unknown as object);
+
+    expect(port.name).toBe("native-port");
+    expect(nativeCalls).toEqual([[OTHER_EXTENSION_ID]]);
+  });
+});
+
+describe("installRuntimeProxyShim", () => {
+  test("shadows only sendMessage and connect, and leaves the rest native", () => {
+    const nativeSendMessage = () => undefined;
+
+    const getUrl = (resourcePath: string) => `chrome-extension://${EXTENSION_ID}/${resourcePath}`;
+
+    const runtime: ChromeNamespace = {
+      id: EXTENSION_ID,
+      sendMessage: nativeSendMessage,
+      getURL: getUrl,
+    };
+
+    installRuntimeProxyShim({ runtime });
+
+    expect(runtime.sendMessage).not.toBe(nativeSendMessage);
+    expect(runtime.getURL).toBe(getUrl);
+    expect(runtime.id).toBe(EXTENSION_ID);
+  });
+
+  test("does nothing for an API object without a runtime", () => {
+    const extensionApi: ChromeNamespace = {};
+
+    installRuntimeProxyShim(extensionApi);
+
+    expect(extensionApi.runtime).toBeUndefined();
+  });
+});

--- a/packages/electron-extensions/runtime-proxy/shim.ts
+++ b/packages/electron-extensions/runtime-proxy/shim.ts
@@ -17,20 +17,22 @@ import {
 const DISCONNECTED_PORT_ERROR = "Attempting to use a disconnected port object";
 
 /**
- * What the content script can say about where it runs, read from the isolated
- * world's own globals. The main process checks the claim against the session's
- * frame tree before anything trusts it.
+ * What a shimmed context can say about where it runs, read from its own
+ * globals. The same two facts serve a content script and an extension page: the
+ * main process checks the claim against the session's frame tree before
+ * anything trusts it, and reads a top-level document on the extension's own
+ * scheme as the page it is.
  */
-function getContentScriptSenderReport(): RuntimeProxySenderReport {
-  const contentScriptGlobals = globalThis as unknown as {
+function getContextSenderReport(): RuntimeProxySenderReport {
+  const contextGlobals = globalThis as unknown as {
     location?: { href?: string };
     self?: unknown;
     top?: unknown;
   };
 
   return {
-    url: contentScriptGlobals.location?.href ?? "",
-    isTopFrame: contentScriptGlobals.self === contentScriptGlobals.top,
+    url: contextGlobals.location?.href ?? "",
+    isTopFrame: contextGlobals.self === contextGlobals.top,
   };
 }
 
@@ -292,16 +294,21 @@ export type InstallRuntimeProxyShimOptions = {
 
 /**
  * Shadows `chrome.runtime.sendMessage` and `chrome.runtime.connect` in a
- * content script's isolated world, pointing both at the runtime proxy instead
- * of at this session's own extension instance, which has no service worker to
- * receive them. It runs before any of the extension's own content scripts —
- * the derive prepends it to every `content_scripts` entry — so the extension
- * only ever sees the shadowed functions. Everything else on `chrome.runtime`,
- * `getURL` and `id` above all, stays exactly as Electron made it.
+ * context of a content-script-only session, pointing both at the runtime proxy
+ * instead of at this session's own extension instance, which has no service
+ * worker to receive them. It runs before any of the extension's own code — the
+ * derive prepends it to every `content_scripts` entry and writes it into every
+ * extension page ahead of the page's own scripts — so the extension only ever
+ * sees the shadowed functions. Everything else on `chrome.runtime`, `getURL`
+ * and `id` above all, stays exactly as Electron made it.
+ *
+ * `onMessage` and `onConnect` are left native, which is what bounds the shim:
+ * an extension page hears what it opened a port for, and not what the worker
+ * broadcasts with `sendMessage` to a session it isn't in.
  */
 export function installRuntimeProxyShim(
   extensionApi: ChromeNamespace,
-  { getSenderReport = getContentScriptSenderReport }: InstallRuntimeProxyShimOptions = {},
+  { getSenderReport = getContextSenderReport }: InstallRuntimeProxyShimOptions = {},
 ) {
   const runtime = extensionApi.runtime as ChromeNamespace | undefined;
 

--- a/packages/electron-extensions/runtime-proxy/shim.ts
+++ b/packages/electron-extensions/runtime-proxy/shim.ts
@@ -1,0 +1,323 @@
+import { isExtensionId } from "../derive/extension-id";
+import { postBridge } from "../facade/lib/bridge";
+import type { ChromeNamespace } from "../facade/lib/chrome";
+import { createEvent } from "../facade/lib/event";
+import { withLastError } from "../facade/lib/last-error";
+import { NativeMessageDecoder } from "../native-messaging/framing";
+import {
+  MAX_RUNTIME_PROXY_FRAME_BYTES,
+  PORT_CLOSED_ERROR,
+  RECEIVING_END_ERROR,
+  RUNTIME_PROXY_PATHS,
+  type RuntimeProxyPortFrame,
+  type RuntimeProxySenderReport,
+  type RuntimeProxySendMessageResult,
+} from "./bridge-protocol";
+
+const DISCONNECTED_PORT_ERROR = "Attempting to use a disconnected port object";
+
+/**
+ * What the content script can say about where it runs, read from the isolated
+ * world's own globals. The main process checks the claim against the session's
+ * frame tree before anything trusts it.
+ */
+function getContentScriptSenderReport(): RuntimeProxySenderReport {
+  const contentScriptGlobals = globalThis as unknown as {
+    location?: { href?: string };
+    self?: unknown;
+    top?: unknown;
+  };
+
+  return {
+    url: contentScriptGlobals.location?.href ?? "",
+    isTopFrame: contentScriptGlobals.self === contentScriptGlobals.top,
+  };
+}
+
+export type ParsedSendMessageArguments = {
+  targetExtensionId?: string;
+  message: unknown;
+};
+
+/**
+ * `sendMessage`'s optional leading extension id, told apart the way Chrome
+ * tells it: three arguments make the first one the target, and with two the
+ * first is a target only when it reads as an extension id. A 32-character
+ * lowercase message with an options bag is misread the same way Chrome
+ * misreads it.
+ */
+export function parseSendMessageArguments(callArguments: unknown[]): ParsedSendMessageArguments {
+  if (callArguments.length >= 3) {
+    return {
+      targetExtensionId:
+        typeof callArguments[0] === "string" ? (callArguments[0] as string) : undefined,
+      message: callArguments[1],
+    };
+  }
+
+  if (
+    callArguments.length === 2 &&
+    typeof callArguments[0] === "string" &&
+    isExtensionId(callArguments[0])
+  ) {
+    return { targetExtensionId: callArguments[0], message: callArguments[1] };
+  }
+
+  return { message: callArguments[0] };
+}
+
+type NativeMethod = (...callArguments: unknown[]) => unknown;
+
+function getNativeMethod(runtime: ChromeNamespace, name: string): NativeMethod | undefined {
+  const method = runtime[name];
+
+  return typeof method === "function" ? (method as NativeMethod).bind(runtime) : undefined;
+}
+
+function createProxiedSendMessage(
+  runtime: ChromeNamespace,
+  nativeSendMessage: NativeMethod | undefined,
+  getSenderReport: () => RuntimeProxySenderReport,
+) {
+  return (...callArguments: unknown[]) => {
+    const callback =
+      typeof callArguments.at(-1) === "function"
+        ? (callArguments.pop() as (reply: unknown) => void)
+        : undefined;
+
+    const { targetExtensionId, message } = parseSendMessageArguments(callArguments);
+
+    // A message aimed at another extension is none of the proxy's business;
+    // whatever Electron does with it natively is the right answer
+    if (targetExtensionId !== undefined && targetExtensionId !== runtime.id && nativeSendMessage) {
+      return callback
+        ? nativeSendMessage(...callArguments, callback)
+        : nativeSendMessage(...callArguments);
+    }
+
+    const deliver = async () => {
+      let result: RuntimeProxySendMessageResult;
+
+      try {
+        const response = await postBridge(RUNTIME_PROXY_PATHS.sendMessage, {
+          message,
+          sender: getSenderReport(),
+        });
+
+        if (!response.ok) {
+          throw new Error(`The runtime proxy bridge answered ${response.status}`);
+        }
+
+        result = (await response.json()) as RuntimeProxySendMessageResult;
+      } catch {
+        // An unreachable bridge reads exactly like a session with no worker
+        throw new Error(RECEIVING_END_ERROR);
+      }
+
+      if (result?.status === "replied") {
+        return result.reply;
+      }
+
+      throw new Error(result?.status === "closed" ? PORT_CLOSED_ERROR : RECEIVING_END_ERROR);
+    };
+
+    const reply = deliver();
+
+    if (!callback) {
+      return reply;
+    }
+
+    reply.then(
+      (replyValue) => {
+        callback(replyValue);
+      },
+      (error: Error) => {
+        withLastError(runtime, error.message, () => {
+          callback(undefined);
+        });
+      },
+    );
+
+    return undefined;
+  };
+}
+
+function createProxiedPort(
+  runtime: ChromeNamespace,
+  name: string,
+  getSenderReport: () => RuntimeProxySenderReport,
+) {
+  const portId = crypto.randomUUID();
+
+  const onMessage = createEvent();
+
+  const onDisconnect = createEvent();
+
+  let isDisconnected = false;
+
+  let markOpened = () => {};
+
+  /**
+   * Resolves once the bridge has answered the connect request. Everything
+   * posted before that waits here, since two fetches have no order between
+   * them and a message must never overtake the connect that opens its port.
+   */
+  const opened = new Promise<void>((resolve) => {
+    markOpened = resolve;
+  });
+
+  let sendChain: Promise<unknown> = opened;
+
+  const port = {
+    name,
+    onMessage,
+    onDisconnect,
+    postMessage(message: unknown) {
+      if (isDisconnected) {
+        throw new Error(DISCONNECTED_PORT_ERROR);
+      }
+
+      sendChain = sendChain
+        .then(() => postBridge(RUNTIME_PROXY_PATHS.portPost, { portId, message }))
+        .catch(() => undefined);
+    },
+    disconnect() {
+      if (isDisconnected) {
+        return;
+      }
+
+      isDisconnected = true;
+
+      markOpened();
+
+      void postBridge(RUNTIME_PROXY_PATHS.portDisconnect, { portId });
+    },
+  };
+
+  // Chrome stays quiet about a port the content script disconnected itself
+  const disconnected = (error?: string) => {
+    markOpened();
+
+    if (isDisconnected) {
+      return;
+    }
+
+    isDisconnected = true;
+
+    withLastError(runtime, error, () => {
+      onDisconnect.emit(port);
+    });
+  };
+
+  const readFrames = async () => {
+    const response = await postBridge(RUNTIME_PROXY_PATHS.connect, {
+      portId,
+      name,
+      sender: getSenderReport(),
+    });
+
+    if (!response.ok || !response.body) {
+      throw new Error(`The runtime proxy bridge answered ${response.status}`);
+    }
+
+    markOpened();
+
+    const reader = response.body.getReader();
+
+    const decoder = new NativeMessageDecoder(MAX_RUNTIME_PROXY_FRAME_BYTES);
+
+    for (;;) {
+      const { value, done } = await reader.read();
+
+      if (done) {
+        return;
+      }
+
+      for (const frame of decoder.push(value) as RuntimeProxyPortFrame[]) {
+        if (frame.type === "message") {
+          onMessage.emit(frame.message, port);
+        } else {
+          disconnected(frame.error);
+
+          return;
+        }
+      }
+    }
+  };
+
+  readFrames().then(
+    () => {
+      // The relay closed the stream without a disconnect frame: the far end
+      // went away cleanly, which Chrome reports without an error
+      disconnected();
+    },
+    () => {
+      // Never opened, exactly like a session with no worker to receive it
+      disconnected(RECEIVING_END_ERROR);
+    },
+  );
+
+  return port;
+}
+
+function createProxiedConnect(
+  runtime: ChromeNamespace,
+  nativeConnect: NativeMethod | undefined,
+  getSenderReport: () => RuntimeProxySenderReport,
+) {
+  return (...callArguments: unknown[]) => {
+    const targetExtensionId = typeof callArguments[0] === "string" ? callArguments[0] : undefined;
+
+    if (targetExtensionId !== undefined && targetExtensionId !== runtime.id && nativeConnect) {
+      return nativeConnect(...callArguments);
+    }
+
+    const connectInfo = (
+      typeof callArguments[0] === "object" && callArguments[0] !== null
+        ? callArguments[0]
+        : callArguments[1]
+    ) as { name?: unknown } | undefined;
+
+    return createProxiedPort(
+      runtime,
+      typeof connectInfo?.name === "string" ? connectInfo.name : "",
+      getSenderReport,
+    );
+  };
+}
+
+export type InstallRuntimeProxyShimOptions = {
+  getSenderReport?: () => RuntimeProxySenderReport;
+};
+
+/**
+ * Shadows `chrome.runtime.sendMessage` and `chrome.runtime.connect` in a
+ * content script's isolated world, pointing both at the runtime proxy instead
+ * of at this session's own extension instance, which has no service worker to
+ * receive them. It runs before any of the extension's own content scripts —
+ * the derive prepends it to every `content_scripts` entry — so the extension
+ * only ever sees the shadowed functions. Everything else on `chrome.runtime`,
+ * `getURL` and `id` above all, stays exactly as Electron made it.
+ */
+export function installRuntimeProxyShim(
+  extensionApi: ChromeNamespace,
+  { getSenderReport = getContentScriptSenderReport }: InstallRuntimeProxyShimOptions = {},
+) {
+  const runtime = extensionApi.runtime as ChromeNamespace | undefined;
+
+  if (!runtime) {
+    return;
+  }
+
+  runtime.sendMessage = createProxiedSendMessage(
+    runtime,
+    getNativeMethod(runtime, "sendMessage"),
+    getSenderReport,
+  );
+
+  runtime.connect = createProxiedConnect(
+    runtime,
+    getNativeMethod(runtime, "connect"),
+    getSenderReport,
+  );
+}

--- a/packages/electron-extensions/runtime-proxy/shim.ts
+++ b/packages/electron-extensions/runtime-proxy/shim.ts
@@ -19,9 +19,9 @@ const DISCONNECTED_PORT_ERROR = "Attempting to use a disconnected port object";
 /**
  * What a shimmed context can say about where it runs, read from its own
  * globals. The same two facts serve a content script and an extension page: the
- * main process checks the claim against the session's frame tree before
- * anything trusts it, and reads a top-level document on the extension's own
- * scheme as the page it is.
+ * main process holds the claim against the frame Chromium recorded as the
+ * request's caller before anything trusts it, and reads a top-level document on
+ * the extension's own scheme as the page it is.
  */
 function getContextSenderReport(): RuntimeProxySenderReport {
   const contextGlobals = globalThis as unknown as {

--- a/packages/electron-extensions/web-navigation/web-navigation.test.ts
+++ b/packages/electron-extensions/web-navigation/web-navigation.test.ts
@@ -192,6 +192,9 @@ describe("WebNavigation", () => {
         },
         unhandle: () => undefined,
       },
+      webRequest: {
+        onBeforeSendHeaders: () => undefined,
+      },
     } as unknown as Session;
 
     const { contents } = createTab({ session: bridgeSession });

--- a/packages/electron-extensions/web-navigation/web-navigation.ts
+++ b/packages/electron-extensions/web-navigation/web-navigation.ts
@@ -14,7 +14,7 @@ const MAIN_FRAME_ID = 0;
  * the main frame pinned to 0 — which is why the main frame never answers to its
  * own node id.
  */
-function getExtensionFrameId(frame: WebFrameMain) {
+export function getExtensionFrameId(frame: WebFrameMain) {
   return frame.parent ? frame.frameTreeNodeId : MAIN_FRAME_ID;
 }
 

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -94,10 +94,10 @@ function buildAppFiles() {
 
   // Runs inside extensions rather than in Meru, so it is bundled like a preload
   // and copied into every extension the loader derives
-  const buildExtensionsChromeFacade = () =>
+  const buildExtensionScript = (inputPath: string, outputFileName: string) =>
     rolldown({
       ...rolldownOptions,
-      input: "./packages/electron-extensions/facade/index.ts",
+      input: inputPath,
       platform: "browser",
       transform: {
         ...rolldownOptions.transform,
@@ -105,7 +105,7 @@ function buildAppFiles() {
       },
     }).then((bundle) =>
       bundle.write({
-        file: path.join(process.cwd(), "build-js", "extensions-chrome-facade.js"),
+        file: path.join(process.cwd(), "build-js", outputFileName),
         codeSplitting: false,
         format: "iife",
       }),
@@ -140,7 +140,18 @@ function buildAppFiles() {
     buildPreloadFile("preload-gmail"),
     buildPreloadFile("preload-workspace-app"),
     buildPreloadFile("preload-renderer"),
-    buildExtensionsChromeFacade(),
+    buildExtensionScript(
+      "./packages/electron-extensions/facade/index.ts",
+      "extensions-chrome-facade.js",
+    ),
+    buildExtensionScript(
+      "./packages/electron-extensions/runtime-proxy/shim-entry.ts",
+      "extensions-runtime-proxy-shim.js",
+    ),
+    buildExtensionScript(
+      "./packages/electron-extensions/runtime-proxy/relay-entry.ts",
+      "extensions-runtime-proxy-relay.js",
+    ),
   ]);
 }
 

--- a/tests/bundle-budget.json
+++ b/tests/bundle-budget.json
@@ -1,6 +1,8 @@
 {
   "app.js": 2294784,
   "extensions-chrome-facade.js": 25600,
+  "extensions-runtime-proxy-relay.js": 15360,
+  "extensions-runtime-proxy-shim.js": 15360,
   "preload-gmail.js": 108544,
   "preload-renderer.js": 5120,
   "preload-workspace-app.js": 84992,


### PR DESCRIPTION
## Summary
One shared extension instance serving every account session, in place of one instance per session: the first session set up keeps the whole extension and its single MV3 service worker, every later session gets a content-script-only copy, and a main-process relay carries that copy's `chrome.runtime` messaging — from its content scripts **and its extension pages** — to the one worker and back. The prize is one sign-in to a password manager instead of one per account. Two review findings deferred to `todo.md` are closed here too: a relayed sender is now bound to the frame that actually sent it, and extension pages of every derived copy — not just the content-script-only one — can reach the bridge. It is off by default behind `is.dev && MERU_EXTENSIONS_SHARED_INSTANCE`, and it has never been run against 1Password itself.

## Problem
Chromium scopes an extension to the session it is loaded into, so the same directory loaded into N account sessions gives N independent instances: N service workers, N `chrome.storage` areas, and N sign-ins to 1Password. Signing in once per account is the user-facing cost; N workers created at launch before any account is selected is the other, at roughly 88 MB each with no ceiling on the account count.

The action popup is what makes this more than plumbing. It is an extension page, it opens in whichever account session the user is looking at, and it is where 1Password's unlock UI lives — so a shared worker that content scripts can reach but the popup cannot is a feature nobody can actually use. Extension pages turned out to be wider than the popup, too: 1Password's inline menu, notification, modal and universal-sign-on frames are extension pages loaded as iframes inside web pages, which puts them on the fill path rather than only the unlock path.

## Solution
The whole mechanism lives in `packages/electron-extensions/runtime-proxy/`, following the `native-messaging/` and `web-navigation/` pattern. The app's entire connection to it is one `sharedInstance:` option in `packages/app/extensions.ts`.

- The derive grows one explicit option with two roles. The `worker` copy is the extension whole, plus a relay client imported by its service worker wrapper. The `contentScriptOnly` copy loses its `background` key entirely — Electron still injects its content scripts — and gets the proxy's shim prepended to every `content_scripts` entry and written into every extension page, ahead of the page's own scripts.
- The relay carries `sendMessage` and `connect`/ports both ways, with delivery bookkept rather than assumed. A `protocol.handle` request's abort signal never fires when the worker behind it is killed, so a parked stream from a dead worker looks live forever: streams are invalidated from `running-status-changed`, every handed job is acked by id, an un-acked job is redelivered while an acked one fails the way Chrome's closed message port does, and `startWorkerForScope` wakes a stopped worker when a job needs it.
- **A page's own `<meta>` CSP governs it alongside the manifest's, and the stricter one decides.** 1Password's popup declares `default-src 'none'` with no `connect-src`, so it refuses the bridge however wide the manifest was made — measured on Electron 43, where the fetch fails with "Refused to connect because it violates the document's Content Security Policy" before any handler is asked. The derive widens the page policy the way `allowConnectSource` already widens the manifest's, reusing that function — for every copy, because the facade calls the bridge from pages whatever the copy's role: `connectNative` and the webNavigation queries go over it, so an ordinary or worker copy's page under a strict `<meta>` policy had the same refusal. The widening belongs to the facade transport, like the manifest widening that was always unconditional, not to the shared instance. `DERIVE_VERSION` moves to 8 so copies already on disk are re-derived.
- **A sender is bound to the frame that sent it, or delivered as `id` alone.** `protocol.handle` hands the bridge only the session, never the caller — but the session's `webRequest` sees the same request first and Chromium tells it the initiating frame, something no caller has a hand in. The bridge's own scheme-filtered `onBeforeSendHeaders` listener records that frame under a fresh nonce and stamps the nonce onto the request as a header the handler reads back; anything the caller wrote there itself is dropped, a record answers exactly once, the store is capped, and a destroyed frame is not handed over. The sender is then built from that frame — `webContents.fromFrame` names the tab, so with one URL open in two tabs the message is attributed to the tab that called, not the first match — with the shim's self-report kept only as a claim the frame has to back: a report the caller's own frame does not back arrives as `id` alone rather than as the URL it asked for, and an extension checking `sender.origin` against its own then refuses it. Being an extension page decides one thing only: whether `tab` and `frameId` attach. A top-level one is no tab, as Chrome's action popup is none; a subframe one keeps the host tab. Measured on Electron 43.2.0: the listener runs before the handler with its callback gating the request, the stamp arrives intact, and two windows on one URL in one session each came back as their own `WebContents` through the real `ExtensionBridge`.
- Tab ids are `WebContents` ids, which Electron numbers across the app — Chromium's own extension tab ids restart per session and two sessions' tabs would collide the moment one worker served both.

Why this way and not the obvious alternative. **Opening the popup in the worker's session** needs no proxying at all, but Electron implements `chrome.tabs` natively and per-session, so the popup would enumerate the wrong account's tabs and fill into the wrong page; it needs a second seam in `packages/app`; and it does nothing for the inline frames, which are extension pages inside web pages and cannot move sessions. **Giving the bridge scheme `bypassCSP`** would fix the page-policy problem in one line, but it hands the scheme to every document in every session, where today a page's own policy still stands between it and the bridge; the other alternative the todo row weighed — stopping the facade needing the bridge from pages — means dropping `connectNative` and webNavigation from pages, since the bridge is the only transport an extension page has. **For the caller stamp, `onBeforeSendHeaders` rather than `onBeforeRequest`**, because Electron gives a session exactly one listener per `webRequest` event and the app's blocker holds `onBeforeRequest`; the scheme filter keeps Gmail's own traffic out of the listener entirely, and the blocking callback is what guarantees the record exists before the handler runs, rather than an observed ordering.

Removability was checked in the disable sense: deleting the one `sharedInstance:` option leaves `bun run types`, `bun run lint` and `bun test` green. The ordinary derive output is no longer byte-identical to before — the page-policy widening now goes into every copy — but the removability proof never needed that: deleting the `sharedInstance` option and the `runtime-proxy/` directory still removes the whole feature, while the page widening stays with the facade transport it serves. What stays resident either way is the type, the field, three lifecycle call sites and a memo-key change in `packages/electron-extensions/extensions.ts`.

**What this does not add** is a way for the worker to reach a context it did not hear from first. `runtime.onMessage` in a page or content script stays native, so a worker's `sendMessage` broadcast crosses no session, and `tabs.sendMessage` is not carried. Ports carry both ways, which is what 1Password's messaging library opens. `chrome.storage` from a content-script-only copy still answers from its own session's store — 1Password keeps all six of its call sites in the worker and sets `setAccessLevel({ accessLevel: "TRUSTED_CONTEXTS" })`, so one shared worker already means one shared unlock state, but any extension that reads storage from a content script would see divergence.

### Review
Both halves were reviewed by Fable, separately, and every finding is applied here. From the first pass: the sender hardening above, a backstop timeout so a worker that dies without its session ever reporting it stopped cannot wedge a job forever (which left the content script's `sendMessage` neither resolving nor rejecting), and a seen-jobId guard so a redelivered job whose ack was lost is not dispatched to the extension's listeners twice. From the second: the page-CSP rewrite failed on hexadecimal character references — `default-src &#x27;none&#x27;` came apart along the `;` ending each undecoded reference — which was that reviewer's blocker, and it is fixed with the round trip now going through one pass. Both reviews found the extension-page sender independently.

Two findings were deferred to `todo.md` at review time and are now closed by the two most recent commits: the relayed sender no longer takes the first tab whose URL matches (it is bound to the calling frame, above), and the page-policy widening covers every copy rather than only the content-script-only role. The rows stay in `todo.md` until this merges.

### The cold-launch wake race, fixed 2026-08-28

`e950ae2` closes a race the fixture extension's end-to-end suite (#991) caught on macOS CI, after five throwaway probes and five review rounds had not: a `chrome.runtime` message relayed before the worker session finished its **first** service worker registration was answered instantly with "Could not establish connection. Receiving end does not exist." Chromium rejects `startWorkerForScope` with `kErrorNotFound` while the scope has no stored registration, and `wakeWorker`'s rejection path failed every queued job on the spot instead of arming the bounded `wakeTimeoutMs` wait its resolve path arms. This is not only a CI race — the same window opens at every cold launch in production, because another session's content scripts inject at `document_start` and can message before the worker session's copy has registered, which handed 1Password's fill path an instant, final-looking refusal. The rejection now arms the same bounded wait, and the starting worker's parked job stream already clears the wake and flushes the queue; a rejection with a live registration still fails, one timeout later rather than instantly, which is closer to Chrome, where a message never races the extension's own startup. Diagnosed from the macOS trace (the app's first `send-message` answered `noListener` in 10 ms, 1.5 s into its life), reproduced byte-for-byte on Linux by holding the worker session's extension load back five seconds, and that same handicapped run passes with the fix in place. Pinned by two unit tests on the fake `startWorkerForScope`, mutation-checked: with the fix reverted, both fail.

## Try it
There is no preview deployment for an Electron app, so this is a local run: two accounts, 1Password installed, then `MERU_EXTENSIONS_SHARED_INSTANCE=1 bun run dev`. Sign in to 1Password in the first account, then select the second, open the extensions button in the titlebar and pick 1Password — its popup should already be unlocked, against the worker in the first account's session.

Without 1Password, any MV3 extension with a `manifest.key`, an `action.default_popup` and a background worker that answers `runtime.onMessage` shows the mechanism; drop it in the gitignored `extensions/` folder. The key matters: without one the two derived copies get different generated ids and the relay never matches them, which fails honestly as "Could not establish connection. Receiving end does not exist."

## Not verified
- **The four flows that must keep working — log in with a password, log in with a passkey, create a password, create a passkey — and shared unlock across accounts.** They need a real signed-in Google account and the 1Password desktop app, neither of which exists in the sandbox this was written in. macOS and Windows were also unavailable, so everything below is Linux-only.
- **CI has not run.** GitHub Actions has been in an outage; the last run on this branch predates the rebase, the bundle budget entries and every fix above. Local `types`, `lint`, `fmt:check` and 635 tests pass, and `test:perf`'s bundle-budget test was run against a real build. Nothing here should be called green until an actual run passes.
- The caller stamp's electron-facing mechanics — filter syntax, stamping order, `frame` on a custom-scheme request, `webContents.fromFrame` — were measured in a real Electron 43.2.0 run against the real `ExtensionBridge`, but not from a content script's isolated world specifically; a content script's `fetch` goes through its document's loader, which is the same frame Chromium reports for the page's own fetches.
- Whether 1Password's popup depends on a worker-initiated `runtime.sendMessage` broadcast, which is not carried. Its messaging library talks over named ports, which do work.
- What was verified, in a bare Electron harness against the loader with two sessions and a purpose-built extension whose popup carries a `default-src 'none'` policy written with the hexadecimal references that broke the rewrite: a popup in the content-script-only session completed a `sendMessage` round trip and a named-port echo against the worker in the other session, with the sender `{id, url, origin}` and no `tab`; the same extension embedded as an iframe in a web page in that session got the host tab and its frame id; and the worker session's own popup still went the native path untouched.
- One asymmetry worth knowing: Electron's own sender for a popup carries a `tab` and `frameId: 0`, where Chrome's carries neither. The shimmed side follows Chrome, so the first account's popup and a later account's popup look different to the extension.


