### PR TITLE
Reach the one worker from an extension page too

### DIFF
--- a/packages/electron-extensions/derive/html.test.ts
+++ b/packages/electron-extensions/derive/html.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { injectFacadeScript } from "./html";
+import { allowPageConnectSource, injectPageScripts } from "./html";
 
-describe("injectFacadeScript", () => {
-  test("runs the facade before the page's own scripts", () => {
-    const page = injectFacadeScript(
+describe("injectPageScripts", () => {
+  test("runs the loader's scripts before the page's own", () => {
+    const page = injectPageScripts(
       '<!doctype html><html><head><title>Popup</title><script src="/popup.js"></script></head></html>',
-      "/chrome-facade.js",
+      ["/chrome-facade.js"],
     );
 
     expect(page).toStartWith(
@@ -14,21 +14,85 @@ describe("injectFacadeScript", () => {
     expect(page.indexOf("/chrome-facade.js")).toBeLessThan(page.indexOf("/popup.js"));
   });
 
+  test("keeps the order it was given", () => {
+    const page = injectPageScripts('<html><head><script src="/popup.js"></script></head></html>', [
+      "/chrome-facade.js",
+      "/chrome-runtime-proxy-shim.js",
+    ]);
+
+    expect(page).toBe(
+      '<html><head><script src="/chrome-facade.js"></script><script src="/chrome-runtime-proxy-shim.js"></script><script src="/popup.js"></script></head></html>',
+    );
+  });
+
   test("falls back to the html tag when there is no head", () => {
-    expect(injectFacadeScript("<html><body>Hi</body></html>", "/chrome-facade.js")).toBe(
+    expect(injectPageScripts("<html><body>Hi</body></html>", ["/chrome-facade.js"])).toBe(
       '<html><script src="/chrome-facade.js"></script><body>Hi</body></html>',
     );
   });
 
   test("prepends when there is no markup to anchor to", () => {
-    expect(injectFacadeScript("Hi", "/chrome-facade.js")).toBe(
+    expect(injectPageScripts("Hi", ["/chrome-facade.js"])).toBe(
       '<script src="/chrome-facade.js"></script>Hi',
     );
   });
 
-  test("injects once", () => {
-    const page = injectFacadeScript("<html><head></head></html>", "/chrome-facade.js");
+  test("injects each script once", () => {
+    const scriptUrls = ["/chrome-facade.js", "/chrome-runtime-proxy-shim.js"];
 
-    expect(injectFacadeScript(page, "/chrome-facade.js")).toBe(page);
+    const page = injectPageScripts("<html><head></head></html>", scriptUrls);
+
+    expect(injectPageScripts(page, scriptUrls)).toBe(page);
+  });
+});
+
+describe("allowPageConnectSource", () => {
+  test("widens a page policy that pins connect-src", () => {
+    expect(
+      allowPageConnectSource(
+        `<html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src https://1password.com" /></head></html>`,
+        "extension-bridge:",
+      ),
+    ).toBe(
+      `<html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; connect-src https://1password.com extension-bridge:" /></head></html>`,
+    );
+  });
+
+  test("gives a page policy without connect-src one, the way the manifest gets it", () => {
+    expect(
+      allowPageConnectSource(
+        `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'">`,
+        "extension-bridge:",
+      ),
+    ).toBe(
+      `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; connect-src extension-bridge:">`,
+    );
+  });
+
+  test("leaves a page that declares no policy of its own alone", () => {
+    const page = `<html><head><meta charset="utf-8"><title>Popup</title></head></html>`;
+
+    expect(allowPageConnectSource(page, "extension-bridge:")).toBe(page);
+  });
+
+  test("widens every policy the page declares", () => {
+    const page = allowPageConnectSource(
+      `<meta http-equiv="content-security-policy" content="default-src 'none'"><meta http-equiv="Content-Security-Policy" content="connect-src 'self'">`,
+      "extension-bridge:",
+    );
+
+    expect(page).toContain(`content="default-src 'none'; connect-src extension-bridge:"`);
+    expect(page).toContain(`content="connect-src 'self' extension-bridge:"`);
+  });
+
+  test("reads and writes the attribute's escapes rather than through them", () => {
+    expect(
+      allowPageConnectSource(
+        `<meta http-equiv="Content-Security-Policy" content='default-src &#39;none&#39;'>`,
+        "extension-bridge:",
+      ),
+    ).toBe(
+      `<meta http-equiv="Content-Security-Policy" content='default-src &#39;none&#39;; connect-src extension-bridge:'>`,
+    );
   });
 });

--- a/packages/electron-extensions/derive/html.ts
+++ b/packages/electron-extensions/derive/html.ts
@@ -1,27 +1,78 @@
+import { allowConnectSource } from "./manifest";
+
 const HEAD_TAG = /<head\b[^>]*>/i;
 
 const HTML_TAG = /<html\b[^>]*>/i;
 
+const META_CONTENT_SECURITY_POLICY_TAG =
+  /<meta\b[^>]*\bhttp-equiv\s*=\s*["']?content-security-policy["']?[^>]*>/gi;
+
+const CONTENT_ATTRIBUTE = /(\bcontent\s*=\s*)(["'])([\s\S]*?)\2/i;
+
 /**
- * Puts the facade in front of every script an extension page runs. Extension
- * pages get the same incomplete `chrome` object the service worker does, and a
- * page has no preload of its own that reliably reaches its main world, so the
- * script tag is written into the page when the extension is derived.
+ * Puts the loader's scripts in front of every script an extension page runs, in
+ * the order given. Extension pages get the same incomplete `chrome` object the
+ * service worker does, and a page has no preload of its own that reliably
+ * reaches its main world, so the script tags are written into the page when the
+ * extension is derived.
  */
-export function injectFacadeScript(html: string, facadeUrl: string) {
-  if (html.includes(facadeUrl)) {
+export function injectPageScripts(html: string, scriptUrls: string[]) {
+  const missingScriptUrls = scriptUrls.filter((scriptUrl) => !html.includes(scriptUrl));
+
+  if (missingScriptUrls.length === 0) {
     return html;
   }
 
-  const scriptTag = `<script src="${facadeUrl}"></script>`;
+  const scriptTags = missingScriptUrls
+    .map((scriptUrl) => `<script src="${scriptUrl}"></script>`)
+    .join("");
 
   const openingTag = HEAD_TAG.exec(html) ?? HTML_TAG.exec(html);
 
   if (!openingTag) {
-    return `${scriptTag}${html}`;
+    return `${scriptTags}${html}`;
   }
 
   const insertAt = openingTag.index + openingTag[0].length;
 
-  return `${html.slice(0, insertAt)}${scriptTag}${html.slice(insertAt)}`;
+  return `${html.slice(0, insertAt)}${scriptTags}${html.slice(insertAt)}`;
+}
+
+function decodeAttribute(value: string) {
+  return value
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;|&#0*39;/gi, "'")
+    .replace(/&amp;/gi, "&");
+}
+
+function encodeAttribute(value: string, quote: string) {
+  const encoded = value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+  return quote === '"' ? encoded.replace(/"/g, "&quot;") : encoded.replace(/'/g, "&#39;");
+}
+
+/**
+ * Widens the `connect-src` of a page's own `<meta>` content security policy,
+ * the way `allowConnectSource` widens the manifest's.
+ *
+ * Both policies govern an extension page and the stricter one decides, so a
+ * page declaring `default-src 'none'` — which is what 1Password's popup and
+ * each of its inline frames declare — refuses the bridge however wide the
+ * manifest was made. Measured on Electron 43: the fetch fails with "Refused to
+ * connect because it violates the document's Content Security Policy" before
+ * any handler is asked.
+ */
+export function allowPageConnectSource(html: string, source: string) {
+  return html.replace(META_CONTENT_SECURITY_POLICY_TAG, (metaTag) =>
+    metaTag.replace(
+      CONTENT_ATTRIBUTE,
+      (_attribute, assignment: string, quote: string, policy: string) =>
+        `${assignment}${quote}${encodeAttribute(
+          allowConnectSource(decodeAttribute(policy), source),
+          quote,
+        )}${quote}`,
+    ),
+  );
 }

--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -388,6 +388,11 @@ describe("deriveExtension for a shared instance", () => {
     });
 
     await writeSourceFile("content.js", "// content\n");
+
+    await writeSourceFile(
+      "popup.html",
+      `<html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'"><script src="/popup.js"></script></head></html>`,
+    );
   });
 
   test("the worker copy carries the relay client under the facade's token", async () => {
@@ -435,6 +440,42 @@ describe("deriveExtension for a shared instance", () => {
 
     expect(shimSource).toContain(bridgeToken);
     expect(shimSource).toEndWith("// shim\n");
+  });
+
+  test("the content-script-only copy's pages run the shim and may reach the bridge", async () => {
+    const { derivedDir } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      sharedInstance: { role: "contentScriptOnly", shimScriptPath },
+    });
+
+    const page = await readFile(path.join(derivedDir, "popup.html"), "utf8");
+
+    // The popup is where a password manager keeps its unlock UI, and this copy
+    // has no worker of its own for it to talk to
+    expect(page.indexOf("/chrome-facade.js")).toBeLessThan(
+      page.indexOf("/chrome-runtime-proxy-shim.js"),
+    );
+    expect(page.indexOf("/chrome-runtime-proxy-shim.js")).toBeLessThan(page.indexOf("/popup.js"));
+
+    expect(page).toContain(
+      `content="default-src 'none'; script-src 'self'; connect-src extension-bridge:"`,
+    );
+  });
+
+  test("the worker copy's pages are derived exactly as the ordinary copy's", async () => {
+    const { derivedDir } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      sharedInstance: { role: "worker", relayScriptPath },
+    });
+
+    const page = await readFile(path.join(derivedDir, "popup.html"), "utf8");
+
+    expect(page).not.toContain("chrome-runtime-proxy-shim.js");
+    expect(page).toContain(`content="default-src 'none'; script-src 'self'"`);
   });
 
   test("the two copies exist side by side, from one source, as one extension id", async () => {

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -3,7 +3,7 @@ import { cp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { EXTENSION_BRIDGE_SCHEME, EXTENSION_BRIDGE_TOKEN_GLOBAL } from "../bridge/protocol";
 import { getExtensionIdFromManifestKey } from "./extension-id";
-import { injectFacadeScript } from "./html";
+import { allowPageConnectSource, injectPageScripts } from "./html";
 import {
   deriveManifest,
   type ExtensionManifest,
@@ -31,7 +31,7 @@ const RUNTIME_PROXY_RELAY_FILE_NAME = "chrome-runtime-proxy-relay.js";
 const CONTENT_SCRIPT_ONLY_DIR_SUFFIX = "-content-scripts";
 
 /** Bump whenever what is written into a derived copy changes. */
-const DERIVE_VERSION = 6;
+const DERIVE_VERSION = 7;
 
 /**
  * The copy's part in one shared extension instance serving every session (see
@@ -115,7 +115,24 @@ async function directoryExists(dirPath: string) {
 /** Chromium serves `Popup.HTM` as a page just as well, so the net is this wide. */
 const PAGE_FILE_EXTENSIONS = new Set([".html", ".htm"]);
 
-async function injectFacadeIntoPages(derivedDir: string) {
+/**
+ * Writes the loader's scripts into every page of the copy. A content-script-only
+ * copy has no worker of its own to receive what its pages send, so the proxy's
+ * shim goes in behind the facade and its pages are let through to the bridge —
+ * both only for that role, so the ordinary copy is derived byte for byte as it
+ * always was.
+ */
+async function derivePages(
+  derivedDir: string,
+  sharedInstance: SharedInstanceDeriveOptions | undefined,
+) {
+  const isContentScriptOnly = sharedInstance?.role === "contentScriptOnly";
+
+  const scriptUrls = [
+    `/${FACADE_FILE_NAME}`,
+    ...(isContentScriptOnly ? [`/${RUNTIME_PROXY_SHIM_FILE_NAME}`] : []),
+  ];
+
   const fileNames = await readdir(derivedDir, { recursive: true });
 
   for (const fileName of fileNames) {
@@ -127,7 +144,11 @@ async function injectFacadeIntoPages(derivedDir: string) {
 
     const page = await readFile(pagePath, "utf8");
 
-    await writeFile(pagePath, injectFacadeScript(page, `/${FACADE_FILE_NAME}`));
+    const bridgeReachablePage = isContentScriptOnly
+      ? allowPageConnectSource(page, `${EXTENSION_BRIDGE_SCHEME}:`)
+      : page;
+
+    await writeFile(pagePath, injectPageScripts(bridgeReachablePage, scriptUrls));
   }
 }
 
@@ -210,7 +231,7 @@ export async function deriveExtension({
       await writeFile(path.join(derivedDir, SERVICE_WORKER_FILE_NAME), serviceWorkerWrapper);
     }
 
-    await injectFacadeIntoPages(derivedDir);
+    await derivePages(derivedDir, sharedInstance);
 
     await writeFile(stampPath, stamp);
   }

--- a/packages/electron-extensions/derive/manifest.ts
+++ b/packages/electron-extensions/derive/manifest.ts
@@ -185,7 +185,9 @@ function deriveContentSecurityPolicy(
  * `contentScriptOnly` copy loses its `background` key entirely — Electron still
  * injects its content scripts (measured 2026-08-25) — and gets the proxy's shim
  * prepended to every one of them, so its `chrome.runtime` messaging reaches the
- * one worker instead of a receiving end that does not exist.
+ * one worker instead of a receiving end that does not exist. Its extension
+ * pages are shimmed too, which is the derive's own job rather than the
+ * manifest's.
  */
 export type SharedInstanceManifestOptions =
   | { role: "worker"; relayFileName: string }

--- a/packages/electron-extensions/runtime-proxy/bridge-protocol.ts
+++ b/packages/electron-extensions/runtime-proxy/bridge-protocol.ts
@@ -3,13 +3,17 @@
  * shared by the content-script shim, the worker-side relay client, and the
  * main-process relay.
  *
- * The proxy carries `chrome.runtime` messaging from content scripts in
- * worker-less sessions to the one session that keeps the extension's service
- * worker. Content-script calls go up as ordinary bridge POSTs; everything
- * flowing the other way rides a streaming response body — port frames to a
- * content script, jobs to the worker — in the same length-prefixed JSON frames
- * native messaging uses (`native-messaging/framing.ts`).
+ * The proxy carries `chrome.runtime` messaging from the contexts of a
+ * worker-less session — its content scripts and its extension pages, the action
+ * popup above all — to the one session that keeps the extension's service
+ * worker. Their calls go up as ordinary bridge POSTs; everything flowing the
+ * other way rides a streaming response body — port frames to the caller, jobs
+ * to the worker — in the same length-prefixed JSON frames native messaging uses
+ * (`native-messaging/framing.ts`).
  */
+
+/** What every extension URL starts with, from a worker scope to a page's own. */
+export const EXTENSION_SCHEME_PREFIX = "chrome-extension://";
 
 export const RUNTIME_PROXY_PATHS = {
   /** Content-script side, called by the shim. */
@@ -38,11 +42,13 @@ export const RECEIVING_END_ERROR = "Could not establish connection. Receiving en
 export const PORT_CLOSED_ERROR = "The message port closed before a response was received.";
 
 /**
- * What a content script can truthfully say about itself: a bridge request
+ * What a shimmed context can truthfully say about itself: a bridge request
  * carries no sender at all — no `Origin` header, nothing — so the shim reports
  * where it runs and the main process checks the claim against the session's
  * real frame tree before building the sender the worker sees. The bridge token
- * has already proven the caller is the extension's own isolated world.
+ * has already proven the caller is the extension's own — its isolated world, or
+ * one of its pages. Together the two fields say which: a top-level document on
+ * the extension's own scheme is an extension page, and no tab.
  */
 export type RuntimeProxySenderReport = {
   url: string;
@@ -109,8 +115,9 @@ export type RuntimeProxyTab = {
 
 /**
  * The `MessageSender` a relayed message hands the worker's listeners. `tab` and
- * `frameId` are missing when the reported frame could not be found in the
- * session — it navigated away while the message was in flight.
+ * `frameId` are missing when the message came from an extension page, which is
+ * no tab, and when the reported frame could not be found in the session — it
+ * navigated away while the message was in flight.
  */
 export type RuntimeProxySender = {
   id: string;

--- a/packages/electron-extensions/runtime-proxy/index.ts
+++ b/packages/electron-extensions/runtime-proxy/index.ts
@@ -5,8 +5,9 @@ import type { RuntimeProxyTabsProvider } from "./sender";
 
 export type CreateSharedExtensionInstanceOptions = {
   /**
-   * The bundled content-script shim, written into every content-script-only
-   * copy and prepended to each of its `content_scripts` entries.
+   * The bundled shim, written into every content-script-only copy, prepended to
+   * each of its `content_scripts` entries and injected into each of its
+   * extension pages.
    */
   shimScriptPath: string;
   /**
@@ -23,9 +24,11 @@ export type CreateSharedExtensionInstanceOptions = {
  * instance per session: the first session set up keeps the whole extension —
  * the one service worker, the one `chrome.storage` — and every later session
  * gets a content-script-only copy whose `chrome.runtime` messaging the
- * `RuntimeProxy` relays to that worker and back. The prize is one sign-in to a
- * password manager instead of one per account; one worker at any session count
- * instead of one per session comes with it.
+ * `RuntimeProxy` relays to that worker and back — from its content scripts and
+ * from its extension pages, which is where a password manager keeps its unlock
+ * UI. The prize is one sign-in to a password manager instead of one per
+ * account; one worker at any session count instead of one per session comes
+ * with it.
  *
  * The whole feature hangs off the one `sharedInstance` option this creates a
  * value for. An embedder that never passes it runs exactly as before, and

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
@@ -4,6 +4,7 @@ import type { ExtensionBridge } from "../bridge/bridge";
 import type { ExtensionsLogger } from "../logger";
 import { encodeNativeMessage } from "../native-messaging/framing";
 import {
+  EXTENSION_SCHEME_PREFIX,
   PORT_CLOSED_ERROR,
   RECEIVING_END_ERROR,
   RUNTIME_PROXY_PATHS,
@@ -22,8 +23,6 @@ import {
   type RuntimeProxyWorkerReplyRequest,
 } from "./bridge-protocol";
 import { parseSenderReport, reconstructSender, type RuntimeProxyTabsProvider } from "./sender";
-
-const EXTENSION_SCHEME_PREFIX = "chrome-extension://";
 
 type RelayJobBase = {
   jobId: string;
@@ -103,8 +102,8 @@ const DEFAULT_MAX_DELIVERY_ATTEMPTS = 3;
 
 /**
  * The main-process relay carrying `chrome.runtime` messaging between
- * content-script-only sessions and the one session that keeps an extension's
- * service worker.
+ * content-script-only sessions — their content scripts and their extension
+ * pages alike — and the one session that keeps an extension's service worker.
  *
  * The shim's calls arrive as bridge requests; jobs flow to the worker on a
  * streaming response its relay client keeps parked, and replies come back as

--- a/packages/electron-extensions/runtime-proxy/sender.test.ts
+++ b/packages/electron-extensions/runtime-proxy/sender.test.ts
@@ -139,6 +139,47 @@ describe("reconstructSender", () => {
     expect(firstSender.tab?.id).not.toBe(secondSender.tab?.id);
   });
 
+  test("a top-level extension page is no tab, the way Chrome's popup is none", () => {
+    const popupUrl = `chrome-extension://${EXTENSION_ID}/popup/index.html`;
+
+    // The popup's own view lives in the session and would otherwise be found
+    const contents = createContents(7, "1Password", [createFrame(popupUrl, 12)]);
+
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: popupUrl, isTopFrame: true },
+      getTabWebContents: () => [contents],
+    });
+
+    expect(sender).toEqual({
+      id: EXTENSION_ID,
+      url: popupUrl,
+      origin: `chrome-extension://${EXTENSION_ID}`,
+    });
+  });
+
+  test("an extension frame inside a page keeps the tab hosting it", () => {
+    const menuUrl = `chrome-extension://${EXTENSION_ID}/inline/menu/menu.html`;
+
+    const mainFrame = createFrame("https://accounts.google.com/", 12);
+
+    const menuFrame = createFrame(menuUrl, 34, mainFrame);
+
+    const contents = createContents(7, "Sign in", [mainFrame, menuFrame]);
+
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: menuUrl, isTopFrame: false },
+      getTabWebContents: () => [contents],
+    });
+
+    expect(sender.frameId).toBe(34);
+    expect(sender.tab?.id).toBe(7);
+    expect(sender.origin).toBe(`chrome-extension://${EXTENSION_ID}`);
+  });
+
   test("a report no live frame backs still delivers, without tab and frame", () => {
     const contents = createContents(7, "Sign in", [
       createFrame("https://accounts.google.com/", 12),

--- a/packages/electron-extensions/runtime-proxy/sender.ts
+++ b/packages/electron-extensions/runtime-proxy/sender.ts
@@ -1,9 +1,10 @@
 import type { Session, WebContents } from "electron";
 import { getExtensionFrameId } from "../web-navigation/web-navigation";
-import type {
-  RuntimeProxySender,
-  RuntimeProxySenderReport,
-  RuntimeProxyTab,
+import {
+  EXTENSION_SCHEME_PREFIX,
+  type RuntimeProxySender,
+  type RuntimeProxySenderReport,
+  type RuntimeProxyTab,
 } from "./bridge-protocol";
 
 /**
@@ -78,6 +79,15 @@ export type ReconstructSenderOptions = {
  * and frame ids come from that frame, never from the report. A report no frame
  * backs — the page navigated away mid-flight — still delivers, as a sender
  * without `tab` and `frameId`.
+ *
+ * An extension page reports itself the same way, and a top-level one is no tab:
+ * Chrome gives an action popup's messages a sender of `id`, `url` and `origin`
+ * alone, so that is what the worker sees. An extension page in a subframe is a
+ * different thing — 1Password's inline menu is an iframe of the extension
+ * inside a web page — and keeps the host tab and its frame id, which the frame
+ * lookup finds without being told. Meru renders extension pages only as the
+ * popup; Chrome would hand one opened in a browser tab a `tab`, and there is no
+ * such surface here.
  */
 export function reconstructSender({
   session,
@@ -90,6 +100,10 @@ export function reconstructSender({
     url: report.url,
     origin: getOrigin(report.url),
   };
+
+  if (report.isTopFrame && report.url.startsWith(EXTENSION_SCHEME_PREFIX)) {
+    return sender;
+  }
 
   for (const contents of getTabWebContents(session)) {
     if (contents.isDestroyed()) {
@@ -115,7 +129,20 @@ export function reconstructSender({
   return sender;
 }
 
+/**
+ * `new URL().origin` answers "null" for every scheme it does not know as
+ * special, and outside a browser process `chrome-extension:` is one of those.
+ * Chromium gives an extension URL the origin the extension runs on, which is
+ * what an extension checking `sender.origin` against its own `getURL("")`
+ * expects — 1Password refuses a request from any other origin.
+ */
 function getOrigin(url: string) {
+  if (url.startsWith(EXTENSION_SCHEME_PREFIX)) {
+    const extensionId = url.slice(EXTENSION_SCHEME_PREFIX.length).replace(/[/?#].*$/, "");
+
+    return `${EXTENSION_SCHEME_PREFIX}${extensionId}`;
+  }
+
   try {
     return new URL(url).origin;
   } catch {

--- a/packages/electron-extensions/runtime-proxy/shim-entry.ts
+++ b/packages/electron-extensions/runtime-proxy/shim-entry.ts
@@ -2,17 +2,19 @@ import type { ChromeNamespace } from "../facade/lib/chrome";
 import { installRuntimeProxyShim } from "./shim";
 
 /**
- * Entry point of the runtime proxy's content-script shim. It is bundled on its
- * own, like the facade, and the derive prepends it to every `content_scripts`
- * entry of a content-script-only copy, so it runs in the extension's isolated
- * world before any of the extension's own scripts. Electron hands content
- * scripts the extension API under both `chrome` and `browser`, so both get the
+ * Entry point of the runtime proxy's shim. It is bundled on its own, like the
+ * facade, and a content-script-only copy runs it in every context of the
+ * extension that can message: the derive prepends it to every `content_scripts`
+ * entry, so it reaches the isolated world before the extension's own scripts,
+ * and writes it into every extension page — the action popup, and the frames an
+ * extension embeds in web pages — ahead of the page's own. Electron hands these
+ * contexts the extension API under both `chrome` and `browser`, so both get the
  * shadowed `runtime` methods.
  */
-const contentScriptGlobals = globalThis as unknown as Record<string, ChromeNamespace | undefined>;
+const contextGlobals = globalThis as unknown as Record<string, ChromeNamespace | undefined>;
 
 for (const globalName of ["chrome", "browser"]) {
-  const extensionApi = contentScriptGlobals[globalName];
+  const extensionApi = contextGlobals[globalName];
 
   if (extensionApi) {
     installRuntimeProxyShim(extensionApi);

--- a/packages/electron-extensions/runtime-proxy/shim.ts
+++ b/packages/electron-extensions/runtime-proxy/shim.ts
@@ -17,20 +17,22 @@ import {
 const DISCONNECTED_PORT_ERROR = "Attempting to use a disconnected port object";
 
 /**
- * What the content script can say about where it runs, read from the isolated
- * world's own globals. The main process checks the claim against the session's
- * frame tree before anything trusts it.
+ * What a shimmed context can say about where it runs, read from its own
+ * globals. The same two facts serve a content script and an extension page: the
+ * main process checks the claim against the session's frame tree before
+ * anything trusts it, and reads a top-level document on the extension's own
+ * scheme as the page it is.
  */
-function getContentScriptSenderReport(): RuntimeProxySenderReport {
-  const contentScriptGlobals = globalThis as unknown as {
+function getContextSenderReport(): RuntimeProxySenderReport {
+  const contextGlobals = globalThis as unknown as {
     location?: { href?: string };
     self?: unknown;
     top?: unknown;
   };
 
   return {
-    url: contentScriptGlobals.location?.href ?? "",
-    isTopFrame: contentScriptGlobals.self === contentScriptGlobals.top,
+    url: contextGlobals.location?.href ?? "",
+    isTopFrame: contextGlobals.self === contextGlobals.top,
   };
 }
 
@@ -292,16 +294,21 @@ export type InstallRuntimeProxyShimOptions = {
 
 /**
  * Shadows `chrome.runtime.sendMessage` and `chrome.runtime.connect` in a
- * content script's isolated world, pointing both at the runtime proxy instead
- * of at this session's own extension instance, which has no service worker to
- * receive them. It runs before any of the extension's own content scripts —
- * the derive prepends it to every `content_scripts` entry — so the extension
- * only ever sees the shadowed functions. Everything else on `chrome.runtime`,
- * `getURL` and `id` above all, stays exactly as Electron made it.
+ * context of a content-script-only session, pointing both at the runtime proxy
+ * instead of at this session's own extension instance, which has no service
+ * worker to receive them. It runs before any of the extension's own code — the
+ * derive prepends it to every `content_scripts` entry and writes it into every
+ * extension page ahead of the page's own scripts — so the extension only ever
+ * sees the shadowed functions. Everything else on `chrome.runtime`, `getURL`
+ * and `id` above all, stays exactly as Electron made it.
+ *
+ * `onMessage` and `onConnect` are left native, which is what bounds the shim:
+ * an extension page hears what it opened a port for, and not what the worker
+ * broadcasts with `sendMessage` to a session it isn't in.
  */
 export function installRuntimeProxyShim(
   extensionApi: ChromeNamespace,
-  { getSenderReport = getContentScriptSenderReport }: InstallRuntimeProxyShimOptions = {},
+  { getSenderReport = getContextSenderReport }: InstallRuntimeProxyShimOptions = {},
 ) {
   const runtime = extensionApi.runtime as ChromeNamespace | undefined;
 


### PR DESCRIPTION
## Summary
An extension page in a content-script-only session can now reach the one shared service worker, which is what the action popup needs — it is where 1Password keeps its unlock UI, and in any account but the first there was no worker in its session to talk to. The derive writes the runtime proxy's shim into every page of that copy, widens the page's own content security policy so the shim can reach the bridge, and the relay hands the worker the sender Chrome would have given it. Still off by default behind `MERU_EXTENSIONS_SHARED_INSTANCE`, and still never run against 1Password itself.

## Problem
[PR #985](https://github.com/zoidsh/meru/pull/985) put one shared extension instance behind that switch: the first session set up keeps the whole extension and its single service worker, every later session gets a content-script-only copy, and a shim in that copy's content scripts relays their `chrome.runtime` messaging to the one worker. It deliberately left one gap. The action popup is an extension page, not a content script, and it opens in whichever account session the user is looking at — so in a content-script-only session its `chrome.runtime` messaging had nothing to reach. The popup is 1Password's unlock UI, which made this the one thing standing between #985 and a real 1Password test.

It turned out to be wider than the popup. 1Password's inline UI — `inline/menu/menu.html`, `notification`, `modal`, `universal-sign-on` — is extension pages loaded as iframes inside web pages, and those are on the fill path, not just the unlock path.

## Solution
- The shim already knew how to relay and only ran in content scripts. The derive now also writes it into every extension page of a content-script-only copy, behind the facade and ahead of the page's own scripts, which is the injection vehicle extension pages already had for the facade.
- A page's own `<meta>` policy governs it alongside the manifest's, and the stricter one decides, so 1Password's popup — `default-src 'none'`, no `connect-src` — refuses the bridge however wide the manifest was made. Measured on Electron 43: the fetch fails with "Refused to connect because it violates the document's Content Security Policy" before any handler is asked. `derive/html.ts` widens the page policy the way `allowConnectSource` already widens the manifest's, reusing that function, and only for this role — so the ordinary copy is still derived byte for byte as it was.
- A top-level extension page is no tab. Chrome hands an action popup's messages a sender of `id`, `url` and `origin` alone, so the reconstruction stops before the frame lookup rather than reporting the popup's own `WebContentsView` as a tab. An extension page in a subframe is the other case and keeps the host tab and its frame id, which is what the inline frames need. No new field was required: the shim already reports `isTopFrame`, and a top-level document on the extension's own scheme is an extension page.
- `new URL().origin` answers `"null"` for `chrome-extension:` outside a browser process, and 1Password compares `sender.origin` against its own `getURL("")` and refuses anything else, so extension URLs get the origin Chromium would have given them.
- `DERIVE_VERSION` goes 6 → 7, since what the derive writes changed and the source tree's hash cannot see a change that lives in this repository.

Why this way and not the two obvious alternatives. **Opening the popup in the worker's session** would need no proxying at all, but Electron implements `chrome.tabs` natively and per-session, so the popup would enumerate the wrong account's tabs and fill into the wrong page; it also needs a second seam in `packages/app`, and it does nothing for the inline frames, which are extension pages inside web pages and cannot move sessions. **Giving the bridge scheme `bypassCSP`** would fix the policy problem in one line, but it changes default behavior for every session and hands the scheme to every document in it, where today only the token is the gate.

There are no changes in `packages/app`: the whole feature still hangs off the one `sharedInstance` option. Removability was proven the way #985 proved it — deleting that option leaves `bun run types`, `bun run lint` and `bun test` green, and the derive output of a copy without the option is byte-identical to this branch's base, the stamp's `deriveVersion` alone excepted, which is what forces the re-derive.

What this does **not** add is a way for the worker to reach a page it did not hear from first. `runtime.onMessage` in a page stays native, so a worker's `sendMessage` broadcast crosses no session — the same gap #985 has for content scripts and `tabs.sendMessage`. Ports carry both ways, which is what 1Password's messaging library opens.

## Try it
There is no preview deployment for an Electron app, so this is a local run: two accounts, 1Password installed, then `MERU_EXTENSIONS_SHARED_INSTANCE=1 bun run dev`. Select the second account, open the extensions button in the titlebar and pick 1Password. Before this branch its popup sits there with nothing behind it; after, it reaches the worker in the first account's session, so an unlock in either account is an unlock in both.

Without 1Password, the mechanism is visible with any MV3 extension that has a `manifest.key`, an `action.default_popup` and a background worker that answers `runtime.onMessage` — drop it in the gitignored `extensions/` folder. A key matters: without one the two derived copies get different generated ids and the relay never matches them, which is a #985 limitation this branch does not change.

## Not verified
- **The four flows that must keep working — log in with a password, log in with a passkey, create a password, create a passkey — and shared unlock across accounts.** They need a real signed-in Google account and the 1Password desktop app, neither of which exists in the sandbox this was written in. macOS and Windows were also unavailable, so this is Linux-only.
- Whether 1Password's popup needs any worker-initiated `runtime.sendMessage` broadcast, which this branch does not carry. Its messaging library talks over named ports, which do work, but only a real run says whether anything depends on the broadcast path.
- What was verified, in a bare Electron harness against the loader with two sessions and a purpose-built extension whose popup carries 1Password's own strict page policy: a popup in the content-script-only session completed a `sendMessage` round trip and a named-port echo against the worker in the other session, with the sender `{id, url, origin}` and no `tab`; the same extension's page embedded as an iframe in a web page in that session got the host tab and its frame id; and the worker session's own popup still went the native path untouched.
