### PR TITLE
Gate workspace apps at the config read, not at the call sites

### DIFF
--- a/packages/app/accounts.ts
+++ b/packages/app/accounts.ts
@@ -202,11 +202,30 @@ class Accounts {
     }
   }
 
+  /**
+   * The accounts the app runs on, which is not everything the config holds. A
+   * second account and a workspace app are both Pro, so the free version is
+   * handed one account carrying no saved tabs — and every consumer reads them
+   * from here, which is what keeps the gate off the paths that use a tab.
+   * Restoring one, loading it on launch and waking a dormant one were each
+   * ungated on their own, so a trial that ended left its pinned apps working
+   * indefinitely.
+   *
+   * What the config holds is left alone: this slices what it returns, so
+   * activating a license brings back the accounts and the tabs the user had.
+   * Nothing written back to disk may be built from this list.
+   */
   getAccountConfigs() {
     const accountConfigs = config.get("accounts");
 
     if (!licenseKey.isValid) {
-      return accountConfigs.slice(0, 1);
+      return accountConfigs.slice(0, 1).map((accountConfig) => ({
+        ...accountConfig,
+        workspaceApps: {
+          ...accountConfig.workspaceApps,
+          savedTabs: [],
+        },
+      }));
     }
 
     return accountConfigs;
@@ -273,9 +292,13 @@ class Accounts {
   }
 
   selectAccount(selectedAccountId: string) {
+    // Written from what the config holds rather than from `getAccountConfigs`,
+    // which is filtered down for the free version: selecting an account there
+    // would have persisted that filtering, dropping every account past the
+    // first and the saved tabs of the one that stayed.
     config.set(
       "accounts",
-      this.getAccountConfigs().map((accountConfig) => {
+      config.get("accounts").map((accountConfig) => {
         return {
           ...accountConfig,
           selected: accountConfig.id === selectedAccountId,
@@ -453,9 +476,16 @@ class Accounts {
       return;
     }
 
+    // The free version restores no saved tabs, so its accounts hold none to
+    // serialize — and writing that back would erase what the user pinned under
+    // a license or a trial, on the quit after it ended.
+    if (!licenseKey.isValid) {
+      return;
+    }
+
     config.set(
       "accounts",
-      this.getAccountConfigs().map((accountConfig) => {
+      config.get("accounts").map((accountConfig) => {
         const instance = this.instances.get(accountConfig.id);
 
         if (!instance) {

--- a/packages/app/bookmarks.ts
+++ b/packages/app/bookmarks.ts
@@ -8,6 +8,7 @@ import { accounts } from "./accounts";
 import { config } from "./config";
 import { ipc } from "./ipc";
 import { Popup } from "./lib/popup";
+import { licenseKey } from "./license-key";
 
 /**
  * The URLs an account has saved. A bookmark keeps the URL, title and app it was
@@ -37,7 +38,18 @@ class Bookmarks {
     });
   }
 
+  /**
+   * An account's bookmarks, which the free version has none of. A bookmark
+   * opens a workspace app, and those are Pro, so every reader here — the popup,
+   * the star on a tab row, opening one — is answered with an empty list rather
+   * than gated one at a time. A trial that ended would otherwise have left its
+   * bookmarks opening apps indefinitely.
+   */
   getAccountBookmarks(accountId: AccountConfig["id"]): Bookmark[] {
+    if (!licenseKey.isValid) {
+      return [];
+    }
+
     const accountConfig = config.get("accounts").find((account) => account.id === accountId);
 
     // Accounts written before bookmarks became a list of their own carry none
@@ -45,6 +57,13 @@ class Bookmarks {
   }
 
   private setAccountBookmarks(accountId: AccountConfig["id"], updatedBookmarks: Bookmark[]) {
+    // Every list written here is built from the empty one above, so a write
+    // without a license would erase the bookmarks a license or a trial made.
+    // Activating one brings them back.
+    if (!licenseKey.isValid) {
+      return;
+    }
+
     config.set(
       "accounts",
       config.get("accounts").map((accountConfig) =>

--- a/packages/renderer/components/app-titlebar.tsx
+++ b/packages/renderer/components/app-titlebar.tsx
@@ -384,21 +384,29 @@ export function AppTitlebar() {
           <div className="flex items-center gap-2">
             <Trial />
             <FindInPage />
-            <TitlebarButtonGroup
-              className={cn(
-                HOST_HANDOVER_FADE_CLASS_NAME,
-                areLauncherAndBookmarksPlacementedByVerticalTabs && "hidden opacity-0",
-              )}
-            >
-              {shouldShowWorkspaceAppsLauncher && (
-                <WorkspaceAppsLauncher
-                  launcherApps={config["workspaceApps.launcherApps"]}
-                  display={config["workspaceApps.launcherDisplay"]}
-                  disabled={isUnifiedInboxLocation}
-                />
-              )}
-              <BookmarksButton />
-            </TitlebarButtonGroup>
+            {/*
+             * The group goes rather than emptying out on the free version.
+             * Both controls in it open a workspace app, which is Pro, and an
+             * empty group would still spend the gap between the controls
+             * either side of it.
+             */}
+            {isLicenseKeyValid && (
+              <TitlebarButtonGroup
+                className={cn(
+                  HOST_HANDOVER_FADE_CLASS_NAME,
+                  areLauncherAndBookmarksPlacementedByVerticalTabs && "hidden opacity-0",
+                )}
+              >
+                {shouldShowWorkspaceAppsLauncher && (
+                  <WorkspaceAppsLauncher
+                    launcherApps={config["workspaceApps.launcherApps"]}
+                    display={config["workspaceApps.launcherDisplay"]}
+                    disabled={isUnifiedInboxLocation}
+                  />
+                )}
+                <BookmarksButton />
+              </TitlebarButtonGroup>
+            )}
             <ExtensionActions />
             {shouldShowSavedSearchesButton && (
               <TitlebarDropdownMenu

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -589,7 +589,12 @@ export function VerticalTabs() {
        * spacing and alignment they took from the strip, which they no longer
        * sit directly in.
        */}
-      {hostsLauncherAndBookmarks && (
+      {/*
+       * Nothing here on the free version: both controls open a workspace app,
+       * which is Pro, and the column would otherwise spend its gap on an empty
+       * row above the width toggle.
+       */}
+      {hostsLauncherAndBookmarks && isLicenseKeyValid && (
         <div
           className={cn(
             HOST_HANDOVER_FADE_CLASS_NAME,

--- a/tests/lib/views.ts
+++ b/tests/lib/views.ts
@@ -23,13 +23,14 @@ export type ViewSnapshot = {
   storagePath: string;
   isDefaultSession: boolean;
   /**
-   * Whether the view is still loading. What it is for is timing: a view that has
-   * finished is proof the main process has run past whatever awaited that load,
-   * which is the only handle a test has on startup steps it cannot otherwise
-   * see. Asserting an absence before them passes against an app that was about
-   * to do the thing.
+   * Whether the view throttles when it is backgrounded. What it is for is
+   * timing: `createViews` creates every account view with it off and switches it
+   * back on once they have all loaded, so a view reporting it on is proof
+   * startup has reached that line — which is the only handle a test has on
+   * startup steps it cannot otherwise see. Asserting an absence before them
+   * passes against an app that was about to do the thing.
    */
-  isLoading: boolean;
+  backgroundThrottling: boolean;
 };
 
 /**
@@ -57,7 +58,7 @@ export function readViews(meru: MeruApp): Promise<ViewSnapshot[]> {
         bounds: child.getBounds(),
         storagePath: webContents ? (webContents.session.storagePath ?? "") : "",
         isDefaultSession: webContents ? webContents.session === session.defaultSession : false,
-        isLoading: webContents ? webContents.isLoading() : false,
+        backgroundThrottling: webContents ? webContents.backgroundThrottling : false,
       };
     });
   });

--- a/tests/lib/views.ts
+++ b/tests/lib/views.ts
@@ -22,6 +22,14 @@ export type ViewSnapshot = {
    */
   storagePath: string;
   isDefaultSession: boolean;
+  /**
+   * Whether the view is still loading. What it is for is timing: a view that has
+   * finished is proof the main process has run past whatever awaited that load,
+   * which is the only handle a test has on startup steps it cannot otherwise
+   * see. Asserting an absence before them passes against an app that was about
+   * to do the thing.
+   */
+  isLoading: boolean;
 };
 
 /**
@@ -49,6 +57,7 @@ export function readViews(meru: MeruApp): Promise<ViewSnapshot[]> {
         bounds: child.getBounds(),
         storagePath: webContents ? (webContents.session.storagePath ?? "") : "",
         isDefaultSession: webContents ? webContents.session === session.defaultSession : false,
+        isLoading: webContents ? webContents.isLoading() : false,
       };
     });
   });

--- a/tests/workspace-apps.e2e.ts
+++ b/tests/workspace-apps.e2e.ts
@@ -5,20 +5,43 @@
  * partitioning their sessions — is covered in
  * `tests/workspace-apps-pro.e2e.ts`, under the license workspace apps ship
  * behind. What is left here is the gate, asserted from the side a license does
- * not open.
+ * not open: the launcher that offers an app, and the saved tabs and bookmarks
+ * that a trial leaves behind when it ends.
  *
  * The pair is the point. Neither file keeps a list of what a license unlocks, so
  * a launcher that stopped being gated fails here, and one that stopped appearing
  * at all fails there.
  */
 import { expect, test } from "@playwright/test";
-import { seedAccount } from "./lib/accounts";
+import { seedAccount, seedSavedTab } from "./lib/accounts";
 import { useApp } from "./lib/app";
+import { startTestServer, type TestServer } from "./lib/server";
 import { waitForVerticalTabs } from "./lib/strip";
+import { readViews } from "./lib/views";
 
 const ACCOUNT_ID = "5eeded00-0000-4000-8000-00000000ac01";
 
-const meru = useApp({
+/** The saved tab seeded with `loadOnLaunch`, which startup would restore into a live view. */
+const LAUNCH_TAB_TITLE = "Restored";
+
+/** The saved tab seeded without it, which would come back as an entry in the strip. */
+const DORMANT_TAB_TITLE = "Keep";
+
+let server: TestServer;
+
+test.beforeAll(async () => {
+  server = await startTestServer();
+});
+
+test.afterAll(async () => {
+  await server.close();
+});
+
+/*
+ * A function rather than an object, because the port the server ends up on
+ * cannot be named while this file is being read.
+ */
+const meru = useApp(() => ({
   /*
    * Seeded so that the launcher has apps to offer. Both hosts gate it on
    * `isLicenseKeyValid && launcherApps.length > 0`, and the default list is
@@ -29,17 +52,60 @@ const meru = useApp({
   /*
    * And so that the strip is drawn at all. `getVerticalTabsWidth` gives it no
    * width for an account with a single tab, and a free account has exactly that
-   * — the saved tabs that would make a second are a Pro feature. `sidebar` is
-   * the one placement that keeps the strip for good, because it hands it the
-   * launcher and the bookmarks button permanently.
-   *
-   * The alternative was seeding saved tabs here, which is the path this version
-   * of the app wrongly allows without a license, and the one the todo has
-   * against it. A gating test standing on a gating bug is not worth having.
+   * — the saved tabs seeded below are refused, which is what this file asserts,
+   * so they cannot be what makes a second. `sidebar` is the one placement that
+   * keeps the strip for good, because it hands it the launcher and the
+   * bookmarks button permanently.
    */
   "workspaceApps.launcherAndBookmarksPlacement": "sidebar",
-  accounts: [seedAccount({ id: ACCOUNT_ID, label: "Default" })],
-});
+  accounts: [
+    seedAccount({
+      id: ACCOUNT_ID,
+      label: "Default",
+      /*
+       * A trial's pinned tabs, as they sit in the config on the launch after it
+       * ended. Both kinds, because they arrive by different paths:
+       * `loadLaunchTabs` materializes the first during startup, and the second
+       * waits in the strip for a click to wake it. Neither was gated, so a
+       * trial user kept their workspace apps working indefinitely.
+       */
+      savedTabs: [
+        seedSavedTab({
+          app: "calendar",
+          url: server.pageUrl(LAUNCH_TAB_TITLE),
+          title: "Calendar",
+          loadOnLaunch: true,
+        }),
+        seedSavedTab({
+          app: "keep",
+          url: server.pageUrl(DORMANT_TAB_TITLE),
+          title: DORMANT_TAB_TITLE,
+        }),
+      ],
+    }),
+  ],
+}));
+
+/**
+ * Resolves once startup has passed the point where a saved tab would have been
+ * restored.
+ *
+ * `accounts.createViews` awaits every account's Gmail view and then, with
+ * nothing awaited in between, runs `loadLaunchTabs`. So a child view that has
+ * finished loading is proof the launch tabs have already been dealt with —
+ * which is what makes the absences below a decision the app made rather than a
+ * moment that has not arrived yet. The same trap as `waitForVerticalTabs`, on
+ * the other side of the window.
+ *
+ * The view is not named by its URL, because the account's is Gmail's sign-in
+ * page rather than Gmail: nobody is signed in here, and matching on the Gmail
+ * URL waits for a page that never arrives.
+ */
+async function waitForLaunchTabs() {
+  await expect
+    .poll(async () => (await readViews(meru)).some((view) => view.url !== "" && !view.isLoading))
+    .toBe(true);
+}
 
 test("the workspace apps launcher is absent without a license", async () => {
   /*
@@ -52,4 +118,29 @@ test("the workspace apps launcher is absent without a license", async () => {
   await waitForVerticalTabs(meru);
 
   await expect(meru.renderer.getByRole("button", { name: "Open app" })).toHaveCount(0);
+});
+
+test("saved tabs are not restored without a license", async () => {
+  await waitForLaunchTabs();
+
+  /*
+   * Counted by origin rather than by the one URL, so a launch tab that loaded
+   * and a dormant one that was woken are both caught. The account's Gmail view
+   * is the only child the window should have.
+   */
+  const restoredViews = (await readViews(meru)).filter((view) =>
+    view.url.startsWith(server.origin),
+  );
+
+  expect(restoredViews).toHaveLength(0);
+
+  // And neither saved tab holds a place in the strip, which is the other half:
+  // a tab listed and refused on click would pass the assertion above.
+  await waitForVerticalTabs(meru);
+
+  await expect(meru.renderer.getByRole("button", { name: LAUNCH_TAB_TITLE })).toHaveCount(0);
+
+  await expect(
+    meru.renderer.getByRole("button", { name: DORMANT_TAB_TITLE, exact: true }),
+  ).toHaveCount(0);
 });

--- a/tests/workspace-apps.e2e.ts
+++ b/tests/workspace-apps.e2e.ts
@@ -5,8 +5,8 @@
  * partitioning their sessions — is covered in
  * `tests/workspace-apps-pro.e2e.ts`, under the license workspace apps ship
  * behind. What is left here is the gate, asserted from the side a license does
- * not open: the launcher that offers an app, and the saved tabs and bookmarks
- * that a trial leaves behind when it ends.
+ * not open: the two controls that reach a workspace app, and the saved tabs a
+ * trial leaves behind when it ends.
  *
  * The pair is the point. Neither file keeps a list of what a license unlocks, so
  * a launcher that stopped being gated fails here, and one that stopped appearing
@@ -54,8 +54,9 @@ const meru = useApp(() => ({
    * width for an account with a single tab, and a free account has exactly that
    * — the saved tabs seeded below are refused, which is what this file asserts,
    * so they cannot be what makes a second. `sidebar` is the one placement that
-   * keeps the strip for good, because it hands it the launcher and the
-   * bookmarks button permanently.
+   * keeps the strip whatever it holds, and it reads the setting rather than the
+   * license, so it holds the strip open here for a Gmail row and the width
+   * toggle alone.
    */
   "workspaceApps.launcherAndBookmarksPlacement": "sidebar",
   accounts: [
@@ -88,36 +89,48 @@ const meru = useApp(() => ({
 
 /**
  * Resolves once startup has passed the point where a saved tab would have been
- * restored.
+ * restored, which is what makes the absences below a decision the app made
+ * rather than a moment that has not arrived yet — the same trap as
+ * `waitForVerticalTabs`, on the other side of the window.
  *
- * `accounts.createViews` awaits every account's Gmail view and then, with
- * nothing awaited in between, runs `loadLaunchTabs`. So a child view that has
- * finished loading is proof the launch tabs have already been dealt with —
- * which is what makes the absences below a decision the app made rather than a
- * moment that has not arrived yet. The same trap as `waitForVerticalTabs`, on
- * the other side of the window.
+ * `accounts.createViews` awaits every account's Gmail view, switches background
+ * throttling back on for each, and then runs `loadLaunchTabs`, with nothing
+ * awaited between the last two. A view reporting throttling on is therefore
+ * proof the launch tabs have already been dealt with.
  *
- * The view is not named by its URL, because the account's is Gmail's sign-in
- * page rather than Gmail: nobody is signed in here, and matching on the Gmail
- * URL waits for a page that never arrives.
+ * Nothing about the page the account view loaded goes into that, deliberately.
+ * Waiting on the Gmail URL waits for a page that never arrives, because nobody
+ * is signed in here and the view sits on the sign-in page instead. Waiting on a
+ * load that finished is worse than it looks: `Gmail.createView` retries once
+ * when the first load fails, so "loaded something, not loading now" is a state
+ * that also describes an app still on its way to the line this is anchored to.
  */
 async function waitForLaunchTabs() {
   await expect
-    .poll(async () => (await readViews(meru)).some((view) => view.url !== "" && !view.isLoading))
+    .poll(async () => (await readViews(meru)).some((view) => view.backgroundThrottling))
     .toBe(true);
 }
 
-test("the workspace apps launcher is absent without a license", async () => {
+test("neither control that reaches a workspace app is offered without a license", async () => {
   /*
-   * The strip is waited for first, which is what makes the absence below a
+   * The strip is waited for first, which is what makes the absences below a
    * decision the app made rather than a moment arriving too early. An earlier
    * version of this test asserted straight away and passed while the app was
-   * showing the launcher — see `waitForVerticalTabs` for why this anchor and not
-   * the bookmarks button beside it.
+   * showing the launcher — see `waitForVerticalTabs` for why the width toggle is
+   * the anchor and not one of the controls asserted here.
    */
   await waitForVerticalTabs(meru);
 
   await expect(meru.renderer.getByRole("button", { name: "Open app" })).toHaveCount(0);
+
+  /*
+   * The bookmarks button was ungated long after the launcher beside it was, and
+   * a bookmark opens a workspace app just as the launcher does. Both hosts draw
+   * it — the titlebar and the strip — and this account's placement puts it in
+   * the strip, so the titlebar's copy is `display: none` and out of the
+   * accessibility tree either way.
+   */
+  await expect(meru.renderer.getByRole("button", { name: "Show bookmarks" })).toHaveCount(0);
 });
 
 test("saved tabs are not restored without a license", async () => {


### PR DESCRIPTION
## Summary
Workspace apps are Pro, but only *acquiring* one was gated — restoring a saved tab, loading it on launch, waking a dormant one and opening a bookmark all read the config and never the license. A Pro trial ending reaches every one of them with nothing edited by hand, so a trial user's pinned apps kept working indefinitely on the free version. The gate moves to `getAccountConfigs` and `Bookmarks.getAccountBookmarks`, the single config reads their consumers go through, and the bookmarks button goes with it. Nothing is written back to disk, so activating a license brings the tabs and bookmarks back.

## Problem
`workspaceApps.openApp` and `WorkspaceApp.handleWindowOpen` both check `licenseKey.isValid`. Three paths that *use* a workspace app did not: `Account`'s constructor restores `savedTabs` straight from the config, `accounts.init` calls `loadLaunchTabs`, and `tabs.selectTab` wakes a dormant saved tab into a live `WorkspaceApp`. All three gate on `canOpenWorkspaceAppInApp`, which reads the **Open in App** setting and the excluded list and never the license. `bookmarks.openBookmark` was ungated the same way, and the bookmarks button is not license-gated in either host — so the popup was a live route from a trial bookmark into a workspace app.

The reachable path is a trial ending. `Trial.validate` sets `trial.expired`, offers "Continue with the free version", and leaves `licenseKey.isValid` false; every later launch returns early on that key and restores the trial's pinned workspace apps anyway.

That this is an oversight rather than deliberate grandfathering is visible one method away: `getAccountConfigs` already slices a downgraded user back to a single account, so the accounts gate survives the downgrade and the workspace apps gate does not.

Found by reading the code while writing `tests/workspace-apps-pro.e2e.ts` (56e864d), which deliberately does not lean on the ungated path.

## Solution
- `accounts.getAccountConfigs()` hands the free version one account carrying no `savedTabs`, alongside the account slice that was already there.
- `Bookmarks.getAccountBookmarks` answers with an empty list without a license, which covers the popup, the star on a tab row, and opening one.
- `accounts.selectAccount` and `accounts.saveTabs` now read `config.get("accounts")` instead of the filtered list, `saveTabs` returns early without a license, and `setAccountBookmarks` refuses for the same reason.
- The bookmarks button is hidden in both hosts without a license, matching the launcher beside it.
- `tests/workspace-apps.e2e.ts` seeds the saved tabs it used to avoid and asserts they produce neither a view nor a strip entry, and that neither control that reaches a workspace app is offered.

**Why the config read and not the three call sites.** The list of paths that use a workspace app is open-ended — restoring, launching, waking, a designated links tab, a bookmark — and each one added has to remember the check. That is how this hole opened, and gating them one at a time leaves the next one to the same omission. One filtered read makes it structurally impossible for a consumer, including one written later, to see a tab or a bookmark without a license.

**Why nothing is written back.** Stripping what the app reads and rewriting the config are different things: a user who upgrades later must get their tabs back. Leaving the config intact matches what the account slice already does. It also makes the filtered list a thing no disk write may be built from — and two writes were built from it. `selectAccount` and `saveTabs` both mapped over `getAccountConfigs()`, so on the free version they persisted the slice: selecting an account dropped every account past the first from the config for good, reachable today from the mouse's back button, which sends `selectNextAccount`. Fixing those is part of this change rather than adjacent to it, because the `savedTabs` strip would otherwise have ridden the same paths onto disk.

**Why the button goes rather than showing an empty popup.** Gating only the config read would leave a downgraded trial user clicking a button and finding their bookmarks gone with nothing saying why, and nothing they could do there afterwards — the star that adds one only appears on workspace app rows the free version cannot have. The group each control sits in is dropped rather than emptied, because an empty flex child still spends the gap between its neighbors.

**Why the test anchors on background throttling.** `toHaveCount(0)` passes the instant it finds nothing, so an absence asserted too early passes against an app that was about to restore the tab. Anchoring on a view that finished loading is not enough: `Gmail.createView` retries once when the first load fails, and between the two attempts the view has a URL and is not loading while `createViews` is still pending — so on any run where the first Gmail load fails, the assertion could execute before the app had a chance to restore anything. `createViews` switches background throttling back on for every account view in the synchronous stretch immediately before the `loadLaunchTabs` loop, so reading that marks the app's own progress rather than a page's. `ViewSnapshot` grows the field for it.

Recorded in the project docs' `decisions.md`, superseding the "checked at the IPC surface" half of the extensions-as-a-Pro-feature entry.

## Try it
No preview deployment for a desktop app. Locally:

```sh
MERU_SKIP_BUILD=1 xvfb-run -a bun run test:e2e -- tests/workspace-apps.e2e.ts tests/workspace-apps-pro.e2e.ts
```

Both tests in `workspace-apps.e2e.ts` are new or rewritten. Each was checked against the code that fails it: reverting the `.map` in `getAccountConfigs` to the bare `accountConfigs.slice(0, 1)` turns the saved-tabs one red on the view assertion, and dropping `isLicenseKeyValid` from the strip's launcher-and-bookmarks group turns the controls one red on the bookmarks button.

By hand: run a build with a license, pin a workspace app and bookmark a page, quit, remove `licenseKey` from `config.json` and set `"trial.expired": true`, then launch. Before this change the pinned app comes back and works; after it, the strip holds Gmail alone, the bookmarks button is gone, and the config still carries both.

## Not verified
- Not run on macOS or Windows. Nothing here is platform-dependent, but the e2e suite ran on Linux only.
- The upgrade direction — activating a license and seeing the tabs and bookmarks come back — is argued from the config being left intact, not exercised.
- `Bookmarks.getAccountBookmarks` and `setAccountBookmarks` are covered only through the button that is now absent. Seeding a bookmark and asserting the popup lists none would need `seedAccount` to seed bookmarks and a handle on the popup's own `WebContentsView`.
- Between activating a license and restarting, `useIsLicenseKeyValid` unlocks the renderer on `config.licenseKey` while the main process's `licenseKey.isValid` is still false, so bookmarks read as empty until the restart the dialog asks for. The account slice has always behaved this way in that window; nothing is lost, and it comes back on restart.
- On the `sidebar` placement the strip still opens for a free user, now holding only the Gmail row and the width toggle. `getVerticalTabsWidth` is a pure function in `@meru/shared` that reads the placement setting, and plumbing entitlement into it was out of proportion to an empty column.