### PR TITLE
Fix three release-risk bugs and the release skill's broken precondition

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -13,13 +13,12 @@ The version commit goes straight onto `main` — no branch, no PR. Publishing th
 Check all of these first. If one fails, report it and stop — never work around it.
 
 - On `main`, clean and up to date: `git status --porcelain` empty, then `git checkout main && git pull --ff-only`.
-- The workflow names below are real: `.github/workflows/` holds `ci.yml` and `build.yml`. Check that before running either command — GitHub answers a renamed workflow with its pre-rename runs instead of an error, so a stale name here reads as "no run yet" on every release and never verifies anything.
+- The workflow names below are real: `.github/workflows/` holds `ci.yml` and `release.yml`. Check that before running any `gh run list --workflow=` command — GitHub answers a renamed workflow with its pre-rename runs instead of an error, so a stale name here reads as "no run yet" on every release and never verifies anything.
 - The last `ci.yml` run is for the current `HEAD` and passed: `gh run list --workflow=ci.yml --branch=main -L 1 --json headSha,status,conclusion,url`.
   - `headSha` must equal `git rev-parse HEAD`. A `HEAD` with no run yet, or a run still `in_progress`, means waiting — say which and ask whether to wait for it.
   - Any `conclusion` other than `success` means `main` is broken. Report the run URL and stop.
-- The newest `build.yml` run on `main` is not a failure: `gh run list --workflow=build.yml --branch=main -L 1 --json headSha,status,conclusion,url`. A green `ci.yml` says nothing about whether the app compiles, and `release.yml` builds all three platforms — a broken build fails the release where it costs the most.
-  - A `conclusion` of `failure` means the release build will fail too. Report the run URL and stop. A run still `in_progress` means waiting — ask whether to wait for it.
-  - Its `headSha` may lag `HEAD`, because `build.yml` ignores commits that only touch Markdown. Don't require a match, and don't wait for a run that will never start.
+  - That run is also the build check. `ci.yml`'s `e2e` job builds the app with electron-builder and launches it on macOS, Windows and Linux, so a green run at `HEAD` is what says the app still compiles on all three — the thing `release.yml` does next, at the most expensive place for it to fail. There is no second workflow to query; `build.yml` was deleted when its jobs moved here.
+  - What it still doesn't cover: `e2e` builds `--dir` and unsigned, so installer packaging and macOS signing run for the first time in the release itself. That is a known risk of every release, not something to check here.
 - There is something to release: the range from the last release's tag to `HEAD` is non-empty. For a stable release that's the last stable tag, from `gh release list --exclude-pre-releases -L 1`. For an experimental release it's the last release of any kind, from `gh release list -L 1`.
 
 ## Choose the bump
@@ -36,7 +35,7 @@ Arguments naming a level or an explicit version override this triage — take th
 
 An `experimental` argument, or an explicit `-alpha.N` version, cuts a prerelease for the Experimental update channel instead of a stable release. Only cut one when asked — never propose one unprompted.
 
-The channel is named Experimental in the app and versioned `alpha` on the wire, so the interface says Experimental everywhere the version string says `-alpha.N`. That seam is deliberate, and the version suffix is never `-experimental.N`. The reasoning is in `docs/decisions.md` under "The prerelease channel is named Experimental and versioned as `alpha`".
+The channel is named Experimental in the app and versioned `alpha` on the wire, so the interface says Experimental everywhere the version string says `-alpha.N`. That seam is deliberate, and the version suffix is never `-experimental.N`. The reasoning is in the project docs, in `decisions.md` under "The prerelease channel is named Experimental and versioned as `alpha`".
 
 - The version is the next stable version per the triage above with `-alpha.N` appended: the first experimental release of a cycle is `X.Y.Z-alpha.1`. Each further one before that stable ships increments `N`.
 - Everything else follows the stable flow, with two differences: `gh release create` gets `--prerelease`, and the triage range runs from the last release of any kind, not the last stable.

--- a/packages/app/lib/load-url.test.ts
+++ b/packages/app/lib/load-url.test.ts
@@ -1,11 +1,33 @@
 import { describe, expect, test } from "bun:test";
 import type { NavigationEntry, RestoreOptions, WebContents } from "electron";
-import { restoreNavigationHistory } from "./load-url";
+import { loadUrlOrRestoreNavigationHistory, restoreNavigationHistory } from "./load-url";
 
 function makeWebContents(restore: (options: RestoreOptions) => Promise<void>) {
   return {
     navigationHistory: { restore },
   } as unknown as WebContents;
+}
+
+function makeLoadableWebContents({
+  restore,
+  loadURL,
+  destroyed = false,
+}: {
+  restore: (options: RestoreOptions) => Promise<void>;
+  loadURL: (url: string) => Promise<void>;
+  destroyed?: boolean;
+}) {
+  return {
+    navigationHistory: { restore },
+    loadURL,
+    isDestroyed: () => destroyed,
+  } as unknown as WebContents;
+}
+
+const url = "https://calendar.google.com/";
+
+function rejects() {
+  return Promise.reject(new Error("ERR_NAME_NOT_RESOLVED"));
 }
 
 const entries: NavigationEntry[] = [
@@ -35,5 +57,91 @@ describe("restoreNavigationHistory", () => {
     );
 
     expect(restored).toBe(false);
+  });
+});
+
+describe("loadUrlOrRestoreNavigationHistory", () => {
+  test("loads the URL outright when the tab has no history to come back to", async () => {
+    const loadedUrls: string[] = [];
+
+    const loaded = await loadUrlOrRestoreNavigationHistory(
+      makeLoadableWebContents({
+        restore: async () => {
+          throw new Error("Should not restore without history");
+        },
+        loadURL: async (requestedUrl) => {
+          loadedUrls.push(requestedUrl);
+        },
+      }),
+      url,
+    );
+
+    expect(loaded).toBe(true);
+    expect(loadedUrls).toEqual([url]);
+  });
+
+  test("leaves the URL alone when the history restores", async () => {
+    const loadedUrls: string[] = [];
+
+    const loaded = await loadUrlOrRestoreNavigationHistory(
+      makeLoadableWebContents({
+        restore: async () => {},
+        loadURL: async (requestedUrl) => {
+          loadedUrls.push(requestedUrl);
+        },
+      }),
+      url,
+      { entries, index: 1 },
+    );
+
+    expect(loaded).toBe(true);
+    expect(loadedUrls).toEqual([]);
+  });
+
+  test("falls back to the URL when the history fails to restore", async () => {
+    const loadedUrls: string[] = [];
+
+    const loaded = await loadUrlOrRestoreNavigationHistory(
+      makeLoadableWebContents({
+        restore: rejects,
+        loadURL: async (requestedUrl) => {
+          loadedUrls.push(requestedUrl);
+        },
+      }),
+      url,
+      { entries, index: 1 },
+    );
+
+    expect(loaded).toBe(true);
+    expect(loadedUrls).toEqual([url]);
+  });
+
+  test("answers false rather than rejecting when the fallback fails too", async () => {
+    const loaded = await loadUrlOrRestoreNavigationHistory(
+      makeLoadableWebContents({ restore: rejects, loadURL: rejects }),
+      url,
+      { entries, index: 1 },
+    );
+
+    expect(loaded).toBe(false);
+  });
+
+  test("leaves a view destroyed mid-restore alone", async () => {
+    const loadedUrls: string[] = [];
+
+    const loaded = await loadUrlOrRestoreNavigationHistory(
+      makeLoadableWebContents({
+        restore: rejects,
+        loadURL: async (requestedUrl) => {
+          loadedUrls.push(requestedUrl);
+        },
+        destroyed: true,
+      }),
+      url,
+      { entries, index: 1 },
+    );
+
+    expect(loaded).toBe(false);
+    expect(loadedUrls).toEqual([]);
   });
 });

--- a/packages/app/lib/load-url.test.ts
+++ b/packages/app/lib/load-url.test.ts
@@ -12,16 +12,23 @@ function makeLoadableWebContents({
   restore,
   loadURL,
   destroyed = false,
+  currentUrl = "",
 }: {
   restore: (options: RestoreOptions) => Promise<void>;
   loadURL: (url: string) => Promise<void>;
   destroyed?: boolean;
+  currentUrl?: string;
 }) {
   return {
     navigationHistory: { restore },
     loadURL,
     isDestroyed: () => destroyed,
+    getURL: () => currentUrl,
   } as unknown as WebContents;
+}
+
+function neverRestores(): Promise<void> {
+  throw new Error("Should not restore");
 }
 
 const url = "https://calendar.google.com/";
@@ -66,9 +73,7 @@ describe("loadUrlOrRestoreNavigationHistory", () => {
 
     const loaded = await loadUrlOrRestoreNavigationHistory(
       makeLoadableWebContents({
-        restore: async () => {
-          throw new Error("Should not restore without history");
-        },
+        restore: neverRestores,
         loadURL: async (requestedUrl) => {
           loadedUrls.push(requestedUrl);
         },
@@ -142,6 +147,47 @@ describe("loadUrlOrRestoreNavigationHistory", () => {
     );
 
     expect(loaded).toBe(false);
+    expect(loadedUrls).toEqual([]);
+  });
+
+  test("loads the URL when the tab hibernated before its first load committed", async () => {
+    const loadedUrls: string[] = [];
+
+    // A view that never committed answers `{ entries: [], index: -1 }`, which
+    // is not an index `restore` accepts.
+    const loaded = await loadUrlOrRestoreNavigationHistory(
+      makeLoadableWebContents({
+        restore: neverRestores,
+        loadURL: async (requestedUrl) => {
+          loadedUrls.push(requestedUrl);
+        },
+      }),
+      url,
+      { entries: [], index: -1 },
+    );
+
+    expect(loaded).toBe(true);
+    expect(loadedUrls).toEqual([url]);
+  });
+
+  test("leaves a restore that was superseded rather than failed alone", async () => {
+    const loadedUrls: string[] = [];
+
+    // Chromium aborts the entry being restored when another navigation takes
+    // over, which rejects the restore on a view that is showing a page.
+    const loaded = await loadUrlOrRestoreNavigationHistory(
+      makeLoadableWebContents({
+        restore: rejects,
+        loadURL: async (requestedUrl) => {
+          loadedUrls.push(requestedUrl);
+        },
+        currentUrl: "https://calendar.google.com/r/day",
+      }),
+      url,
+      { entries, index: 1 },
+    );
+
+    expect(loaded).toBe(true);
     expect(loadedUrls).toEqual([]);
   });
 });

--- a/packages/app/lib/load-url.ts
+++ b/packages/app/lib/load-url.ts
@@ -58,7 +58,10 @@ export async function loadUrlOrRestoreNavigationHistory(
   url: string,
   navigationHistory?: RestoreOptions,
 ) {
-  if (!navigationHistory) {
+  // Entries rather than the object: a tab that hibernated before its first
+  // load committed carries `{ entries: [], index: -1 }`, which is not a history
+  // to come back to and not an index `restore` accepts.
+  if (!navigationHistory?.entries.length) {
     return loadUrl(webContents, url);
   }
 
@@ -68,6 +71,16 @@ export async function loadUrlOrRestoreNavigationHistory(
   // and reaching for one throws rather than answering false.
   if (restored || webContents.isDestroyed()) {
     return restored;
+  }
+
+  // A restore is reported failed when it is superseded as well as when it
+  // fails: the entry it was loading aborts, and the navigation that replaced it
+  // — a redirect, a client-side route, a link the user clicked into the waking
+  // tab — is the one they want. Loading over that is the only thing here that
+  // could lose a page. What is worth rescuing is the view that arrived nowhere
+  // at all, and having committed nothing is what says so.
+  if (webContents.getURL()) {
+    return true;
   }
 
   return loadUrl(webContents, url);

--- a/packages/app/lib/load-url.ts
+++ b/packages/app/lib/load-url.ts
@@ -42,3 +42,33 @@ export function restoreNavigationHistory(webContents: WebContents, options: Rest
       return false;
     });
 }
+
+/**
+ * Brings a view up on the history its tab hibernated with, and settles for the
+ * page itself when that history cannot be restored — a restore that never
+ * commits otherwise leaves a blank view under a tab still wearing the title it
+ * went to sleep with, with nothing the user can do about it. Losing the back
+ * stack and the scroll position is the price of the page being there at all.
+ *
+ * A view with no history to come back to is loaded outright, which is every
+ * tab that was opened rather than woken.
+ */
+export async function loadUrlOrRestoreNavigationHistory(
+  webContents: WebContents,
+  url: string,
+  navigationHistory?: RestoreOptions,
+) {
+  if (!navigationHistory) {
+    return loadUrl(webContents, url);
+  }
+
+  const restored = await restoreNavigationHistory(webContents, navigationHistory);
+
+  // A tab closed while its restore was in flight has no view left to load into,
+  // and reaching for one throws rather than answering false.
+  if (restored || webContents.isDestroyed()) {
+    return restored;
+  }
+
+  return loadUrl(webContents, url);
+}

--- a/packages/app/lib/update-channel.test.ts
+++ b/packages/app/lib/update-channel.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { resolveUpdateChannel } from "./update-channel";
+
+const stableVersion = { prerelease: [] };
+const prereleaseVersion = { prerelease: ["alpha", 2] };
+
+describe("resolveUpdateChannel", () => {
+  test("names the stable channel rather than leaving it unset", () => {
+    // electron-updater's setter throws on anything but a non-empty string once
+    // a channel has been assigned, so switching Experimental back to Stable in
+    // one session depends on this never being null.
+    expect(resolveUpdateChannel("stable", stableVersion).channel).toBe("latest");
+  });
+
+  test("passes the prerelease channel through", () => {
+    expect(resolveUpdateChannel("alpha", stableVersion).channel).toBe("alpha");
+  });
+
+  test("allows prereleases only on the prerelease channel", () => {
+    expect(resolveUpdateChannel("alpha", prereleaseVersion).allowPrerelease).toBe(true);
+    expect(resolveUpdateChannel("stable", prereleaseVersion).allowPrerelease).toBe(false);
+  });
+
+  test("downgrades a prerelease build the moment it leaves the channel", () => {
+    expect(resolveUpdateChannel("stable", prereleaseVersion).allowDowngrade).toBe(true);
+  });
+
+  test("leaves a stable build on the stable channel with nothing to downgrade to", () => {
+    expect(resolveUpdateChannel("stable", stableVersion).allowDowngrade).toBe(false);
+  });
+
+  test("never downgrades while the prerelease channel is selected", () => {
+    expect(resolveUpdateChannel("alpha", prereleaseVersion).allowDowngrade).toBe(false);
+  });
+});

--- a/packages/app/lib/update-channel.ts
+++ b/packages/app/lib/update-channel.ts
@@ -1,0 +1,42 @@
+import type { Config } from "@meru/shared/types";
+
+/**
+ * The name electron-updater resolves a stable feed under — `latest-mac.yml`,
+ * `latest-linux.yml`, `latest.yml` — and what its providers fall back to when
+ * no channel is set.
+ *
+ * Naming it is what makes leaving Experimental work. `autoUpdater.channel`
+ * refuses anything but a non-empty string once a channel has been assigned, so
+ * a session that visited Experimental cannot be handed `null` to get back to
+ * stable: the setter throws `ERR_UPDATER_INVALID_CHANNEL` out of the
+ * configuration listener, and the properties after it never get applied.
+ *
+ * It also makes the stable feed independent of the build asking for it. Unset,
+ * the GitHub provider falls through to the channel baked into the build's
+ * `app-update.yml`, which on an Experimental build is `alpha` — so a user
+ * stepping back to stable would ask a stable release for `alpha-mac.yml` and
+ * get a 404 with no fallback.
+ */
+const STABLE_CHANNEL_NAME = "latest";
+
+/**
+ * The `autoUpdater` properties the configured channel decides, in the order
+ * they have to be assigned: the channel setter force-enables `allowDowngrade`,
+ * so what this returns for it only survives if it is written afterwards.
+ *
+ * `allowDowngrade` is what carries a user off a prerelease the moment they
+ * leave the channel, rather than leaving them there until a stable overtakes
+ * the version they are on.
+ */
+export function resolveUpdateChannel(
+  channel: Config["updates.channel"],
+  currentVersion: { prerelease: readonly (string | number)[] },
+) {
+  const isStable = channel === "stable";
+
+  return {
+    channel: isStable ? STABLE_CHANNEL_NAME : channel,
+    allowPrerelease: !isStable,
+    allowDowngrade: isStable && currentVersion.prerelease.length > 0,
+  };
+}

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -255,6 +255,16 @@ export class Tabs {
   activateTab(tabId: string) {
     const activatedTab = this.getTab(tabId);
 
+    // A tab id outlives the tab it names: hibernating one swaps it for a
+    // `DormantTab` under an id of its own, so anything holding the old id —
+    // a notification click, above all — asks for a tab that is no longer here.
+    // Making it the active id instead is what turns that into a thrown
+    // `activeTab` on the menu refresh, the view refresh, and every sweep tick
+    // after it.
+    if (!activatedTab) {
+      return;
+    }
+
     if (activatedTab instanceof WorkspaceApp && activatedTab.isWindowed) {
       activatedTab.focusWindow();
 

--- a/packages/app/updater.ts
+++ b/packages/app/updater.ts
@@ -3,17 +3,20 @@ import { autoUpdater } from "electron-updater";
 import { config } from "@/config";
 import { ipc } from "./ipc";
 import { log } from "./lib/log";
+import { resolveUpdateChannel } from "./lib/update-channel";
 import { main } from "./main";
 
 class AppUpdater {
   private applyChannel() {
-    const channel = config.get("updates.channel");
+    const { channel, allowPrerelease, allowDowngrade } = resolveUpdateChannel(
+      config.get("updates.channel"),
+      autoUpdater.currentVersion,
+    );
 
     // The channel setter force-enables allowDowngrade, so it must be assigned last.
-    autoUpdater.channel = channel === "stable" ? null : channel;
-    autoUpdater.allowPrerelease = channel !== "stable";
-    autoUpdater.allowDowngrade =
-      channel === "stable" && autoUpdater.currentVersion.prerelease.length > 0;
+    autoUpdater.channel = channel;
+    autoUpdater.allowPrerelease = allowPrerelease;
+    autoUpdater.allowDowngrade = allowDowngrade;
   }
 
   init() {

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -30,7 +30,7 @@ import { bookmarks } from "./bookmarks";
 import { config } from "./config";
 import { extensions } from "./extensions";
 import { ipc } from "./ipc";
-import { loadUrl, restoreNavigationHistory } from "./lib/load-url";
+import { loadUrl, loadUrlOrRestoreNavigationHistory } from "./lib/load-url";
 import {
   createChildWebContentsView,
   openViewDevToolsOnLaunch,
@@ -621,11 +621,7 @@ export class WorkspaceApp {
       },
     });
 
-    if (navigationHistory) {
-      restoreNavigationHistory(view.webContents, navigationHistory);
-    } else {
-      loadUrl(view.webContents, url);
-    }
+    loadUrlOrRestoreNavigationHistory(view.webContents, url, navigationHistory);
 
     openViewDevToolsOnLaunch(view);
 


### PR DESCRIPTION
## Summary
Four small fixes the [release-risk review](https://github.com/zoidsh/meru/compare/v3.59.0...main) flagged as pre-release work: leaving the Experimental update channel no longer throws, a stale tab id no longer wedges the app in a repeating error dialog, a woken tab whose history fails to restore now loads its page instead of showing a blank view, and `/release` no longer stops at a precondition naming a workflow that was deleted. Three of the four are hibernation- or channel-related dead ends a user cannot get out of without relaunching. Unit tests cover the two fixes with a seam; the tab guard has none.

## Problem
Four independent bugs, all landed since v3.59.0 and all worth closing before the release rather than after it.

**Switching Experimental → Stable in one session throws.** `updater.ts` assigned `autoUpdater.channel = null` for stable, and electron-updater's setter refuses anything but a non-empty string once a channel has been assigned — which it has, the moment the user picks Experimental. The `ERR_UPDATER_INVALID_CHANNEL` escapes the `config.onDidChange` listener as an uncaught main-process exception (there is no `uncaughtException` handler), so the user gets an Electron error dialog, and `allowPrerelease`, `allowDowngrade` and the check that follow never run — they stay on Experimental until the next launch. That defeats [Immediate downgrade on leaving the beta channel](https://github.com/zoidsh/meru/pull/843) and the release-channels doc's "the channel applies live".

**A notification click for a hibernated tab wedges the app.** The workspace-app notification closure captures a tab id; hibernating that tab swaps it for a `DormantTab` with a new UUID, so the captured id names nothing. `activateTab` had no not-found guard and fell through to making that dead id the active one — and the `activeTab` getter throws on an id it cannot resolve, from the menu refresh, from the selected view refresh, and from every one-minute hibernation sweep after it. Blank content area plus an error dialog that returns every minute until the user clicks a live tab. The missing guard predates the range; hibernation is what makes ids go stale.

**A failed history restore leaves a blank view.** Waking a hibernated tab restores its navigation history. `restoreNavigationHistory` already answers whether the page arrived, and the caller dropped that answer — a restore that never commits left a blank view under a tab still wearing its old title.

**`/release` stops at its own precondition.** `8ff4181` deleted `.github/workflows/build.yml` when its jobs moved into `ci.yml`, but the skill still listed the file as one that must be present and still required a non-failing `build.yml` run.

## Solution
- **Updater** — assigns `"latest"` for stable instead of `null`. That is electron-updater's own default channel name and resolves the same `latest*.yml` an unset channel does, so stable resolution is unchanged, with one case it repairs: unset, the GitHub provider falls through to the channel baked into the build's `app-update.yml`, which on an Experimental build is `alpha` — so stepping back to stable asked a stable release for `alpha-mac.yml` and got a 404 with no fallback. The alternative of guarding the assignment was rejected because it leaves that wrong-feed case standing and leaves `_channel` holding `alpha` on a user who has left the channel. The three properties move into a pure `resolveUpdateChannel` in `lib/`, following `lib/hibernation.ts`, so the never-null invariant has somewhere to be tested — the updater itself reaches too far into Electron to test directly.
- **Tabs** — `if (!activatedTab) return;` at the top of `activateTab`, matching the shape `moveTab` already uses. The click still brings the window forward and selects the account, with the hibernated tab in the strip to be opened. Waking the dormant successor instead would need a back-reference the swap doesn't keep, and is a scope question rather than a fix (see **Not verified**).
- **Hibernation wake** — the restore-or-load choice moves into `loadUrlOrRestoreNavigationHistory`, next to the two functions it picks between, where it is unit-testable; the caller sits inside `WorkspaceApp`'s view construction and is not. The fallback is deliberately narrower than "the restore failed", because a restore is reported failed when it is *superseded* as well: Chromium aborts the entry being restored the moment another navigation takes over — a redirect, a client-side route, a link clicked into the waking tab — and loading over that would lose a page the user had reached, which is worse than the blank view being fixed. Having committed nothing is what tells the two apart, and a view created for a waking tab has committed nothing by definition, so an empty `getURL()` is the blank case exactly. Two other states are left alone for the same reason: a view destroyed mid-restore, because loading into one throws rather than answering false, and a history of no entries, which is what a tab that hibernated before its first load committed carries — `restorableNavigationHistory` always answers an object, `{ entries: [], index: -1 }` in that case, and `canHibernateTab` lets such a tab hibernate because `WorkspaceApp.url` falls back to the app's own.
- **Release skill** — the build check is kept rather than dropped. `ci.yml`'s `e2e` job builds the app with electron-builder and launches it on macOS, Windows and Linux, so it rides on the `ci.yml` run already required to be green at the exact `HEAD` being released. That is stricter than what it replaces: `build.yml` carried `paths-ignore: "**.md"` and was allowed to lag `HEAD`. What the merged check gives up is written into the skill rather than assumed — `e2e` builds `--dir` and unsigned, so installer packaging and macOS signing still run for the first time in the release itself. `decisions.md` gets a new entry marking the old two-workflow entry superseded. Also fixes the `docs/decisions.md` path in the same skill file, left behind by the same deletion wave.

## Try it
No preview deployment for a desktop app — `bun run dev`, then:

- **Updater**: Settings → Updates → set channel to Experimental, then back to Stable, same session. Before: an Electron error dialog and the select stuck on Experimental. After: it switches, and one update check fires. (`is.dev` short-circuits `checkForUpdates`, so a packaged build is what shows the check itself.)
- **Hibernation**: Settings → Workspace Apps → hibernation on with the shortest timeout, mark a tab, let it idle past the timeout, then click a notification that tab fired. Before: blank content area and an error dialog every minute. After: the window comes forward on the right account and nothing throws.
- **Release skill**: `/release` now gets past its preconditions.

## Not verified
- The superseded-restore and empty-entries cases above are covered by unit tests against a stubbed `WebContents`, not against Chromium. That `navigationHistory.restore` rejects on `ERR_ABORTED` is read off Electron's own contract — it "rejects if the page fails to load (see `did-fail-load`)" — rather than observed; the guard is correct either way, since it only ever declines to load over a view that is already showing something.
- No manual run of any of the three app fixes — the sandbox has no display, so all three are reasoned from the code and covered only by unit tests. The updater path in particular is only exercised as a pure function; the real `autoUpdater` was never driven.
- The tab guard has no test. `Tabs` reaches into Electron throughout and there is no harness for it; the two fixes with a seam got one (13 new unit tests across `lib/update-channel.test.ts` and `lib/load-url.test.ts`).
- Whether a notification click should wake the hibernated tab's dormant successor rather than doing nothing is open — the review asked for the guard alone, and the successor mapping is real scope.
- `bun run types`, `bun run lint`, `bun run fmt:check` and `bun test` (550 pass, 0 fail) were run. The e2e and perf suites were not — they need a display.
