### PR TITLE
Check in a fixture extension and drive the runtime proxy with it end to end

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,9 @@
       "build-js",
       "static"
     ],
+    "asarUnpack": [
+      "build-js/fixture-extension/**"
+    ],
     "appId": "sh.zoid.meru",
     "protocols": {
       "name": "Meru",

--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -44,6 +44,37 @@ function getDevExtensionDirs() {
 }
 
 /**
+ * Whether this run loads the checked-in fixture extension
+ * (`packages/electron-extensions/fixture`): always in development, and behind
+ * this flag in a packaged build, which is what the end-to-end suite runs. The
+ * flag is a boolean on purpose — one that took a path would hand a shipped
+ * Meru "load any unpacked extension into every account session" from an
+ * environment variable, around both the curated catalog and the license gate.
+ * Set, it can only ever enable the fixture the app already carries.
+ */
+function isFixtureExtensionEnabled() {
+  return Boolean(process.env.MERU_EXTENSIONS_FIXTURE);
+}
+
+/**
+ * The bundled fixture, which `scripts/build.ts` assembles into
+ * `build-js/fixture-extension`. That directory is `asarUnpack`ed, because
+ * deriving reads and copies it as plain files; in development the app path is
+ * the repo root and the replace matches nothing.
+ */
+function getFixtureExtensionDirs() {
+  if (!is.dev && !isFixtureExtensionEnabled()) {
+    return [];
+  }
+
+  return [
+    path
+      .join(app.getAppPath(), "build-js", "fixture-extension")
+      .replace("app.asar", "app.asar.unpacked"),
+  ];
+}
+
+/**
  * `MERU_EXTENSIONS_STRIP=content_scripts,declarative_net_request` derives every
  * extension without those manifest keys, so a run can tell which part of an
  * extension a page is reacting to. Development only, like the extensions
@@ -94,7 +125,11 @@ async function getInstalledExtensionDirs() {
  * after an install gets that extension without anything being rebuilt.
  */
 async function getExtensionDirs() {
-  return [...getDevExtensionDirs(), ...(await getInstalledExtensionDirs())];
+  return [
+    ...getDevExtensionDirs(),
+    ...getFixtureExtensionDirs(),
+    ...(await getInstalledExtensionDirs()),
+  ];
 }
 
 /**
@@ -120,10 +155,12 @@ export const extensions = new Extensions({
   // One shared extension instance across all account sessions — one 1Password
   // sign-in instead of one per account. It has never been run against
   // 1Password itself, so nothing loads it by default: development builds opt
-  // in with MERU_EXTENSIONS_SHARED_INSTANCE=1, and deleting this one option
-  // removes the whole feature.
+  // in with MERU_EXTENSIONS_SHARED_INSTANCE=1, the end-to-end suite does the
+  // same alongside the fixture flag — its packaged build is the only automated
+  // coverage the runtime proxy has — and deleting this one option removes the
+  // whole feature.
   sharedInstance:
-    is.dev && process.env.MERU_EXTENSIONS_SHARED_INSTANCE
+    (is.dev || isFixtureExtensionEnabled()) && process.env.MERU_EXTENSIONS_SHARED_INSTANCE
       ? createSharedExtensionInstance({
           shimScriptPath: path.join(__dirname, "extensions-runtime-proxy-shim.js"),
           relayScriptPath: path.join(__dirname, "extensions-runtime-proxy-relay.js"),

--- a/packages/electron-extensions/fixture/background.ts
+++ b/packages/electron-extensions/fixture/background.ts
@@ -1,0 +1,98 @@
+/**
+ * The fixture extension's service worker: the receiving end every probe
+ * context messages, deliberately free of any behavior beyond answering.
+ *
+ * Everything it answers carries `workerInstanceId`, a value minted once per
+ * worker instance. Two contexts whose replies carry the same id were served
+ * by the same worker instance — which is the shared-instance claim: a
+ * content-script-only session's messages land on the one worker another
+ * session keeps, not on a worker of its own.
+ *
+ * Worker lifetime is deliberately not probed, here or in the tests. The
+ * end-to-end suite launches through Playwright, whose CDP debugger disables
+ * Chromium's MV3 idle timer, so from that suite a worker reads as
+ * permanently alive whether it is or not — a test about the worker stopping
+ * would pass or fail with confidence and mean nothing. That also makes
+ * `workerInstanceId` and `portEvents` stable for a test's lifetime; without
+ * the debugger they would reset whenever the worker idled out.
+ */
+import { type FixtureMessageSender, getChromeRuntime } from "./chrome";
+
+const workerGlobals = globalThis as unknown as { crypto: { randomUUID: () => string } };
+
+const workerInstanceId = workerGlobals.crypto.randomUUID();
+
+/**
+ * Port connects and disconnects, in the order the worker saw them. A context
+ * that closed its own port cannot observe the worker noticing, so it asks for
+ * this log over `sendMessage` instead.
+ */
+const portEvents: string[] = [];
+
+/**
+ * The sender flattened to one comparable shape. `hasTab` is its own field
+ * because the claim "an extension page's message carries no tab" is about the
+ * key being absent, which a null `tabId` alone would blur.
+ */
+function serializeSender(sender: FixtureMessageSender | undefined) {
+  return {
+    url: sender?.url ?? null,
+    origin: sender?.origin ?? null,
+    frameId: sender?.frameId ?? null,
+    hasTab: sender?.tab !== undefined,
+    tabId: sender?.tab?.id ?? null,
+    tabUrl: sender?.tab?.url ?? null,
+  };
+}
+
+type ProbeMessage = {
+  type?: string;
+  nonce?: string;
+};
+
+const runtime = getChromeRuntime();
+
+runtime.onMessage.addListener((message, sender, sendResponse) => {
+  const probeMessage = message as ProbeMessage | undefined;
+
+  if (probeMessage?.type === "echo") {
+    sendResponse({
+      type: "echo-reply",
+      nonce: probeMessage.nonce,
+      workerInstanceId,
+      sender: serializeSender(sender),
+    });
+  }
+
+  if (probeMessage?.type === "read-events") {
+    sendResponse({ type: "events-reply", events: [...portEvents] });
+  }
+
+  // Every answer above is synchronous, so no listener returns true
+});
+
+runtime.onConnect.addListener((port) => {
+  portEvents.push(`connect:${port.name}`);
+
+  port.onMessage.addListener((message) => {
+    const probeMessage = message as ProbeMessage | undefined;
+
+    if (probeMessage?.type === "marco") {
+      port.postMessage({
+        type: "polo",
+        nonce: probeMessage.nonce,
+        workerInstanceId,
+        portName: port.name,
+        sender: serializeSender(port.sender),
+      });
+    }
+
+    if (probeMessage?.type === "disconnect-me") {
+      port.disconnect();
+    }
+  });
+
+  port.onDisconnect.addListener(() => {
+    portEvents.push(`disconnect:${port.name}`);
+  });
+});

--- a/packages/electron-extensions/fixture/chrome.ts
+++ b/packages/electron-extensions/fixture/chrome.ts
@@ -1,0 +1,63 @@
+/**
+ * The slice of Chrome's extension API the fixture extension uses, typed by
+ * hand: the repository carries no `@types/chrome`, and the facade's own
+ * `ChromeNamespace` is deliberately an opaque bag. Only what the fixture
+ * calls is declared, so a call outside this slice is a type error rather
+ * than an untyped reach into the namespace.
+ */
+
+export type FixtureTab = {
+  id?: number;
+  url?: string;
+};
+
+export type FixtureMessageSender = {
+  id?: string;
+  url?: string;
+  origin?: string;
+  frameId?: number;
+  tab?: FixtureTab;
+};
+
+export type FixtureEvent<Listener> = {
+  addListener: (listener: Listener) => void;
+};
+
+export type FixturePort = {
+  name: string;
+  sender?: FixtureMessageSender;
+  postMessage: (message: unknown) => void;
+  disconnect: () => void;
+  onMessage: FixtureEvent<(message: unknown) => void>;
+  onDisconnect: FixtureEvent<() => void>;
+};
+
+export type FixtureManifest = {
+  background?: unknown;
+};
+
+export type FixtureRuntime = {
+  id: string;
+  lastError?: { message?: string };
+  getManifest?: () => FixtureManifest;
+  sendMessage: (message: unknown, callback: (reply: unknown) => void) => void;
+  connect: (connectInfo: { name: string }) => FixturePort;
+  onMessage: FixtureEvent<
+    (message: unknown, sender: FixtureMessageSender, sendResponse: (reply: unknown) => void) => void
+  >;
+  onConnect: FixtureEvent<(port: FixturePort) => void>;
+};
+
+/**
+ * The `chrome` global of whatever extension context this runs in — the
+ * service worker, a content script's isolated world, or an extension page.
+ * In a content-script-only derived copy the runtime proxy's shim has already
+ * shadowed `runtime.sendMessage` and `runtime.connect` by the time the
+ * fixture's scripts run, which is exactly what the fixture is here to
+ * exercise.
+ */
+export function getChromeRuntime(): FixtureRuntime {
+  const contextGlobals = globalThis as unknown as { chrome: { runtime: FixtureRuntime } };
+
+  return contextGlobals.chrome.runtime;
+}

--- a/packages/electron-extensions/fixture/fixture-frame.html
+++ b/packages/electron-extensions/fixture/fixture-frame.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Meru fixture frame</title>
+  </head>
+  <body>
+    <!-- Embedded as an iframe by a loopback page,
+         which is what its web_accessible_resources entry allows -->
+    <script src="probe.js"></script>
+  </body>
+</html>

--- a/packages/electron-extensions/fixture/fixture.test.ts
+++ b/packages/electron-extensions/fixture/fixture.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { getExtensionIdFromManifestKey } from "../derive/extension-id";
+import { FIXTURE_EXTENSION_ID } from "./id";
+
+/**
+ * The invariants that make the fixture extension safe to ship inside the app
+ * bundle, held against the manifest itself so an edit to one without the
+ * other fails here rather than in an end-to-end run.
+ */
+type FixtureManifestFile = {
+  key?: string;
+  background?: { service_worker?: string };
+  action?: { default_popup?: string };
+  content_scripts?: { matches?: string[]; js?: string[] }[];
+  web_accessible_resources?: { resources?: string[]; matches?: string[] }[];
+};
+
+async function readManifest(): Promise<FixtureManifestFile> {
+  return JSON.parse(await readFile(path.join(import.meta.dir, "manifest.json"), "utf8"));
+}
+
+/** The only pages the fixture may touch: a test's own loopback server. */
+const LOOPBACK_MATCHES = ["http://127.0.0.1/*", "http://localhost/*"];
+
+describe("the fixture manifest", () => {
+  test("derives the pinned extension id from its key", async () => {
+    const { key } = await readManifest();
+
+    expect(getExtensionIdFromManifestKey(key)).toBe(FIXTURE_EXTENSION_ID);
+  });
+
+  test("aims its content scripts at loopback pages and nowhere else", async () => {
+    const { content_scripts } = await readManifest();
+
+    expect(content_scripts?.map((contentScript) => contentScript.matches)).toEqual([
+      LOOPBACK_MATCHES,
+    ]);
+  });
+
+  test("exposes its frame page to loopback pages and nowhere else", async () => {
+    const { web_accessible_resources } = await readManifest();
+
+    expect(web_accessible_resources?.map((resource) => resource.matches)).toEqual([
+      LOOPBACK_MATCHES,
+    ]);
+  });
+
+  test("carries the surface the runtime proxy tests drive", async () => {
+    const manifest = await readManifest();
+
+    expect(manifest.background?.service_worker).toBe("background.js");
+
+    expect(manifest.action?.default_popup).toBe("popup.html");
+
+    expect(manifest.web_accessible_resources?.map((resource) => resource.resources)).toEqual([
+      ["fixture-frame.html"],
+    ]);
+  });
+});

--- a/packages/electron-extensions/fixture/id.ts
+++ b/packages/electron-extensions/fixture/id.ts
@@ -1,0 +1,11 @@
+/**
+ * The fixture extension's identity, importable without touching Electron so
+ * the end-to-end tests can address the extension before it is loaded.
+ *
+ * The id is fixed because the manifest carries a `key`: without one Chromium
+ * generates a different id per derived copy, and the shared instance's worker
+ * and shim would never find each other. The value is pinned here by hand and
+ * proven against the manifest in `fixture.test.ts`, so a key change that
+ * forgot this constant fails a unit test rather than an end-to-end run.
+ */
+export const FIXTURE_EXTENSION_ID = "fjcmflaeedcpibfikabpoadlcjblpgje";

--- a/packages/electron-extensions/fixture/manifest.json
+++ b/packages/electron-extensions/fixture/manifest.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": 3,
+  "name": "Meru fixture",
+  "version": "1.0.0",
+  "description": "Meru's own test extension. It ships inside the app, loads only in development or behind the end-to-end flag, and its content scripts match loopback pages alone.",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjpdyC58E6LINMdwynN1Cr88rSysuYHtG0mRMs0o1Vhh3IdBugheaJhpWozxKi75SL2eOZI3hW0oiMnhxJW5mmPWdoRL90KXX+4FxREbGJXpmAtUgWs4yBDjeePSSBffHTd4vDtByrQ/0PHmoP1fRlWUU85oJoT1y26ZGQ9FQUvnx9PYG2rviHgF8in9dsopZ8QQHCQZe7qis4Ms8zoQcf0IzKNPEn3y7L6y9LbMGp9wDAtSGqXM9EoddVQnIekv62bM43TqFJVmFc2ZrsvWV2LT0rE5HY3crZ4XLYHdh0nXPuqecmAcIl4ZpG9FGNxCDLrBhmtqSvWQ6Xq8V8ckldQIDAQAB",
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["http://127.0.0.1/*", "http://localhost/*"],
+      "js": ["probe.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["fixture-frame.html"],
+      "matches": ["http://127.0.0.1/*", "http://localhost/*"]
+    }
+  ]
+}

--- a/packages/electron-extensions/fixture/popup.html
+++ b/packages/electron-extensions/fixture/popup.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Meru fixture popup</title>
+  </head>
+  <body>
+    <!-- The derive step injects the loader's scripts ahead of this one -->
+    <script src="probe.js"></script>
+  </body>
+</html>

--- a/packages/electron-extensions/fixture/probe.ts
+++ b/packages/electron-extensions/fixture/probe.ts
@@ -1,0 +1,24 @@
+/**
+ * The one probe entry point, run as the fixture's content script and by both
+ * of its pages. It runs the probe suite and writes the results where the
+ * end-to-end tests read them: a `data-` attribute on the document element,
+ * which a content script's isolated world and the page's main world share,
+ * and which no page Content-Security-Policy has any say over — a `<script>`
+ * results block would invite exactly the CSP question one of the probes is
+ * asking.
+ */
+import { runProbes } from "./probes";
+
+type FixtureDocument = {
+  documentElement: {
+    setAttribute: (name: string, value: string) => void;
+  };
+};
+
+const RESULTS_ATTRIBUTE = "data-meru-fixture-results";
+
+const { document } = globalThis as unknown as { document: FixtureDocument };
+
+runProbes().then((results) => {
+  document.documentElement.setAttribute(RESULTS_ATTRIBUTE, JSON.stringify(results));
+});

--- a/packages/electron-extensions/fixture/probes.ts
+++ b/packages/electron-extensions/fixture/probes.ts
@@ -1,0 +1,221 @@
+/**
+ * The probes every fixture context runs against the worker, identical in a
+ * content script and in an extension page. Each probe records an outcome
+ * rather than throwing, so one broken path still leaves the others' results
+ * to read — the tests assert on the whole outcome objects.
+ */
+import { type FixturePort, type FixtureRuntime, getChromeRuntime } from "./chrome";
+
+/** Long enough for a relay wake, far under the test runner's own timeouts. */
+const PROBE_TIMEOUT_MS = 15_000;
+
+const EVENT_POLL_INTERVAL_MS = 250;
+
+export type EchoOutcome =
+  | { status: "replied"; reply: unknown }
+  | { status: "error"; message: string };
+
+export type PortOutcome =
+  | { status: "replied"; reply: unknown }
+  | { status: "disconnected" }
+  | { status: "timeout" };
+
+export type ProbeResults = {
+  /** Minted per context, so every port name and nonce names its context. */
+  contextId: string;
+  documentUrl: string;
+  extensionId: string;
+  /**
+   * Whether this context's copy of the extension still carries a `background`
+   * key: `true` is the full copy, `false` the content-script-only one, and
+   * `null` a context where `getManifest` does not exist.
+   */
+  manifestHasBackground: boolean | null;
+  echo: EchoOutcome;
+  port: PortOutcome;
+  /** Whether this context saw its port die after asking the worker to close it. */
+  workerClosedPort: boolean;
+  /** Whether the worker's event log recorded this context closing its own port. */
+  selfCloseSeenByWorker: boolean;
+};
+
+function delay(durationMs: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, durationMs);
+  });
+}
+
+function sendMessage(runtime: FixtureRuntime, message: unknown): Promise<EchoOutcome> {
+  return new Promise((resolve) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      timer = setTimeout(() => {
+        resolve({ status: "error", message: "The reply never arrived" });
+      }, PROBE_TIMEOUT_MS);
+
+      runtime.sendMessage(message, (reply) => {
+        clearTimeout(timer);
+
+        const lastError = runtime.lastError;
+
+        resolve(
+          lastError
+            ? { status: "error", message: lastError.message ?? "unknown" }
+            : { status: "replied", reply },
+        );
+      });
+    } catch (error) {
+      clearTimeout(timer);
+
+      resolve({ status: "error", message: String(error) });
+    }
+  });
+}
+
+/** Connects, says marco, resolves on the first thing that comes back. */
+function probePort(runtime: FixtureRuntime, contextId: string): Promise<PortOutcome> {
+  return new Promise((resolve) => {
+    const port = runtime.connect({ name: `marco:${contextId}` });
+
+    let isSettled = false;
+
+    const settle = (outcome: PortOutcome) => {
+      if (isSettled) {
+        return;
+      }
+
+      isSettled = true;
+
+      clearTimeout(timer);
+
+      resolve(outcome);
+    };
+
+    const timer = setTimeout(() => {
+      settle({ status: "timeout" });
+    }, PROBE_TIMEOUT_MS);
+
+    port.onMessage.addListener((message) => {
+      settle({ status: "replied", reply: message });
+
+      port.disconnect();
+    });
+
+    port.onDisconnect.addListener(() => {
+      settle({ status: "disconnected" });
+    });
+
+    port.postMessage({ type: "marco", nonce: `marco:${contextId}` });
+  });
+}
+
+/**
+ * A marco round trip on the port, so that what follows is known to happen on
+ * a live, listened-to port: a port that dies instantly — no listener, no
+ * relay — resolves false here rather than letting its disconnect pass for
+ * the one a later probe asked for.
+ */
+function portRoundTrip(port: FixturePort, contextId: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      resolve(false);
+    }, PROBE_TIMEOUT_MS);
+
+    port.onMessage.addListener(() => {
+      clearTimeout(timer);
+
+      resolve(true);
+    });
+
+    port.onDisconnect.addListener(() => {
+      clearTimeout(timer);
+
+      resolve(false);
+    });
+
+    port.postMessage({ type: "marco", nonce: `round-trip:${contextId}` });
+  });
+}
+
+/** Asks the worker to close the port, and reports whether this end saw it die. */
+async function probeWorkerClosedPort(runtime: FixtureRuntime, contextId: string): Promise<boolean> {
+  const port = runtime.connect({ name: `worker-closes:${contextId}` });
+
+  if (!(await portRoundTrip(port, contextId))) {
+    return false;
+  }
+
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      resolve(false);
+    }, PROBE_TIMEOUT_MS);
+
+    port.onDisconnect.addListener(() => {
+      clearTimeout(timer);
+
+      resolve(true);
+    });
+
+    port.postMessage({ type: "disconnect-me" });
+  });
+}
+
+/**
+ * Whether a port this context closes is a disconnect the worker's `onConnect`
+ * port sees. A round trip on the port first, so the close cannot outrun the
+ * connect it is closing; then the worker's event log is polled, because the
+ * closing side has nothing local left to observe.
+ */
+async function probeSelfClose(runtime: FixtureRuntime, contextId: string): Promise<boolean> {
+  const portName = `self-closes:${contextId}`;
+
+  const port = runtime.connect({ name: portName });
+
+  if (!(await portRoundTrip(port, contextId))) {
+    return false;
+  }
+
+  port.disconnect();
+
+  const deadline = Date.now() + PROBE_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    const outcome = await sendMessage(runtime, { type: "read-events" });
+
+    if (
+      outcome.status === "replied" &&
+      ((outcome.reply as { events?: string[] }).events ?? []).includes(`disconnect:${portName}`)
+    ) {
+      return true;
+    }
+
+    await delay(EVENT_POLL_INTERVAL_MS);
+  }
+
+  return false;
+}
+
+export async function runProbes(): Promise<ProbeResults> {
+  const runtime = getChromeRuntime();
+
+  const contextGlobals = globalThis as unknown as {
+    crypto: { randomUUID: () => string };
+    location: { href: string };
+  };
+
+  const contextId = contextGlobals.crypto.randomUUID();
+
+  const manifest = runtime.getManifest?.();
+
+  return {
+    contextId,
+    documentUrl: contextGlobals.location.href,
+    extensionId: runtime.id,
+    manifestHasBackground: manifest ? manifest.background !== undefined : null,
+    echo: await sendMessage(runtime, { type: "echo", nonce: `echo:${contextId}` }),
+    port: await probePort(runtime, contextId),
+    workerClosedPort: await probeWorkerClosedPort(runtime, contextId),
+    selfCloseSeenByWorker: await probeSelfClose(runtime, contextId),
+  };
+}

--- a/packages/electron-extensions/package.json
+++ b/packages/electron-extensions/package.json
@@ -5,7 +5,9 @@
   "exports": {
     ".": "./index.ts",
     "./crx": "./crx/index.ts",
-    "./install": "./install/index.ts"
+    "./install": "./install/index.ts",
+    "./fixture/id": "./fixture/id.ts",
+    "./fixture/probes": "./fixture/probes.ts"
   },
   "scripts": {
     "test": "bun test",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -111,6 +111,47 @@ function buildAppFiles() {
       }),
     );
 
+  /*
+   * The checked-in fixture extension, assembled as a loadable unpacked
+   * extension: its scripts bundled like the other extension scripts — rolldown,
+   * never `bun build`, whose node polyfills once inflated the shim about 70x —
+   * and its static files copied next to them. It ships with the app so the
+   * end-to-end flag can only ever enable this directory, not name one.
+   */
+  const buildFixtureExtension = () => {
+    const fixtureDir = path.join(process.cwd(), "packages", "electron-extensions", "fixture");
+
+    const fixtureOutDir = path.join(process.cwd(), "build-js", "fixture-extension");
+
+    const buildFixtureScript = (scriptFileName: string) =>
+      rolldown({
+        ...rolldownOptions,
+        input: path.join(fixtureDir, `${scriptFileName}.ts`),
+        platform: "browser",
+        transform: {
+          ...rolldownOptions.transform,
+          target: browserTarget,
+        },
+      }).then((bundle) =>
+        bundle.write({
+          file: path.join(fixtureOutDir, `${scriptFileName}.js`),
+          codeSplitting: false,
+          format: "iife",
+        }),
+      );
+
+    const copyFixtureFile = (fileName: string) =>
+      Bun.write(path.join(fixtureOutDir, fileName), Bun.file(path.join(fixtureDir, fileName)));
+
+    return Promise.all([
+      buildFixtureScript("background"),
+      buildFixtureScript("probe"),
+      copyFixtureFile("manifest.json"),
+      copyFixtureFile("popup.html"),
+      copyFixtureFile("fixture-frame.html"),
+    ]);
+  };
+
   return Promise.all([
     rolldown({
       ...rolldownOptions,
@@ -152,6 +193,7 @@ function buildAppFiles() {
       "./packages/electron-extensions/runtime-proxy/relay-entry.ts",
       "extensions-runtime-proxy-relay.js",
     ),
+    buildFixtureExtension(),
   ]);
 }
 

--- a/tests/bundle-budget.json
+++ b/tests/bundle-budget.json
@@ -3,6 +3,8 @@
   "extensions-chrome-facade.js": 25600,
   "extensions-runtime-proxy-relay.js": 15360,
   "extensions-runtime-proxy-shim.js": 15360,
+  "fixture-extension/background.js": 4096,
+  "fixture-extension/probe.js": 7168,
   "preload-gmail.js": 108544,
   "preload-renderer.js": 5120,
   "preload-workspace-app.js": 84992,

--- a/tests/extension-proxy.e2e.ts
+++ b/tests/extension-proxy.e2e.ts
@@ -1,0 +1,421 @@
+/*
+ * The runtime proxy, exercised through the checked-in fixture extension
+ * (`packages/electron-extensions/fixture`) — the only automated coverage the
+ * shared extension instance has, since 1Password needs a real Google account,
+ * the desktop app and a display.
+ *
+ * The launch carries both extension flags: `MERU_EXTENSIONS_FIXTURE` puts the
+ * bundled fixture into every account session of this packaged build, and
+ * `MERU_EXTENSIONS_SHARED_INSTANCE` turns on the shared instance, so the
+ * first account's session keeps the fixture's service worker while the second
+ * account's session gets the content-script-only copy whose `chrome.runtime`
+ * messaging the proxy relays. Two accounts need Pro, which is why this file
+ * launches through `useProApp` — and a file is entirely one entitlement or
+ * the other, because `useApp` registers its hooks once at module scope.
+ *
+ * Every probe context — a popup, a content script, an embedded extension
+ * frame — runs the same suite (`fixture/probes.ts`) and writes its results
+ * into a `data-` attribute on its document, where these tests read them
+ * through the main process. The windows the probes run in are created here
+ * rather than through the app's UI: which surfaces open extension pages is
+ * the embedder's business, and what is under test is the messaging layer
+ * those surfaces would sit on.
+ *
+ * Worker lifetime is deliberately not covered. Playwright's launch attaches a
+ * CDP debugger that disables Chromium's MV3 idle timer, so from this suite a
+ * worker reads as permanently alive whether it is or not — a lifetime test
+ * here would be confidently wrong rather than failing.
+ */
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { FIXTURE_EXTENSION_ID } from "@meru/electron-extensions/fixture/id";
+import type { ProbeResults } from "@meru/electron-extensions/fixture/probes";
+import { expect, test } from "@playwright/test";
+import { useProApp } from "./lib/app";
+
+/** The shape `accounts` is stored in, as in `pro.e2e.ts`. */
+function account(id: string, label: string, selected: boolean) {
+  return {
+    id,
+    label,
+    color: null,
+    selected,
+    notifications: true,
+    gmail: { unreadBadge: true, delegatedAccountId: null, unifiedInbox: true },
+    workspaceApps: { savedTabs: [], bookmarks: [] },
+  };
+}
+
+/*
+ * The first account's session is the one the shared instance hands the worker
+ * role, because sessions adopt roles in the order they are set up and accounts
+ * are constructed in config order. The tests do not take that on faith: the
+ * copy each session got is asserted from its own manifest.
+ */
+const WORKER_PARTITION = "persist:worker-account";
+
+const SHIM_PARTITION = "persist:shim-account";
+
+const meru = useProApp(
+  {
+    accounts: [account("worker-account", "Worker", true), account("shim-account", "Shim", false)],
+  },
+  { env: { MERU_EXTENSIONS_FIXTURE: "1", MERU_EXTENSIONS_SHARED_INSTANCE: "1" } },
+);
+
+/**
+ * The pages the fixture's content scripts inject into, served from this test
+ * process — which is the whole reason the fixture's `matches` are loopback
+ * only. The extension frame's URL needs no port, so every page body is static.
+ */
+const SERVED_PAGES: Record<string, string> = {
+  "/plain":
+    "<!doctype html><html><head><meta charset='utf-8'><title>plain</title></head><body>plain</body></html>",
+  /*
+   * The strictest policy a page can declare: no connect-src at all. The
+   * fixture's content script still has to reach the worker through the
+   * bridge, because the page's own policy does not govern the extension's
+   * isolated world — 1Password's popup taught this layer that lesson once.
+   */
+  "/csp":
+    "<!doctype html><html><head><meta charset='utf-8'><meta http-equiv=\"Content-Security-Policy\" content=\"default-src 'none'\"><title>csp</title></head><body>csp</body></html>",
+  "/frame": `<!doctype html><html><head><meta charset='utf-8'><title>frame</title></head><body><iframe src="chrome-extension://${FIXTURE_EXTENSION_ID}/fixture-frame.html"></iframe></body></html>`,
+  "/same":
+    "<!doctype html><html><head><meta charset='utf-8'><title>same</title></head><body>same</body></html>",
+};
+
+let server: http.Server;
+
+let serverOrigin: string;
+
+test.beforeAll(async () => {
+  server = http.createServer((request, response) => {
+    const page = SERVED_PAGES[request.url ?? ""];
+
+    if (!page) {
+      response.writeHead(404).end();
+
+      return;
+    }
+
+    response.writeHead(200, { "content-type": "text/html" }).end(page);
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  serverOrigin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+test.afterAll(async () => {
+  await new Promise((resolve) => {
+    server.close(resolve);
+  });
+});
+
+/**
+ * Waits until the app has loaded the fixture into the session, which happens
+ * while the accounts come up. `fromPartition` returns the session the app
+ * uses for that account, creating an empty one only until the app gets there
+ * — either way the poll only reads.
+ */
+async function waitForFixture(partition: string) {
+  await expect
+    .poll(() =>
+      meru.app.evaluate(
+        ({ session }, { partition: partitionName, extensionId }) =>
+          session
+            .fromPartition(partitionName)
+            .extensions.getAllExtensions()
+            .some((extension) => extension.id === extensionId),
+        { partition, extensionId: FIXTURE_EXTENSION_ID },
+      ),
+    )
+    .toBe(true);
+}
+
+/** Opens a hidden window in the session and resolves to its WebContents id. */
+async function openProbeWindow(partition: string, url: string) {
+  await waitForFixture(partition);
+
+  return meru.app.evaluate(
+    async ({ BrowserWindow }, { partition: partitionName, url: probeUrl }) => {
+      const probeWindow = new BrowserWindow({
+        show: false,
+        webPreferences: { partition: partitionName },
+      });
+
+      await probeWindow.loadURL(probeUrl);
+
+      return probeWindow.webContents.id;
+    },
+    { partition, url },
+  );
+}
+
+/**
+ * Reads a context's probe results off its document, through the main process
+ * rather than through a Playwright page: an attribute crosses the isolated
+ * world, and reading it needs no assumptions about which windows Playwright
+ * has discovered. `frameUrlPrefix` picks a subframe — the embedded extension
+ * frame — instead of the main frame.
+ */
+async function readProbeResults(webContentsId: number, frameUrlPrefix?: string) {
+  let serializedResults: string | null = null;
+
+  await expect
+    .poll(async () => {
+      serializedResults = await meru.app.evaluate(
+        ({ webContents }, { webContentsId: contentsId, frameUrlPrefix: urlPrefix }) => {
+          const contents = webContents.fromId(contentsId);
+
+          if (!contents) {
+            return null;
+          }
+
+          const frame = urlPrefix
+            ? contents.mainFrame.frames.find((candidate) => candidate.url.startsWith(urlPrefix))
+            : contents.mainFrame;
+
+          if (!frame) {
+            return null;
+          }
+
+          return frame.executeJavaScript(
+            'document.documentElement.getAttribute("data-meru-fixture-results")',
+          ) as Promise<string | null>;
+        },
+        { webContentsId, frameUrlPrefix },
+      );
+
+      return serializedResults;
+    })
+    .not.toBeNull();
+
+  return JSON.parse(serializedResults as unknown as string) as ProbeResults;
+}
+
+function popupUrl(context: string) {
+  return `chrome-extension://${FIXTURE_EXTENSION_ID}/popup.html?context=${context}`;
+}
+
+/** The reply an echo probe records, with the sender the proxy reconstructed. */
+function echoReply(
+  results: ProbeResults,
+  workerInstanceId: unknown,
+  sender: Record<string, unknown>,
+) {
+  return {
+    status: "replied",
+    reply: {
+      type: "echo-reply",
+      nonce: `echo:${results.contextId}`,
+      workerInstanceId,
+      sender,
+    },
+  };
+}
+
+test("both sessions' popups reach the one worker the first session keeps", async () => {
+  const workerPopupId = await openProbeWindow(WORKER_PARTITION, popupUrl("worker-popup"));
+
+  const shimPopupId = await openProbeWindow(SHIM_PARTITION, popupUrl("shim-popup"));
+
+  const workerPopup = await readProbeResults(workerPopupId);
+
+  const shimPopup = await readProbeResults(shimPopupId);
+
+  // Which copy each session got, read from the manifest each context sees:
+  // the worker session keeps the whole extension, every other session a copy
+  // with no background at all
+  expect(workerPopup.manifestHasBackground).toBe(true);
+
+  expect(shimPopup.manifestHasBackground).toBe(false);
+
+  expect(workerPopup.extensionId).toBe(FIXTURE_EXTENSION_ID);
+
+  expect(shimPopup.extensionId).toBe(FIXTURE_EXTENSION_ID);
+
+  /*
+   * The worker session's popup messages its own worker natively, with no
+   * proxy in the path, which makes its reply the ground truth for which
+   * worker instance exists. Its sender is Electron's own shape rather than
+   * the proxy's, so only the reply's identity is asserted here.
+   */
+  expect(workerPopup.echo.status).toBe("replied");
+
+  const workerReply = (workerPopup.echo as { reply: { nonce: string; workerInstanceId: string } })
+    .reply;
+
+  expect(workerReply.nonce).toBe(`echo:${workerPopup.contextId}`);
+
+  expect(workerReply.workerInstanceId).toEqual(expect.any(String));
+
+  /*
+   * The shim session's popup has no worker in its own session to answer — its
+   * copy carries none — so a reply at all is cross-session relay, and the
+   * matching `workerInstanceId` pins it to the same worker instance the
+   * worker session's popup reached. The sender is the proxy's whole contract
+   * for an extension page: URL and origin, and deliberately no tab.
+   */
+  expect(shimPopup.echo).toEqual(
+    echoReply(shimPopup, workerReply.workerInstanceId, {
+      url: popupUrl("shim-popup"),
+      origin: `chrome-extension://${FIXTURE_EXTENSION_ID}`,
+      frameId: null,
+      hasTab: false,
+      tabId: null,
+      tabUrl: null,
+    }),
+  );
+});
+
+test("content scripts inject into the shim session and round-trip, a strict page CSP included", async () => {
+  const plainPageUrl = `${serverOrigin}/plain`;
+
+  const cspPageUrl = `${serverOrigin}/csp`;
+
+  const plainPageId = await openProbeWindow(SHIM_PARTITION, plainPageUrl);
+
+  const cspPageId = await openProbeWindow(SHIM_PARTITION, cspPageUrl);
+
+  // The results existing at all is the injection claim: the only thing that
+  // writes them into a loopback page is the fixture's content script, and the
+  // only copy in this session is the content-script-only one
+  const plainPage = await readProbeResults(plainPageId);
+
+  const cspPage = await readProbeResults(cspPageId);
+
+  expect(plainPage.manifestHasBackground).toBe(false);
+
+  expect(plainPage.echo).toEqual(
+    echoReply(plainPage, expect.any(String), {
+      url: plainPageUrl,
+      origin: serverOrigin,
+      frameId: 0,
+      hasTab: true,
+      tabId: plainPageId,
+      tabUrl: plainPageUrl,
+    }),
+  );
+
+  // The page's own `default-src 'none'` has no say over the content script's
+  // path to the worker
+  expect(cspPage.echo).toEqual(
+    echoReply(cspPage, expect.any(String), {
+      url: cspPageUrl,
+      origin: serverOrigin,
+      frameId: 0,
+      hasTab: true,
+      tabId: cspPageId,
+      tabUrl: cspPageUrl,
+    }),
+  );
+});
+
+test("ports relay both ways and both ends observe a disconnect", async () => {
+  const pageUrl = `${serverOrigin}/plain`;
+
+  const pageId = await openProbeWindow(SHIM_PARTITION, pageUrl);
+
+  const page = await readProbeResults(pageId);
+
+  // marco went shim-to-worker, polo came worker-to-shim, and the connect
+  // carried the same reconstructed sender a message does
+  expect(page.port).toEqual({
+    status: "replied",
+    reply: {
+      type: "polo",
+      nonce: `marco:${page.contextId}`,
+      workerInstanceId: expect.any(String),
+      portName: `marco:${page.contextId}`,
+      sender: {
+        url: pageUrl,
+        origin: serverOrigin,
+        frameId: 0,
+        hasTab: true,
+        tabId: pageId,
+        tabUrl: pageUrl,
+      },
+    },
+  });
+
+  // The worker closing a port reaches the shim end as its onDisconnect
+  expect(page.workerClosedPort).toBe(true);
+
+  // The shim closing a port reaches the worker end as that port's
+  // onDisconnect, observed through the worker's own event log
+  expect(page.selfCloseSeenByWorker).toBe(true);
+});
+
+test("a message is attributed to the frame that sent it, an embedded extension frame included", async () => {
+  const samePageUrl = `${serverOrigin}/same`;
+
+  /*
+   * Two tabs of one session on the same URL, which is exactly the case where
+   * nothing but the caller stamp can tell the senders apart: each message
+   * must carry its own tab's id, not the other's. The WebContents ids the
+   * windows were created with are what the proxy's tab ids are defined to be.
+   */
+  const firstSameId = await openProbeWindow(SHIM_PARTITION, samePageUrl);
+
+  const secondSameId = await openProbeWindow(SHIM_PARTITION, samePageUrl);
+
+  const firstSame = await readProbeResults(firstSameId);
+
+  const secondSame = await readProbeResults(secondSameId);
+
+  expect(firstSame.echo).toEqual(
+    echoReply(firstSame, expect.any(String), {
+      url: samePageUrl,
+      origin: serverOrigin,
+      frameId: 0,
+      hasTab: true,
+      tabId: firstSameId,
+      tabUrl: samePageUrl,
+    }),
+  );
+
+  expect(secondSame.echo).toEqual(
+    echoReply(secondSame, expect.any(String), {
+      url: samePageUrl,
+      origin: serverOrigin,
+      frameId: 0,
+      hasTab: true,
+      tabId: secondSameId,
+      tabUrl: samePageUrl,
+    }),
+  );
+
+  /*
+   * An extension page embedded as an iframe of a web page — the
+   * web_accessible_resources path, and the one extension-page shape that does
+   * carry a tab: the host page's, with a subframe id of its own.
+   */
+  const frameHostUrl = `${serverOrigin}/frame`;
+
+  const frameHostId = await openProbeWindow(SHIM_PARTITION, frameHostUrl);
+
+  const embeddedFrameUrl = `chrome-extension://${FIXTURE_EXTENSION_ID}/fixture-frame.html`;
+
+  const embeddedFrame = await readProbeResults(frameHostId, embeddedFrameUrl);
+
+  expect(embeddedFrame.echo).toEqual(
+    echoReply(embeddedFrame, expect.any(String), {
+      url: embeddedFrameUrl,
+      origin: `chrome-extension://${FIXTURE_EXTENSION_ID}`,
+      frameId: expect.any(Number),
+      hasTab: true,
+      tabId: frameHostId,
+      tabUrl: frameHostUrl,
+    }),
+  );
+
+  const embeddedFrameSender = (embeddedFrame.echo as { reply: { sender: { frameId: number } } })
+    .reply.sender;
+
+  // A subframe is never frame 0; 0 would mean the proxy attributed the
+  // message to the host document rather than the extension frame
+  expect(embeddedFrameSender.frameId).toBeGreaterThan(0);
+});

--- a/tests/launch.e2e.ts
+++ b/tests/launch.e2e.ts
@@ -51,3 +51,35 @@ test("launches and renders appearance settings", async () => {
 
   expect(rendererErrors.map((error) => error.stack ?? error.message)).toEqual([]);
 });
+
+test("a packaged run without the fixture flag loads no extensions", async () => {
+  /*
+   * The checked-in fixture extension ships inside this build, and
+   * MERU_EXTENSIONS_FIXTURE is what may load it. This launch does not set the
+   * flag, so the account session has to come up with no extensions at all —
+   * the claim that a shipped Meru loads nothing unless told to.
+   *
+   * The account's id is generated on first launch, so it is read back from
+   * the config the app wrote rather than seeded.
+   */
+  let accountId: string | undefined;
+
+  await expect
+    .poll(async () => {
+      accountId = (await meru.readConfig()).accounts?.[0]?.id;
+
+      return accountId;
+    })
+    .toEqual(expect.any(String));
+
+  const loadedExtensions = await meru.app.evaluate(
+    ({ session }, partition) =>
+      session
+        .fromPartition(partition)
+        .extensions.getAllExtensions()
+        .map((extension) => extension.id),
+    `persist:${accountId}`,
+  );
+
+  expect(loadedExtensions).toEqual([]);
+});

--- a/tests/lib/app.ts
+++ b/tests/lib/app.ts
@@ -117,6 +117,12 @@ export type UseAppOptions = {
    * stays the app as it ships.
    */
   profile?: boolean;
+  /**
+   * Extra environment for the launched app, on top of the runner's own rather
+   * than in place of it — the launch needs DISPLAY and friends either way.
+   * What the extension tests use to set the fixture and shared-instance flags.
+   */
+  env?: Record<string, string>;
 };
 
 type LaunchedApp = {
@@ -210,6 +216,7 @@ async function launchApp(seedConfig: SeedConfig, options: UseAppOptions): Promis
     executablePath: EXECUTABLE_PATH,
     args: launchArguments(userDataDir, options),
     cwd: process.cwd(),
+    env: options.env ? { ...(process.env as Record<string, string>), ...options.env } : undefined,
   });
 
   /*
@@ -558,7 +565,7 @@ function requireLicenseKey() {
  * walk in `settings.e2e.ts` possible, and this is what makes its inverse
  * possible here.
  */
-export function useProApp(seedConfig: SeedConfig = {}): MeruApp {
+export function useProApp(seedConfig: SeedConfig = {}, options: UseAppOptions = {}): MeruApp {
   // Read here rather than inside the seed, so a file missing the key still
   // fails as the module is read rather than once per test inside a launch.
   const licenseKey = requireLicenseKey();
@@ -566,8 +573,8 @@ export function useProApp(seedConfig: SeedConfig = {}): MeruApp {
   // A seed function cannot be spread — doing so would quietly drop everything
   // it seeds and launch a Pro app with none of it.
   if (typeof seedConfig === "function") {
-    return useApp(async (context) => ({ licenseKey, ...(await seedConfig(context)) }));
+    return useApp(async (context) => ({ licenseKey, ...(await seedConfig(context)) }), options);
   }
 
-  return useApp({ licenseKey, ...seedConfig });
+  return useApp({ licenseKey, ...seedConfig }, options);
 }


### PR DESCRIPTION
## Summary
Checks in the fixture extension the tests table has described for weeks — a tiny MV3 extension of Meru's own, scoped to the runtime proxy — ships it inside the app bundle behind a boolean flag, and drives it from a new end-to-end suite that gives the shared extension instance (#985) its first automated coverage. Every end-to-end test was mutation-checked: eight deliberate breaks of the code under test each turned the suite red.

## Problem
The runtime proxy in #985 has no automated coverage and cannot get any from 1Password, which needs a real Google account, the desktop app and a display. Purpose-built probe extensions have been written and thrown away five times over — for the content-script injection question, the idle-stop measurement, the proxy spike, the popup/CSP verification and the caller-frame probes — and this workstream has four earlier cases of tests passing against broken implementations because they ran against fakes. The shape is settled in the decision "A checked-in fixture extension, loaded in development and behind a flag in end-to-end tests".

## Solution
- `packages/electron-extensions/fixture/` holds the extension: a keyed manifest (the fixed id is what lets the derived worker and content-script-only copies find each other), a worker answering `runtime.onMessage` and `onConnect` that stamps every reply with a per-instance id, an action popup, a web-accessible frame page, and one probe script that runs the same suite in every context and writes its results into a `data-` attribute — shared across worlds and outside any page CSP's say.
- `scripts/build.ts` assembles it into `build-js/fixture-extension` (rolldown for the scripts, like the other extension bundles) and it ships `asarUnpack`ed, because deriving reads it as plain files.
- A development build loads it always; a packaged build only behind `MERU_EXTENSIONS_FIXTURE`. The flag is a boolean rather than a path on purpose: a path taken from the environment would hand a shipped Meru "load any unpacked extension into every account session", around both the curated catalog and the license gate. The same flag lets a packaged build honor `MERU_EXTENSIONS_SHARED_INSTANCE`, which was `is.dev`-only and unreachable from the electron-builder output the suite runs.
- `tests/extension-proxy.e2e.ts` launches with both flags and two Pro accounts, opens probe windows straight in the account sessions, and asserts whole reply objects: cross-session `sendMessage` from a popup and from content scripts to the one worker (pinned by the worker-instance id), ports both ways with disconnects observed from both ends, sender attribution held to the caller frame — two same-URL tabs each attributed to themselves, and an embedded extension frame carrying its host tab and a nonzero frame id — and a page's own `default-src 'none'` CSP not blocking the bridge. `launch.e2e.ts` gains the inverse claim: a packaged run without the flag loads no extensions.
- Unit tests pin the fixture's id to its manifest key and hold its content scripts and frame page to loopback matches, so it can never touch a real page.
- Deliberately not covered: worker lifetime. Playwright's CDP debugger disables Chromium's MV3 idle timer, so a worker reads as permanently alive from this suite whether it is or not; the fixture and the suite both carry that in a comment.

## Try it
`xvfb-run -a bun run test:e2e extension-proxy` on the branch — four tests, all green against a fresh electron-builder build. To see the fixture live, `MERU_EXTENSIONS_SHARED_INSTANCE=1 bun run dev` and open `chrome-extension://fjcmflaeedcpibfikabpoadlcjblpgje/popup.html` in an account session, or just look for the "Meru fixture" action in the extensions button.

## Not verified
- CI has now run: ubuntu and windows green; macOS failed the ports test deterministically — a real proxy defect this suite caught, a cold-launch race where a message relayed before the worker's first service worker registration was refused instantly. Fixed underneath in `e950ae2` on `extension-shared-instance` (see that PR's addendum); this branch is restacked onto it unchanged, and the macOS rerun is the confirmation to watch. Locally, the rebased branch passes all four tests even with the worker session's load held back five seconds, which is the handicap that reproduced the macOS failure byte-for-byte before the fix.
- The widened shared-instance gate (`is.dev || MERU_EXTENSIONS_FIXTURE`) means a shipped Meru with both environment variables set runs the shared instance for curated extensions. That is a behavior toggle, not a load-anything hole, but it is a loosening of what was a development-only gate — flagging it for an explicit OK.

