### PR TITLE
Point the release precondition at the build check that still exists

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -13,13 +13,12 @@ The version commit goes straight onto `main` — no branch, no PR. Publishing th
 Check all of these first. If one fails, report it and stop — never work around it.
 
 - On `main`, clean and up to date: `git status --porcelain` empty, then `git checkout main && git pull --ff-only`.
-- The workflow names below are real: `.github/workflows/` holds `ci.yml` and `build.yml`. Check that before running either command — GitHub answers a renamed workflow with its pre-rename runs instead of an error, so a stale name here reads as "no run yet" on every release and never verifies anything.
+- The workflow names below are real: `.github/workflows/` holds `ci.yml` and `release.yml`. Check that before running any `gh run list --workflow=` command — GitHub answers a renamed workflow with its pre-rename runs instead of an error, so a stale name here reads as "no run yet" on every release and never verifies anything.
 - The last `ci.yml` run is for the current `HEAD` and passed: `gh run list --workflow=ci.yml --branch=main -L 1 --json headSha,status,conclusion,url`.
   - `headSha` must equal `git rev-parse HEAD`. A `HEAD` with no run yet, or a run still `in_progress`, means waiting — say which and ask whether to wait for it.
   - Any `conclusion` other than `success` means `main` is broken. Report the run URL and stop.
-- The newest `build.yml` run on `main` is not a failure: `gh run list --workflow=build.yml --branch=main -L 1 --json headSha,status,conclusion,url`. A green `ci.yml` says nothing about whether the app compiles, and `release.yml` builds all three platforms — a broken build fails the release where it costs the most.
-  - A `conclusion` of `failure` means the release build will fail too. Report the run URL and stop. A run still `in_progress` means waiting — ask whether to wait for it.
-  - Its `headSha` may lag `HEAD`, because `build.yml` ignores commits that only touch Markdown. Don't require a match, and don't wait for a run that will never start.
+  - That run is also the build check. `ci.yml`'s `e2e` job builds the app with electron-builder and launches it on macOS, Windows and Linux, so a green run at `HEAD` is what says the app still compiles on all three — the thing `release.yml` does next, at the most expensive place for it to fail. There is no second workflow to query; `build.yml` was deleted when its jobs moved here.
+  - What it still doesn't cover: `e2e` builds `--dir` and unsigned, so installer packaging and macOS signing run for the first time in the release itself. That is a known risk of every release, not something to check here.
 - There is something to release: the range from the last release's tag to `HEAD` is non-empty. For a stable release that's the last stable tag, from `gh release list --exclude-pre-releases -L 1`. For an experimental release it's the last release of any kind, from `gh release list -L 1`.
 
 ## Choose the bump
@@ -36,7 +35,7 @@ Arguments naming a level or an explicit version override this triage — take th
 
 An `experimental` argument, or an explicit `-alpha.N` version, cuts a prerelease for the Experimental update channel instead of a stable release. Only cut one when asked — never propose one unprompted.
 
-The channel is named Experimental in the app and versioned `alpha` on the wire, so the interface says Experimental everywhere the version string says `-alpha.N`. That seam is deliberate, and the version suffix is never `-experimental.N`. The reasoning is in `docs/decisions.md` under "The prerelease channel is named Experimental and versioned as `alpha`".
+The channel is named Experimental in the app and versioned `alpha` on the wire, so the interface says Experimental everywhere the version string says `-alpha.N`. That seam is deliberate, and the version suffix is never `-experimental.N`. The reasoning is in the project docs, in `decisions.md` under "The prerelease channel is named Experimental and versioned as `alpha`".
 
 - The version is the next stable version per the triage above with `-alpha.N` appended: the first experimental release of a cycle is `X.Y.Z-alpha.1`. Each further one before that stable ships increments `N`.
 - Everything else follows the stable flow, with two differences: `gh release create` gets `--prerelease`, and the triage range runs from the last release of any kind, not the last stable.


### PR DESCRIPTION
## Summary
`/release` stops at its own precondition: it requires a non-failing run of `.github/workflows/build.yml`, which was deleted when its jobs moved into `ci.yml`. Points the check at `ci.yml`'s `e2e` job instead, which is what now builds and launches the app on all three platforms. Skill and docs only — no app code.

## Problem
`8ff4181` deleted `.github/workflows/build.yml`, absorbing what it proved into `ci.yml` and the Playwright runner work. `.claude/skills/release/SKILL.md` was not updated: line 16 still listed the file as one that must be present in `.github/workflows/`, and line 20 still required `gh run list --workflow=build.yml` to come back non-failing. Both fail against a repository that no longer has the file, so the skill stops before it reaches the version bump.

The check itself is not vestigial. It exists because a release must not be the first time packaging runs — `release.yml` builds and uploads all three platforms, which is the most expensive place for a build to fail. Deleting the precondition along with the workflow would drop that guarantee silently.

## Solution
- The build check now rides on the `ci.yml` run the skill already requires to be green at the exact `HEAD` being released. `ci.yml`'s `e2e` job builds the app with electron-builder and launches it on macOS, Windows and Linux, so that one run answers both questions.
- Merging the two is stricter than what it replaces rather than looser: `build.yml` carried `paths-ignore: "**.md"`, so its run was allowed to lag `HEAD` and the skill deliberately did not require a SHA match. `ci.yml` has no paths filter and runs on every push to `main`, so the existing equality check covers the build too. The carve-out that existed for the lag goes away with it.
- What the merged check gives up is written into the skill rather than left to be rediscovered: `e2e` builds `--dir` and unsigned, so installer packaging and macOS signing still run for the first time in the release itself. That gap predates this change — `build.yml` built unsigned too unless a `sign-macos` label was applied, and that escape hatch went with it.
- The file-presence check is kept and now names `ci.yml` and `release.yml`, the two workflows the skill queries by name. That check exists because `gh run list` answers a renamed workflow with its pre-rename runs instead of an error, so a stale name reads as "no run yet" and verifies nothing — which is exactly how this broke.
- `decisions.md` gets a new entry marking the two-workflow entry from #938 superseded. The old entry is left as it stands, per that file's append-only rule.
- Also fixes the `docs/decisions.md` path in the same file, left behind by the same deletion wave that removed the `docs/` directory from the repository.

## Try it
`/release` now gets past its preconditions. Reviewing the reasoning without running it: `.github/workflows/` holds `ci.yml` and `release.yml` and nothing else, and `ci.yml`'s `e2e` job is the matrix over `macos-latest`, `ubuntu-latest` and `windows-latest` whose own comment already says "Builds the app and launches it, so this is also what proves each platform still compiles. There is no separate build workflow."

## Not verified
- `/release` was not run end to end — doing so cuts a real release. The precondition commands were checked by hand against the repository state, not executed through the skill.