### PR TITLE
Ignore a request to activate a tab that is no longer there

### DIFF
--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -255,6 +255,16 @@ export class Tabs {
   activateTab(tabId: string) {
     const activatedTab = this.getTab(tabId);
 
+    // A tab id outlives the tab it names: hibernating one swaps it for a
+    // `DormantTab` under an id of its own, so anything holding the old id —
+    // a notification click, above all — asks for a tab that is no longer here.
+    // Making it the active id instead is what turns that into a thrown
+    // `activeTab` on the menu refresh, the view refresh, and every sweep tick
+    // after it.
+    if (!activatedTab) {
+      return;
+    }
+
     if (activatedTab instanceof WorkspaceApp && activatedTab.isWindowed) {
       activatedTab.focusWindow();
 


### PR DESCRIPTION
## Summary
Clicking a workspace-app notification for a tab that has since hibernated leaves the app throwing from three places once a minute, with a blank content area and a main-process error dialog that keeps coming back. `activateTab` gains the not-found guard it never had. One `if`, no behavior change for any live tab.

## Problem
A tab id outlives the tab it names. Hibernating a tab replaces it with a `DormantTab` carrying a `randomUUID` of its own (`tabs.ts`, `dormantizeTab`), so anything still holding the old id is asking for a tab that no longer exists.

The workspace-app notification click is the path that reaches users: its closure captures the tab id (`ipc.ts`), and a notification created with `requireInteraction` gets `timeoutType: "never"`, so it sits on screen indefinitely — well past the 30-minute minimum hibernation timeout.

`activateTab` had no guard for that. It fell through every `instanceof` branch to `this.activeTabId = tabId`, and the `activeTab` getter throws on an id it cannot resolve. That throw then comes from `appMenu.refresh()`, from `refreshSelectedAccountView` (`accounts.ts`), and from `hibernateIdleTabs` on every one-minute sweep tick. There is no `uncaughtException` handler, so the user gets a blank content area plus an Electron error dialog that returns every minute until they happen to click a live tab.

The missing guard predates the hibernation work; hibernation is what makes ids go stale in the first place.

## Solution
- `if (!activatedTab) return;` at the top of `activateTab`, matching the shape `moveTab` in the same class already uses for the same reason.
- Verified safe for every caller rather than assumed. Nine call sites; the only one that can hold an id absent from `tabs.tabs` is the notification click. `GMAIL_TAB_ID` never reaches the guard, because the Gmail tab is constructed as element zero of `this.tabs` and is never spliced out.
- The click is left doing what it still can — the window comes forward and the account is selected, with the hibernated tab visible in the strip one click away. Waking the dormant successor instead would be the better behavior, and is deliberately not here: `dormantizeTab` keeps no reference back to the tab it replaced, and two dormant tabs can share an app and a URL, so this is new state on the hibernation swap rather than a better lookup. Filed on the board as its own item.

## Try it
Settings → Workspace Apps → hibernation on with the shortest timeout, mark a tab, let it idle past the timeout, then click a notification that tab fired. Before: blank content area and an error dialog every minute. After: the window comes forward on the right account and nothing throws.

## Not verified
- No manual run — the sandbox has no display, so this is reasoned from the code and from tracing the callers, not observed.
- No test. `Tabs` reaches into Electron throughout and there is no unit harness for it; the end-to-end suite does not cover the hibernation sweep either, which is its own open item.