### PR TITLE
Name the stable update channel instead of unsetting it

### DIFF
--- a/packages/app/lib/update-channel.test.ts
+++ b/packages/app/lib/update-channel.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { resolveUpdateChannel } from "./update-channel";
+
+const stableVersion = { prerelease: [] };
+const prereleaseVersion = { prerelease: ["alpha", 2] };
+
+describe("resolveUpdateChannel", () => {
+  test("names the stable channel rather than leaving it unset", () => {
+    // electron-updater's setter throws on anything but a non-empty string once
+    // a channel has been assigned, so switching Experimental back to Stable in
+    // one session depends on this never being null.
+    expect(resolveUpdateChannel("stable", stableVersion).channel).toBe("latest");
+  });
+
+  test("passes the prerelease channel through", () => {
+    expect(resolveUpdateChannel("alpha", stableVersion).channel).toBe("alpha");
+  });
+
+  test("allows prereleases only on the prerelease channel", () => {
+    expect(resolveUpdateChannel("alpha", prereleaseVersion).allowPrerelease).toBe(true);
+    expect(resolveUpdateChannel("stable", prereleaseVersion).allowPrerelease).toBe(false);
+  });
+
+  test("downgrades a prerelease build the moment it leaves the channel", () => {
+    expect(resolveUpdateChannel("stable", prereleaseVersion).allowDowngrade).toBe(true);
+  });
+
+  test("leaves a stable build on the stable channel with nothing to downgrade to", () => {
+    expect(resolveUpdateChannel("stable", stableVersion).allowDowngrade).toBe(false);
+  });
+
+  test("never downgrades while the prerelease channel is selected", () => {
+    expect(resolveUpdateChannel("alpha", prereleaseVersion).allowDowngrade).toBe(false);
+  });
+});

--- a/packages/app/lib/update-channel.ts
+++ b/packages/app/lib/update-channel.ts
@@ -1,0 +1,42 @@
+import type { Config } from "@meru/shared/types";
+
+/**
+ * The name electron-updater resolves a stable feed under — `latest-mac.yml`,
+ * `latest-linux.yml`, `latest.yml` — and what its providers fall back to when
+ * no channel is set.
+ *
+ * Naming it is what makes leaving Experimental work. `autoUpdater.channel`
+ * refuses anything but a non-empty string once a channel has been assigned, so
+ * a session that visited Experimental cannot be handed `null` to get back to
+ * stable: the setter throws `ERR_UPDATER_INVALID_CHANNEL` out of the
+ * configuration listener, and the properties after it never get applied.
+ *
+ * It also makes the stable feed independent of the build asking for it. Unset,
+ * the GitHub provider falls through to the channel baked into the build's
+ * `app-update.yml`, which on an Experimental build is `alpha` — so a user
+ * stepping back to stable would ask a stable release for `alpha-mac.yml` and
+ * get a 404 with no fallback.
+ */
+const STABLE_CHANNEL_NAME = "latest";
+
+/**
+ * The `autoUpdater` properties the configured channel decides, in the order
+ * they have to be assigned: the channel setter force-enables `allowDowngrade`,
+ * so what this returns for it only survives if it is written afterwards.
+ *
+ * `allowDowngrade` is what carries a user off a prerelease the moment they
+ * leave the channel, rather than leaving them there until a stable overtakes
+ * the version they are on.
+ */
+export function resolveUpdateChannel(
+  channel: Config["updates.channel"],
+  currentVersion: { prerelease: readonly (string | number)[] },
+) {
+  const isStable = channel === "stable";
+
+  return {
+    channel: isStable ? STABLE_CHANNEL_NAME : channel,
+    allowPrerelease: !isStable,
+    allowDowngrade: isStable && currentVersion.prerelease.length > 0,
+  };
+}

--- a/packages/app/updater.ts
+++ b/packages/app/updater.ts
@@ -3,17 +3,20 @@ import { autoUpdater } from "electron-updater";
 import { config } from "@/config";
 import { ipc } from "./ipc";
 import { log } from "./lib/log";
+import { resolveUpdateChannel } from "./lib/update-channel";
 import { main } from "./main";
 
 class AppUpdater {
   private applyChannel() {
-    const channel = config.get("updates.channel");
+    const { channel, allowPrerelease, allowDowngrade } = resolveUpdateChannel(
+      config.get("updates.channel"),
+      autoUpdater.currentVersion,
+    );
 
     // The channel setter force-enables allowDowngrade, so it must be assigned last.
-    autoUpdater.channel = channel === "stable" ? null : channel;
-    autoUpdater.allowPrerelease = channel !== "stable";
-    autoUpdater.allowDowngrade =
-      channel === "stable" && autoUpdater.currentVersion.prerelease.length > 0;
+    autoUpdater.channel = channel;
+    autoUpdater.allowPrerelease = allowPrerelease;
+    autoUpdater.allowDowngrade = allowDowngrade;
   }
 
   init() {


### PR DESCRIPTION
## Summary
Switching Updates from Experimental back to Stable in one session throws an uncaught main-process exception, leaves an Electron error dialog on screen, and strands the user on Experimental until they relaunch. Assigns `"latest"` for stable instead of `null`, which is electron-updater's own default channel name and resolves the same feed. Six unit tests.

## Problem
`autoUpdater.channel` refuses anything but a non-empty string once a channel has been assigned:

```js
set channel(value) {
  if (this._channel != null) {
    if (typeof value !== "string") {
      throw newError(`Channel must be a string, but got: ${value}`, "ERR_UPDATER_INVALID_CHANNEL")
    }
    ...
```

`updater.ts` assigned `autoUpdater.channel = channel === "stable" ? null : channel;`. `_channel` is null on a fresh launch, so picking Experimental works; picking Stable afterwards hands the setter a `null` it now rejects.

Nothing catches it. The throw escapes the `config.onDidChange("updates.channel")` listener as an uncaught main-process exception — there is no `uncaughtException` handler — so the user gets an Electron error dialog. Worse, `allowPrerelease`, `allowDowngrade` and the `checkForUpdates()` that follow on the next lines never run, so the setting reads Stable while the updater stays on Experimental for the rest of the session. It self-heals on relaunch, which is what has kept it quiet.

That defeats [Immediate downgrade on leaving the beta channel](https://github.com/zoidsh/meru/pull/843) and the release-channels doc's "The channel applies live."

## Solution
- Assigns `"latest"` for stable. `Provider.getDefaultChannelName()` is literally `getCustomChannelName("latest")`, and `GitHubProvider.channel` falls back to it when no channel is set, so the resolved channel file — `latest-mac.yml`, `latest-linux.yml`, `latest.yml` — is byte-identical to what an unset channel produced.
- It also repairs a second case rather than only dodging the throw. Unset, `GitHubProvider.channel` reads `this.updater.channel || this.options.channel`, and `options.channel` is whatever the running build's `app-update.yml` was published with — `alpha` on an Experimental build, since `release.yml` passes `--config.publish.channel=alpha` on prerelease events. So a user stepping back to stable asked a stable release for `alpha-mac.yml`, got a 404, and got no `latest.yml` fallback, because that fallback is gated on `allowPrerelease`. Naming the channel makes stable resolution independent of the build asking for it.
- Guarding the assignment instead was rejected: it leaves that wrong-feed case standing, and leaves `_channel` holding `alpha` on a user who has left the channel.
- The three properties move into a pure `resolveUpdateChannel` in `lib/`, following `lib/hibernation.ts`, so the never-null invariant has somewhere to be tested — the updater itself reaches too far into Electron to test directly. The assignment order is unchanged and still matters: the channel setter force-enables `allowDowngrade`, so it has to be written last.
- Checked that nothing else regresses from `channel` becoming non-null on stable. `GitHubProvider.getLatestVersion` only reads it as `currentChannel` inside `if (this.updater.allowPrerelease)`, and `allowPrerelease` is re-derived from the running version exactly once, in electron-updater's constructor, which runs before `init()`. So a stable channel and `allowPrerelease` can never be true together.

## Try it
`bun run dev`, then Settings → Updates → set the channel to Experimental, then back to Stable in the same session. Before: an Electron error dialog, and the updater silently still on Experimental. After: it switches cleanly.

The update check that follows is `is.dev`-short-circuited, so a packaged build is what shows the check itself firing.

## Not verified
- No manual run — the sandbox has no display, so both the throw and the fix are reasoned from electron-updater's source in `node_modules` (`AppUpdater.js:34-46`, `GitHubProvider.js:37-38` and `128-133`), not observed in the app.
- The real `autoUpdater` is never driven by the tests; `resolveUpdateChannel` is covered as a pure function only.
- No update was actually downloaded on either channel, so the end-to-end feed resolution — including the `alpha-mac.yml` 404 this also fixes — is unconfirmed against GitHub.