### PR TITLE
Load the page when a woken tab's history cannot be restored

### DIFF
--- a/packages/app/lib/load-url.test.ts
+++ b/packages/app/lib/load-url.test.ts
@@ -1,11 +1,40 @@
 import { describe, expect, test } from "bun:test";
 import type { NavigationEntry, RestoreOptions, WebContents } from "electron";
-import { restoreNavigationHistory } from "./load-url";
+import { loadUrlOrRestoreNavigationHistory, restoreNavigationHistory } from "./load-url";
 
 function makeWebContents(restore: (options: RestoreOptions) => Promise<void>) {
   return {
     navigationHistory: { restore },
   } as unknown as WebContents;
+}
+
+function makeLoadableWebContents({
+  restore,
+  loadURL,
+  destroyed = false,
+  currentUrl = "",
+}: {
+  restore: (options: RestoreOptions) => Promise<void>;
+  loadURL: (url: string) => Promise<void>;
+  destroyed?: boolean;
+  currentUrl?: string;
+}) {
+  return {
+    navigationHistory: { restore },
+    loadURL,
+    isDestroyed: () => destroyed,
+    getURL: () => currentUrl,
+  } as unknown as WebContents;
+}
+
+function neverRestores(): Promise<void> {
+  throw new Error("Should not restore");
+}
+
+const url = "https://calendar.google.com/";
+
+function rejects() {
+  return Promise.reject(new Error("ERR_NAME_NOT_RESOLVED"));
 }
 
 const entries: NavigationEntry[] = [
@@ -35,5 +64,130 @@ describe("restoreNavigationHistory", () => {
     );
 
     expect(restored).toBe(false);
+  });
+});
+
+describe("loadUrlOrRestoreNavigationHistory", () => {
+  test("loads the URL outright when the tab has no history to come back to", async () => {
+    const loadedUrls: string[] = [];
+
+    const loaded = await loadUrlOrRestoreNavigationHistory(
+      makeLoadableWebContents({
+        restore: neverRestores,
+        loadURL: async (requestedUrl) => {
+          loadedUrls.push(requestedUrl);
+        },
+      }),
+      url,
+    );
+
+    expect(loaded).toBe(true);
+    expect(loadedUrls).toEqual([url]);
+  });
+
+  test("leaves the URL alone when the history restores", async () => {
+    const loadedUrls: string[] = [];
+
+    const loaded = await loadUrlOrRestoreNavigationHistory(
+      makeLoadableWebContents({
+        restore: async () => {},
+        loadURL: async (requestedUrl) => {
+          loadedUrls.push(requestedUrl);
+        },
+      }),
+      url,
+      { entries, index: 1 },
+    );
+
+    expect(loaded).toBe(true);
+    expect(loadedUrls).toEqual([]);
+  });
+
+  test("falls back to the URL when the history fails to restore", async () => {
+    const loadedUrls: string[] = [];
+
+    const loaded = await loadUrlOrRestoreNavigationHistory(
+      makeLoadableWebContents({
+        restore: rejects,
+        loadURL: async (requestedUrl) => {
+          loadedUrls.push(requestedUrl);
+        },
+      }),
+      url,
+      { entries, index: 1 },
+    );
+
+    expect(loaded).toBe(true);
+    expect(loadedUrls).toEqual([url]);
+  });
+
+  test("answers false rather than rejecting when the fallback fails too", async () => {
+    const loaded = await loadUrlOrRestoreNavigationHistory(
+      makeLoadableWebContents({ restore: rejects, loadURL: rejects }),
+      url,
+      { entries, index: 1 },
+    );
+
+    expect(loaded).toBe(false);
+  });
+
+  test("leaves a view destroyed mid-restore alone", async () => {
+    const loadedUrls: string[] = [];
+
+    const loaded = await loadUrlOrRestoreNavigationHistory(
+      makeLoadableWebContents({
+        restore: rejects,
+        loadURL: async (requestedUrl) => {
+          loadedUrls.push(requestedUrl);
+        },
+        destroyed: true,
+      }),
+      url,
+      { entries, index: 1 },
+    );
+
+    expect(loaded).toBe(false);
+    expect(loadedUrls).toEqual([]);
+  });
+
+  test("loads the URL when the tab hibernated before its first load committed", async () => {
+    const loadedUrls: string[] = [];
+
+    // A view that never committed answers `{ entries: [], index: -1 }`, which
+    // is not an index `restore` accepts.
+    const loaded = await loadUrlOrRestoreNavigationHistory(
+      makeLoadableWebContents({
+        restore: neverRestores,
+        loadURL: async (requestedUrl) => {
+          loadedUrls.push(requestedUrl);
+        },
+      }),
+      url,
+      { entries: [], index: -1 },
+    );
+
+    expect(loaded).toBe(true);
+    expect(loadedUrls).toEqual([url]);
+  });
+
+  test("leaves a restore that was superseded rather than failed alone", async () => {
+    const loadedUrls: string[] = [];
+
+    // Chromium aborts the entry being restored when another navigation takes
+    // over, which rejects the restore on a view that is showing a page.
+    const loaded = await loadUrlOrRestoreNavigationHistory(
+      makeLoadableWebContents({
+        restore: rejects,
+        loadURL: async (requestedUrl) => {
+          loadedUrls.push(requestedUrl);
+        },
+        currentUrl: "https://calendar.google.com/r/day",
+      }),
+      url,
+      { entries, index: 1 },
+    );
+
+    expect(loaded).toBe(true);
+    expect(loadedUrls).toEqual([]);
   });
 });

--- a/packages/app/lib/load-url.ts
+++ b/packages/app/lib/load-url.ts
@@ -42,3 +42,46 @@ export function restoreNavigationHistory(webContents: WebContents, options: Rest
       return false;
     });
 }
+
+/**
+ * Brings a view up on the history its tab hibernated with, and settles for the
+ * page itself when that history cannot be restored — a restore that never
+ * commits otherwise leaves a blank view under a tab still wearing the title it
+ * went to sleep with, with nothing the user can do about it. Losing the back
+ * stack and the scroll position is the price of the page being there at all.
+ *
+ * A view with no history to come back to is loaded outright, which is every
+ * tab that was opened rather than woken.
+ */
+export async function loadUrlOrRestoreNavigationHistory(
+  webContents: WebContents,
+  url: string,
+  navigationHistory?: RestoreOptions,
+) {
+  // Entries rather than the object: a tab that hibernated before its first
+  // load committed carries `{ entries: [], index: -1 }`, which is not a history
+  // to come back to and not an index `restore` accepts.
+  if (!navigationHistory?.entries.length) {
+    return loadUrl(webContents, url);
+  }
+
+  const restored = await restoreNavigationHistory(webContents, navigationHistory);
+
+  // A tab closed while its restore was in flight has no view left to load into,
+  // and reaching for one throws rather than answering false.
+  if (restored || webContents.isDestroyed()) {
+    return restored;
+  }
+
+  // A restore is reported failed when it is superseded as well as when it
+  // fails: the entry it was loading aborts, and the navigation that replaced it
+  // — a redirect, a client-side route, a link the user clicked into the waking
+  // tab — is the one they want. Loading over that is the only thing here that
+  // could lose a page. What is worth rescuing is the view that arrived nowhere
+  // at all, and having committed nothing is what says so.
+  if (webContents.getURL()) {
+    return true;
+  }
+
+  return loadUrl(webContents, url);
+}

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -30,7 +30,7 @@ import { bookmarks } from "./bookmarks";
 import { config } from "./config";
 import { extensions } from "./extensions";
 import { ipc } from "./ipc";
-import { loadUrl, restoreNavigationHistory } from "./lib/load-url";
+import { loadUrl, loadUrlOrRestoreNavigationHistory } from "./lib/load-url";
 import {
   createChildWebContentsView,
   openViewDevToolsOnLaunch,
@@ -621,11 +621,7 @@ export class WorkspaceApp {
       },
     });
 
-    if (navigationHistory) {
-      restoreNavigationHistory(view.webContents, navigationHistory);
-    } else {
-      loadUrl(view.webContents, url);
-    }
+    loadUrlOrRestoreNavigationHistory(view.webContents, url, navigationHistory);
 
     openViewDevToolsOnLaunch(view);
 


### PR DESCRIPTION
## Summary
Waking a hibernated tab whose navigation history fails to restore leaves a blank view under a tab still showing its old title. Adds the `loadUrl` fallback that was missing, narrowed so it rescues only the view that arrived nowhere — a restore is reported failed when it is superseded as well as when it fails, and loading over a page the user reached would be worse than the bug. Seven unit tests.

## Problem
Waking a hibernated tab restores the navigation history it went to sleep with, which is what brings back its back stack, scroll position and form state. `restoreNavigationHistory` (`lib/load-url.ts`) already answers whether the page arrived — it exists precisely so a rejected load is logged and turned into a boolean rather than an unhandled rejection.

`WorkspaceApp.createView` dropped that answer on the floor:

```ts
if (navigationHistory) {
  restoreNavigationHistory(view.webContents, navigationHistory);
} else {
  loadUrl(view.webContents, url);
}
```

So a restore that never committed left a blank `WebContentsView` under a tab still wearing the title it hibernated with, with nothing the user could do about it short of closing the tab.

## Solution
The restore-or-load choice moves into `loadUrlOrRestoreNavigationHistory`, next to the two functions it picks between, where it is unit-testable — the caller sits inside `WorkspaceApp`'s view construction and is not. Three states are deliberately left alone, and the reason is the same each time: the fallback must not be the thing that loses a page.

- **A superseded restore.** Electron's contract is that `restore` "rejects if the page fails to load (see `did-fail-load`)", and Chromium raises `did-fail-load` with `ERR_ABORTED` whenever a pending main-frame navigation is taken over rather than genuinely failing — a redirect, a client-side route, a link clicked into the waking tab. A naive `if (!restored) loadUrl(...)` would drag such a view back to the URL captured at hibernation, discarding wherever the page actually got to. Having committed nothing is what tells the two apart, and a view created for a waking tab has committed nothing by definition, so an empty `getURL()` is the blank case exactly.
- **A view destroyed mid-restore**, because loading into one throws rather than answering false.
- **A history of no entries.** `WorkspaceApp.restorableNavigationHistory` always returns an object — `{ entries: [], index: -1 }` for a view whose first load never committed — so testing the object rather than its contents would hand `restore` an index it does not accept. Such a tab really can hibernate: `canHibernateTab` only requires a non-empty `url`, and `WorkspaceApp.url` falls back to `getWorkspaceAppUrl(this.app)` when `getURL()` is empty.

## Try it
`bun run dev`, then Settings → Workspace Apps → hibernation on with the shortest timeout. Mark a tab, let it idle past the timeout, then open it again. The restore path is the normal one and is unchanged; the fallback needs a restore that fails, which is easiest to force by waking with the network down — before, a blank view under the old title; after, the tab's own URL loads.

## Not verified
- No manual run of either path — the sandbox has no display, so this is reasoned from the code and covered by unit tests against a stubbed `WebContents`, not against Chromium.
- That `navigationHistory.restore` rejects on `ERR_ABORTED` is read off Electron's own documented contract rather than observed; the Electron JS is compiled into the binary and could not be inspected here. The guard is correct either way, since it only ever declines to load over a view that is already showing something.
- What `restore` does with `{ entries: [], index: -1 }` was likewise not observed. The guard means it is never called that way, so whether it throws, rejects or no-ops no longer matters.