### PR TITLE
Parse a meru URL instead of splitting it by hand

### DIFF
--- a/packages/app/context-menu.ts
+++ b/packages/app/context-menu.ts
@@ -6,8 +6,8 @@ import {
 } from "electron";
 import electronContextMenu from "electron-context-menu";
 import { accounts } from "./accounts";
+import { createMeruMessageUrl } from "./lib/deep-link";
 import { licenseKey } from "./license-key";
-import { createMeruMessageUrl } from "./protocol";
 import { openExternalUrl } from "./url";
 
 export function setupWindowContextMenu(window: BrowserWindow | WebContentsView) {

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -22,13 +22,13 @@ import { theme } from "@/theme";
 import { appTray } from "@/tray";
 import { appUpdater } from "@/updater";
 import { doNotDisturb } from "./do-not-disturb";
+import { isMeruUrl } from "./lib/deep-link";
 import {
   findMailtoUrlArg,
   findMeruUrlArg,
   handleMailtoUrl,
   handleMeruUrl,
   isMailtoUrl,
-  isMeruUrl,
   PROCESS_MAILTO_URL_ARG,
   PROCESS_MERU_URL_ARG,
   setMeruProtocolClient,

--- a/packages/app/lib/deep-link.test.ts
+++ b/packages/app/lib/deep-link.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { parseMeruUrl, resolveRoutableUrl } from "./deep-link";
+
+describe("parseMeruUrl", () => {
+  test("resolves the message route", () => {
+    expect(parseMeruUrl("meru://someone@gmail.com/message/abc123")).toEqual({
+      type: "message",
+      email: "someone@gmail.com",
+      messageId: "abc123",
+    });
+  });
+
+  test("resolves the open route without an account", () => {
+    expect(parseMeruUrl("meru://open?url=https%3A%2F%2Fmeet.google.com%2Fabc-defg-hij")).toEqual({
+      type: "open",
+      url: "https://meet.google.com/abc-defg-hij",
+      email: undefined,
+    });
+  });
+
+  test("resolves the open route addressed to an account", () => {
+    expect(
+      parseMeruUrl("meru://someone@gmail.com/open?url=https%3A%2F%2Fchat.google.com%2F"),
+    ).toEqual({
+      type: "open",
+      url: "https://chat.google.com/",
+      email: "someone@gmail.com",
+    });
+  });
+
+  test("keeps a query string belonging to the target url", () => {
+    expect(
+      parseMeruUrl("meru://open?url=https%3A%2F%2Fcalendar.google.com%2F%3Fpli%3D1%26tab%3Dmc"),
+    ).toEqual({
+      type: "open",
+      url: "https://calendar.google.com/?pli=1&tab=mc",
+      email: undefined,
+    });
+  });
+
+  test("returns undefined for another scheme", () => {
+    expect(parseMeruUrl("https://meet.google.com/abc-defg-hij")).toBeUndefined();
+    expect(parseMeruUrl("mailto:someone@gmail.com")).toBeUndefined();
+  });
+
+  test("returns undefined for an unknown route", () => {
+    expect(parseMeruUrl("meru://someone@gmail.com/compose/abc123")).toBeUndefined();
+    expect(parseMeruUrl("meru://")).toBeUndefined();
+    expect(parseMeruUrl("meru://open")).toBeUndefined();
+  });
+
+  test("returns undefined for a route missing its argument", () => {
+    expect(parseMeruUrl("meru://someone@gmail.com/message")).toBeUndefined();
+    expect(parseMeruUrl("meru://someone@gmail.com/message/")).toBeUndefined();
+    expect(parseMeruUrl("meru://open?url=")).toBeUndefined();
+    expect(parseMeruUrl("meru://open?query=hello")).toBeUndefined();
+  });
+
+  test("requires an address on the message route", () => {
+    expect(parseMeruUrl("meru://message/abc123")).toBeUndefined();
+  });
+});
+
+describe("resolveRoutableUrl", () => {
+  test("accepts a workspace app url", () => {
+    expect(resolveRoutableUrl("https://meet.google.com/abc-defg-hij")).toBe(
+      "https://meet.google.com/abc-defg-hij",
+    );
+    expect(resolveRoutableUrl("https://chat.google.com/u/0/")).toBe("https://chat.google.com/u/0/");
+    expect(resolveRoutableUrl("https://docs.google.com/spreadsheets/d/abc123/edit")).toBe(
+      "https://docs.google.com/spreadsheets/d/abc123/edit",
+    );
+  });
+
+  test("rejects a host that only carries a workspace app name in its path", () => {
+    expect(resolveRoutableUrl("https://evil.com/meet.google.com/x")).toBeUndefined();
+  });
+
+  test("rejects a host that only ends in a google.com lookalike", () => {
+    expect(resolveRoutableUrl("https://meet.google.com.evil.com/")).toBeUndefined();
+    expect(resolveRoutableUrl("https://notgoogle.com/")).toBeUndefined();
+  });
+
+  test("rejects a google host with no workspace app", () => {
+    expect(resolveRoutableUrl("https://photos.google.com/")).toBeUndefined();
+  });
+
+  test("rejects every scheme but https", () => {
+    expect(resolveRoutableUrl("http://meet.google.com/abc-defg-hij")).toBeUndefined();
+    expect(resolveRoutableUrl("javascript:alert(1)")).toBeUndefined();
+    expect(resolveRoutableUrl("file:///etc/passwd")).toBeUndefined();
+    expect(resolveRoutableUrl("meru://open?url=https%3A%2F%2Fmeet.google.com%2F")).toBeUndefined();
+  });
+
+  test("rejects a url that does not parse", () => {
+    expect(resolveRoutableUrl("not a url at all")).toBeUndefined();
+    expect(resolveRoutableUrl("")).toBeUndefined();
+  });
+
+  test("rejects credentials smuggled into the authority", () => {
+    expect(resolveRoutableUrl("https://meet.google.com@evil.com/")).toBeUndefined();
+  });
+});

--- a/packages/app/lib/deep-link.ts
+++ b/packages/app/lib/deep-link.ts
@@ -1,0 +1,117 @@
+import { getWorkspaceAppFromUrl } from "@meru/shared/google";
+
+export const MERU_PROTOCOL = "meru";
+
+const MERU_URL_PREFIX = `${MERU_PROTOCOL}://`;
+
+/**
+ * A `meru://` URL that resolved to something the app knows how to carry out.
+ * The address is optional on the open route and required on the message route,
+ * which is what tells `meru://open?url=…` apart from `meru://<email>/open?url=…`.
+ */
+export type MeruDeepLink =
+  | { type: "message"; email: string; messageId: string }
+  | { type: "open"; url: string; email: string | undefined };
+
+export function isMeruUrl(url: string) {
+  return url.startsWith(MERU_URL_PREFIX);
+}
+
+export function createMeruMessageUrl(userEmail: string, messageId: string) {
+  return `${MERU_URL_PREFIX}${userEmail}/message/${messageId}`;
+}
+
+/**
+ * Deliberately hand-parsed rather than handed to `new URL`. `meru:` is not a
+ * special scheme, so the parser reads the address as userinfo and splits
+ * `meru://someone@gmail.com/message/x` into a username and a host that have to
+ * be glued back together. The query is a genuine query string, so that half
+ * does go through `URLSearchParams`.
+ */
+export function parseMeruUrl(url: string): MeruDeepLink | undefined {
+  if (!isMeruUrl(url)) {
+    return undefined;
+  }
+
+  const body = url.slice(MERU_URL_PREFIX.length);
+
+  const queryIndex = body.indexOf("?");
+
+  const pathname = queryIndex === -1 ? body : body.slice(0, queryIndex);
+
+  const searchParams = new URLSearchParams(queryIndex === -1 ? "" : body.slice(queryIndex + 1));
+
+  const segments = pathname.split("/");
+
+  // An address is the only segment that can carry an "@", so it is what says
+  // whether the route name is the first segment or the second.
+  const email = segments[0]?.includes("@") ? segments[0] : undefined;
+
+  const [route, argument] = email ? [segments[1], segments[2]] : [segments[0], segments[1]];
+
+  if (route === "open") {
+    const openedUrl = searchParams.get("url");
+
+    if (!openedUrl) {
+      return undefined;
+    }
+
+    return { type: "open", url: openedUrl, email };
+  }
+
+  // Addressed to nobody, a message id resolves to no account, so the route
+  // needs the address the open route can do without.
+  if (route === "message" && email && argument) {
+    return { type: "message", email, messageId: argument };
+  }
+
+  return undefined;
+}
+
+const GOOGLE_HOSTNAME = "google.com";
+
+function isGoogleHostname(hostname: string) {
+  return hostname === GOOGLE_HOSTNAME || hostname.endsWith(`.${GOOGLE_HOSTNAME}`);
+}
+
+/**
+ * The URL a deep link asked for, when the app may open it in one of its own
+ * views, and undefined otherwise.
+ *
+ * A `meru://` URL is reachable from any page and any message, so this is an
+ * untrusted entry point and neither check below is optional.
+ * `getWorkspaceAppFromUrl` matches a substring rather than a host, so it alone
+ * resolves `https://evil.com/meet.google.com/x` to Meet; and `Tabs.openUrl`
+ * asks `canOpenWorkspaceAppInApp`, which answers true for a URL belonging to no
+ * workspace app at all. The host is parsed and verified first, and only then is
+ * the matcher asked which app it belongs to.
+ */
+export function resolveRoutableUrl(rawUrl: string): string | undefined {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(rawUrl);
+  } catch {
+    return undefined;
+  }
+
+  if (parsedUrl.protocol !== "https:") {
+    return undefined;
+  }
+
+  // Credentials in the authority are never something a link router meant to
+  // send, and they are how a lookalike host gets read as a real one.
+  if (parsedUrl.username || parsedUrl.password) {
+    return undefined;
+  }
+
+  if (!isGoogleHostname(parsedUrl.hostname)) {
+    return undefined;
+  }
+
+  if (!getWorkspaceAppFromUrl(parsedUrl.href)) {
+    return undefined;
+  }
+
+  return parsedUrl.href;
+}

--- a/packages/app/menu.ts
+++ b/packages/app/menu.ts
@@ -20,8 +20,8 @@ import { main } from "@/main";
 import { appUpdater } from "@/updater";
 import { openExternalUrl } from "@/url";
 import { WorkspaceApp } from "@/workspace-app";
+import { createMeruMessageUrl } from "./lib/deep-link";
 import { licenseKey } from "./license-key";
-import { createMeruMessageUrl } from "./protocol";
 
 export class AppMenu {
   private _menu: Menu | undefined;

--- a/packages/app/protocol.ts
+++ b/packages/app/protocol.ts
@@ -4,6 +4,7 @@ import { app, dialog } from "electron";
 import { accounts } from "./accounts";
 import { showProUpgradeDialog } from "./dialogs";
 import { ipc } from "./ipc";
+import { isMeruUrl, MERU_PROTOCOL, type MeruDeepLink, parseMeruUrl } from "./lib/deep-link";
 import { licenseKey } from "./license-key";
 import { main } from "./main";
 
@@ -21,6 +22,34 @@ export function isMailtoUrl(url: string) {
   return url.startsWith(`${MAILTO_PROTOCOL}:`);
 }
 
+/**
+ * Which account a protocol handler should act on. Answered without asking when
+ * there is only one account to answer with, and undefined when the user
+ * cancels the dialog.
+ */
+async function promptForAccount(message: string) {
+  const accountConfigs = accounts.getAccountConfigs();
+
+  if (accountConfigs.length <= 1) {
+    return accountConfigs[0]?.id;
+  }
+
+  const cancelId = accountConfigs.length;
+
+  const { response } = await dialog.showMessageBox(main.window, {
+    type: "question",
+    message,
+    buttons: [...accountConfigs.map((accountConfig) => accountConfig.label), "Cancel"],
+    cancelId,
+  });
+
+  if (response === cancelId) {
+    return undefined;
+  }
+
+  return accountConfigs[response]?.id;
+}
+
 export async function handleMailtoUrl(url: string) {
   if (!licenseKey.isValid) {
     showProUpgradeDialog("Meru Pro is required to set Meru as the default mail client.");
@@ -32,44 +61,17 @@ export async function handleMailtoUrl(url: string) {
     return;
   }
 
-  const accountConfigs = accounts.getAccountConfigs();
-
-  let accountId = accountConfigs[0]?.id;
-
-  if (accountConfigs.length > 1) {
-    const cancelId = accountConfigs.length + 1;
-
-    const { response } = await dialog.showMessageBox(main.window, {
-      type: "question",
-      message: "Which account should compose this email?",
-      buttons: [...accountConfigs.map((account) => account.label), "Cancel"],
-      cancelId,
-    });
-
-    if (response === cancelId) {
-      return;
-    }
-
-    const accountConfig = accountConfigs[response];
-
-    if (!accountConfig) {
-      throw new Error("Could not find account config");
-    }
-
-    accountId = accountConfig.id;
-  }
+  const accountId = await promptForAccount("Which account should compose this email?");
 
   if (!accountId) {
-    throw new Error("Could not determine account id");
+    return;
   }
 
   accounts.getAccount(accountId).instance.gmail.createComposeWindow(url);
 }
 
-export const MERU_PROTOCOL = "meru";
-
 export function findMeruUrlArg(argv: string[]) {
-  return argv.find((arg) => arg.startsWith(`${MERU_PROTOCOL}://`));
+  return argv.find(isMeruUrl);
 }
 
 export const PROCESS_MERU_URL_ARG = !platform.isMacOS ? findMeruUrlArg(process.argv) : undefined;
@@ -90,8 +92,16 @@ export function setMeruProtocolClient() {
   }
 }
 
-export function isMeruUrl(url: string) {
-  return url.startsWith(`${MERU_PROTOCOL}://`);
+function openMessageDeepLink({ email, messageId }: Extract<MeruDeepLink, { type: "message" }>) {
+  for (const [accountId, account] of accounts.instances) {
+    if (account.gmail.userEmail === email) {
+      accounts.selectAccount(accountId);
+
+      ipc.renderer.send(account.gmail.view.webContents, "gmail.openMessage", messageId);
+
+      return;
+    }
+  }
 }
 
 export function handleMeruUrl(url: string) {
@@ -101,29 +111,16 @@ export function handleMeruUrl(url: string) {
     return;
   }
 
-  if (!isMeruUrl(url)) {
+  const deepLink = parseMeruUrl(url);
+
+  if (!deepLink) {
     return;
   }
 
-  const paths = url.replace(`${MERU_PROTOCOL}://`, "").split("/");
-
-  if (paths[0]?.includes("@")) {
-    const email = paths[0];
-
-    if (paths[1] === "message" && paths[2]) {
-      for (const [accountId, account] of accounts.instances) {
-        if (account.gmail.userEmail === email) {
-          accounts.selectAccount(accountId);
-
-          ipc.renderer.send(account.gmail.view.webContents, "gmail.openMessage", paths[2]);
-
-          return;
-        }
-      }
-    }
+  if (deepLink.type === "message") {
+    openMessageDeepLink(deepLink);
   }
-}
 
-export function createMeruMessageUrl(userEmail: string, messageId: string) {
-  return `${MERU_PROTOCOL}://${userEmail}/message/${messageId}`;
+  // The open route parses but is not carried out yet; it lands in the slice
+  // that adds the routing behind it.
 }


### PR DESCRIPTION
## Summary
Moves the `meru://` grammar out of `handleMeruUrl` into a pure, tested module, so the second route — one that takes a Google URL rather than a message id — has somewhere to live and something to guard it. No behavior changes, with one exception: the account picker this lifts out of `handleMailtoUrl` threw when you clicked Cancel, and no longer does. Groundwork only; nothing new is reachable from the app yet.

## Problem
A Discord user asked whether clicking a Hangout link could land in Meru instead of a browser, and Meru has no deep link that takes a URL. Adding one runs into two things.

`handleMeruUrl` read its route by stripping the scheme and splitting on `/` inline. There is no way to test that grammar, and no place to put the check a URL-taking route needs — which is the second thing, because the route is an untrusted entry point. A `meru://` URL is reachable from any page and any message, and neither existing check holds on its own: `getWorkspaceAppFromUrl` matches a substring rather than a host, so it alone resolves `https://evil.com/meet.google.com/x` to Meet, and `Tabs.openUrl` asks `canOpenWorkspaceAppInApp`, which answers true for a URL belonging to no workspace app at all.

Design and the remaining slices: [deep links](https://github.com/zoidsh/docs/blob/main/meru/features/deep-links.md).

## Solution
- `packages/app/lib/deep-link.ts` holds the grammar as pure functions: `parseMeruUrl` returning a discriminated union, plus `isMeruUrl` and `createMeruMessageUrl`, which are the same grammar written rather than read. `handleMeruUrl` is rewritten on top of it and does what it did.
- `parseMeruUrl` deliberately does not reach for `new URL`. `meru:` is not a special scheme, so the parser reads the address as userinfo and splits `meru://someone@gmail.com/message/x` into a username and a host that then have to be glued back together. The query is a real query string, so that half does go through `URLSearchParams`.
- `resolveRoutableUrl` ships with no caller. It parses the target with `new URL`, requires `https:`, rejects credentials in the authority, and requires the parsed hostname to be `google.com` or a subdomain of it — and only then asks `getWorkspaceAppFromUrl` which app it is. Host first, matcher second. It lands here rather than with the route it guards because the route is where it would be easiest to get wrong, and here it is testable on its own.
- The account picker comes out of `handleMailtoUrl` as `promptForAccount`, which the new route will ask the same question through. It was setting `cancelId` one past its last button, so clicking **Cancel** returned an index no account config answered to and threw `Could not find account config` in the main process; Escape happened to work, because Electron returns `cancelId` itself whatever value it holds. Fixed in the extraction rather than left in a helper a second route was about to call.

## Try it
Nothing new to open — the only reachable change is the Cancel fix. With Pro and two or more accounts, set Meru as the default mail client and click a `mailto:` link, then click **Cancel** in the account picker. It closes; on `main` it throws `Could not find account config` in the main process.

## Not verified
- Nothing exercises any of this in a running app. The unit tests cover the parser and the URL guard; the end-to-end slice is the third of three and is not written yet.
- The Cancel fix was reasoned from the button indices and Electron's `cancelId` semantics, not reproduced in a build.