### PR TITLE
Stop loading 1Password in development on macOS

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { is } from "@electron-toolkit/utils";
+import { is, platform } from "@electron-toolkit/utils";
 import {
   createSharedExtensionInstance,
   Extensions,
@@ -9,10 +9,15 @@ import {
   type LatestExtensionInstall,
   pruneDerivedExtensions,
   pruneExtensionVersions,
+  readExtensionDirId,
   registerExtensionBridgeScheme,
   uninstallExtension,
 } from "@meru/electron-extensions";
-import { curatedExtensions, isCuratedExtensionId } from "@meru/shared/extensions";
+import {
+  curatedExtensions,
+  isCuratedExtensionId,
+  ONEPASSWORD_EXTENSION_ID,
+} from "@meru/shared/extensions";
 import { ms } from "@meru/shared/ms";
 import type { ExtensionUpdateResult, InstalledExtensionState } from "@meru/shared/types";
 import { app } from "electron";
@@ -27,6 +32,40 @@ const INSTALL_DIR = path.join(app.getPath("userData"), "extensions");
 const DERIVED_EXTENSIONS_DIR = path.join(app.getPath("userData"), "derived-extensions");
 
 /**
+ * The curated extensions a development build doesn't load, because they can't
+ * work in one and a loaded extension that can't work is worse than an absent
+ * one. 1Password's desktop app verifies the calling browser's code signature
+ * before it talks to it, and `bun run dev` runs an unsigned `electron`, so the
+ * extension sits in every session unable to unlock — and while it is loaded
+ * `workspace-app.ts` holds back the passkey dialog that would otherwise carry
+ * sign-in, leaving neither route working.
+ *
+ * macOS is where that is measured: the host answers `BrowserVerificationFailed`
+ * and `UnknownBrowser`. Windows runs the same browser-trust flow and is
+ * probably the same, but nobody has checked, so it keeps loading until someone
+ * does. Linux trusts a binary name rather than a signature, through
+ * `/etc/1password/custom_allowed_browsers`, so a development run can be
+ * allowlisted there.
+ *
+ * `MERU_EXTENSIONS_ENABLE=<id>,<id>` loads them anyway, which is what working
+ * on the extension layer itself wants.
+ */
+function getDevDisabledExtensionIds() {
+  if (!is.dev) {
+    return [];
+  }
+
+  const enabledExtensionIds = (process.env.MERU_EXTENSIONS_ENABLE ?? "")
+    .split(",")
+    .map((extensionId) => extensionId.trim())
+    .filter(Boolean);
+
+  return (platform.isMacOS ? [ONEPASSWORD_EXTENSION_ID] : []).filter(
+    (extensionId) => !enabledExtensionIds.includes(extensionId),
+  );
+}
+
+/**
  * Unpacked extensions to load on top of the installed ones, one directory
  * holding a `manifest.json` per extension:
  *
@@ -34,13 +73,23 @@ const DERIVED_EXTENSIONS_DIR = path.join(app.getPath("userData"), "derived-exten
  *
  * The folder is gitignored, and `app.getAppPath()` is the repo root in
  * development because `bun run dev` starts Electron as `electron .` there.
+ *
+ * A copy of an extension development disables is skipped here too, since the
+ * folder is how a development build gets one at all. An unpacked extension
+ * carrying no `manifest.key` has no id to match, and loads.
  */
 function getDevExtensionDirs() {
   if (!is.dev) {
     return [];
   }
 
-  return findExtensionDirs(path.join(app.getAppPath(), "extensions"));
+  const devDisabledExtensionIds = getDevDisabledExtensionIds();
+
+  return findExtensionDirs(path.join(app.getAppPath(), "extensions")).filter((extensionDir) => {
+    const extensionId = readExtensionDirId(extensionDir);
+
+    return !extensionId || !devDisabledExtensionIds.includes(extensionId);
+  });
 }
 
 /**
@@ -105,7 +154,13 @@ function getOptedInExtensionIds() {
 async function getInstalledExtensionDirs() {
   const extensionDirs: string[] = [];
 
+  const devDisabledExtensionIds = getDevDisabledExtensionIds();
+
   for (const extensionId of getOptedInExtensionIds()) {
+    if (devDisabledExtensionIds.includes(extensionId)) {
+      continue;
+    }
+
     const installedExtension = await getInstalledExtension({
       installDir: INSTALL_DIR,
       extensionId,

--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -47,7 +47,7 @@ const DERIVED_EXTENSIONS_DIR = path.join(app.getPath("userData"), "derived-exten
  * `/etc/1password/custom_allowed_browsers`, so a development run can be
  * allowlisted there.
  *
- * `MERU_EXTENSIONS_ENABLE=<id>,<id>` loads them anyway, which is what working
+ * `MERU_DEV_ENABLED_EXTENSIONS=<id>,<id>` loads them anyway, which is what working
  * on the extension layer itself wants.
  */
 function getDevDisabledExtensionIds() {
@@ -55,7 +55,7 @@ function getDevDisabledExtensionIds() {
     return [];
   }
 
-  const enabledExtensionIds = (process.env.MERU_EXTENSIONS_ENABLE ?? "")
+  const enabledExtensionIds = (process.env.MERU_DEV_ENABLED_EXTENSIONS ?? "")
     .split(",")
     .map((extensionId) => extensionId.trim())
     .filter(Boolean);

--- a/packages/electron-extensions/index.ts
+++ b/packages/electron-extensions/index.ts
@@ -41,4 +41,4 @@ export type { ExtensionsLogger } from "./logger";
 export type { NativeMessagingHostPolicy } from "./native-messaging/native-messaging";
 export { createSharedExtensionInstance } from "./runtime-proxy";
 export type { CreateSharedExtensionInstanceOptions } from "./runtime-proxy";
-export { findExtensionDirs } from "./scan";
+export { findExtensionDirs, readExtensionDirId } from "./scan";

--- a/packages/electron-extensions/scan.test.ts
+++ b/packages/electron-extensions/scan.test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { findExtensionDirs } from "./scan";
+import { FIXTURE_EXTENSION_ID } from "./fixture/id";
+import fixtureManifest from "./fixture/manifest.json";
+import { findExtensionDirs, readExtensionDirId } from "./scan";
 
 let workDir: string;
 
@@ -56,5 +58,38 @@ describe("findExtensionDirs", () => {
   test("returns nothing for an empty or missing directory", async () => {
     expect(findExtensionDirs(workDir)).toEqual([]);
     expect(findExtensionDirs(path.join(workDir, "missing"))).toEqual([]);
+  });
+});
+
+describe("readExtensionDirId", () => {
+  test("reads the id the manifest key derives", async () => {
+    const extensionDir = path.join(workDir, "fixture");
+
+    await mkdir(extensionDir);
+
+    await writeFile(
+      path.join(extensionDir, "manifest.json"),
+      JSON.stringify({ name: "Extension", key: fixtureManifest.key }),
+    );
+
+    expect(readExtensionDirId(extensionDir)).toBe(FIXTURE_EXTENSION_ID);
+  });
+
+  test("reads nothing from a manifest without a key", async () => {
+    const extensionDir = await createExtensionDir(path.join(workDir, "keyless"));
+
+    expect(readExtensionDirId(extensionDir)).toBeUndefined();
+  });
+
+  test("reads nothing from a missing or unparsable manifest", async () => {
+    const extensionDir = path.join(workDir, "broken");
+
+    await mkdir(extensionDir);
+
+    expect(readExtensionDirId(extensionDir)).toBeUndefined();
+
+    await writeFile(path.join(extensionDir, "manifest.json"), "{");
+
+    expect(readExtensionDirId(extensionDir)).toBeUndefined();
   });
 });

--- a/packages/electron-extensions/scan.ts
+++ b/packages/electron-extensions/scan.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { getExtensionIdFromManifestKey } from "./derive/extension-id";
 
 const MANIFEST_FILE_NAME = "manifest.json";
 
@@ -29,4 +30,26 @@ export function findExtensionDirs(dirPath: string) {
     .map((entryName) => path.join(dirPath, entryName))
     .filter((extensionDir) => fs.existsSync(path.join(extensionDir, MANIFEST_FILE_NAME)))
     .map((extensionDir) => fs.realpathSync(extensionDir));
+}
+
+/**
+ * The id an unpacked extension loads under, read from the `key` its manifest
+ * carries, or nothing where the directory has no readable manifest or no key.
+ *
+ * An extension without a key has no id until Chromium derives one from the
+ * directory it is loaded from, so a caller filtering on ids can only ever pass
+ * one over.
+ */
+export function readExtensionDirId(extensionDir: string) {
+  let manifest: { key?: string };
+
+  try {
+    manifest = JSON.parse(fs.readFileSync(path.join(extensionDir, MANIFEST_FILE_NAME), "utf8")) as {
+      key?: string;
+    };
+  } catch {
+    return undefined;
+  }
+
+  return getExtensionIdFromManifestKey(manifest.key);
 }


### PR DESCRIPTION
## Summary
A development build can't reach the 1Password desktop app, so the extension loaded into every account session and sat there unable to unlock. This drops it from both development sources on macOS, with `MERU_DEV_ENABLED_EXTENSIONS=<id>` to load it anyway for work on the extension layer. macOS alone: Windows is untested and left loading.

## Problem
The 1Password desktop app verifies the calling browser's code signature before it will talk to it, and `bun run dev` runs an unsigned `electron`, so the native-messaging host answers `BrowserVerificationFailed` and `UnknownBrowser`. The extension still loads, so every account session in development carries a 1Password that can never unlock.

It costs more than nothing. While the extension is loaded, `workspace-app.ts:179` holds back the passkey dialog, on the grounds that 1Password's `navigator.credentials` override makes it moot — so development gets a 1Password that can't sign you in and no fallback dialog either.

## Solution
- `getDevDisabledExtensionIds` in `packages/app/extensions.ts` names the curated extensions a development build refuses to load, which on macOS is 1Password. `MERU_DEV_ENABLED_EXTENSIONS=<id>,<id>` loads them anyway, comma-separated so it isn't a 1Password switch.
- Both development sources are gated, the `extensions.installed` opt-in and the repository's `extensions/` folder, because either can carry a copy and gating one leaves the other loading.
- Matching the folder's copy needs its id, so `readExtensionDirId` in `@meru/electron-extensions` reads it from the manifest `key` — the value the download script injects and the same one Chromium derives the id from. A folder with no key has no id before it loads, so it loads; that is a hand-placed extension, which is deliberate by definition.
- macOS alone rather than every platform. Windows runs the same Add Browser trust flow and probably fails the same way, but nobody has run it, so guessing would disable something that may work. Linux trusts a binary name through `/etc/1password/custom_allowed_browsers` rather than a signature, so a development run can be allowlisted there.

The `extensions/` folder stays as it is. It is the only route to an extension outside the curated catalog or one with local edits, which install-from-settings refuses.

## Try it
On a Mac, `bun run dev` with 1Password installed from the Extensions settings page: the account sessions come up without it, and the passkey dialog appears again on a Google sign-in page. `MERU_DEV_ENABLED_EXTENSIONS=aeblfdkhhhdcdjpifhhbdiojplfjncoa bun run dev` brings it back. No preview deployment applies.

## Not verified
- Nothing was run in the app. This sandbox is Linux with no 1Password desktop app, so the gate is verified by unit tests and reading only — `bun test`, `bun run types`, `bun run lint` and `bun run fmt:check` all pass.
- Whether a development build reaches the 1Password host on Windows is still unknown, which is why Windows keeps loading the extension. Recorded as an open question in the feature doc.
