### PR TITLE
Load one directory per extension id

### DIFF
--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -277,6 +277,61 @@ describe("Extensions", () => {
     expect(sessionEvents).toEqual(["loadExtension"]);
   });
 
+  test("loads the first of several directories carrying one extension id", async () => {
+    const loggedInfo: { message: string; details: Record<string, unknown> }[] = [];
+
+    const { session, sessionEvents } = createSession();
+
+    const firstExtensionDir = await createExtensionDir("one", "dGVzdC1rZXk=");
+
+    const secondExtensionDir = await createExtensionDir("two", "dGVzdC1rZXk=");
+
+    // Chromium loads both copies under the one id, where the second load's
+    // storage clear drops the service worker the first just registered
+    await createExtensions([firstExtensionDir, secondExtensionDir], {
+      info: (message, details) => {
+        loggedInfo.push({ message, details });
+      },
+      error: () => {},
+    }).setupSession(session);
+
+    expect(sessionEvents).toEqual([
+      "clearStorageData chrome-extension://gckpihaehgepkpiokicpmgbmojmemdja serviceworkers",
+      "loadExtension",
+    ]);
+    expect(loggedInfo).toEqual([
+      {
+        message: "Skipped duplicate extension directory",
+        details: {
+          id: "gckpihaehgepkpiokicpmgbmojmemdja",
+          extensionDir: secondExtensionDir,
+        },
+      },
+      {
+        message: "Loaded extension",
+        details: {
+          id: "aaa",
+          name: "Extension aaa",
+          version: "1.0.0",
+          extensionDir: firstExtensionDir,
+        },
+      },
+    ]);
+  });
+
+  test("loads every directory of an extension it has no id for", async () => {
+    const { session, sessionEvents } = createSession();
+
+    // Chromium derives a keyless extension's id from the directory it loads
+    // from, so two of them are two extensions rather than one twice
+    await createExtensions([
+      await createExtensionDir("one"),
+      await createExtensionDir("two"),
+    ]).setupSession(session);
+
+    expect(sessionEvents).toEqual(["loadExtension", "loadExtension"]);
+  });
+
   test("answers the bridge in every session sharing a derived copy", async () => {
     const derivedDirs: string[] = [];
 

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -14,6 +14,7 @@ import {
   NativeMessaging,
   type NativeMessagingHostPolicy,
 } from "./native-messaging/native-messaging";
+import { readExtensionDirId } from "./scan";
 import { WebNavigation } from "./web-navigation/web-navigation";
 
 /**
@@ -61,6 +62,9 @@ export type ExtensionsOptions = {
    * Unpacked extension directories, loaded into every session handed to
    * `setupSession`. A function is asked again for every session, so a session
    * set up after an extension was installed loads that extension too.
+   *
+   * Where two directories carry the same extension id, only the first is
+   * loaded; see `dedupeExtensionDirs`.
    */
   extensionDirs: ExtensionDirs;
   /**
@@ -221,9 +225,48 @@ export class Extensions {
     return derivedExtension;
   }
 
+  /**
+   * The directories to load, without the ones carrying an extension id an
+   * earlier directory already carries. Two copies of one extension are one
+   * extension to Chromium, which loads them both under that id: the second load
+   * clears the storage the first just made, the service worker registration
+   * with it, and which copy ends up running is nowhere to be seen. First in the
+   * list wins, so the embedder picks the copy purely by the order it lists them
+   * in.
+   *
+   * A directory whose manifest carries no `key` has no id and is never dropped,
+   * since Chromium derives that extension's id from the path it loads from and
+   * two such directories are two different extensions.
+   */
+  private dedupeExtensionDirs(extensionDirs: string[]) {
+    const seenExtensionIds = new Set<string>();
+
+    return extensionDirs.filter((extensionDir) => {
+      const extensionId = readExtensionDirId(extensionDir);
+
+      if (!extensionId) {
+        return true;
+      }
+
+      if (seenExtensionIds.has(extensionId)) {
+        this.logger?.info("Skipped duplicate extension directory", {
+          id: extensionId,
+          extensionDir,
+        });
+
+        return false;
+      }
+
+      seenExtensionIds.add(extensionId);
+
+      return true;
+    });
+  }
+
   async setupSession(session: Session) {
-    const extensionDirs =
-      typeof this.extensionDirs === "function" ? await this.extensionDirs() : this.extensionDirs;
+    const extensionDirs = this.dedupeExtensionDirs(
+      typeof this.extensionDirs === "function" ? await this.extensionDirs() : this.extensionDirs,
+    );
 
     if (extensionDirs.length === 0) {
       return;

--- a/packages/electron-extensions/index.ts
+++ b/packages/electron-extensions/index.ts
@@ -41,4 +41,4 @@ export type { ExtensionsLogger } from "./logger";
 export type { NativeMessagingHostPolicy } from "./native-messaging/native-messaging";
 export { createSharedExtensionInstance } from "./runtime-proxy";
 export type { CreateSharedExtensionInstanceOptions } from "./runtime-proxy";
-export { findExtensionDirs } from "./scan";
+export { findExtensionDirs, readExtensionDirId } from "./scan";

--- a/packages/electron-extensions/scan.test.ts
+++ b/packages/electron-extensions/scan.test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { findExtensionDirs } from "./scan";
+import { FIXTURE_EXTENSION_ID } from "./fixture/id";
+import fixtureManifest from "./fixture/manifest.json";
+import { findExtensionDirs, readExtensionDirId } from "./scan";
 
 let workDir: string;
 
@@ -56,5 +58,38 @@ describe("findExtensionDirs", () => {
   test("returns nothing for an empty or missing directory", async () => {
     expect(findExtensionDirs(workDir)).toEqual([]);
     expect(findExtensionDirs(path.join(workDir, "missing"))).toEqual([]);
+  });
+});
+
+describe("readExtensionDirId", () => {
+  test("reads the id the manifest key derives", async () => {
+    const extensionDir = path.join(workDir, "fixture");
+
+    await mkdir(extensionDir);
+
+    await writeFile(
+      path.join(extensionDir, "manifest.json"),
+      JSON.stringify({ name: "Extension", key: fixtureManifest.key }),
+    );
+
+    expect(readExtensionDirId(extensionDir)).toBe(FIXTURE_EXTENSION_ID);
+  });
+
+  test("reads nothing from a manifest without a key", async () => {
+    const extensionDir = await createExtensionDir(path.join(workDir, "keyless"));
+
+    expect(readExtensionDirId(extensionDir)).toBeUndefined();
+  });
+
+  test("reads nothing from a missing or unparsable manifest", async () => {
+    const extensionDir = path.join(workDir, "broken");
+
+    await mkdir(extensionDir);
+
+    expect(readExtensionDirId(extensionDir)).toBeUndefined();
+
+    await writeFile(path.join(extensionDir, "manifest.json"), "{");
+
+    expect(readExtensionDirId(extensionDir)).toBeUndefined();
   });
 });

--- a/packages/electron-extensions/scan.ts
+++ b/packages/electron-extensions/scan.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { getExtensionIdFromManifestKey } from "./derive/extension-id";
 
 const MANIFEST_FILE_NAME = "manifest.json";
 
@@ -29,4 +30,26 @@ export function findExtensionDirs(dirPath: string) {
     .map((entryName) => path.join(dirPath, entryName))
     .filter((extensionDir) => fs.existsSync(path.join(extensionDir, MANIFEST_FILE_NAME)))
     .map((extensionDir) => fs.realpathSync(extensionDir));
+}
+
+/**
+ * The id an unpacked extension loads under, read from the `key` its manifest
+ * carries, or nothing where the directory has no readable manifest or no key.
+ *
+ * An extension without a key has no id until Chromium derives one from the
+ * directory it is loaded from, so a caller filtering on ids can only ever pass
+ * one over.
+ */
+export function readExtensionDirId(extensionDir: string) {
+  let manifest: { key?: string };
+
+  try {
+    manifest = JSON.parse(fs.readFileSync(path.join(extensionDir, MANIFEST_FILE_NAME), "utf8")) as {
+      key?: string;
+    };
+  } catch {
+    return undefined;
+  }
+
+  return getExtensionIdFromManifestKey(manifest.key);
 }


### PR DESCRIPTION
## Summary
`Extensions.setupSession` loaded every directory it was given, so two directories carrying the same `manifest.key` were both handed to Chromium under the one id — which happens in development whenever an extension sits in both the repository's `extensions/` folder and the config-backed installs. It now deduplicates by extension id before the derive, first directory in the list winning. Nothing here has been exercised in a running app.

## Problem
`getExtensionDirs` in `packages/app/extensions.ts` concatenates the `extensions/` folder, the fixture, and the installs, so a developer with 1Password in the folder *and* installed from the Extensions settings page loads it twice.

Two things go wrong, both read off the code rather than measured. `dropServiceWorkerRegistration` runs before each `loadExtension`, so the second load clears the worker registration the first just made — the registration that clear exists to refresh in the first place. And which of the two copies ends up running is invisible: Chromium either refuses the second load or swaps the path, nobody has checked which, and the per-directory `catch` treats both outcomes alike, so the only trace is the `extensionDir` the `Loaded extension` log line names.

## Solution
- `readExtensionDirId` in the loader package's `scan.ts` reads the id from a directory's `manifest.key`, synchronously, alongside `findExtensionDirs`. The derive step already derives that id, but only once it has copied the directory, which is too late to decide whether to copy it.
- `setupSession` maps the directories through it and drops any whose id it has already seen, logging the skipped directory.

Two choices worth naming. Deduplicating in the loader rather than in `getExtensionDirs` keeps the app free of the mechanism and covers every embedder, and doing it before the derive rather than after avoids deriving a copy that is then dropped. And first-in-the-list-wins rather than any rule over the directories themselves means the embedder keeps choosing the copy purely by the order it lists them in — the order already puts the `extensions/` folder ahead of the installs, which is the copy a developer is editing.

A directory whose manifest carries no `key` is never deduplicated. It has no id, and Chromium derives one from the path it loads from, so two keyless directories are two different extensions rather than one twice.

## Try it
`bun run dev` with 1Password in both `extensions/1password` and the Extensions settings page. The log carries one `Loaded extension` line for it, naming the `extensions/1password` path, and a `Skipped duplicate extension directory` line naming the install directory. Before this change there were two `Loaded extension` lines.

## Not verified
- Nothing has been run in the app; the duplicate case and both consequences above are read off the code rather than observed.
- Which of the two behaviors Chromium actually had on the second load — refusing it or swapping the path — is still unchecked, and this change removes the need to know.