### PR TITLE
Label extensions Experimental rather than Beta

### DIFF
--- a/packages/renderer/components/beta-field-badge.tsx
+++ b/packages/renderer/components/beta-field-badge.tsx
@@ -1,5 +1,0 @@
-import { Badge } from "@meru/ui/components/badge";
-
-export function BetaFieldBadge() {
-  return <Badge variant="outline">Beta</Badge>;
-}

--- a/packages/renderer/components/config-switch-field.tsx
+++ b/packages/renderer/components/config-switch-field.tsx
@@ -4,15 +4,15 @@ import { Switch } from "@meru/ui/components/switch";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { useConfig, useConfigMutation } from "@/lib/react-query";
 import { restartRequiredToast } from "@/lib/toast";
-import { BetaFieldBadge } from "./beta-field-badge";
 import { LicenseKeyRequiredFieldBadge } from "./license-key-required-field-badge";
+import { type FieldMaturity, MaturityFieldBadge } from "./maturity-field-badge";
 
 export function ConfigSwitchField({
   configKey,
   label,
   description,
   licenseKeyRequired,
-  beta,
+  maturity,
   disabled,
   restartRequired,
 }: {
@@ -20,7 +20,7 @@ export function ConfigSwitchField({
   label: string;
   description: string;
   licenseKeyRequired?: boolean;
-  beta?: boolean;
+  maturity?: FieldMaturity;
   disabled?: boolean;
   restartRequired?: boolean;
 }) {
@@ -51,7 +51,7 @@ export function ConfigSwitchField({
       <FieldContent>
         <FieldLabel htmlFor={configKey} className="flex items-center gap-2">
           {label}
-          {beta && <BetaFieldBadge />}
+          {maturity && <MaturityFieldBadge maturity={maturity} />}
           {licenseKeyRequired && <LicenseKeyRequiredFieldBadge />}
         </FieldLabel>
         <FieldDescription>{description}</FieldDescription>

--- a/packages/renderer/components/maturity-field-badge.tsx
+++ b/packages/renderer/components/maturity-field-badge.tsx
@@ -1,0 +1,16 @@
+import { Badge } from "@meru/ui/components/badge";
+
+/**
+ * The maturity badge on a feature that isn't stable yet.
+ *
+ * The two labels rank, and a feature takes the one it has earned: Experimental
+ * means it may still change shape or be withdrawn, Beta that it is
+ * feature-complete and still finding bugs. The set is closed so those stay the
+ * whole vocabulary — Experimental deliberately reusing the prerelease update
+ * channel's name, since to a user both say the same thing.
+ */
+export type FieldMaturity = "Experimental" | "Beta";
+
+export function MaturityFieldBadge({ maturity }: { maturity: FieldMaturity }) {
+  return <Badge variant="outline">{maturity}</Badge>;
+}

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -38,11 +38,11 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { ExternalLinkIcon, KeyRoundIcon } from "lucide-react";
 import { type ComponentProps, useState } from "react";
 import { toast } from "sonner";
-import { BetaFieldBadge } from "@/components/beta-field-badge";
 import { ConfigSwitchField } from "@/components/config-switch-field";
 import { CopyButton } from "@/components/copy-button";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { LicenseKeyRequiredFieldBadge } from "@/components/license-key-required-field-badge";
+import { MaturityFieldBadge } from "@/components/maturity-field-badge";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
 import { queryClient, useConfig } from "@/lib/react-query";
@@ -422,7 +422,7 @@ export function ExtensionsSettings() {
       <SettingsHeader>
         <SettingsTitle className="flex items-center gap-2">
           Extensions
-          <BetaFieldBadge />
+          <MaturityFieldBadge maturity="Experimental" />
         </SettingsTitle>
         {config["extensions.installed"].length > 0 && <UpdateExtensionsButton />}
       </SettingsHeader>

--- a/packages/renderer/routes/settings/gmail/index.tsx
+++ b/packages/renderer/routes/settings/gmail/index.tsx
@@ -81,7 +81,7 @@ export function GmailSettings() {
               configKey="gmail.extendDarkTheme"
               restartRequired
               licenseKeyRequired
-              beta
+              maturity="Beta"
             />
           </FieldSet>
           <FieldSeparator />

--- a/tests/lib/settings.ts
+++ b/tests/lib/settings.ts
@@ -43,6 +43,6 @@ export async function readSettingsPageLabels(navigation: Locator) {
 export async function openSettingsPage(meru: MeruApp, navigation: Locator, label: string) {
   await navigation.getByRole("button", { name: label, exact: true }).click();
 
-  // Contained, not equal: Extensions carries a beta badge inside its title.
+  // Contained, not equal: Extensions carries a maturity badge inside its title.
   await expect(meru.renderer.getByTestId("settings-title"), label).toContainText(label);
 }


### PR DESCRIPTION
## Summary
The Extensions settings page now carries an **Experimental** badge instead of **Beta**, because the layer can still change shape or be withdrawn. The Gmail dark theme keeps **Beta**, so the badge takes its label from a closed union rather than hardcoding one word. Not run in a real app — the change is a string and a prop rename.

## Problem
Extensions was labeled Beta, which oversells it. Beta is widely read as feature-complete and nearly ready, and Meru's `chrome.*` layer is neither: it needs more testing, and it may still change shape or be dropped. That is the same reading the prerelease channel rejected the word for, in [the Experimental channel decision](https://github.com/zoidsh/meru/pull/936) — Experimental was chosen there precisely because it needs no release vocabulary and an experiment is understood to be something that can fail.

The badge component hardcoded "Beta", so it had no way to say anything else, and `ConfigSwitchField` exposed it as `beta?: boolean`.

## Solution
- `BetaFieldBadge` becomes `MaturityFieldBadge`, taking a `maturity` prop typed as `FieldMaturity = "Experimental" | "Beta"`. The union is closed rather than a free string, so the vocabulary stays two words and a caller can't invent a third.
- Extensions reads Experimental; the Gmail dark theme reads Beta. They differ because their maturity differs — dark theme is unfinished, extensions is unsettled — and folding both into one label would have lost that.
- `ConfigSwitchField`'s `beta?: boolean` becomes `maturity?: FieldMaturity`.

Experimental deliberately reuses the prerelease update channel's name, which means the same word appears twice in Settings meaning two things: a build channel on Updates, and a feature's maturity on Extensions. That overlap was weighed and accepted — to a user both say "this can break", and one vocabulary beats two. The alternatives that avoid it were worse: "Early access" understates, and "Alpha" only ranks below beta for people who already know release vocabulary, which is the reason [decisions.md](https://github.com/zoidsh/meru/pull/936) rejected it for the channel.

No end-to-end assertion matched the badge text, so nothing needed rewriting; one comment in `tests/lib/settings.ts` naming it a "beta badge" is now a "maturity badge".

## Try it
Settings → Extensions: the badge beside the page title reads **Experimental**. Settings → Gmail → **Extend dark theme**: the badge beside the field label still reads **Beta**.

## Not verified
- Not run in a real app. `bun run types`, `bun run lint`, `bun run fmt:check` and `bun test` (673 pass, 1 skip, 0 fail) all pass; the end-to-end suite was not run, as no assertion touches the badge text.