### PR TITLE
Show the extensions button setting above the password managers

### DIFF
--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -433,6 +433,13 @@ export function ExtensionsSettings() {
             Extensions are loaded into every account and take effect after a restart. Meru installs
             the official extensions from the Chrome Web Store.
           </FieldDescription>
+          <ConfigSwitchField
+            label="Show extensions button"
+            description="Show a titlebar button that lists the installed extensions and opens their popups."
+            configKey="extensions.showTitlebarButton"
+            licenseKeyRequired
+          />
+          <FieldSeparator />
           <FieldSet>
             <FieldLegend>Password managers</FieldLegend>
             <PasskeysAlert />
@@ -451,13 +458,6 @@ export function ExtensionsSettings() {
                 ))}
             </ItemGroup>
           </FieldSet>
-          <FieldSeparator />
-          <ConfigSwitchField
-            label="Show extensions button"
-            description="Show a titlebar button that lists the installed extensions and opens their popups."
-            configKey="extensions.showTitlebarButton"
-            licenseKeyRequired
-          />
         </FieldGroup>
       </SettingsContent>
     </Settings>


### PR DESCRIPTION
## Summary
Moves the "Show extensions button" switch in Extensions settings above the "Password managers" section, so the page's one setting sits at the top instead of below a list that grows. Presentation only — no config, behavior or copy changes.

## Problem
Extensions settings put the "Show extensions button" switch last, under the "Password managers" field set and its extension list. The switch is the page's only actual setting; everything above it is a list of installable extensions. Every extension added to that list pushes the setting further down, and on a short window it already sits below the fold.

## Solution
- Moves the `ConfigSwitchField` above the `FieldSet`, carrying the `FieldSeparator` with it so the two stay divided.
- Leaves it below the intro `FieldDescription` rather than making it the very first element, so the description still introduces the page as a whole instead of floating between the switch and the list.

## Try it
Settings → Extensions. The "Show extensions button" switch is now directly under the intro paragraph, above the "Password managers" heading.

## Not verified
- Not run in the app; checked by reading the rendered order in the JSX. `bun run types`, `bun run lint` and `bun run fmt:check` all pass.