### PR TITLE
Lead the passkey alerts with the sign-in they enable

### DIFF
--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -287,9 +287,8 @@ function PasskeysAlert() {
         <AlertTitle>Sign in to Google with a passkey and Touch ID</AlertTitle>
         <AlertDescription>
           Add a passkey to your Google account from its security settings inside Meru, then sign in
-          with Touch ID — no password manager extension to install, and nothing extra running in the
-          background to slow Meru down. iCloud passkeys don't work here, and filling passwords still
-          needs a password manager.
+          with Touch ID — no password manager extension to install, so Meru stays fast and light.
+          iCloud passkeys don't work here, and filling passwords still needs a password manager.
         </AlertDescription>
       </Alert>
     );
@@ -302,8 +301,8 @@ function PasskeysAlert() {
         <AlertTitle>Sign in to Google with a passkey and Windows Hello</AlertTitle>
         <AlertDescription>
           Google sign-in uses Windows' own passkey dialog, so Windows Hello and synced passkeys work
-          without a password manager extension, and with nothing extra running in the background to
-          slow Meru down. Filling passwords still needs a password manager.
+          with no password manager extension to install, keeping Meru fast and light. Filling
+          passwords still needs a password manager.
         </AlertDescription>
       </Alert>
     );

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -287,8 +287,8 @@ function PasskeysAlert() {
         <AlertTitle>Sign in to Google with a passkey and Touch ID</AlertTitle>
         <AlertDescription>
           Add a passkey to your Google account from its security settings inside Meru, then sign in
-          with Touch ID — no password manager extension to install, and none of the memory and CPU
-          one costs while it runs. iCloud passkeys don't work here, and filling passwords still
+          with Touch ID — no password manager extension to install, and nothing extra running in the
+          background to slow Meru down. iCloud passkeys don't work here, and filling passwords still
           needs a password manager.
         </AlertDescription>
       </Alert>
@@ -302,8 +302,8 @@ function PasskeysAlert() {
         <AlertTitle>Sign in to Google with a passkey and Windows Hello</AlertTitle>
         <AlertDescription>
           Google sign-in uses Windows' own passkey dialog, so Windows Hello and synced passkeys work
-          without a password manager extension — and without the memory and CPU one costs while it
-          runs. Filling passwords still needs a password manager.
+          without a password manager extension, and with nothing extra running in the background to
+          slow Meru down. Filling passwords still needs a password manager.
         </AlertDescription>
       </Alert>
     );

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -284,11 +284,12 @@ function PasskeysAlert() {
     return (
       <Alert>
         <KeyRoundIcon />
-        <AlertTitle>Passkeys work with Touch ID</AlertTitle>
+        <AlertTitle>Sign in to Google with a passkey and Touch ID</AlertTitle>
         <AlertDescription>
-          Add a passkey to your Google account from its security settings inside Meru and sign in
-          with Touch ID — lighter than running an extension. iCloud passkeys don't work here, and
-          filling passwords still needs a password manager.
+          Add a passkey to your Google account from its security settings inside Meru, then sign in
+          with Touch ID — no password manager extension to install, and none of the memory and CPU
+          one costs while it runs. iCloud passkeys don't work here, and filling passwords still
+          needs a password manager.
         </AlertDescription>
       </Alert>
     );
@@ -298,10 +299,11 @@ function PasskeysAlert() {
     return (
       <Alert>
         <KeyRoundIcon />
-        <AlertTitle>Passkeys work with Windows Hello</AlertTitle>
+        <AlertTitle>Sign in to Google with a passkey and Windows Hello</AlertTitle>
         <AlertDescription>
           Google sign-in uses Windows' own passkey dialog, so Windows Hello and synced passkeys work
-          with no extension. Filling passwords still needs a password manager.
+          without a password manager extension — and without the memory and CPU one costs while it
+          runs. Filling passwords still needs a password manager.
         </AlertDescription>
       </Alert>
     );


### PR DESCRIPTION
## Summary
Rewrites the macOS and Windows passkey alerts in extension settings so the title says what you can now do — sign in to Google with a passkey and Touch ID or Windows Hello — and the description explains that this replaces a password manager extension and keeps Meru fast and light. Copy only; the Linux alert is unchanged.

## Problem
Both titles named what passkeys are compatible with ("Passkeys work with Touch ID"), which reads as a compatibility footnote rather than a capability the app has. Someone scanning the extensions page can't tell from it that native passkey sign-in is available and that installing a password manager for sign-in is optional. The efficiency argument was a half-clause — "lighter than running an extension" on macOS, absent on Windows — so the strongest reason to prefer the system dialog was the least visible part of the alert.

## Solution
- macOS title becomes "Sign in to Google with a passkey and Touch ID"; Windows becomes "Sign in to Google with a passkey and Windows Hello"
- Both descriptions now say outright that no password manager extension is needed, and close on Meru staying fast and light
- Stated that as the gain rather than the cost avoided, and in plain terms rather than "memory and CPU" — the earlier wording asked the reader to know what those are, then spent the sentence on a downside they hadn't chosen
- Kept the existing caveats in place — iCloud passkeys don't work on macOS, and filling passwords still needs a password manager on both
- Left Linux alone rather than giving it a matching title: it has no system passkey support, so a password manager extension really is the only route there, and a parallel headline would be false

## Try it
Settings → Extensions, on macOS or Windows — the alert above the password manager list carries the new title and description.

## Not verified
- Not seen rendered in the app; the strings were only read in the source
- Windows and Linux branches not exercised — this sandbox is Linux without a display, and only `bun run types`, `oxfmt` and `oxlint` were run