### PR TITLE
Add a master switch that turns extensions off

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -93,7 +93,7 @@ function getStrippedManifestKeys() {
 
 /** The curated extensions the user opted into, and Pro is what they run on. */
 function getOptedInExtensionIds() {
-  if (!licenseKey.isValid) {
+  if (!config.get("extensions.enabled") || !licenseKey.isValid) {
     return [];
   }
 
@@ -123,8 +123,16 @@ async function getInstalledExtensionDirs() {
  * Everything an account session loads: what the user opted into, plus the
  * development folder. Asked again for every session, so an account created
  * after an install gets that extension without anything being rebuilt.
+ *
+ * The master switch is checked here rather than only on the opt-ins, so that
+ * off means nothing loads at all — the development and fixture folders
+ * included, which no opt-in covers.
  */
 async function getExtensionDirs() {
+  if (!config.get("extensions.enabled")) {
+    return [];
+  }
+
   return [
     ...getDevExtensionDirs(),
     ...getFixtureExtensionDirs(),
@@ -293,10 +301,10 @@ class ExtensionUpdater {
       return;
     }
 
-    // The interval stands even when nothing is installed yet, and every check
-    // re-reads the opt-ins, so an extension installed mid-session is kept up to
-    // date without a restart
-    if (config.get("extensions.installed").length > 0) {
+    // The interval stands even when nothing is installed yet and even when the
+    // master switch is off, and every check re-reads both, so an extension
+    // installed mid-session is kept up to date without a restart
+    if (config.get("extensions.enabled") && config.get("extensions.installed").length > 0) {
       this.checkForUpdates();
     }
 

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -171,14 +171,21 @@ function ExtensionErrorDialog({
 
 function ExtensionItem({
   extension,
+  extensionsEnabled,
   installed,
   installedVersion,
 }: {
   extension: CuratedExtension;
+  extensionsEnabled: boolean;
   installed: boolean;
   installedVersion: string | undefined;
 }) {
   const isLicenseKeyValid = useIsLicenseKeyValid();
+
+  // Installing an extension the app would never load only leaves the user
+  // waiting for a restart that changes nothing, so the master switch locks
+  // these the way the license does
+  const locked = !extensionsEnabled || !isLicenseKeyValid;
 
   const isOnePassword = extension.id === ONEPASSWORD_EXTENSION_ID;
 
@@ -244,8 +251,9 @@ function ExtensionItem({
               className="mt-1 self-start"
               // The dialog explains how to pair the extension with 1Password's
               // desktop app, which there is nothing to pair until it is
-              // installed. Installing needs Meru Pro, so this locks with it.
-              disabled={!installed}
+              // installed and loaded. Installing needs Meru Pro and loading
+              // needs the master switch, so this locks with both.
+              disabled={locked || !installed}
               onClick={() => {
                 setIsSetupDialogOpen(true);
               }}
@@ -257,8 +265,8 @@ function ExtensionItem({
         <ItemActions>
           {extensionMutation.isPending && <Spinner />}
           <Switch
-            checked={isLicenseKeyValid && installed}
-            disabled={!isLicenseKeyValid || extensionMutation.isPending}
+            checked={!locked && installed}
+            disabled={locked || extensionMutation.isPending}
             onCheckedChange={(checked) => {
               extensionMutation.mutate(checked);
             }}
@@ -417,6 +425,8 @@ export function ExtensionsSettings() {
     return;
   }
 
+  const extensionsEnabled = config["extensions.enabled"];
+
   return (
     <Settings>
       <SettingsHeader>
@@ -424,7 +434,9 @@ export function ExtensionsSettings() {
           Extensions
           <MaturityFieldBadge maturity="Experimental" />
         </SettingsTitle>
-        {config["extensions.installed"].length > 0 && <UpdateExtensionsButton />}
+        {extensionsEnabled && config["extensions.installed"].length > 0 && (
+          <UpdateExtensionsButton />
+        )}
       </SettingsHeader>
       <SettingsContent>
         <LicenseKeyRequiredBanner />
@@ -434,10 +446,18 @@ export function ExtensionsSettings() {
             the official extensions from the Chrome Web Store.
           </FieldDescription>
           <ConfigSwitchField
+            label="Enable extensions"
+            description="Run the installed extensions. Turning this off stops them without uninstalling them."
+            configKey="extensions.enabled"
+            licenseKeyRequired
+            restartRequired
+          />
+          <ConfigSwitchField
             label="Show extensions button"
             description="Show a titlebar button that lists the installed extensions and opens their popups."
             configKey="extensions.showTitlebarButton"
             licenseKeyRequired
+            disabled={!extensionsEnabled}
           />
           <FieldSeparator />
           <FieldSet>
@@ -450,6 +470,7 @@ export function ExtensionsSettings() {
                   <ExtensionItem
                     key={extension.id}
                     extension={extension}
+                    extensionsEnabled={extensionsEnabled}
                     installed={config["extensions.installed"].includes(extension.id)}
                     installedVersion={
                       installedExtensions?.find(({ id }) => id === extension.id)?.version

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -140,6 +140,7 @@ export function createDefaultConfig({
     "verticalTabs.showWidthToggle": true,
     "verticalTabs.hideUnreadBadgeWhenActive": false,
     "verticalTabs.showAppLinksBadge": true,
+    "extensions.enabled": true,
     "extensions.installed": [],
     "extensions.showTitlebarButton": false,
   };

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -196,6 +196,7 @@ export type Config = {
   "verticalTabs.showWidthToggle": boolean;
   "verticalTabs.hideUnreadBadgeWhenActive": boolean;
   "verticalTabs.showAppLinksBadge": boolean;
+  "extensions.enabled": boolean;
   "extensions.installed": string[];
   "extensions.showTitlebarButton": boolean;
 };


### PR DESCRIPTION
## Summary
Adds an **Enable extensions** switch at the top of the Extensions settings page, backed by a new `extensions.enabled` configuration key defaulting to `true`, so the whole feature can be turned off in one place. Off means nothing loads and nothing is fetched, and the rest of the page goes disabled rather than hidden. Turning it off is restart-gated like every other extension change.

## Problem
The only way to stop extensions running was to toggle off each curated extension one by one, which also uninstalls it and throws away the download. There was no way to say "not right now" and keep what is installed.

## Solution
- `extensions.enabled` in `packages/shared/types.ts` with a `true` default in `packages/shared/config.ts`. No migration is needed, because `electron-store`'s `defaults` fills a key an existing config has never seen, and no zod schema is needed either — `packages/shared/schemas.ts` holds the structured shapes, not the flat keys.
- Gated in two places in `packages/app/extensions.ts`, ahead of the license check in both, per the repository rule that the global setting short-circuits first. `getOptedInExtensionIds` returning nothing stops the installed extensions loading and stops every updater path — the three-hour cycle, the launch check, and the manual **Update extensions** button — from reaching the network. `getExtensionDirs` returning nothing stops the development `extensions/` folder and the checked-in fixture too, neither of which any opt-in covers, so off means off rather than off-for-users-only.
- One consequence is deliberate rather than incidental: `pruneDerivedExtensionCopies` reads `getExtensionDirs`, so the first launch with the feature off collects every derived copy, and turning it back on derives them again. That is the same trade the launch-time sweep already makes, and it frees the disk of copies nothing is loading.
- The titlebar button gets no gate of its own. `ExtensionActions` already draws nothing when no extension is loaded, so a second check there would only be a second thing to keep in step.
- The updater's interval is left running while the switch is off rather than early-returning out of `init`. The check re-reads both the switch and the opt-ins and does nothing when either is empty, so an interval that stands is what lets the feature come back mid-session without a restart — the same reasoning the existing "nothing installed yet" case already rests on.
- On the page, the rest goes disabled rather than hidden while the switch is off: the **Show extensions button** switch, each curated extension's install switch, and 1Password's **Set up desktop app** button, with **Update extensions** dropping out of the header. Hiding would have been fewer lines, but it takes away the user's view of what stays installed at exactly the moment the answer matters. Installing while nothing can load would leave the user waiting for a restart that changes nothing, so the master switch locks those controls the way the license already does, reusing the same shown-off-while-locked rendering. The version badge still shows, so what is installed stays legible.

## Try it
There is no preview deployment for a desktop app. Run `bun run dev`, open Settings > Extensions with a valid license, and the new **Enable extensions** switch is the first field. Turning it off greys the rest of the page and drops the **Update extensions** button from the header; restarting leaves no extension loaded, the fixture and any folder in `extensions/` included.

## Not verified
- The disabled-while-off state has not been seen in a running app. It only appears with a valid license, and this sandbox has no `MERU_TEST_LICENSE_KEY`, so both the Pro e2e suite and a manual look at it were out of reach. What did run: `bun run types`, `bun run lint`, `bun run fmt:check`, `bun test` (673 pass), and `tests/settings.e2e.ts` under Xvfb, whose free-version walk renders the new field and asserts it comes up Pro-locked. A screenshot of the free version confirms the field order.
- That the feature actually stops loading at runtime is read off the code, not measured — no launch was made with the switch off to confirm no extension reaches a session.