### PR TITLE
Name the prerelease channel Beta again

### DIFF
--- a/.claude/skills/release-notes/SKILL.md
+++ b/.claude/skills/release-notes/SKILL.md
@@ -7,11 +7,11 @@ description: Write release notes for Meru. Use when drafting or updating GitHub 
 
 ## Gather the changes
 
-- The release being written is the one the version commit at `HEAD` bumps to — a commit whose subject is the bare version number, matching `version` in `package.json`, such as `3.58.0` or `3.60.0-alpha.1`, tagged `v3.58.0` or `v3.60.0-alpha.1`.
+- The release being written is the one the version commit at `HEAD` bumps to — a commit whose subject is the bare version number, matching `version` in `package.json`, such as `3.58.0` or `3.60.0-beta.1`, tagged `v3.58.0` or `v3.60.0-beta.1`.
 - The range runs from the previous release's tag to that commit, and which tag counts as previous depends on the channel:
-  - **Stable** — the last stable tag, from `gh release list --exclude-pre-releases -L 1`. Never `gh release list -L 2`, which picks up an interleaved `-alpha.N` tag and truncates the notes to the tail of the cycle.
-  - **Experimental** — the last release of any kind, from `gh release list -L 1`, so each prerelease covers only what's new since the previous one.
-- Every release gets its own notes, prereleases included, written exactly the same way. A stable that promotes a cycle of experimental releases therefore restates the changes those already carried, because its range runs back to the last stable. That repetition is intended: the stable notes have to be complete for the users who never saw a prerelease.
+  - **Stable** — the last stable tag, from `gh release list --exclude-pre-releases -L 1`. Never `gh release list -L 2`, which picks up an interleaved `-beta.N` tag and truncates the notes to the tail of the cycle.
+  - **Beta** — the last release of any kind, from `gh release list -L 1`, so each prerelease covers only what's new since the previous one.
+- Every release gets its own notes, prereleases included, written exactly the same way. A stable that promotes a cycle of beta releases therefore restates the changes those already carried, because its range runs back to the last stable. That repetition is intended: the stable notes have to be complete for the users who never saw a prerelease.
 - Triage the log before opening a single diff. Drop on the commit subject alone: comment and docs edits, refactors and extractions, `TODO.md` notes, tests, CI, and dependency bumps other than Electron. A release of 40 commits usually has around 10 user-facing ones.
 - For the commits that survive, `gh pr view <number>` is the fastest read — the PR body states what changed for the user, and the commit subject often doesn't. Fall back to `git show` when there's no PR.
 - Don't trust a commit message's scope — verify the actual fix from the diff. Messages often name a single platform or quote a GitHub issue title, such as "fix window position resetting after Windows reboot", when the underlying bug affects every platform. Only scope a note to a platform with `**macOS:**` or `**Windows:**` when the code confirms the fix is platform-specific.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: release
 description: Cut a Meru release. Use when asked to release, cut a release, ship a version, or bump the version.
-argument-hint: [major|minor|patch|experimental]
+argument-hint: [major|minor|patch|beta]
 ---
 
 # Release
@@ -19,7 +19,7 @@ Check all of these first. If one fails, report it and stop — never work around
   - Any `conclusion` other than `success` means `main` is broken. Report the run URL and stop.
   - That run is also the build check. `ci.yml`'s `e2e` job builds the app with electron-builder and launches it on macOS, Windows and Linux, so a green run at `HEAD` is what says the app still compiles on all three — the thing `release.yml` does next, at the most expensive place for it to fail. There is no second workflow to query; `build.yml` was deleted when its jobs moved here.
   - What it still doesn't cover: `e2e` builds `--dir` and unsigned, so installer packaging and macOS signing run for the first time in the release itself. That is a known risk of every release, not something to check here.
-- There is something to release: the range from the last release's tag to `HEAD` is non-empty. For a stable release that's the last stable tag, from `gh release list --exclude-pre-releases -L 1`. For an experimental release it's the last release of any kind, from `gh release list -L 1`.
+- There is something to release: the range from the last release's tag to `HEAD` is non-empty. For a stable release that's the last stable tag, from `gh release list --exclude-pre-releases -L 1`. For a beta release it's the last release of any kind, from `gh release list -L 1`.
 
 ## Choose the bump
 
@@ -31,15 +31,15 @@ Read `git log --oneline <lastTag>..HEAD` — a release usually runs to a few doz
 
 Arguments naming a level or an explicit version override this triage — take them, and still confirm.
 
-## Experimental releases
+## Beta releases
 
-An `experimental` argument, or an explicit `-alpha.N` version, cuts a prerelease for the Experimental update channel instead of a stable release. Only cut one when asked — never propose one unprompted.
+A `beta` argument, or an explicit `-beta.N` version, cuts a prerelease for the Beta update channel instead of a stable release. Only cut one when asked — never propose one unprompted.
 
-The channel is named Experimental in the app and versioned `alpha` on the wire, so the interface says Experimental everywhere the version string says `-alpha.N`. That seam is deliberate, and the version suffix is never `-experimental.N`. The reasoning is in the project docs, in `decisions.md` under "The prerelease channel is named Experimental and versioned as `alpha`".
+The channel is named Beta in the app and versioned `beta` on the wire, so the interface and the version string agree. The reasoning is in the project docs, in `decisions.md` under "The prerelease channel is named Beta".
 
-- The version is the next stable version per the triage above with `-alpha.N` appended: the first experimental release of a cycle is `X.Y.Z-alpha.1`. Each further one before that stable ships increments `N`.
+- The version is the next stable version per the triage above with `-beta.N` appended: the first beta release of a cycle is `X.Y.Z-beta.1`. Each further one before that stable ships increments `N`.
 - Everything else follows the stable flow, with two differences: `gh release create` gets `--prerelease`, and the triage range runs from the last release of any kind, not the last stable.
-- Promoting an experimental release to stable is the normal stable flow with the suffix dropped, as in `3.60.0-alpha.2` → `3.60.0`. Experimental users are moved onto the stable build automatically.
+- Promoting a beta release to stable is the normal stable flow with the suffix dropped, as in `3.60.0-beta.2` → `3.60.0`. Beta users are moved onto the stable build automatically.
 
 ## Confirm the bump
 
@@ -59,7 +59,7 @@ Always confirm before editing `package.json`, even when the bump is obvious.
 
 - `gh release create v<version> --target "$(git rev-parse HEAD)" --notes ""`.
   - `--target` pins the tag to the version commit rather than wherever `main` has drifted to.
-  - For an experimental release, add `--prerelease`. It keeps the release off `/releases/latest`, so stable users never see it, and it makes `release.yml` publish `alpha*.yml` update metadata instead of `latest*.yml`.
+  - For a beta release, add `--prerelease`. It keeps the release off `/releases/latest`, so stable users never see it, and it makes `release.yml` publish `beta*.yml` update metadata instead of `latest*.yml`.
   - Pass no `--title`. Every prior release leaves the title empty, so GitHub shows the tag.
   - Empty notes are deliberate — the next step writes them. Don't pass `--generate-notes`.
 - Never create it as a draft. `release.yml` triggers on `released` or `prereleased` only, so a draft never builds.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         # without it macOS refuses to launch the signed app.
         run: |
           echo "$APPLE_PROVISIONING_PROFILE" | base64 --decode > build/embedded.provisionprofile
-          bun run build:mac -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=alpha' || '' }}
+          bun run build:mac -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=beta' || '' }}
         env:
           APPLE_PROVISIONING_PROFILE: ${{ secrets.APPLE_PROVISIONING_PROFILE }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
@@ -43,10 +43,10 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: startsWith(matrix.os, 'ubuntu')
-        run: bun run build:linux -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=alpha' || '' }}
+        run: bun run build:linux -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=beta' || '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - if: startsWith(matrix.os, 'windows')
-        run: bun run build:win -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=alpha' || '' }}
+        run: bun run build:win -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=beta' || '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/app/lib/update-channel.test.ts
+++ b/packages/app/lib/update-channel.test.ts
@@ -2,22 +2,22 @@ import { describe, expect, test } from "bun:test";
 import { resolveUpdateChannel } from "./update-channel";
 
 const stableVersion = { prerelease: [] };
-const prereleaseVersion = { prerelease: ["alpha", 2] };
+const prereleaseVersion = { prerelease: ["beta", 2] };
 
 describe("resolveUpdateChannel", () => {
   test("names the stable channel rather than leaving it unset", () => {
     // electron-updater's setter throws on anything but a non-empty string once
-    // a channel has been assigned, so switching Experimental back to Stable in
-    // one session depends on this never being null.
+    // a channel has been assigned, so switching Beta back to Stable in one
+    // session depends on this never being null.
     expect(resolveUpdateChannel("stable", stableVersion).channel).toBe("latest");
   });
 
   test("passes the prerelease channel through", () => {
-    expect(resolveUpdateChannel("alpha", stableVersion).channel).toBe("alpha");
+    expect(resolveUpdateChannel("beta", stableVersion).channel).toBe("beta");
   });
 
   test("allows prereleases only on the prerelease channel", () => {
-    expect(resolveUpdateChannel("alpha", prereleaseVersion).allowPrerelease).toBe(true);
+    expect(resolveUpdateChannel("beta", prereleaseVersion).allowPrerelease).toBe(true);
     expect(resolveUpdateChannel("stable", prereleaseVersion).allowPrerelease).toBe(false);
   });
 
@@ -30,6 +30,6 @@ describe("resolveUpdateChannel", () => {
   });
 
   test("never downgrades while the prerelease channel is selected", () => {
-    expect(resolveUpdateChannel("alpha", prereleaseVersion).allowDowngrade).toBe(false);
+    expect(resolveUpdateChannel("beta", prereleaseVersion).allowDowngrade).toBe(false);
   });
 });

--- a/packages/app/lib/update-channel.ts
+++ b/packages/app/lib/update-channel.ts
@@ -5,17 +5,17 @@ import type { Config } from "@meru/shared/types";
  * `latest-linux.yml`, `latest.yml` — and what its providers fall back to when
  * no channel is set.
  *
- * Naming it is what makes leaving Experimental work. `autoUpdater.channel`
- * refuses anything but a non-empty string once a channel has been assigned, so
- * a session that visited Experimental cannot be handed `null` to get back to
- * stable: the setter throws `ERR_UPDATER_INVALID_CHANNEL` out of the
- * configuration listener, and the properties after it never get applied.
+ * Naming it is what makes leaving Beta work. `autoUpdater.channel` refuses
+ * anything but a non-empty string once a channel has been assigned, so a
+ * session that visited Beta cannot be handed `null` to get back to stable: the
+ * setter throws `ERR_UPDATER_INVALID_CHANNEL` out of the configuration
+ * listener, and the properties after it never get applied.
  *
  * It also makes the stable feed independent of the build asking for it. Unset,
  * the GitHub provider falls through to the channel baked into the build's
- * `app-update.yml`, which on an Experimental build is `alpha` — so a user
- * stepping back to stable would ask a stable release for `alpha-mac.yml` and
- * get a 404 with no fallback.
+ * `app-update.yml`, which on a Beta build is `beta` — so a user stepping back
+ * to stable would ask a stable release for `beta-mac.yml` and get a 404 with no
+ * fallback.
  */
 const STABLE_CHANNEL_NAME = "latest";
 

--- a/packages/renderer/components/maturity-field-badge.tsx
+++ b/packages/renderer/components/maturity-field-badge.tsx
@@ -6,8 +6,9 @@ import { Badge } from "@meru/ui/components/badge";
  * The two labels rank, and a feature takes the one it has earned: Experimental
  * means it may still change shape or be withdrawn, Beta that it is
  * feature-complete and still finding bugs. The set is closed so those stay the
- * whole vocabulary — Experimental deliberately reusing the prerelease update
- * channel's name, since to a user both say the same thing.
+ * whole vocabulary — Beta doubling as the prerelease update channel's name,
+ * which is the same split Apple runs: Beta names a build you opt into,
+ * Experimental a single feature that might not survive.
  */
 export type FieldMaturity = "Experimental" | "Beta";
 

--- a/packages/renderer/routes/settings/updates.tsx
+++ b/packages/renderer/routes/settings/updates.tsx
@@ -5,7 +5,7 @@ import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/comp
 
 const releaseChannelItems = [
   { value: "stable", label: "Stable" },
-  { value: "alpha", label: "Experimental" },
+  { value: "beta", label: "Beta" },
 ];
 
 export function UpdatesSettings() {
@@ -29,15 +29,15 @@ export function UpdatesSettings() {
           />
           <ConfigSelectField
             label="Release channel"
-            description="Choose which releases to receive. The experimental channel gets upcoming features early."
+            description="Choose which releases to receive. The beta channel gets upcoming features early."
             configKey="updates.channel"
             items={releaseChannelItems}
             confirmation={{
-              when: (value) => value === "alpha",
-              title: "Switch to the experimental channel?",
+              when: (value) => value === "beta",
+              title: "Switch to the beta channel?",
               description:
-                "Experimental releases are unfinished builds of upcoming versions. They can contain bugs and break in ways a stable release won't. You can switch back to the stable channel at any time.",
-              confirmLabel: "Switch to experimental",
+                "Beta releases are unfinished builds of upcoming versions. They can contain bugs and break in ways a stable release won't. You can switch back to the stable channel at any time.",
+              confirmLabel: "Switch to beta",
             }}
           />
         </FieldGroup>

--- a/packages/renderer/routes/settings/version-history.tsx
+++ b/packages/renderer/routes/settings/version-history.tsx
@@ -84,7 +84,7 @@ export function VersionHistorySettings() {
     }
 
     const releases =
-      config?.["updates.channel"] === "alpha"
+      config?.["updates.channel"] === "beta"
         ? data
         : data.filter((release) => !release.prerelease || release.tag_name === currentTagName);
 

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -130,7 +130,7 @@ export type Config = {
   "notifications.times": NotificationTime[];
   "updates.autoCheck": boolean;
   "updates.showNotifications": boolean;
-  "updates.channel": "stable" | "alpha";
+  "updates.channel": "stable" | "beta";
   "blocker.enabled": boolean;
   "blocker.ads": boolean;
   "blocker.tracking": boolean;

--- a/tests/settings.e2e.ts
+++ b/tests/settings.e2e.ts
@@ -68,11 +68,11 @@ test("a select behind a confirmation writes only once confirmed", async () => {
 
   await releaseChannel.click();
 
-  await meru.renderer.getByRole("option", { name: "Experimental" }).click();
+  await meru.renderer.getByRole("option", { name: "Beta" }).click();
 
   const confirmation = meru.renderer.getByRole("dialog");
 
-  await expect(confirmation).toContainText("Switch to the experimental channel?");
+  await expect(confirmation).toContainText("Switch to the beta channel?");
 
   await confirmation.getByRole("button", { name: "Cancel" }).click();
 
@@ -85,13 +85,13 @@ test("a select behind a confirmation writes only once confirmed", async () => {
 
   await releaseChannel.click();
 
-  await meru.renderer.getByRole("option", { name: "Experimental" }).click();
+  await meru.renderer.getByRole("option", { name: "Beta" }).click();
 
   // Changing the channel sends the updater off to check the new feed. That call
   // is fire and forget, and the app already makes one like it on every launch.
-  await confirmation.getByRole("button", { name: "Switch to experimental" }).click();
+  await confirmation.getByRole("button", { name: "Switch to beta" }).click();
 
-  await expect.poll(async () => (await meru.readConfig())["updates.channel"]).toBe("alpha");
+  await expect.poll(async () => (await meru.readConfig())["updates.channel"]).toBe("beta");
 });
 
 test("every field label points at its control", async () => {


### PR DESCRIPTION
## Summary
Renames the prerelease update channel from Experimental back to Beta, in the interface and on the wire alike: the Updates select reads **Beta**, the config value is `beta`, and releases become `X.Y.Z-beta.N` publishing `beta*.yml`. Apple's own split is the reason — a build you opt into is a beta, a single feature that may not survive is experimental — and it frees Experimental to mean only what the Extensions badge uses it for. Nothing has ever shipped on the channel, so there is no migration.

## Problem
Two words were doing one job each until [#1000](https://github.com/zoidsh/meru/pull/1000) badged Extensions **Experimental**, at which point Experimental named both the prerelease channel on Updates and a feature's maturity on Extensions. That decision weighed the collision and accepted it, flagging the risk it takes: "Extensions [Experimental]" can be read as "available only on the Experimental channel", which isn't true — extensions ship in stable.

The channel had been Beta first, and [#936](https://github.com/zoidsh/meru/pull/936) renamed it on the grounds that beta is widely read as feature-complete and nearly ready, which oversells a build that can break. That objection is right about a *feature* and wrong about a *channel*.

## Solution
- `updates.channel` becomes `"stable" | "beta"`, the select reads Beta, and the confirmation dialog, its copy and the e2e strings follow.
- `release.yml` publishes with `--config.publish.channel=beta`, and both release skills move to `-beta.N` versions and a `beta` argument.
- The `MaturityFieldBadge` union is untouched — Extensions keeps **Experimental**, the Gmail dark theme keeps **Beta** — but its comment now records the split rather than the collision.
- Apple is the reference for the naming, not a coin toss: macOS and iOS ship **Beta Updates** in Software Update with **Public Beta** and **Developer Beta** tiers and a **Release Candidate** at the end, while Safari's **Experimental Features** menu is where a single feature that may be withdrawn lives. No Apple update channel is labeled Experimental. Users have been trained by a decade of those public betas that a beta channel means bugs, which is exactly the reading the confirmation dialog asks for and states outright anyway.
- The tier moves `alpha` → `beta` rather than staying `alpha` under a Beta label. Both satisfy the `["alpha", "beta"].includes(currentChannel)` gate in `GitHubProvider.getLatestVersion` that convergence onto a promoted stable depends on, so the hard constraint is met either way; moving it closes the interface-vs-version-string seam #936 knowingly opened. The cost is that Meru's first prerelease tier is now nominally the higher one, which only matters if a second tier is ever cut below it.
- No config migration, for the same reason #936 needed none: `updates.channel` has not shipped in any release, no prerelease has ever been cut, and only dev profiles can hold `"alpha"`.

## Try it
Settings → Updates → **Release channel**. The select offers Stable and Beta; picking Beta raises "Switch to the beta channel?" and only writes `"beta"` once confirmed. Settings → Extensions still shows the **Experimental** badge, which is now the only place that word appears.

## Not verified
- No prerelease has been cut against the renamed channel, so the end-to-end feed resolution — `beta*.yml` published by `release.yml`, an update picked up on the channel, and the fallback onto a promoted stable — is unexercised. It is the same path #843 verified against the vendored sources rather than a live release.
- The e2e suite ran only `tests/settings.e2e.ts` locally; the Pro specs fail to collect here for want of `MERU_TEST_LICENSE_KEY`.