### PR TITLE
Run config migrations at a prerelease's base version

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -114,6 +114,7 @@
   "patchedDependencies": {
     "conf@14.0.0": "patches/conf@14.0.0.patch",
     "electron-context-menu@4.1.0": "patches/electron-context-menu@4.1.0.patch",
+    "electron-store@10.1.0": "patches/electron-store@10.1.0.patch",
     "sonner@2.0.7": "patches/sonner@2.0.7.patch",
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -200,7 +200,8 @@
   "patchedDependencies": {
     "electron-context-menu@4.1.0": "patches/electron-context-menu@4.1.0.patch",
     "conf@14.0.0": "patches/conf@14.0.0.patch",
-    "sonner@2.0.7": "patches/sonner@2.0.7.patch"
+    "sonner@2.0.7": "patches/sonner@2.0.7.patch",
+    "electron-store@10.1.0": "patches/electron-store@10.1.0.patch"
   },
   "productName": "Meru"
 }

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -12,19 +12,12 @@ type LegacySavedTab = SavedTab & {
   persistence?: "pinned" | "bookmarked";
 };
 
-/**
- * electron-store omits conf's `projectVersion` from its options type and fills
- * it with `app.getVersion()`, whose prerelease suffix on a Beta build misses
- * every key in the ladder below. Its runtime still honors one we pass.
- */
-const migrationVersion = {
-  projectVersion: resolveMigrationVersion(app.getVersion()),
-};
-
 export const config = new Store<Config>({
-  ...migrationVersion,
   name: is.dev ? "config.dev" : "config",
   accessPropertiesByDotNotation: false,
+  // electron-store fills this with `app.getVersion()`, whose prerelease suffix
+  // on a Beta build misses every key in the ladder below.
+  projectVersion: resolveMigrationVersion(app.getVersion()),
   defaults: createDefaultConfig({
     accountId: randomUUID(),
     downloadsLocation: app.getPath("downloads"),

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -5,13 +5,24 @@ import type { SavedTab } from "@meru/shared/schemas";
 import type { Config } from "@meru/shared/types";
 import { app } from "electron";
 import Store from "electron-store";
+import { resolveMigrationVersion } from "./lib/migration-version";
 
 /** A saved tab as it was written before bookmarks became a list of their own. */
 type LegacySavedTab = SavedTab & {
   persistence?: "pinned" | "bookmarked";
 };
 
+/**
+ * electron-store omits conf's `projectVersion` from its options type and fills
+ * it with `app.getVersion()`, whose prerelease suffix on a Beta build misses
+ * every key in the ladder below. Its runtime still honors one we pass.
+ */
+const migrationVersion = {
+  projectVersion: resolveMigrationVersion(app.getVersion()),
+};
+
 export const config = new Store<Config>({
+  ...migrationVersion,
   name: is.dev ? "config.dev" : "config",
   accessPropertiesByDotNotation: false,
   defaults: createDefaultConfig({

--- a/packages/app/lib/migration-version.test.ts
+++ b/packages/app/lib/migration-version.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { resolveMigrationVersion } from "./migration-version";
+
+describe("resolveMigrationVersion", () => {
+  test("leaves a stable version alone", () => {
+    expect(resolveMigrationVersion("3.60.0")).toBe("3.60.0");
+  });
+
+  test("drops a prerelease suffix so a Beta build still matches the migration keys", () => {
+    // `semver.satisfies("3.60.0-beta.1", ">=3.60.0")` is false, and conf passes
+    // no `includePrerelease`, so the raw version misses every key in the ladder.
+    expect(resolveMigrationVersion("3.60.0-beta.1")).toBe("3.60.0");
+    expect(resolveMigrationVersion("3.61.0-alpha.12")).toBe("3.61.0");
+  });
+
+  test("passes an unrecognized version through rather than emptying it", () => {
+    expect(resolveMigrationVersion("dev")).toBe("dev");
+  });
+});

--- a/packages/app/lib/migration-version.ts
+++ b/packages/app/lib/migration-version.ts
@@ -1,0 +1,11 @@
+/**
+ * The app version with any prerelease suffix dropped — `3.60.0-beta.1` becomes
+ * `3.60.0` — for the `projectVersion` conf matches migration keys against.
+ *
+ * Semver excludes prereleases from a range, and conf passes no
+ * `includePrerelease`, so a Beta build would otherwise miss every key in the
+ * ladder and run no migration at all.
+ */
+export function resolveMigrationVersion(version: string) {
+  return /^\d+\.\d+\.\d+/.exec(version)?.[0] ?? version;
+}

--- a/patches/electron-store@10.1.0.patch
+++ b/patches/electron-store@10.1.0.patch
@@ -1,0 +1,13 @@
+diff --git a/index.d.ts b/index.d.ts
+index 9d771ab6d912ae4d0c0a34867c0601c7b82febc3..458b29bc6c87bf950e3bbca348de619b53bcf88a 100644
+--- a/index.d.ts
++++ b/index.d.ts
+@@ -3,7 +3,7 @@ import Conf, {type Options as ConfigOptions} from 'conf';
+ 
+ export {Schema} from 'conf';
+ 
+-export type Options<T extends Record<string, any>> = Except<ConfigOptions<T>, 'configName' | 'projectName' | 'projectVersion' | 'projectSuffix'> & {
++export type Options<T extends Record<string, any>> = Except<ConfigOptions<T>, 'configName' | 'projectName' | 'projectSuffix'> & {
+ 	/**
+ 	Name of the storage file (without extension).
+ 


### PR DESCRIPTION
## Summary
A Beta build ran no config migration at all — not just the one its cycle added, but the whole eighteen-key ladder — because conf matches range keys with a bare `semver.satisfies` that excludes prereleases. This passes conf an explicit `projectVersion` with the suffix stripped, so `3.60.0-beta.1` matches as `3.60.0`. The bug was already recorded as a release-mechanics blocker in the 3.60 risk review; it was not blocking 3.60 in fact, because that cycle's only migration is a key deletion, but every later cycle carrying a reshape would have hit it.

## Problem
Every key in the ladder is a range — `">=3.60.0"`, `">3.57.0"` — and conf's `_shouldPerformMigration` matches those with `semver.satisfies(projectVersion, key)`, passing no `includePrerelease`. Semver excludes a prerelease from a range unless the range carries a prerelease comparator at the same version, so on a Beta build every one of the eighteen keys evaluates false. electron-store hands conf `app.getVersion()`, which on a prerelease is `3.60.0-beta.1`, and Meru overrode nothing.

conf then records the version anyway: its final stamp write is guarded by `!semver.eq` rather than `semver.lt`, so the store claims to be migrated to a version whose migrations never ran.

It self-corrects at stable promotion — the recorded prerelease fails the same check, so the ladder re-runs, and Meru's migrations are written idempotently. But a Beta user runs the entire cycle on an unmigrated store, and a user who is behind the ladder and switches to Beta runs it on a store several shapes out of date.

Not reported upstream in `sindresorhus/conf` or `sindresorhus/electron-store`, and pull requests are disabled on both repositories.

## Solution
- `resolveMigrationVersion` strips a prerelease suffix, and `config` passes the result as conf's `projectVersion`
- Coerced the version rather than keying the eighteen ladder entries for prereleases: that needs per-key reasoning about whether `>3.57.0` becomes `>=3.57.1-0`, and permanent discipline on every key added after
- Also rather than patching conf's matcher to pass `includePrerelease` — a behavioral patch to migration matching is covered by no test here, while the coercion is a pure function with one
- electron-store hides `projectVersion` in its options type while its runtime honors one that is passed, so `patches/electron-store@10.1.0.patch` drops it from the `Except` list. The patch is types-only, like the conf patch beside it, and a patch that stops applying fails `bun install` loudly rather than silently restoring the bug

Verified against the vendored conf 14.0.0 with a two-migration ladder: `3.60.0-beta.1` ran nothing, the coerced `3.60.0` ran both.

Docs updated in `zoidsh/docs`: two decision entries, a configuration section in the release-channels doc, and the risk review's blocker struck.

## Not verified
- No packaged prerelease build was run. The proof is against conf directly plus the unit test, not a real `3.60.0-beta.1` install migrating a stale store.
- The related round-trip risk is unaddressed by design and now carried as a written rule instead: a Beta release may add or remove config keys, but a migration that reshapes an existing key must land in a stable release, because leaving the channel downgrades onto a binary whose ladder ends earlier and conf's stamp cannot detect it (an older build stamps it backward on first launch). Nothing in code enforces this.