### PR TITLE
Fix three extension guards in the app glue

### DIFF
--- a/packages/app/account.ts
+++ b/packages/app/account.ts
@@ -145,7 +145,16 @@ export class Account {
   }
 
   private registerSessionPermissionsCheckHandler() {
-    this.session.setPermissionCheckHandler((_webContents, permission) => {
+    this.session.setPermissionCheckHandler((_webContents, permission, requestingOrigin) => {
+      // The same carve-out the request handler makes, because the two answers
+      // have to agree: answered here from the workspace-app setting, an
+      // extension page would be told its `requestPermission()` was granted
+      // while `Notification.permission` read denied and every notification it
+      // posted was dropped
+      if (extensions.isLoadedExtensionUrl(this.session, requestingOrigin)) {
+        return EXTENSION_PAGE_PERMISSIONS.has(permission);
+      }
+
       if (permission === "notifications") {
         return areWorkspaceAppNotificationsAllowed();
       }

--- a/packages/electron-extensions/action.test.ts
+++ b/packages/electron-extensions/action.test.ts
@@ -111,6 +111,12 @@ describe("getActionPopupUrl", () => {
     ).toBe(null);
   });
 
+  test("is nothing for a popup that isn't a URL", () => {
+    expect(
+      getActionPopupUrl("aaa", { action: { default_popup: "chrome-extension://aaa\\x" } }),
+    ).toBe(null);
+  });
+
   test("keeps a page a relative path walks back to the extension root", () => {
     expect(getActionPopupUrl("aaa", { action: { default_popup: "../../popup.html" } })).toBe(
       "chrome-extension://aaa/popup.html",

--- a/packages/electron-extensions/action.test.ts
+++ b/packages/electron-extensions/action.test.ts
@@ -100,6 +100,22 @@ describe("getActionPopupUrl", () => {
     expect(getActionPopupUrl("aaa", { action: { default_title: "Title" } })).toBe(null);
     expect(getActionPopupUrl("aaa", {})).toBe(null);
   });
+
+  test("refuses a popup that resolves outside the extension", () => {
+    expect(getActionPopupUrl("aaa", { action: { default_popup: "https://example.com/x" } })).toBe(
+      null,
+    );
+    expect(getActionPopupUrl("aaa", { action: { default_popup: "//example.com/x" } })).toBe(null);
+    expect(
+      getActionPopupUrl("aaa", { action: { default_popup: "chrome-extension://bbb/popup.html" } }),
+    ).toBe(null);
+  });
+
+  test("keeps a page a relative path walks back to the extension root", () => {
+    expect(getActionPopupUrl("aaa", { action: { default_popup: "../../popup.html" } })).toBe(
+      "chrome-extension://aaa/popup.html",
+    );
+  });
 });
 
 describe("createExtensionAction", () => {

--- a/packages/electron-extensions/action.ts
+++ b/packages/electron-extensions/action.ts
@@ -110,7 +110,20 @@ export function getActionPopupUrl(extensionId: string, manifest: ActionManifest)
     return null;
   }
 
-  return new URL(defaultPopup, `chrome-extension://${extensionId}/`).href;
+  const popupUrl = new URL(defaultPopup, `chrome-extension://${extensionId}/`);
+
+  // An absolute `default_popup` resolves to itself, and the popup is loaded in
+  // the viewed account's session with that account's cookies, so a manifest
+  // declaring one would be handed a window on the signed-in user. Chrome
+  // refuses a non-relative `default_popup` when it parses the manifest; this is
+  // the same refusal, one step later. `URL.origin` is no use for the
+  // comparison, since it is `"null"` for every scheme the URL standard doesn't
+  // call special, `chrome-extension:` among them.
+  if (popupUrl.protocol !== "chrome-extension:" || popupUrl.host !== extensionId) {
+    return null;
+  }
+
+  return popupUrl.href;
 }
 
 export function createExtensionAction(extension: ActionExtension): ExtensionAction {

--- a/packages/electron-extensions/action.ts
+++ b/packages/electron-extensions/action.ts
@@ -110,7 +110,14 @@ export function getActionPopupUrl(extensionId: string, manifest: ActionManifest)
     return null;
   }
 
-  const popupUrl = new URL(defaultPopup, `chrome-extension://${extensionId}/`);
+  const popupUrl = URL.parse(defaultPopup, `chrome-extension://${extensionId}/`);
+
+  // A `default_popup` that isn't a URL at all leaves the button with nothing to
+  // open, which is what no popup already means. Throwing here would take the
+  // whole extension down instead, since the load path catches per directory.
+  if (!popupUrl) {
+    return null;
+  }
 
   // An absolute `default_popup` resolves to itself, and the popup is loaded in
   // the viewed account's session with that account's cookies, so a manifest

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -521,6 +521,18 @@ describe("Extensions", () => {
     ).toBe(false);
   });
 
+  test("matches a bare extension origin, which is all a permission check gets", async () => {
+    const { session } = createSession();
+
+    const extensions = createExtensions([await createExtensionDir("one")]);
+
+    await extensions.setupSession(session);
+
+    expect(extensions.isLoadedExtensionUrl(session, "chrome-extension://aaa")).toBe(true);
+    expect(extensions.isLoadedExtensionUrl(session, "chrome-extension://aaa/")).toBe(true);
+    expect(extensions.isLoadedExtensionUrl(session, "chrome-extension://aaabbb")).toBe(false);
+  });
+
   test("reports an extension as loaded in that session only", async () => {
     const { session: sessionWithExtension } = createSession();
     const { session: sessionWithoutExtension } = createSession();

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -514,6 +514,12 @@ export class Extensions {
     return this.loadedExtensionIdsBySession.get(session)?.has(extensionId) ?? false;
   }
 
+  /**
+   * Whether a URL belongs to an extension loaded into this session. A bare
+   * origin counts, since that is all a permission check is given, and Chromium
+   * serializes one with and without its trailing slash depending on where it
+   * came from.
+   */
   isLoadedExtensionUrl(session: Session, url: string) {
     const loadedExtensionIds = this.loadedExtensionIdsBySession.get(session);
 
@@ -522,7 +528,9 @@ export class Extensions {
     }
 
     for (const extensionId of loadedExtensionIds) {
-      if (url.startsWith(`chrome-extension://${extensionId}/`)) {
+      const extensionOrigin = `chrome-extension://${extensionId}`;
+
+      if (url === extensionOrigin || url.startsWith(`${extensionOrigin}/`)) {
         return true;
       }
     }

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -516,9 +516,10 @@ export class Extensions {
 
   /**
    * Whether a URL belongs to an extension loaded into this session. A bare
-   * origin counts, since that is all a permission check is given, and Chromium
-   * serializes one with and without its trailing slash depending on where it
-   * came from.
+   * origin counts too, since that is all a permission check is given: Electron
+   * hands the check handler `GURL::spec()`, which for a standard scheme such as
+   * `chrome-extension` always carries the trailing slash, so this is belt and
+   * braces rather than a path anyone has hit.
    */
   isLoadedExtensionUrl(session: Session, url: string) {
     const loadedExtensionIds = this.loadedExtensionIdsBySession.get(session);

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -187,6 +187,12 @@ function ExtensionItem({
   // these the way the license does
   const locked = !extensionsEnabled || !isLicenseKeyValid;
 
+  // Uninstalling is deliberately ungated, so that an extension can be taken off
+  // a device that has lost its license — which needs the switch to stay on and
+  // usable once something is installed, or the only way out of it is gone. The
+  // master switch still locks it, since nothing loads while that is off.
+  const toggleLocked = !extensionsEnabled || (!installed && !isLicenseKeyValid);
+
   const isOnePassword = extension.id === ONEPASSWORD_EXTENSION_ID;
 
   const [isSetupDialogOpen, setIsSetupDialogOpen] = useState(false);
@@ -265,8 +271,8 @@ function ExtensionItem({
         <ItemActions>
           {extensionMutation.isPending && <Spinner />}
           <Switch
-            checked={!locked && installed}
-            disabled={locked || extensionMutation.isPending}
+            checked={extensionsEnabled && installed}
+            disabled={toggleLocked || extensionMutation.isPending}
             onCheckedChange={(checked) => {
               extensionMutation.mutate(checked);
             }}

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -182,11 +182,6 @@ function ExtensionItem({
 }) {
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
-  // Installing an extension the app would never load only leaves the user
-  // waiting for a restart that changes nothing, so the master switch locks
-  // these the way the license does
-  const locked = !extensionsEnabled || !isLicenseKeyValid;
-
   // Uninstalling is deliberately ungated, so that an extension can be taken off
   // a device that has lost its license — which needs the switch to stay on and
   // usable once something is installed, or the only way out of it is gone. The
@@ -259,7 +254,7 @@ function ExtensionItem({
               // desktop app, which there is nothing to pair until it is
               // installed and loaded. Installing needs Meru Pro and loading
               // needs the master switch, so this locks with both.
-              disabled={locked || !installed}
+              disabled={!extensionsEnabled || !isLicenseKeyValid || !installed}
               onClick={() => {
                 setIsSetupDialogOpen(true);
               }}


### PR DESCRIPTION
## Summary
Three independent fixes from the extensions review, all in the app glue around `@meru/electron-extensions`: a permission check that disagreed with the matching request, an install switch that put uninstall out of reach on a lapsed license, and an action popup URL that could resolve outside the extension. Unit tests cover the first and third; the settings page has no renderer test harness, so it is type checking plus a manual pass, and nothing here has been exercised in a running app.

## Problem
**Permission checks and requests disagreed for extension pages.** The request handler answers an extension page from `EXTENSION_PAGE_PERMISSIONS` — clipboard read, sanitized clipboard write, notifications — while the check handler answered `areWorkspaceAppNotificationsAllowed()` for every origin. With workspace notifications off, an extension page saw `Notification.requestPermission()` resolve `"granted"` while `Notification.permission` read `"denied"`, and every notification it posted was dropped.

**A device whose license lapsed could not uninstall.** `extensions.uninstall` is deliberately ungated so an extension can be taken off a device that has lost its license, but the settings page rendered the switch unchecked and disabled whenever the license was invalid. The only route to that IPC was gone, and the version badge still read as installed.

**`default_popup` could escape the extension origin.** `getActionPopupUrl` resolved the manifest value against `chrome-extension://<id>/`, so `"default_popup": "https://example.com/x"` yielded that URL, which `ExtensionActions.openPopup` then loaded into a `WebContentsView` in the viewed account's session with that account's cookies. Chrome refuses a non-relative `default_popup` at manifest parse. Nothing was reachable today, since the manifest comes from a signature-verified CRX or the development folder, but nothing structural kept it that way.

## Solution
- The check handler mirrors the request handler's carve-out: an extension page is answered `EXTENSION_PAGE_PERMISSIONS.has(permission)` and every other origin keeps the behavior it had.
- `isLoadedExtensionUrl` also matches a bare `chrome-extension://<id>`, since an origin is all a permission check is given. This is belt and braces rather than part of the fix: `requestingOrigin` reaches JavaScript as `GURL::spec()`, and `chrome-extension` is a standard scheme, so an empty-path URL always carries its trailing slash and the old prefix match already covered it.
- The settings switch stays checked and enabled while `installed` is true, whatever the license says, so only installing needs Pro. `extensions.enabled` still locks the whole page, since nothing loads while the master switch is off, and 1Password's **Set up desktop app** button stays license-gated because loading is.
- `getActionPopupUrl` returns `null` unless the resolved URL is inside the extension. The check compares `protocol` and `host` rather than `URL.origin`, which the review suggested: `origin` is the string `"null"` for every scheme the URL standard doesn't call special, `chrome-extension:` among them, so comparing it would have rejected every popup including the legitimate relative ones. It parses with `URL.parse` rather than `new URL`, because a malformed `default_popup` throws, and that throw escaped into the loader's per-directory catch after the id had been recorded as loaded — an extension running with no action and a log line claiming it failed to load.

## Try it
No preview deployment for a desktop app, so this needs a local build. **Settings → Extensions** with a lapsed or absent license and an extension already installed: the switch reads on and can be turned off, where it previously read off and was disabled. The other two are not directly visible; `bun test packages/electron-extensions/` covers them.

## Not verified
- Nothing here has been run in the app. The settings page has no renderer test harness, so the settings change is type checking and reading only.
- Tightening the check handler for extension pages means an extension page is now answered `false` for permissions it was answered `true` for. A Fable review pass traced this and found nothing that depended on the old answer — `fullscreen`, `openExternal`, `pointerLock` and `getUserMedia` all route through the request handler, which has refused extension pages since #849 — but that is read off the code, not observed.
- Whether `openExternal` belongs in `EXTENSION_PAGE_PERMISSIONS` at all is open, and the decision for now is that it does not. The review flags that a 1Password popup navigating to a custom scheme dies silently, and that is unverified against 1Password's actual popup.
- With the master switch on, an invalid license and an extension installed, the item shows the **Meru Pro required** badge beside a checked, usable switch. That is the state this PR exists to create, but it contradicts what `tests/settings.e2e.ts` asserts about that badge — every control under it disabled on a free build — and the walk passes today only because no fixture seeds `extensions.installed`. Left as is; a fixture that seeds it would force the question.