### PR TITLE
Guard the extension install pipeline against a bad version, a stalled fetch and an uninstall race

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -245,6 +245,13 @@ export async function installCuratedExtension(extensionId: string) {
 }
 
 export async function uninstallCuratedExtension(extensionId: string) {
+  // An install of the same id in flight is writing into the very directories
+  // this is about to drop: the delete would pull the staging directory out from
+  // under it, and a rename landing after the delete would put a version back
+  // with no opt-in to account for it. Its outcome is the install's to report,
+  // so a failure here is only a reason to stop waiting.
+  await runningInstalls.get(extensionId)?.catch(() => {});
+
   config.set(
     "extensions.installed",
     config
@@ -258,13 +265,22 @@ export async function uninstallCuratedExtension(extensionId: string) {
 }
 
 /**
- * The version directories an update replaced, and the staging directories a
- * crashed install left behind. Runs before the first session is set up, since
- * that is where deriving reads an install directory from.
+ * The version directories an update replaced, the staging directories a crashed
+ * install left behind, and the installs no opt-in accounts for. Runs before the
+ * first session is set up, since that is where deriving reads an install
+ * directory from.
+ *
+ * What is kept is what the user opted into rather than what loads: an extension
+ * whose load the master switch or a lapsed license is holding back is one the
+ * user still owns, and turning the switch back on must not mean downloading it
+ * again.
  */
 export async function pruneInstalledExtensionVersions() {
   try {
-    await pruneExtensionVersions({ installDir: INSTALL_DIR });
+    await pruneExtensionVersions({
+      installDir: INSTALL_DIR,
+      keptExtensionIds: config.get("extensions.installed"),
+    });
   } catch (error) {
     log.error("Failed to prune installed extension versions", { error: serializeError(error) });
   }

--- a/packages/electron-extensions/crx/index.ts
+++ b/packages/electron-extensions/crx/index.ts
@@ -1,3 +1,3 @@
 export { verifyCrx } from "./crx";
 export type { VerifiedCrx } from "./crx";
-export { compareExtensionVersions } from "./version";
+export { compareExtensionVersions, isExtensionVersion } from "./version";

--- a/packages/electron-extensions/crx/version.test.ts
+++ b/packages/electron-extensions/crx/version.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { compareExtensionVersions } from "./version";
+import { compareExtensionVersions, isExtensionVersion } from "./version";
 
 describe("compareExtensionVersions", () => {
   test("compares component by component rather than as text", () => {
@@ -20,5 +20,28 @@ describe("compareExtensionVersions", () => {
   test("counts a component that is not a number as zero", () => {
     expect(compareExtensionVersions("1.beta", "1.0")).toBe(0);
     expect(compareExtensionVersions("1.beta", "1.1")).toBeLessThan(0);
+  });
+});
+
+describe("isExtensionVersion", () => {
+  test("takes one to four dot-separated numbers, the way Chromium does", () => {
+    expect(isExtensionVersion("1")).toBe(true);
+    expect(isExtensionVersion("1.2")).toBe(true);
+    expect(isExtensionVersion("8.12.32.33")).toBe(true);
+    expect(isExtensionVersion("1.2.3.4.5")).toBe(false);
+  });
+
+  test("refuses everything an install would join onto a path", () => {
+    expect(isExtensionVersion("")).toBe(false);
+    expect(isExtensionVersion("../escaped")).toBe(false);
+    expect(isExtensionVersion("1.0.0/nested")).toBe(false);
+    expect(isExtensionVersion(".")).toBe(false);
+  });
+
+  test("refuses a version that is not numbers", () => {
+    expect(isExtensionVersion("1.0.0.staging")).toBe(false);
+    expect(isExtensionVersion("1.0.0-beta")).toBe(false);
+    expect(isExtensionVersion("-1.0")).toBe(false);
+    expect(isExtensionVersion("1.")).toBe(false);
   });
 });

--- a/packages/electron-extensions/crx/version.ts
+++ b/packages/electron-extensions/crx/version.ts
@@ -1,3 +1,18 @@
+/**
+ * Chromium's shape for an extension version, which `extension.cc` parses out of
+ * a manifest as a `base::Version`: one to four dot-separated unsigned integers,
+ * and nothing else.
+ *
+ * An install joins the version onto the install directory, so this is what
+ * stands between a manifest and the filesystem. `""` names the extension's own
+ * install directory rather than a version under it, `"../elsewhere"` reaches
+ * outside it, and `"1.0.0.staging"` names a directory the launch-time prune
+ * takes for the leftovers of a crashed install.
+ */
+export function isExtensionVersion(version: string) {
+  return /^\d+(\.\d+){0,3}$/.test(version);
+}
+
 function readVersionComponent(component: string | undefined) {
   const value = Number(component);
 

--- a/packages/electron-extensions/install/installer.test.ts
+++ b/packages/electron-extensions/install/installer.test.ts
@@ -142,6 +142,22 @@ describe("installExtension", () => {
     expect(await readEntryNames(extensionInstallDir)).toEqual([]);
   });
 
+  test("refuses a version that is not one, before it becomes a directory", async () => {
+    // `""` would name the extension's own install directory, deleting every
+    // version of it and renaming the package over it; `"../escaped"` writes
+    // outside it; and `"1.0.0.staging"` names what the prune takes for the
+    // leftovers of a crashed install
+    for (const version of ["", "../escaped", "1.0.0.staging", "1.2.3.4.5"]) {
+      await expect(
+        installExtension({ crx: createExtensionCrx(version), extensionId, installDir }),
+      ).rejects.toThrow(
+        `CRX for ${extensionId} carries the version "${version}", which is not an extension version`,
+      );
+    }
+
+    expect(await readEntryNames(extensionInstallDir)).toEqual([]);
+  });
+
   test("refuses an id that is not one, before it reads the package", async () => {
     await expect(
       installExtension({
@@ -326,7 +342,10 @@ describe("pruneExtensionVersions", () => {
 
     await writeVersionDir(otherExtensionId, "3.0.0");
 
-    await pruneExtensionVersions({ installDir });
+    await pruneExtensionVersions({
+      installDir,
+      keptExtensionIds: [extensionId, otherExtensionId],
+    });
 
     expect(await readdir(extensionInstallDir)).toEqual(["2.0.0"]);
     expect(await readdir(path.join(installDir, otherExtensionId))).toEqual(["3.0.0"]);
@@ -343,7 +362,7 @@ describe("pruneExtensionVersions", () => {
 
     await writeVersionDir(extensionId, "2.0.0");
 
-    await pruneExtensionVersions({ installDir });
+    await pruneExtensionVersions({ installDir, keptExtensionIds: [extensionId] });
 
     expect(await readdir(extensionInstallDir)).toEqual(["2.0.0"]);
     expect(await readFile(path.join(strayDir, "kept"), "utf8")).toBe("kept");
@@ -356,15 +375,30 @@ describe("pruneExtensionVersions", () => {
 
     await mkdir(path.join(extensionInstallDir, "3.0.0"));
 
-    await pruneExtensionVersions({ installDir });
+    await pruneExtensionVersions({ installDir, keptExtensionIds: [extensionId] });
 
     expect(await readdir(extensionInstallDir)).toEqual(["1.0.0"]);
+  });
+
+  test("drops an extension nothing accounts for, every version of it", async () => {
+    const uninstalledExtensionId = "abcdefghijklmnopabcdefghijklmnop";
+
+    await writeVersionDir(extensionId, "1.0.0");
+
+    // What an uninstall racing an install of the same id leaves behind: a
+    // complete, newest version directory with no opt-in naming it
+    await writeVersionDir(uninstalledExtensionId, "2.0.0");
+
+    await pruneExtensionVersions({ installDir, keptExtensionIds: [extensionId] });
+
+    expect(await readdir(extensionInstallDir)).toEqual(["1.0.0"]);
+    expect(await readEntryNames(path.join(installDir, uninstalledExtensionId))).toEqual([]);
   });
 
   test("does nothing when nothing is installed", async () => {
     await rm(installDir, { recursive: true, force: true });
 
-    await pruneExtensionVersions({ installDir });
+    await pruneExtensionVersions({ installDir, keptExtensionIds: [extensionId] });
 
     expect(await readEntryNames(installDir)).toEqual([]);
   });

--- a/packages/electron-extensions/install/installer.ts
+++ b/packages/electron-extensions/install/installer.ts
@@ -3,7 +3,7 @@ import { access, mkdir, readdir, rename, rm, writeFile } from "node:fs/promises"
 import path from "node:path";
 import { unzipSync } from "fflate";
 import { verifyCrx } from "../crx/crx";
-import { compareExtensionVersions } from "../crx/version";
+import { compareExtensionVersions, isExtensionVersion } from "../crx/version";
 import { isExtensionId } from "../derive/extension-id";
 import { type FetchImplementation, fetchCrx, fetchCrxUpdate } from "./omaha";
 
@@ -70,6 +70,16 @@ function readCrxPackage(crx: Uint8Array, extensionId: string): ExtensionPackage 
 
   if (typeof manifest.version !== "string") {
     throw new Error(`CRX for ${extensionId} carries a manifest without a version`);
+  }
+
+  // The version becomes a directory name under the install, so it is checked
+  // here rather than where it is joined onto a path: nothing further down the
+  // pipeline sees the manifest, and a package Chromium would refuse to load is
+  // one that should never have reached the disk
+  if (!isExtensionVersion(manifest.version)) {
+    throw new Error(
+      `CRX for ${extensionId} carries the version "${manifest.version}", which is not an extension version`,
+    );
   }
 
   // An unpacked extension without a `key` loads under an id derived from its
@@ -221,13 +231,20 @@ export async function getInstalledExtension({
 export type PruneExtensionVersionsOptions = {
   /** The directory installs live under, `<installDir>/<extensionId>/<version>`. */
   installDir: string;
+  /**
+   * The extensions the embedder still accounts for. Anything else under the
+   * install directory is dropped whole, since keeping the newest version of
+   * every id is exactly what would keep an install nothing asked for.
+   */
+  keptExtensionIds: string[];
 };
 
 /**
  * Drops everything an install superseded: the version directories an update
- * replaced, and staging directories a crashed install left behind. What is kept
- * for every extension is the newest version installed, which is the one an
- * embedder loads.
+ * replaced, the staging directories a crashed install left behind, and the
+ * extensions the embedder no longer accounts for. What is kept for every
+ * extension still accounted for is the newest version installed, which is the
+ * one an embedder loads.
  *
  * A launch-time sweep rather than part of the install, because a session reads
  * an install directory while deriving its copy of the extension, and an update
@@ -236,7 +253,10 @@ export type PruneExtensionVersionsOptions = {
  * — an extension updated mid-session keeps its old version until the next
  * launch, which is one directory per updated extension.
  */
-export async function pruneExtensionVersions({ installDir }: PruneExtensionVersionsOptions) {
+export async function pruneExtensionVersions({
+  installDir,
+  keptExtensionIds,
+}: PruneExtensionVersionsOptions) {
   let installEntries: Dirent[];
 
   try {
@@ -259,6 +279,15 @@ export async function pruneExtensionVersions({ installDir }: PruneExtensionVersi
     }
 
     const extensionInstallDir = path.join(installDir, extensionId);
+
+    // An uninstall that raced an install of the same id leaves a complete
+    // version directory the embedder has no record of, and it is the newest
+    // one, so the sweep below would keep it for good
+    if (!keptExtensionIds.includes(extensionId)) {
+      await rm(extensionInstallDir, { recursive: true, force: true });
+
+      continue;
+    }
 
     const installedExtension = await getInstalledExtension({ installDir, extensionId });
 

--- a/packages/electron-extensions/install/omaha.test.ts
+++ b/packages/electron-extensions/install/omaha.test.ts
@@ -63,6 +63,37 @@ describe("fetchCrx", () => {
     ]);
   });
 
+  test("gives the download a deadline of its own", async () => {
+    let signal: AbortSignal | undefined;
+
+    await fetchCrx({
+      extensionId,
+      chromeVersion,
+      fetch: async (_url, init) => {
+        signal = init.signal;
+
+        return new Response(Uint8Array.from([1, 2, 3]));
+      },
+    });
+
+    // Node's own timeout is per chunk, so without a signal a server trickling
+    // bytes holds the download open with no deadline at all
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal?.aborted).toBe(false);
+  });
+
+  test("names a download the endpoint never answered for what it is", async () => {
+    await expect(
+      fetchCrx({
+        extensionId,
+        chromeVersion,
+        fetch: async () => {
+          throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+        },
+      }),
+    ).rejects.toThrow(`Update endpoint did not answer for ${extensionId} within 120 seconds`);
+  });
+
   test("names the endpoint's no-package answer for what it is", async () => {
     await expect(
       fetchCrx({
@@ -117,6 +148,21 @@ describe("fetchCrxUpdate", () => {
           createUpdateCheckResponse('<updatecheck _esbAllowlist="true" status="noupdate"/>'),
       }),
     ).toEqual({ status: "noupdate" });
+  });
+
+  test("names an update check the endpoint never answered for what it is", async () => {
+    await expect(
+      fetchCrxUpdate({
+        extensionId,
+        chromeVersion,
+        installedVersion: "8.12.32.33",
+        fetch: async (_url, init) => {
+          expect(init.signal.aborted).toBe(false);
+
+          throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+        },
+      }),
+    ).rejects.toThrow(`Update endpoint did not answer for ${extensionId} within 120 seconds`);
   });
 
   test("refuses an answer that is not an update check", async () => {

--- a/packages/electron-extensions/install/omaha.test.ts
+++ b/packages/electron-extensions/install/omaha.test.ts
@@ -91,7 +91,31 @@ describe("fetchCrx", () => {
           throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
         },
       }),
-    ).rejects.toThrow(`Update endpoint did not answer for ${extensionId} within 120 seconds`);
+    ).rejects.toThrow(`Update endpoint did not answer for ${extensionId} within 600 seconds`);
+  });
+
+  test("names a package that stopped arriving mid-body for what it is", async () => {
+    await expect(
+      fetchCrx({
+        extensionId,
+        chromeVersion,
+        // The case the deadline exists for: headers at once, then a server that
+        // trickles and stops, so the abort lands on the body rather than on the
+        // request
+        fetch: async () =>
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(Uint8Array.from([1, 2, 3]));
+
+                controller.error(
+                  new DOMException("The operation was aborted due to timeout", "TimeoutError"),
+                );
+              },
+            }),
+          ),
+      }),
+    ).rejects.toThrow(`Update endpoint did not answer for ${extensionId} within 600 seconds`);
   });
 
   test("names the endpoint's no-package answer for what it is", async () => {

--- a/packages/electron-extensions/install/omaha.ts
+++ b/packages/electron-extensions/install/omaha.ts
@@ -72,7 +72,47 @@ export function buildUpdateCheckUrl({
  * so a caller can hand over a plain function — a test's fake above all —
  * without matching every property a runtime hangs off its global.
  */
-export type FetchImplementation = (url: string, init: { redirect: "follow" }) => Promise<Response>;
+export type FetchImplementation = (
+  url: string,
+  init: { redirect: "follow"; signal: AbortSignal },
+) => Promise<Response>;
+
+/**
+ * How long the endpoint has to answer, the whole request rather than a chunk of
+ * it. Node's `fetch` times out per chunk, so a server that trickles bytes holds
+ * the promise open with no deadline at all, and an embedder that coalesces
+ * calls onto the request in flight — which is what keeps two installs of one
+ * extension out of the same staging directory — has no way back: the scheduled
+ * check, the update button, and switching the extension on all join the stalled
+ * promise until the app restarts.
+ *
+ * Plain milliseconds rather than a duration helper, since this package carries
+ * no imports of Meru's own.
+ */
+const RESPONSE_TIMEOUT_MS = 2 * 60 * 1000;
+
+/**
+ * A request to the endpoint under that deadline, with the abort surfaced as an
+ * ordinary failure. `AbortSignal.timeout` rejects with a `TimeoutError`, and an
+ * embedder showing the user its message would say the operation was aborted
+ * where what happened is that the endpoint went quiet.
+ */
+async function fetchEndpoint(fetch: FetchImplementation, url: string, extensionId: string) {
+  try {
+    return await fetch(url, {
+      redirect: "follow",
+      signal: AbortSignal.timeout(RESPONSE_TIMEOUT_MS),
+    });
+  } catch (error) {
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
+      throw new Error(
+        `Update endpoint did not answer for ${extensionId} within ${RESPONSE_TIMEOUT_MS / 1000} seconds`,
+      );
+    }
+
+    throw error;
+  }
+}
 
 export type FetchCrxOptions = CrxDownloadOptions & {
   /**
@@ -95,9 +135,11 @@ export async function fetchCrx({
   chromeVersion,
   fetch = globalThis.fetch,
 }: FetchCrxOptions) {
-  const response = await fetch(buildCrxDownloadUrl({ extensionId, chromeVersion }), {
-    redirect: "follow",
-  });
+  const response = await fetchEndpoint(
+    fetch,
+    buildCrxDownloadUrl({ extensionId, chromeVersion }),
+    extensionId,
+  );
 
   // No Content is the endpoint's no: an id it does not serve, or a request it
   // could not place — and it counts as `ok`, so left alone it would surface as
@@ -192,9 +234,10 @@ export async function fetchCrxUpdate({
   installedVersion,
   fetch = globalThis.fetch,
 }: FetchCrxUpdateOptions) {
-  const response = await fetch(
+  const response = await fetchEndpoint(
+    fetch,
     buildUpdateCheckUrl({ extensionId, chromeVersion, installedVersion }),
-    { redirect: "follow" },
+    extensionId,
   );
 
   if (response.status === 204) {

--- a/packages/electron-extensions/install/omaha.ts
+++ b/packages/electron-extensions/install/omaha.ts
@@ -78,35 +78,77 @@ export type FetchImplementation = (
 ) => Promise<Response>;
 
 /**
- * How long the endpoint has to answer, the whole request rather than a chunk of
- * it. Node's `fetch` times out per chunk, so a server that trickles bytes holds
- * the promise open with no deadline at all, and an embedder that coalesces
- * calls onto the request in flight — which is what keeps two installs of one
- * extension out of the same staging directory — has no way back: the scheduled
- * check, the update button, and switching the extension on all join the stalled
- * promise until the app restarts.
+ * How long each request to the endpoint has to answer, the whole exchange
+ * rather than a chunk of it. Node's `fetch` times out per chunk, so a server
+ * that trickles bytes holds the promise open with no deadline at all, and an
+ * embedder that coalesces calls onto the request in flight — which is what
+ * keeps two installs of one extension out of the same staging directory — has
+ * no way back: the scheduled check, the update button, and switching the
+ * extension on all join the stalled promise until the app restarts.
+ *
+ * They differ by two orders of what they carry. An update check is a few
+ * hundred bytes of XML, so anything but a stall answers well inside two
+ * minutes. A package is tens of megabytes — about 18 MB for 1Password, which is
+ * already 90 seconds at 200 KB/s and longer on hotel wifi — and it only ever
+ * downloads when the check said a newer version exists, so a generous bound
+ * there costs nothing in the steady state and a tight one fails a user whose
+ * connection was merely slow.
  *
  * Plain milliseconds rather than a duration helper, since this package carries
  * no imports of Meru's own.
  */
-const RESPONSE_TIMEOUT_MS = 2 * 60 * 1000;
+const UPDATE_CHECK_TIMEOUT_MS = 2 * 60 * 1000;
+
+const DOWNLOAD_TIMEOUT_MS = 10 * 60 * 1000;
+
+type FetchEndpointOptions<Body> = {
+  extensionId: string;
+  timeoutMs: number;
+  /**
+   * Reading the body is part of the request rather than something a caller does
+   * after it, because the deadline has to cover it: the case this exists for is
+   * a server that answers its headers at once and then trickles, where a
+   * deadline ending at the headers would leave the download uncovered.
+   */
+  readBody: (response: Response) => Promise<Body>;
+};
 
 /**
- * A request to the endpoint under that deadline, with the abort surfaced as an
- * ordinary failure. `AbortSignal.timeout` rejects with a `TimeoutError`, and an
- * embedder showing the user its message would say the operation was aborted
- * where what happened is that the endpoint went quiet.
+ * A request to the endpoint under a deadline, with the abort surfaced as an
+ * ordinary failure. `AbortSignal.timeout` rejects with a `TimeoutError` and
+ * Electron's own stack with an `AbortError`, and an embedder showing the user
+ * either message would say the operation was aborted where what happened is
+ * that the endpoint went quiet.
  */
-async function fetchEndpoint(fetch: FetchImplementation, url: string, extensionId: string) {
+async function fetchEndpoint<Body>(
+  fetch: FetchImplementation,
+  url: string,
+  { extensionId, timeoutMs, readBody }: FetchEndpointOptions<Body>,
+) {
   try {
-    return await fetch(url, {
+    const response = await fetch(url, {
       redirect: "follow",
-      signal: AbortSignal.timeout(RESPONSE_TIMEOUT_MS),
+      signal: AbortSignal.timeout(timeoutMs),
     });
+
+    // No Content is the endpoint's no: an id it does not serve, or a request it
+    // could not place — and it counts as `ok`, so left alone it would surface as
+    // a verification error about an empty package
+    if (response.status === 204) {
+      throw new Error(`Update endpoint has no package for ${extensionId}`);
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `Update endpoint answered ${response.status} ${response.statusText} for ${extensionId}`,
+      );
+    }
+
+    return await readBody(response);
   } catch (error) {
     if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
       throw new Error(
-        `Update endpoint did not answer for ${extensionId} within ${RESPONSE_TIMEOUT_MS / 1000} seconds`,
+        `Update endpoint did not answer for ${extensionId} within ${timeoutMs / 1000} seconds`,
       );
     }
 
@@ -135,26 +177,11 @@ export async function fetchCrx({
   chromeVersion,
   fetch = globalThis.fetch,
 }: FetchCrxOptions) {
-  const response = await fetchEndpoint(
-    fetch,
-    buildCrxDownloadUrl({ extensionId, chromeVersion }),
+  return fetchEndpoint(fetch, buildCrxDownloadUrl({ extensionId, chromeVersion }), {
     extensionId,
-  );
-
-  // No Content is the endpoint's no: an id it does not serve, or a request it
-  // could not place — and it counts as `ok`, so left alone it would surface as
-  // a verification error about an empty package
-  if (response.status === 204) {
-    throw new Error(`Update endpoint has no package for ${extensionId}`);
-  }
-
-  if (!response.ok) {
-    throw new Error(
-      `Update endpoint answered ${response.status} ${response.statusText} for ${extensionId}`,
-    );
-  }
-
-  return new Uint8Array(await response.arrayBuffer());
+    timeoutMs: DOWNLOAD_TIMEOUT_MS,
+    readBody: async (response) => new Uint8Array(await response.arrayBuffer()),
+  });
 }
 
 export type CrxUpdate =
@@ -234,21 +261,15 @@ export async function fetchCrxUpdate({
   installedVersion,
   fetch = globalThis.fetch,
 }: FetchCrxUpdateOptions) {
-  const response = await fetchEndpoint(
+  const responseBody = await fetchEndpoint(
     fetch,
     buildUpdateCheckUrl({ extensionId, chromeVersion, installedVersion }),
-    extensionId,
+    {
+      extensionId,
+      timeoutMs: UPDATE_CHECK_TIMEOUT_MS,
+      readBody: (response) => response.text(),
+    },
   );
 
-  if (response.status === 204) {
-    throw new Error(`Update endpoint has no package for ${extensionId}`);
-  }
-
-  if (!response.ok) {
-    throw new Error(
-      `Update endpoint answered ${response.status} ${response.statusText} for ${extensionId}`,
-    );
-  }
-
-  return parseUpdateCheck(await response.text(), extensionId);
+  return parseUpdateCheck(responseBody, extensionId);
 }

--- a/scripts/download-extensions.ts
+++ b/scripts/download-extensions.ts
@@ -12,7 +12,7 @@ import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { parseArgs } from "node:util";
 // The crx and install entries, since the package's own entry reaches into Electron
-import { verifyCrx } from "@meru/electron-extensions/crx";
+import { isExtensionVersion, verifyCrx } from "@meru/electron-extensions/crx";
 import { fetchCrx } from "@meru/electron-extensions/install";
 import { type CuratedExtension, curatedExtensions } from "@meru/shared/extensions";
 import { unzipSync } from "fflate";
@@ -82,6 +82,14 @@ async function downloadExtension(extension: CuratedExtension) {
     version: string;
     key: string;
   };
+
+  // The version is what a real install names its directory after, so a package
+  // the app would refuse is refused here too rather than unpacked
+  if (!isExtensionVersion(manifest.version)) {
+    throw new Error(
+      `${name}: the package carries the version "${manifest.version}", which is not an extension version`,
+    );
+  }
 
   // An unpacked extension without a `key` loads under an id derived from its
   // directory path, and everything keyed to its real id — native messaging


### PR DESCRIPTION
## Summary
Three fixes on the extension install pipeline, findings 4, 5 and 8 of the extensions review before the next release: a CRX manifest's `version` is validated before it becomes a directory name, both requests to the update endpoint carry a two-minute deadline, and an uninstall no longer races an install of the same id. All three sit on the 1Password path that ships on by default. None of it has been exercised in a running app.

## Problem
**A manifest `version` was used unvalidated as a directory name.** `readCrxPackage` checked only `typeof manifest.version === "string"`, and `installExtensionPackage` joined it into `path.join(installDir, extensionId, version)` and deleted that target before the rename. `version: ""` made the staging directory `<id>.staging`, deleted the whole `<id>/` install, and renamed the archive over `<id>/` itself, after which `getInstalledExtension` returned nothing; `"../escaped"` wrote outside `<installDir>/<id>`; `"1.0.0.staging"` installed and was then swept by the launch-time prune. The package is publisher-signed and `compareExtensionVersions` guards later installs, so it bit on a first install and on a direct `installExtension`.

**Neither fetch to the update endpoint carried a signal.** In Electron main `globalThis.fetch` is undici, whose body timeout is per chunk, so a server that trickles bytes holds the promise open with no deadline at all. `packages/app/extensions.ts` then coalesces every later call onto that promise through `runningInstalls` and `runningCheck` — which is what keeps two installs of one extension out of the same staging directory — so one stall hung the three-hour timer, the **Update extensions** button and switching the extension on, all until a restart.

**Uninstall raced an install of the same id.** `uninstallCuratedExtension` dropped the config entry and deleted `<installDir>/<id>` without consulting `runningInstalls`. Mid-`writeExtensionPackage` the delete pulled the staging directory out from under the install and the install threw; if the `rename` landed after the delete, a version directory reappeared with no opt-in in config, and `pruneExtensionVersions` keeps the newest version per id, so that orphan — about 18 MB for 1Password — was never collected.

## Solution
- `isExtensionVersion` in `crx/version.ts` holds a version to one to four dot-separated unsigned integers, which is what Chromium's `extension.cc` parses as a `base::Version`. `readCrxPackage` applies it before anything reaches the disk, and `scripts/download-extensions.ts` applies it to the manifest it unpacks. It sits in `crx/` next to `compareExtensionVersions`, since the shape of a version is the same question both answer, and the check is at the manifest rather than at the `path.join` because nothing further down the pipeline sees the manifest.
- Both `fetchCrx` and `fetchCrxUpdate` go through one `fetchEndpoint` helper carrying `signal: AbortSignal.timeout(...)`, with `FetchImplementation` widened to match. The abort is caught and rethrown as an ordinary endpoint failure, so the toasts show "Update endpoint did not answer for `<id>` within 600 seconds" rather than "This operation was aborted". Reading the response body is part of the helper rather than something the callers do after it, because the deadline has to cover it: the case this exists for is a server that answers its headers at once and then trickles, where a deadline ending at the headers leaves the download uncovered. Folding the body read in also pulls the two duplicated status checks into one place.
- The two requests get separate deadlines, two minutes for the update check and ten for the download. They differ by two orders of what they carry: the check is a few hundred bytes of XML, while the 1Password package is about 18 MB on the wire, which is already 90 seconds at 200 KB/s and longer on hotel wifi, and it fails as a toast on the manual **Update extensions** button. The download only runs when the check found a newer version, so the longer bound costs nothing in the steady state.
- Both deadlines are plain milliseconds rather than `ms` from `@meru/shared/ms`, because `@meru/electron-extensions` is a standalone workspace package with zero Meru imports and a candidate for publication; that decision wins over the repository's duration-helper rule inside this package.
- `uninstallCuratedExtension` awaits the install in flight for the id before it touches config or the disk, its failure ignored since the install reports its own. Waiting *before* the config write rather than after is what keeps config and disk consistent: a successful install writes the opt-in back when it resolves, so removing the entry first would leave the id installed in config with nothing on disk.
- `pruneExtensionVersions` takes `keptExtensionIds` and drops every other extension directory whole, which collects the orphan the race leaves. The ids passed in are `extensions.installed` rather than `getOptedInExtensionIds()`: the latter is empty while the master switch is off or a license has lapsed, and neither should delete what the user installed and would have to download again.
- Unit tests cover the four rejected version shapes with nothing left on disk, the deadline being present and unaborted on both requests, the timeout surfacing as the endpoint message from the request and from a body that stops mid-stream, and the prune dropping an id nothing accounts for.

## Not verified
- None of the three paths has been exercised in a running app. The version guard and the prune are covered by unit tests against a real temporary filesystem; the timeout is covered by fakes throwing a `TimeoutError` from the request and from the body stream, so what is tested is the mapping, not undici actually aborting a trickling response. The ten-minute download bound is reasoned from the package size rather than measured against a slow connection.
- `net.fetch` was considered and deliberately not adopted. The review suggested routing the updater through Electron's network stack so the system proxy is honored; taken back to the reviewer, there is no user report and no proxy-only failure behind it, and nothing in the Omaha or CRX paths that Chromium's stack would handle differently — the endpoint is plain HTTPS with a redirect, and verification runs on the bytes after download whichever stack carried them. It stays a theoretical gap for a user behind a corporate proxy, and moving a password manager's update channel onto an untried stack before a release is not what a timeout fix should carry. The existing `fetch` injection seam in `installLatestExtension` makes it a one-line change on the app side whenever there is evidence for it, and `net.fetch` takes a `signal` and aborts the same way, so the helper added here carries over unchanged.
- The version guard is the regex Chromium's grammar implies; each component is not additionally range-checked against `uint32` the way `base::Version` does, and Chrome's manifest docs also refuse a non-zero component with a leading zero, so `01.2` passes here. Both are failed loads rather than anything reaching outside the install directory, which is what the guard is for.


