### PR TITLE
Check the bridge token before reading the request body

### DIFF
--- a/packages/electron-extensions/bridge/bridge.test.ts
+++ b/packages/electron-extensions/bridge/bridge.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import type { OnBeforeSendHeadersListenerDetails, Session, WebFrameMain } from "electron";
-import { ExtensionBridge, MAX_BRIDGE_REQUEST_BYTES, MAX_RECORDED_CALLER_FRAMES } from "./bridge";
-import { EXTENSION_BRIDGE_ORIGIN, EXTENSION_BRIDGE_SCHEME } from "./protocol";
+import {
+  ExtensionBridge,
+  MAX_BRIDGE_REQUEST_BYTES,
+  MAX_CONCURRENT_BRIDGE_BODY_READS,
+  MAX_RECORDED_CALLER_FRAMES,
+} from "./bridge";
+import {
+  EXTENSION_BRIDGE_ORIGIN,
+  EXTENSION_BRIDGE_SCHEME,
+  getExtensionBridgeUrl,
+} from "./protocol";
 
 const EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
 
@@ -9,6 +18,43 @@ const BRIDGE_TOKEN = "bridge-token";
 
 function createFrame(url: string): WebFrameMain {
   return { url, parent: null, isDestroyed: () => false } as unknown as WebFrameMain;
+}
+
+/** What the facade builds, plus the case it never builds: no token at all. */
+function bridgeUrl(pathName: string, token: string | undefined) {
+  return token === undefined
+    ? `${EXTENSION_BRIDGE_ORIGIN}${pathName}`
+    : getExtensionBridgeUrl(pathName, token);
+}
+
+/**
+ * A request body the test decides the fate of: it produces nothing until
+ * `finish` is called, so anything that reads it waits, and it says whether it
+ * was canceled instead.
+ */
+function createPendingBody() {
+  let bodyController: ReadableStreamDefaultController<Uint8Array> | undefined;
+
+  let isCanceled = false;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start: (controller) => {
+      bodyController = controller;
+    },
+    cancel: () => {
+      isCanceled = true;
+    },
+  });
+
+  return {
+    stream,
+    finish: (bodySource: string) => {
+      bodyController?.enqueue(new TextEncoder().encode(bodySource));
+
+      bodyController?.close();
+    },
+    isCanceled: () => isCanceled,
+  };
 }
 
 type BeforeSendHeadersListener = (
@@ -22,6 +68,8 @@ type SendOptions = {
   frame?: WebFrameMain;
   /** Headers the caller wrote itself, the way a forger would. */
   headers?: Record<string, string>;
+  /** The token on the query string; omitted, the request carries none at all. */
+  token?: string;
 };
 
 function createSession() {
@@ -97,22 +145,29 @@ function createSession() {
 
   const sendWithHeaders = (
     pathName: string,
-    bodySource: string,
+    body: string | ReadableStream<Uint8Array>,
     requestHeaders: Record<string, string>,
+    token: string | undefined,
   ) =>
     requestHandler?.(
-      new Request(`${EXTENSION_BRIDGE_ORIGIN}${pathName}`, {
+      new Request(bridgeUrl(pathName, token), {
         method: "POST",
         headers: requestHeaders,
-        body: bodySource,
-      }) as GlobalRequest,
+        body,
+        duplex: "half",
+      } as RequestInit) as GlobalRequest,
     ) as Promise<Response>;
 
-  const sendRequest = (pathName: string, bodySource: string, sendOptions: SendOptions = {}) =>
+  const sendRequest = (
+    pathName: string,
+    body: string | ReadableStream<Uint8Array>,
+    sendOptions: SendOptions = {},
+  ) =>
     sendWithHeaders(
       pathName,
-      bodySource,
-      stampHeaders(`${EXTENSION_BRIDGE_ORIGIN}${pathName}`, sendOptions),
+      body,
+      stampHeaders(bridgeUrl(pathName, sendOptions.token), sendOptions),
+      sendOptions.token,
     );
 
   return {
@@ -150,8 +205,8 @@ describe("ExtensionBridge", () => {
 
     const response = await request(
       "/echo",
-      { token: BRIDGE_TOKEN, value: 42 },
-      { origin: "chrome-extension://aaa" },
+      { value: 42 },
+      { origin: "chrome-extension://aaa", token: BRIDGE_TOKEN },
     );
 
     expect(response.status).toBe(200);
@@ -166,7 +221,7 @@ describe("ExtensionBridge", () => {
 
     bridge.handle("/echo", ({ headers }) => new Response(null, { status: 204, headers }));
 
-    expect((await request("/echo", { token: "guessed" })).status).toBe(403);
+    expect((await request("/echo", {}, { token: "guessed" })).status).toBe(403);
     expect((await request("/echo", {})).status).toBe(403);
   });
 
@@ -175,14 +230,14 @@ describe("ExtensionBridge", () => {
 
     createBridge(session);
 
-    expect((await request("/unregistered", { token: BRIDGE_TOKEN })).status).toBe(404);
+    expect((await request("/unregistered", {}, { token: BRIDGE_TOKEN })).status).toBe(404);
 
     // The token is checked first, so an unauthenticated caller learns nothing
     // about which paths exist
-    expect((await request("/unregistered", { token: "guessed" })).status).toBe(403);
+    expect((await request("/unregistered", {}, { token: "guessed" })).status).toBe(403);
   });
 
-  test("refuses a body past the cap without handling it, token or no token", async () => {
+  test("refuses a body past the cap without handling it", async () => {
     const { session, sendRequest } = createSession();
 
     const bridge = createBridge(session);
@@ -197,7 +252,10 @@ describe("ExtensionBridge", () => {
 
     const response = await sendRequest(
       "/echo",
-      `{"token":"${BRIDGE_TOKEN}","padding":"${"x".repeat(MAX_BRIDGE_REQUEST_BYTES)}"}`,
+      `{"padding":"${"x".repeat(MAX_BRIDGE_REQUEST_BYTES)}"}`,
+      {
+        token: BRIDGE_TOKEN,
+      },
     );
 
     expect(response.status).toBe(413);
@@ -213,7 +271,7 @@ describe("ExtensionBridge", () => {
       throw new Error("boom");
     });
 
-    expect((await request("/broken", { token: BRIDGE_TOKEN })).status).toBe(400);
+    expect((await request("/broken", {}, { token: BRIDGE_TOKEN })).status).toBe(400);
   });
 
   test("handles the scheme for the session's lifetime", () => {
@@ -258,7 +316,7 @@ describe("ExtensionBridge", () => {
       return new Response(null, { status: 204, headers });
     });
 
-    await request("/echo", { token: BRIDGE_TOKEN }, { frame });
+    await request("/echo", {}, { frame, token: BRIDGE_TOKEN });
 
     expect(handledSenderFrame).toBe(frame);
   });
@@ -276,7 +334,7 @@ describe("ExtensionBridge", () => {
       return new Response(null, { status: 204, headers });
     });
 
-    await request("/echo", { token: BRIDGE_TOKEN });
+    await request("/echo", {}, { token: BRIDGE_TOKEN });
 
     expect(senderFrames).toEqual([undefined]);
   });
@@ -305,14 +363,14 @@ describe("ExtensionBridge", () => {
      */
     await request(
       "/echo",
-      { token: BRIDGE_TOKEN },
-      { headers: { "X-Extension-Bridge-Caller": "guessed" } },
+      {},
+      { headers: { "X-Extension-Bridge-Caller": "guessed" }, token: BRIDGE_TOKEN },
     );
 
     await request(
       "/echo",
-      { token: BRIDGE_TOKEN },
-      { frame, headers: { "X-Extension-Bridge-Caller": "guessed" } },
+      {},
+      { frame, headers: { "X-Extension-Bridge-Caller": "guessed" }, token: BRIDGE_TOKEN },
     );
 
     expect(senderFrames).toEqual([undefined, frame]);
@@ -341,11 +399,11 @@ describe("ExtensionBridge", () => {
      * reason. What answers it is that a record is spent when it is read — the
      * victim's own request takes it, and the replay that follows finds nothing.
      */
-    const victimHeaders = stampHeaders(`${EXTENSION_BRIDGE_ORIGIN}/echo`, { frame: victimFrame });
+    const victimHeaders = stampHeaders(bridgeUrl("/echo", BRIDGE_TOKEN), { frame: victimFrame });
 
-    await sendWithHeaders("/echo", JSON.stringify({ token: BRIDGE_TOKEN }), victimHeaders);
+    await sendWithHeaders("/echo", "{}", victimHeaders, BRIDGE_TOKEN);
 
-    await sendWithHeaders("/echo", JSON.stringify({ token: BRIDGE_TOKEN }), { ...victimHeaders });
+    await sendWithHeaders("/echo", "{}", { ...victimHeaders }, BRIDGE_TOKEN);
 
     expect(senderFrames).toEqual([victimFrame, undefined]);
   });
@@ -365,14 +423,12 @@ describe("ExtensionBridge", () => {
       return new Response(null, { status: 204, headers });
     });
 
-    const stampedHeaders = stampHeaders(`${EXTENSION_BRIDGE_ORIGIN}/echo`, { frame });
+    const stampedHeaders = stampHeaders(bridgeUrl("/echo", BRIDGE_TOKEN), { frame });
 
-    const bodySource = JSON.stringify({ token: BRIDGE_TOKEN });
-
-    await sendWithHeaders("/echo", bodySource, stampedHeaders);
+    await sendWithHeaders("/echo", "{}", stampedHeaders, BRIDGE_TOKEN);
 
     // Replaying the stamped nonce finds its record already consumed
-    await sendWithHeaders("/echo", bodySource, stampedHeaders);
+    await sendWithHeaders("/echo", "{}", stampedHeaders, BRIDGE_TOKEN);
 
     expect(senderFrames).toEqual([frame, undefined]);
   });
@@ -390,7 +446,7 @@ describe("ExtensionBridge", () => {
       return new Response(null, { status: 204, headers });
     });
 
-    const echoUrl = `${EXTENSION_BRIDGE_ORIGIN}/echo`;
+    const echoUrl = bridgeUrl("/echo", BRIDGE_TOKEN);
 
     const oldestFrame = createFrame("https://oldest.test/");
 
@@ -404,12 +460,10 @@ describe("ExtensionBridge", () => {
 
     const newestHeaders = stampHeaders(echoUrl, { frame: newestFrame });
 
-    const bodySource = JSON.stringify({ token: BRIDGE_TOKEN });
-
     // The oldest record was evicted to make room; the newest one is intact
-    await sendWithHeaders("/echo", bodySource, oldestHeaders);
+    await sendWithHeaders("/echo", "{}", oldestHeaders, BRIDGE_TOKEN);
 
-    await sendWithHeaders("/echo", bodySource, newestHeaders);
+    await sendWithHeaders("/echo", "{}", newestHeaders, BRIDGE_TOKEN);
 
     expect(senderFrames).toEqual([undefined, newestFrame]);
   });
@@ -436,12 +490,129 @@ describe("ExtensionBridge", () => {
     });
 
     // The frame goes away between the request's headers and its handling
-    const stampedHeaders = stampHeaders(`${EXTENSION_BRIDGE_ORIGIN}/echo`, { frame });
+    const stampedHeaders = stampHeaders(bridgeUrl("/echo", BRIDGE_TOKEN), { frame });
 
     isFrameDestroyed = true;
 
-    await sendWithHeaders("/echo", JSON.stringify({ token: BRIDGE_TOKEN }), stampedHeaders);
+    await sendWithHeaders("/echo", "{}", stampedHeaders, BRIDGE_TOKEN);
 
     expect(senderFrames).toEqual([undefined]);
+  });
+
+  test("refuses an unknown token with the body untouched", async () => {
+    const { session, sendRequest } = createSession();
+
+    const bridge = createBridge(session);
+
+    bridge.handle("/echo", ({ headers }) => new Response(null, { status: 204, headers }));
+
+    const pendingBody = createPendingBody();
+
+    /*
+     * The body never produces a chunk and never ends, so a bridge that read it
+     * on the way to the refusal would not answer at all — this test would time
+     * out rather than fail on a status. What it is really pinning is that the
+     * cost of an unauthenticated request is the URL and nothing else, since the
+     * caller is any document in the session and the body is its to size.
+     */
+    const response = await sendRequest("/echo", pendingBody.stream, { token: "guessed" });
+
+    expect(response.status).toBe(403);
+
+    // And what the caller was still sending is dropped rather than left to
+    // arrive
+    expect(pendingBody.isCanceled()).toBe(true);
+  });
+
+  test("refuses past the cap on bodies read at once, and frees as they finish", async () => {
+    const { session, sendRequest } = createSession();
+
+    const bridge = createBridge(session);
+
+    bridge.handle("/echo", ({ headers }) => new Response(null, { status: 204, headers }));
+
+    const pendingBodies = Array.from({ length: MAX_CONCURRENT_BRIDGE_BODY_READS }, () =>
+      createPendingBody(),
+    );
+
+    const pendingResponses = pendingBodies.map((pendingBody) =>
+      sendRequest("/echo", pendingBody.stream, { token: BRIDGE_TOKEN }),
+    );
+
+    // An authenticated caller holding the cap's worth of bodies open cannot
+    // open another, and the one turned away is dropped rather than queued
+    const refusedBody = createPendingBody();
+
+    const refused = await sendRequest("/echo", refusedBody.stream, { token: BRIDGE_TOKEN });
+
+    expect(refused.status).toBe(429);
+    expect(refusedBody.isCanceled()).toBe(true);
+
+    for (const pendingBody of pendingBodies) {
+      pendingBody.finish("{}");
+    }
+
+    const statuses = (await Promise.all(pendingResponses)).map((response) => response.status);
+
+    expect(statuses).toEqual(pendingBodies.map(() => 204));
+
+    // The cap counts bodies in flight rather than requests ever made
+    expect((await sendRequest("/echo", "{}", { token: BRIDGE_TOKEN })).status).toBe(204);
+  });
+
+  test("a refused request spends its nonce all the same", async () => {
+    const { session, stampHeaders, sendWithHeaders } = createSession();
+
+    const bridge = createBridge(session);
+
+    const frame = createFrame("https://accounts.google.com/");
+
+    const senderFrames: (WebFrameMain | undefined)[] = [];
+
+    bridge.handle("/echo", ({ senderFrame, headers }) => {
+      senderFrames.push(senderFrame);
+
+      return new Response(null, { status: 204, headers });
+    });
+
+    const stampedHeaders = stampHeaders(bridgeUrl("/echo", BRIDGE_TOKEN), { frame });
+
+    /*
+     * The record is taken before the token is looked at, so that a request
+     * refused for any reason cannot leave its nonce behind for another to
+     * present. The refusal moved above the body read in the same change that
+     * moved the token to the URL, which is exactly where this could have
+     * slipped below the early return.
+     */
+    expect((await sendWithHeaders("/echo", "{}", stampedHeaders, "guessed")).status).toBe(403);
+
+    await sendWithHeaders("/echo", "{}", stampedHeaders, BRIDGE_TOKEN);
+
+    expect(senderFrames).toEqual([undefined]);
+  });
+
+  test("the cap on bodies read at once is one session's own", async () => {
+    const first = createSession();
+
+    const second = createSession();
+
+    const bridge = new ExtensionBridge();
+
+    bridge.handle("/echo", ({ headers }) => new Response(null, { status: 204, headers }));
+
+    for (const { session } of [first, second]) {
+      bridge.setupSession(session, {
+        getExtensionId: (bridgeToken) => (bridgeToken === BRIDGE_TOKEN ? EXTENSION_ID : undefined),
+      });
+    }
+
+    for (let opened = 0; opened < MAX_CONCURRENT_BRIDGE_BODY_READS; opened += 1) {
+      void first.sendRequest("/echo", createPendingBody().stream, { token: BRIDGE_TOKEN });
+    }
+
+    expect((await first.sendRequest("/echo", "{}", { token: BRIDGE_TOKEN })).status).toBe(429);
+
+    // An account whose extension misbehaves cannot spend another account's room
+    expect((await second.sendRequest("/echo", "{}", { token: BRIDGE_TOKEN })).status).toBe(204);
   });
 });

--- a/packages/electron-extensions/bridge/bridge.ts
+++ b/packages/electron-extensions/bridge/bridge.ts
@@ -1,15 +1,41 @@
 import { randomUUID } from "node:crypto";
 import type { OnBeforeSendHeadersListenerDetails, Session, WebFrameMain } from "electron";
 import type { ExtensionsLogger } from "../logger";
-import { EXTENSION_BRIDGE_SCHEME, type ExtensionBridgeRequest } from "./protocol";
+import { EXTENSION_BRIDGE_SCHEME, EXTENSION_BRIDGE_TOKEN_PARAM } from "./protocol";
 
 /**
- * Far past what any bridge call has business sending, but a bound all the same:
- * the scheme is reachable from every document in the session, and without one a
- * page that never learns the token could still make the main process buffer an
- * arbitrarily large body on the way to its 403.
+ * Far past what any bridge call has business sending, and a bound on the copy
+ * and the parse rather than on what arrives.
+ *
+ * Measured on Electron 43.2.0: a body reaches the handler as a single chunk,
+ * string and `Blob` alike, at least up to 80 MiB — so it is already in the main
+ * process by the time `readBody` sees its first value, and the cap can only
+ * stop it being concatenated, decoded and parsed. Refusing in
+ * `onBeforeSendHeaders` instead does not help: eight 32 MiB posts grew main's
+ * RSS by 225 MiB with the listener canceling every one, against 230 MiB
+ * refusing in the handler without reading and 391 MiB reading first. The
+ * allocation is Chromium's, it happens before anything here is asked, and no
+ * answer from this process prevents it.
+ *
+ * What the cap does buy is the main thread, which is the half that blocks the
+ * app: nothing past it is turned into a string or handed to `JSON.parse`. And
+ * only an authenticated caller reaches it, since the token is checked off the
+ * query string first, so it bounds a loaded extension's own copy of the facade
+ * rather than every document in the session.
  */
 export const MAX_BRIDGE_REQUEST_BYTES = 64 * 1024 * 1024;
+
+/**
+ * How many bodies of one session the bridge will read at once.
+ *
+ * The cap above bounds one request; this bounds them together, because the
+ * facade calls the bridge one round trip at a time per port and per query and
+ * nothing legitimate has sixteen in the air. Past it the request is refused
+ * with 429 and its body dropped, so a caller that holds streams open — an
+ * extension context gone wrong, or a compromised one — cannot make the main
+ * process hold an unbounded multiple of the cap.
+ */
+export const MAX_CONCURRENT_BRIDGE_BODY_READS = 16;
 
 /**
  * The header the bridge stamps onto every request from a frame, carrying the
@@ -29,10 +55,10 @@ export const EXTENSION_BRIDGE_CALLER_HEADER = "x-extension-bridge-caller";
  * Bounds the caller records that were stamped but never consumed — a request
  * canceled between its headers and the handler leaves its record behind.
  *
- * Records go in before the handler has read the token, because the token is in
- * the body and this listener sees only headers, so every document in the
- * session reaches it: a page with no token at all is recorded and then refused.
- * A document making enough concurrent bridge requests can therefore evict an
+ * A record goes in for every request the filter matches, whatever token the
+ * request turns out to carry, so every document in the session reaches it: a
+ * page with no token at all is recorded and then refused by the handler. A
+ * document making enough concurrent bridge requests can therefore evict an
  * honest caller's record that was still coming, which costs that caller its
  * frame and leaves it delivering a sender of `id` alone — refused rather than
  * misattributed. Ordinary traffic never approaches this, and the eviction is
@@ -64,6 +90,8 @@ type ExtensionBridgeSession = {
 type ExtensionBridgeSessionState = ExtensionBridgeSession & {
   /** The frames recorded as callers of in-flight requests, by stamped nonce. */
   callerFramesByNonce: Map<string, WebFrameMain>;
+  /** Authenticated bodies being read right now, against the concurrency cap. */
+  bodyReadCount: number;
 };
 
 /**
@@ -93,7 +121,7 @@ export class ExtensionBridge {
   setupSession(session: Session, sessionOptions: ExtensionBridgeSession) {
     const callerFramesByNonce = new Map<string, WebFrameMain>();
 
-    this.sessions.set(session, { ...sessionOptions, callerFramesByNonce });
+    this.sessions.set(session, { ...sessionOptions, callerFramesByNonce, bodyReadCount: 0 });
 
     // A blocking callback is what puts the record in the map before the handler
     // reads it. That ordering is measured on Electron 43.2.0 rather than
@@ -198,43 +226,78 @@ export class ExtensionBridge {
     return callerFrame && !callerFrame.isDestroyed() ? callerFrame : undefined;
   }
 
+  /**
+   * Everything a request is refused for is settled from its URL, before the
+   * body is so much as touched: the token names a loaded extension or it does
+   * not, the path is registered or it is not, and the session has room for
+   * another body read or it does not. The caller is any document in the session
+   * — Gmail, a workspace app, whatever a user navigated to — and only the
+   * loaded extensions hold a token, so what a refusal costs is what a page
+   * with no token at all can spend.
+   *
+   * What that saves is the concatenation, the UTF-8 decode and the synchronous
+   * `JSON.parse`, which is the part that blocks the thread the app draws on;
+   * see `MAX_BRIDGE_REQUEST_BYTES` for what it does not save, which is the
+   * arriving body itself.
+   */
   private async handleRequest(session: Session, request: GlobalRequest) {
     const headers = {
       "access-control-allow-origin": request.headers.get("origin") ?? "*",
       "cache-control": "no-store",
     };
 
-    const { pathname } = new URL(request.url);
+    const { pathname, searchParams } = new URL(request.url);
 
     try {
       const sessionState = this.sessions.get(session);
 
-      // Consumed whatever else the request turns out to be, so a nonce that
-      // reached a refused request cannot be presented again
-      const senderFrame = sessionState && this.takeCallerFrame(sessionState, request);
-
-      const bodySource = await this.readBody(request);
-
-      if (bodySource === null) {
-        return new Response(null, { status: 413, headers });
+      if (!sessionState) {
+        return this.refuse(request, 403, headers);
       }
 
-      const body = JSON.parse(bodySource) as ExtensionBridgeRequest & Record<string, unknown>;
+      // Consumed whatever else the request turns out to be, so a nonce that
+      // reached a refused request cannot be presented again
+      const senderFrame = this.takeCallerFrame(sessionState, request);
+
+      const bridgeToken = searchParams.get(EXTENSION_BRIDGE_TOKEN_PARAM);
 
       // Everything else in the session — Gmail, workspace apps, any page a user
-      // navigated to — can reach this scheme too, and only the loaded extensions
-      // hold a token.
-      const extensionId = sessionState?.getExtensionId(body.token);
+      // navigated to — can reach this scheme too, and only the loaded
+      // extensions hold a token. Its 122 bits sit behind an in-process fetch,
+      // so the lookup's timing tells a caller nothing a guess would not cost it
+      // already.
+      const extensionId =
+        bridgeToken === null ? undefined : sessionState.getExtensionId(bridgeToken);
 
       if (!extensionId) {
-        return new Response(null, { status: 403, headers });
+        return this.refuse(request, 403, headers);
       }
 
       const handler = this.routes.get(pathname);
 
       if (!handler) {
-        return new Response(null, { status: 404, headers });
+        return this.refuse(request, 404, headers);
       }
+
+      if (sessionState.bodyReadCount >= MAX_CONCURRENT_BRIDGE_BODY_READS) {
+        return this.refuse(request, 429, headers);
+      }
+
+      sessionState.bodyReadCount += 1;
+
+      let bodySource: string | null;
+
+      try {
+        bodySource = await this.readBody(request);
+      } finally {
+        sessionState.bodyReadCount -= 1;
+      }
+
+      if (bodySource === null) {
+        return new Response(null, { status: 413, headers });
+      }
+
+      const body = JSON.parse(bodySource) as Record<string, unknown>;
 
       return await handler({ session, extensionId, senderFrame, body, headers });
     } catch (error) {
@@ -245,8 +308,24 @@ export class ExtensionBridge {
   }
 
   /**
-   * The request body, or `null` the moment it runs past the cap — nothing more
-   * is read then, so an oversized body costs the cap and not its whole length.
+   * A refusal, with whatever the caller was still sending dropped rather than
+   * left to arrive — the point of deciding before the body is that no part of
+   * it is ever held. Canceling is not awaited, so the answer does not wait on
+   * a renderer that may be mid-upload.
+   */
+  private refuse(request: GlobalRequest, status: number, headers: Record<string, string>) {
+    // A body already ended or errored has nothing to cancel and says so by
+    // throwing, which is not a reason to hold up the refusal
+    void request.body?.cancel().catch(() => undefined);
+
+    return new Response(null, { status, headers });
+  }
+
+  /**
+   * The request body, or `null` the moment it runs past the cap. Only reached
+   * for a caller the token has already vouched for, and the cap stops the copy
+   * and the parse rather than the arrival — a body is handed over whole, so
+   * canceling here frees the reference rather than avoiding the allocation.
    */
   private async readBody(request: GlobalRequest) {
     if (!request.body) {

--- a/packages/electron-extensions/bridge/protocol.ts
+++ b/packages/electron-extensions/bridge/protocol.ts
@@ -28,6 +28,26 @@ export const EXTENSION_BRIDGE_ORIGIN = `${EXTENSION_BRIDGE_SCHEME}://bridge`;
  */
 export const EXTENSION_BRIDGE_TOKEN_GLOBAL = "__electronExtensionsBridgeToken";
 
-export type ExtensionBridgeRequest = {
-  token: string;
-};
+/**
+ * The query parameter every bridge call carries its token in.
+ *
+ * The query string rather than the body, so the bridge can answer an unknown
+ * token from the URL alone, before it has touched `request.body`. A header
+ * would say the same thing, but a header outside the CORS safelist makes the
+ * call a preflighted request and the scheme would then have to answer
+ * `OPTIONS` before anything else.
+ *
+ * A URL is the more exposed of the two places, so this is only safe while the
+ * URL stays inside the process. Measured on Electron 43.2.0: a fetch of this
+ * scheme leaves no `PerformanceResourceTiming` entry at all, from the page's
+ * own world or from an isolated world, where an ordinary http fetch from the
+ * page's world does — so the token is not readable through the timeline of the
+ * page a content script runs in. Worth re-measuring if the scheme's privileges
+ * change.
+ */
+export const EXTENSION_BRIDGE_TOKEN_PARAM = "token";
+
+/** The URL a bridge call goes to: the path routes it, the query authenticates it. */
+export function getExtensionBridgeUrl(pathName: string, bridgeToken: string) {
+  return `${EXTENSION_BRIDGE_ORIGIN}${pathName}?${EXTENSION_BRIDGE_TOKEN_PARAM}=${encodeURIComponent(bridgeToken)}`;
+}

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -3,7 +3,7 @@ import fs, { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os, { tmpdir } from "node:os";
 import path from "node:path";
 import type { ClearStorageDataOptions, Extension, Session } from "electron";
-import { EXTENSION_BRIDGE_ORIGIN } from "./bridge/protocol";
+import { getExtensionBridgeUrl } from "./bridge/protocol";
 import { Extensions } from "./extensions";
 import { NATIVE_MESSAGING_PATHS } from "./native-messaging/bridge-protocol";
 
@@ -152,9 +152,9 @@ function createSession({
         listener(undefined, messageDetails);
       }
     },
-    request: (body: Record<string, unknown>) =>
+    request: (bridgeToken: string, body: Record<string, unknown>) =>
       requestHandler?.(
-        new Request(`${EXTENSION_BRIDGE_ORIGIN}${NATIVE_MESSAGING_PATHS.connect}`, {
+        new Request(getExtensionBridgeUrl(NATIVE_MESSAGING_PATHS.connect, bridgeToken), {
           method: "POST",
           body: JSON.stringify(body),
         }) as GlobalRequest,
@@ -349,13 +349,13 @@ describe("Extensions", () => {
     await extensions.setupSession(first.session);
     await extensions.setupSession(second.session);
 
-    const bridgeToken = await readBridgeToken(derivedDirs[0] as string);
+    const bridgeToken = (await readBridgeToken(derivedDirs[0] as string)) as string;
 
     const connect = (
       request: ReturnType<typeof createSession>["request"],
-      token: string | undefined,
+      bridgeToken: string,
       portId: string,
-    ) => request({ token, portId, hostName: "com.meru.test" });
+    ) => request(bridgeToken, { portId, hostName: "com.meru.test" });
 
     expect((await connect(first.request, bridgeToken, "first")).status).not.toBe(403);
     expect((await connect(second.request, bridgeToken, "second")).status).not.toBe(403);

--- a/packages/electron-extensions/facade/api/native-messaging.test.ts
+++ b/packages/electron-extensions/facade/api/native-messaging.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { EXTENSION_BRIDGE_ORIGIN } from "../../bridge/protocol";
 import {
   NATIVE_MESSAGING_PATHS,
   type NativeMessagingFrame,
@@ -42,7 +41,7 @@ function installFakeBridge() {
   });
 
   globalThis.fetch = (async (url: string, init: RequestInit) => {
-    const path = url.slice(EXTENSION_BRIDGE_ORIGIN.length);
+    const { pathname: path } = new URL(url);
 
     requests.push({ path, body: JSON.parse(init.body as string) });
 

--- a/packages/electron-extensions/facade/api/web-navigation.test.ts
+++ b/packages/electron-extensions/facade/api/web-navigation.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { EXTENSION_BRIDGE_ORIGIN } from "../../bridge/protocol";
 import { WEB_NAVIGATION_PATHS } from "../../web-navigation/bridge-protocol";
 import { createWebNavigation } from "./web-navigation";
 
@@ -13,10 +12,13 @@ type FrameQueryMethod = (details: Record<string, unknown>) => Promise<unknown>;
 
 describe("facade webNavigation", () => {
   test("asks the bridge and answers what it said", async () => {
-    const requests: { url: string; body: unknown }[] = [];
+    const requests: { pathName: string; body: unknown }[] = [];
 
     globalThis.fetch = (async (url: string, init: RequestInit) => {
-      requests.push({ url, body: JSON.parse(init.body as string) });
+      requests.push({
+        pathName: new URL(url).pathname,
+        body: JSON.parse(init.body as string),
+      });
 
       return Response.json({ frameId: 42, parentFrameId: 0 });
     }) as typeof fetch;
@@ -27,7 +29,7 @@ describe("facade webNavigation", () => {
 
     expect(requests).toEqual([
       {
-        url: `${EXTENSION_BRIDGE_ORIGIN}${WEB_NAVIGATION_PATHS.getFrame}`,
+        pathName: WEB_NAVIGATION_PATHS.getFrame,
         body: { details: { tabId: 12, frameId: 42 } },
       },
     ]);

--- a/packages/electron-extensions/facade/lib/bridge.test.ts
+++ b/packages/electron-extensions/facade/lib/bridge.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  EXTENSION_BRIDGE_ORIGIN,
+  EXTENSION_BRIDGE_TOKEN_GLOBAL,
+  EXTENSION_BRIDGE_TOKEN_PARAM,
+} from "../../bridge/protocol";
+import { postBridge } from "./bridge";
+
+const BRIDGE_TOKEN = "bridge-token";
+
+const originalFetch = globalThis.fetch;
+
+const tokenGlobal = globalThis as unknown as Record<string, string | undefined>;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+
+  delete tokenGlobal[EXTENSION_BRIDGE_TOKEN_GLOBAL];
+});
+
+function stubFetch() {
+  const requests: { url: string; init: RequestInit }[] = [];
+
+  globalThis.fetch = (async (url: string, init: RequestInit) => {
+    requests.push({ url, init });
+
+    return new Response(null, { status: 204 });
+  }) as unknown as typeof fetch;
+
+  return requests;
+}
+
+describe("postBridge", () => {
+  test("carries the token on the query string and leaves it out of the body", async () => {
+    const requests = stubFetch();
+
+    tokenGlobal[EXTENSION_BRIDGE_TOKEN_GLOBAL] = BRIDGE_TOKEN;
+
+    await postBridge("/native-messaging/post", { portId: "port-1" });
+
+    const [request] = requests;
+
+    expect(request?.url).toBe(
+      `${EXTENSION_BRIDGE_ORIGIN}/native-messaging/post?${EXTENSION_BRIDGE_TOKEN_PARAM}=${BRIDGE_TOKEN}`,
+    );
+
+    // The bridge refuses an unknown token off the URL alone, so nothing about
+    // authentication may depend on the body being read
+    expect(JSON.parse(request?.init.body as string)).toEqual({ portId: "port-1" });
+  });
+
+  test("escapes a token the query string would otherwise take apart", async () => {
+    const requests = stubFetch();
+
+    tokenGlobal[EXTENSION_BRIDGE_TOKEN_GLOBAL] = "a&b=c d";
+
+    await postBridge("/echo", {});
+
+    expect(new URL(requests[0]?.url as string).searchParams.get(EXTENSION_BRIDGE_TOKEN_PARAM)).toBe(
+      "a&b=c d",
+    );
+  });
+
+  test("sends an empty token where the derived copy left none", async () => {
+    const requests = stubFetch();
+
+    await postBridge("/echo", {});
+
+    expect(new URL(requests[0]?.url as string).searchParams.get(EXTENSION_BRIDGE_TOKEN_PARAM)).toBe(
+      "",
+    );
+  });
+});

--- a/packages/electron-extensions/facade/lib/bridge.ts
+++ b/packages/electron-extensions/facade/lib/bridge.ts
@@ -1,19 +1,23 @@
-import { EXTENSION_BRIDGE_ORIGIN, EXTENSION_BRIDGE_TOKEN_GLOBAL } from "../../bridge/protocol";
+import { EXTENSION_BRIDGE_TOKEN_GLOBAL, getExtensionBridgeUrl } from "../../bridge/protocol";
 
 /**
  * A call to the main-process end of the bridge, carrying the token the derived
  * copy of the facade wrote next to this script — what tells the bridge which
  * extension is calling, since the request itself carries no sender.
+ *
+ * The token rides the query string rather than the body so that the bridge can
+ * refuse an unknown one without reading the body at all; see
+ * `EXTENSION_BRIDGE_TOKEN_PARAM`.
  */
 export function postBridge(pathName: string, body: Record<string, unknown>) {
-  const token = (globalThis as unknown as Record<string, string | undefined>)[
-    EXTENSION_BRIDGE_TOKEN_GLOBAL
-  ];
+  const bridgeToken =
+    (globalThis as unknown as Record<string, string | undefined>)[EXTENSION_BRIDGE_TOKEN_GLOBAL] ??
+    "";
 
-  return fetch(`${EXTENSION_BRIDGE_ORIGIN}${pathName}`, {
+  return fetch(getExtensionBridgeUrl(pathName, bridgeToken), {
     method: "POST",
     // A safelisted content type keeps this a simple request, so no preflight
     headers: { "content-type": "text/plain;charset=UTF-8" },
-    body: JSON.stringify({ ...body, token }),
+    body: JSON.stringify(body),
   });
 }

--- a/packages/electron-extensions/native-messaging/native-messaging.test.ts
+++ b/packages/electron-extensions/native-messaging/native-messaging.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Session } from "electron";
 import { ExtensionBridge } from "../bridge/bridge";
-import { EXTENSION_BRIDGE_ORIGIN } from "../bridge/protocol";
+import { getExtensionBridgeUrl } from "../bridge/protocol";
 import { NATIVE_MESSAGING_PATHS, type NativeMessagingFrame } from "./bridge-protocol";
 import { NativeMessageDecoder } from "./framing";
 import { getHostManifestSearchPaths } from "./host-manifest";
@@ -102,7 +102,7 @@ async function writeHostManifest(allowedExtensionId = EXTENSION_ID, hostName = "
 }
 
 function createRequest(pathName: string, body: Record<string, unknown>) {
-  return new Request(`${EXTENSION_BRIDGE_ORIGIN}${pathName}`, {
+  return new Request(getExtensionBridgeUrl(pathName, BRIDGE_TOKEN), {
     method: "POST",
     body: JSON.stringify(body),
   }) as GlobalRequest;
@@ -110,11 +110,7 @@ function createRequest(pathName: string, body: Record<string, unknown>) {
 
 function connect(portId = "port-1") {
   return requestHandler?.(
-    createRequest(NATIVE_MESSAGING_PATHS.connect, {
-      token: BRIDGE_TOKEN,
-      portId,
-      hostName: HOST_NAME,
-    }),
+    createRequest(NATIVE_MESSAGING_PATHS.connect, { portId, hostName: HOST_NAME }),
   ) as Promise<Response>;
 }
 
@@ -190,7 +186,6 @@ describe("NativeMessaging", () => {
 
     await requestHandler?.(
       createRequest(NATIVE_MESSAGING_PATHS.post, {
-        token: BRIDGE_TOKEN,
         portId: "port-1",
         message: { hello: "host" },
       }),

--- a/packages/electron-extensions/runtime-proxy/relay-client.test.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { EXTENSION_BRIDGE_ORIGIN } from "../bridge/protocol";
 import type { ChromeEventListener, ChromeNamespace } from "../facade/lib/chrome";
 import { encodeNativeMessage } from "../native-messaging/framing";
 import {
@@ -49,7 +48,7 @@ function stubBridge() {
   const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
 
   globalThis.fetch = (async (url: string, init: RequestInit) => {
-    const pathName = url.slice(EXTENSION_BRIDGE_ORIGIN.length);
+    const { pathname: pathName } = new URL(url);
 
     const body = JSON.parse(init.body as string) as Record<string, unknown>;
 

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
@@ -8,7 +8,7 @@ import type {
   WebFrameMain,
 } from "electron";
 import { ExtensionBridge } from "../bridge/bridge";
-import { EXTENSION_BRIDGE_ORIGIN } from "../bridge/protocol";
+import { getExtensionBridgeUrl } from "../bridge/protocol";
 import { NativeMessageDecoder } from "../native-messaging/framing";
 import {
   PORT_CLOSED_ERROR,
@@ -134,8 +134,13 @@ function createFakeSession() {
      * the way Chromium names a fetch's initiator — and the handler receives
      * the request with whatever the listener stamped on it.
      */
-    request: (pathName: string, body: Record<string, unknown>, callerFrame?: WebFrameMain) => {
-      const url = `${EXTENSION_BRIDGE_ORIGIN}${pathName}`;
+    request: (
+      pathName: string,
+      bridgeToken: string,
+      body: Record<string, unknown>,
+      callerFrame?: WebFrameMain,
+    ) => {
+      const url = getExtensionBridgeUrl(pathName, bridgeToken);
 
       let requestHeaders: Record<string, string> = {};
 
@@ -214,9 +219,7 @@ function createHarness(proxyOptions: RuntimeProxyOptions = {}) {
 
   /** Parks a worker job stream the way the relay client does, collecting jobs. */
   const openWorkerStream = async () => {
-    const response = await workerSession.request(RUNTIME_PROXY_PATHS.workerJobs, {
-      token: WORKER_TOKEN,
-    });
+    const response = await workerSession.request(RUNTIME_PROXY_PATHS.workerJobs, WORKER_TOKEN, {});
 
     expect(response.status).toBe(200);
 
@@ -256,17 +259,17 @@ function createHarness(proxyOptions: RuntimeProxyOptions = {}) {
   };
 
   const ackJob = (jobId: string) =>
-    workerSession.request(RUNTIME_PROXY_PATHS.workerAck, { token: WORKER_TOKEN, jobId });
+    workerSession.request(RUNTIME_PROXY_PATHS.workerAck, WORKER_TOKEN, { jobId });
 
   const replyToJob = (jobId: string, result: Record<string, unknown>) =>
-    workerSession.request(RUNTIME_PROXY_PATHS.workerReply, { token: WORKER_TOKEN, jobId, result });
+    workerSession.request(RUNTIME_PROXY_PATHS.workerReply, WORKER_TOKEN, { jobId, result });
 
   /** `null` sends the way a frameless caller would; omitted, the page calls. */
   const sendShimMessage = (message: unknown, callerFrame: WebFrameMain | null = page.frame) =>
     shimSession.request(
       RUNTIME_PROXY_PATHS.sendMessage,
+      SHIM_TOKEN,
       {
-        token: SHIM_TOKEN,
         message,
         sender: SENDER_REPORT,
       },
@@ -277,8 +280,8 @@ function createHarness(proxyOptions: RuntimeProxyOptions = {}) {
   const connectShimPort = async (portId: string, name = "relay") => {
     const response = await shimSession.request(
       RUNTIME_PROXY_PATHS.connect,
+      SHIM_TOKEN,
       {
-        token: SHIM_TOKEN,
         portId,
         name,
         sender: SENDER_REPORT,
@@ -654,8 +657,7 @@ describe("RuntimeProxy", () => {
     await harness.replyToJob(connectJob.jobId, { status: "connected" });
 
     // Worker to content script
-    await harness.workerSession.request(RUNTIME_PROXY_PATHS.workerPortPost, {
-      token: WORKER_TOKEN,
+    await harness.workerSession.request(RUNTIME_PROXY_PATHS.workerPortPost, WORKER_TOKEN, {
       portId: "port-1",
       message: { locked: false },
     });
@@ -665,8 +667,7 @@ describe("RuntimeProxy", () => {
     ]);
 
     // Content script to worker
-    await harness.shimSession.request(RUNTIME_PROXY_PATHS.portPost, {
-      token: SHIM_TOKEN,
+    await harness.shimSession.request(RUNTIME_PROXY_PATHS.portPost, SHIM_TOKEN, {
       portId: "port-1",
       message: "fill",
     });
@@ -680,8 +681,7 @@ describe("RuntimeProxy", () => {
     });
 
     // The worker hangs up; the shim hears a clean disconnect
-    await harness.workerSession.request(RUNTIME_PROXY_PATHS.workerPortDisconnect, {
-      token: WORKER_TOKEN,
+    await harness.workerSession.request(RUNTIME_PROXY_PATHS.workerPortDisconnect, WORKER_TOKEN, {
       portId: "port-1",
     });
 
@@ -705,8 +705,7 @@ describe("RuntimeProxy", () => {
 
     await harness.replyToJob(connectJob.jobId, { status: "connected" });
 
-    await harness.shimSession.request(RUNTIME_PROXY_PATHS.portDisconnect, {
-      token: SHIM_TOKEN,
+    await harness.shimSession.request(RUNTIME_PROXY_PATHS.portDisconnect, SHIM_TOKEN, {
       portId: "port-2",
     });
 
@@ -789,14 +788,12 @@ describe("RuntimeProxy", () => {
     const harness = createHarness();
 
     expect(
-      (await harness.shimSession.request(RUNTIME_PROXY_PATHS.workerJobs, { token: SHIM_TOKEN }))
-        .status,
+      (await harness.shimSession.request(RUNTIME_PROXY_PATHS.workerJobs, SHIM_TOKEN, {})).status,
     ).toBe(403);
 
     expect(
       (
-        await harness.shimSession.request(RUNTIME_PROXY_PATHS.workerAck, {
-          token: SHIM_TOKEN,
+        await harness.shimSession.request(RUNTIME_PROXY_PATHS.workerAck, SHIM_TOKEN, {
           jobId: "guessed",
         })
       ).status,
@@ -804,8 +801,7 @@ describe("RuntimeProxy", () => {
 
     expect(
       (
-        await harness.shimSession.request(RUNTIME_PROXY_PATHS.workerReply, {
-          token: SHIM_TOKEN,
+        await harness.shimSession.request(RUNTIME_PROXY_PATHS.workerReply, SHIM_TOKEN, {
           jobId: "guessed",
           result: { status: "replied", reply: "spoofed" },
         })
@@ -818,8 +814,7 @@ describe("RuntimeProxy", () => {
 
     expect(
       (
-        await harness.workerSession.request(RUNTIME_PROXY_PATHS.sendMessage, {
-          token: WORKER_TOKEN,
+        await harness.workerSession.request(RUNTIME_PROXY_PATHS.sendMessage, WORKER_TOKEN, {
           message: "loop",
           sender: SENDER_REPORT,
         })

--- a/packages/electron-extensions/runtime-proxy/shim.test.ts
+++ b/packages/electron-extensions/runtime-proxy/shim.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { EXTENSION_BRIDGE_ORIGIN } from "../bridge/protocol";
 import type { ChromeNamespace } from "../facade/lib/chrome";
 import { encodeNativeMessage } from "../native-messaging/framing";
 import {
@@ -22,7 +21,7 @@ afterEach(() => {
   globalThis.fetch = originalFetch;
 });
 
-type RecordedRequest = { url: string; body: Record<string, unknown> };
+type RecordedRequest = { pathName: string; body: Record<string, unknown> };
 
 function stubFetch(respond: (pathName: string, body: Record<string, unknown>) => Response) {
   const requests: RecordedRequest[] = [];
@@ -30,9 +29,11 @@ function stubFetch(respond: (pathName: string, body: Record<string, unknown>) =>
   globalThis.fetch = (async (url: string, init: RequestInit) => {
     const body = JSON.parse(init.body as string) as Record<string, unknown>;
 
-    requests.push({ url, body });
+    const { pathname: pathName } = new URL(url);
 
-    return respond(url.slice(EXTENSION_BRIDGE_ORIGIN.length), body);
+    requests.push({ pathName, body });
+
+    return respond(pathName, body);
   }) as unknown as typeof fetch;
 
   return requests;
@@ -95,7 +96,7 @@ describe("shimmed sendMessage", () => {
 
     expect(requests).toEqual([
       {
-        url: `${EXTENSION_BRIDGE_ORIGIN}${RUNTIME_PROXY_PATHS.sendMessage}`,
+        pathName: RUNTIME_PROXY_PATHS.sendMessage,
         body: { message: { kind: "unlock" }, sender: SENDER_REPORT },
       },
     ]);
@@ -232,7 +233,7 @@ describe("shimmed connect", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    expect(requests.map(({ url }) => url.slice(EXTENSION_BRIDGE_ORIGIN.length))).toEqual([
+    expect(requests.map(({ pathName }) => pathName)).toEqual([
       RUNTIME_PROXY_PATHS.connect,
       RUNTIME_PROXY_PATHS.portPost,
     ]);
@@ -299,11 +300,9 @@ describe("shimmed connect", () => {
     await new Promise((resolve) => setTimeout(resolve, 5));
 
     expect(disconnectHeard).toBe(false);
-    expect(
-      requests.some(
-        ({ url }) => url === `${EXTENSION_BRIDGE_ORIGIN}${RUNTIME_PROXY_PATHS.portDisconnect}`,
-      ),
-    ).toBe(true);
+    expect(requests.some(({ pathName }) => pathName === RUNTIME_PROXY_PATHS.portDisconnect)).toBe(
+      true,
+    );
 
     expect(() => port.postMessage("too late")).toThrow(
       "Attempting to use a disconnected port object",

--- a/packages/electron-extensions/web-navigation/web-navigation.test.ts
+++ b/packages/electron-extensions/web-navigation/web-navigation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { Session, WebContents } from "electron";
 import { ExtensionBridge } from "../bridge/bridge";
-import { EXTENSION_BRIDGE_ORIGIN } from "../bridge/protocol";
+import { getExtensionBridgeUrl } from "../bridge/protocol";
 import { WEB_NAVIGATION_PATHS } from "./bridge-protocol";
 import { WebNavigation } from "./web-navigation";
 
@@ -208,9 +208,9 @@ describe("WebNavigation", () => {
     });
 
     const response = await requestHandler?.(
-      new Request(`${EXTENSION_BRIDGE_ORIGIN}${WEB_NAVIGATION_PATHS.getFrame}`, {
+      new Request(getExtensionBridgeUrl(WEB_NAVIGATION_PATHS.getFrame, "token"), {
         method: "POST",
-        body: JSON.stringify({ token: "token", details: { tabId: TAB_ID, frameId: 42 } }),
+        body: JSON.stringify({ details: { tabId: TAB_ID, frameId: 42 } }),
       }) as GlobalRequest,
     );
 


### PR DESCRIPTION
## Summary
The extension bridge read and JSON-parsed up to 64 MiB before it looked the token up, because the token was in the body — so any page in an account session could make the main process spend that memory and that thread on the way to a 403, as many times over as it cared to. The token moves to the query string, every refusal is now settled from the URL with the body untouched and canceled, and a per-session cap bounds how many bodies are read at once. Finding 3 of the [3.60 extensions review](https://github.com/zoidsh/docs/blob/main/meru/extensions-review-3.60.md); confirmed by reading rather than exercised in Electron, and the e2e suite that drives the real bridge needs a license key this sandbox does not have.

## Problem
`bridge.ts` awaited `readBody(request)`, ran `JSON.parse` on up to `MAX_BRIDGE_REQUEST_BYTES` (64 MiB) synchronously on the main thread, and only then called `sessionState.getExtensionId(body.token)`.

The scheme is reachable from every document in the session — a workspace app, an XSS in a mail page, anything a user navigated to — and only the loaded extensions hold a token. So a page with no token at all still got the whole body read and parsed before its 403. Nothing capped concurrent bodies either, and `fetch("extension-bridge://bridge/x", { method: "POST", body: new Blob([64MiB]) })` costs the renderer close to nothing, so N in parallel meant N × 64 MiB allocated in main and N synchronous 64 MiB parses on the thread that draws the app. A page's own CSP `connect-src` was the only gate, and a hostile page writes its own CSP.

## Solution
- The token moves from the request body to a `token` query parameter (`EXTENSION_BRIDGE_TOKEN_PARAM`), built by one shared `getExtensionBridgeUrl` that `postBridge` and the tests both use.
- `handleRequest` settles every refusal from the URL before touching `request.body`: unknown token → 403, unregistered path → 404, session at its cap → 429. Each refusal cancels the body rather than leaving it to arrive, and does not await the cancel.
- `MAX_CONCURRENT_BRIDGE_BODY_READS` (16) caps bodies read at once per session, counted around the read and released in a `finally`. It bounds what an authenticated caller can hold open; the facade posts one round trip at a time per port and per query, and a small body read resolves in a microtask, so the count sits at zero in ordinary use.
- `MAX_BRIDGE_REQUEST_BYTES` stays at 64 MiB and now bounds a loaded extension's own facade rather than every page in the session.

**What this does and does not save, measured rather than reasoned.** A body arrives at the handler as a single chunk, string and `Blob` alike, at least up to 80 MiB, so it is already in the main process before `readBody` sees its first value. The change therefore buys the concatenation, the UTF-8 decode and the synchronous `JSON.parse` — the half that blocks the thread the app draws on — and not the allocation. Refusing in `onBeforeSendHeaders` instead, the obvious place to catch it earlier, buys nothing further: eight 32 MiB posts from a tokenless page grew main's RSS by 225 MiB with the listener canceling every one, against 230 MiB refusing in the handler unread and 391 MiB reading first. The allocation is Chromium's and precedes anything this process is asked. The comments in `bridge.ts` claimed the cap bounded what arrived; they now say what it bounds.

**The query string rather than a header.** A header outside the CORS safelist makes the call a preflighted request, and the scheme would then have to answer `OPTIONS` before anything else — a second code path on the transport for no gain. The query string keeps it a simple request. The token is visible to the bridge's own `onBeforeSendHeaders` listener, which is fine, and nothing logs the request URL.

A URL is the more exposed of the two places, so the review asked what a page could read it from. Measured on Electron 43.2.0: a fetch of this scheme leaves no `PerformanceResourceTiming` entry at all — not in the page's own world, not in an isolated world — where an ordinary http fetch from the page's world does. That is the exposure that would matter once the runtime proxy puts the shim in content scripts of a Gmail page, and it does not exist. The measurement is recorded next to the constant.

**The token comparison stays a plain `Map.get`.** At 122 bits of entropy behind in-process fetch latency there is nothing for its timing to give away.

**`onBeforeSendHeaders` still records the initiating frame for every matching request, before any token is known.** That record is what binds a relayed sender to the tab that sent it, and it has to go in before the handler runs. The listener could now read the token off the URL and skip recording for a caller that holds none, which would stop a hostile page evicting honest callers' records — worth doing, but it changes what that listener is for, so it is left out of this change.

**One client change.** Every call goes through `postBridge`, including the runtime proxy's shim and relay client, and `grep -rn "extension-bridge\|BRIDGE_SCHEME" packages/electron-extensions` confirms nothing builds a bridge URL by hand.

**No `DERIVE_VERSION` bump.** The facade and the proxy scripts are rewritten into every derived copy on each launch regardless of the stamp, so a copy already on disk gets the new client without one.

Tests: `bridge.test.ts` gains a refused request whose body never produces a chunk — a bridge that read it before checking the token would not answer at all — asserting the 403 and that the body was canceled, plus the concurrency cap answering 429 and freeing as bodies finish. A new `facade/lib/bridge.test.ts` pins that `postBridge` puts the token on the query string, escapes it, and leaves it out of the body. The existing harnesses in `bridge.test.ts`, `native-messaging.test.ts`, `web-navigation.test.ts`, `runtime-proxy.test.ts`, `extensions.test.ts`, `shim.test.ts` and `relay-client.test.ts` now pass the token as its own argument rather than as a body field.

## Not verified
- The bridge is not exercised end to end in the packaged app here. `tests/extension-proxy.e2e.ts` is that pass, but it is Pro-gated and needs `MERU_TEST_LICENSE_KEY`, which this sandbox does not have; CI runs it on this PR with the secret. The resource-timing, single-chunk and RSS numbers above were measured in a bare Electron 43.2.0 harness, not in Meru.
- The original finding was itself confirmed by reading rather than by exercising the attack.
- `MAX_CONCURRENT_BRIDGE_BODY_READS` at 16 is a judgment call, not a measurement. A legitimate burst past it would be answered 429 rather than served. Ordinary traffic should never approach it, because a small body's read resolves in microtasks and the count returns to zero before the next request is dispatched — but that has not been measured against a real 1Password load with many inline-menu frames.
- Two follow-ups the security pass named are deliberately not in this PR. A tokenless page can still evict honest callers' nonce records, because `onBeforeSendHeaders` records a frame for every matching request before any token is known; the query-string move makes checking the token there a small change, but it alters what that listener is for. And the three `postMessage` chains in `facade/api/native-messaging.ts`, `runtime-proxy/shim.ts` and `runtime-proxy/relay-client.ts` swallow a non-ok response, so a 429 would drop a message with no `lastError` — a pre-existing shape that this PR gives its first plausible trigger, and it overlaps finding 1 of the same review.

