### PR TITLE
Fix two native messaging port and host lifetime bugs

### DIFF
--- a/packages/electron-extensions/facade/api/native-messaging.test.ts
+++ b/packages/electron-extensions/facade/api/native-messaging.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { EXTENSION_BRIDGE_ORIGIN } from "../../bridge/protocol";
+import {
+  NATIVE_MESSAGING_PATHS,
+  type NativeMessagingFrame,
+} from "../../native-messaging/bridge-protocol";
+import { encodeNativeMessage } from "../../native-messaging/framing";
+import type { ChromeNamespace } from "../lib/chrome";
+import { installNativeMessaging } from "./native-messaging";
+
+type NativeMessagingPort = {
+  postMessage: (message: unknown) => void;
+  disconnect: () => void;
+  onMessage: { addListener: (listener: (message: unknown) => void) => void };
+  onDisconnect: { addListener: (listener: () => void) => void };
+};
+
+type BridgeRequest = { path: string; body: Record<string, unknown> };
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+/**
+ * The main-process end of the bridge, with the connect answer held back until
+ * the test lets it through — which is what a real connect does while it looks
+ * up the host manifest and spawns the host.
+ */
+function installFakeBridge() {
+  const requests: BridgeRequest[] = [];
+
+  let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+
+  let isStreamCanceled = false;
+
+  let answerConnect = () => {};
+
+  const connectAnswered = new Promise<void>((resolve) => {
+    answerConnect = resolve;
+  });
+
+  globalThis.fetch = (async (url: string, init: RequestInit) => {
+    const path = url.slice(EXTENSION_BRIDGE_ORIGIN.length);
+
+    requests.push({ path, body: JSON.parse(init.body as string) });
+
+    if (path !== NATIVE_MESSAGING_PATHS.connect) {
+      return new Response(null, { status: 204 });
+    }
+
+    await connectAnswered;
+
+    const body = new ReadableStream<Uint8Array>({
+      start: (streamController) => {
+        controller = streamController;
+      },
+      cancel: () => {
+        isStreamCanceled = true;
+      },
+    });
+
+    return new Response(body);
+  }) as unknown as typeof fetch;
+
+  return {
+    requests,
+    paths: () => requests.map(({ path }) => path),
+    answerConnect,
+    sendFrame: (frame: NativeMessagingFrame) => {
+      controller?.enqueue(encodeNativeMessage(frame));
+    },
+    isStreamCanceled: () => isStreamCanceled,
+  };
+}
+
+function connectNative(hostName = "com.meru.test") {
+  const runtime: ChromeNamespace = {};
+
+  installNativeMessaging({ runtime });
+
+  const connect = runtime.connectNative as (name: string) => NativeMessagingPort;
+
+  return { runtime, port: connect(hostName) };
+}
+
+async function waitFor(description: string, isDone: () => boolean) {
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (isDone()) {
+      return;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+describe("facade connectNative", () => {
+  test("sends the disconnect behind the connect and everything already posted", async () => {
+    const bridge = installFakeBridge();
+
+    const { port } = connectNative();
+
+    port.postMessage({ hello: "host" });
+
+    port.disconnect();
+
+    // Nothing but the connect can have gone out while it is unanswered
+    await waitFor("the connect request", () => bridge.paths().length > 0);
+
+    expect(bridge.paths()).toEqual([NATIVE_MESSAGING_PATHS.connect]);
+
+    bridge.answerConnect();
+
+    await waitFor("the disconnect request", () => bridge.paths().length === 3);
+
+    expect(bridge.paths()).toEqual([
+      NATIVE_MESSAGING_PATHS.connect,
+      NATIVE_MESSAGING_PATHS.post,
+      NATIVE_MESSAGING_PATHS.disconnect,
+    ]);
+
+    expect(bridge.requests[1]?.body.message).toEqual({ hello: "host" });
+  });
+
+  test("cancels the stream once the disconnect has gone out", async () => {
+    const bridge = installFakeBridge();
+
+    const { port } = connectNative();
+
+    port.disconnect();
+
+    bridge.answerConnect();
+
+    await waitFor("the stream cancel", () => bridge.isStreamCanceled());
+
+    expect(bridge.paths()).toEqual([
+      NATIVE_MESSAGING_PATHS.connect,
+      NATIVE_MESSAGING_PATHS.disconnect,
+    ]);
+  });
+
+  test("stays quiet about messages the host sent before the disconnect landed", async () => {
+    const bridge = installFakeBridge();
+
+    const { port } = connectNative();
+
+    const messages: unknown[] = [];
+
+    port.onMessage.addListener((message) => {
+      messages.push(message);
+    });
+
+    let isDisconnectEmitted = false;
+
+    port.onDisconnect.addListener(() => {
+      isDisconnectEmitted = true;
+    });
+
+    bridge.answerConnect();
+
+    await waitFor("the connect answer", () => bridge.paths().length > 0);
+
+    bridge.sendFrame({ type: "message", message: { first: true } });
+
+    await waitFor("the first message", () => messages.length === 1);
+
+    port.disconnect();
+
+    bridge.sendFrame({ type: "message", message: { second: true } });
+
+    await waitFor("the stream cancel", () => bridge.isStreamCanceled());
+
+    expect(messages).toEqual([{ first: true }]);
+
+    // Chrome stays quiet about a port the extension disconnected itself
+    expect(isDisconnectEmitted).toBe(false);
+  });
+
+  test("refuses to post on a disconnected port", () => {
+    installFakeBridge();
+
+    const { port } = connectNative();
+
+    port.disconnect();
+
+    expect(() => {
+      port.postMessage({ hello: "host" });
+    }).toThrow("Attempting to use a disconnected port object");
+  });
+});
+
+describe("facade sendNativeMessage", () => {
+  test("posts one message, answers the first reply and disconnects", async () => {
+    const bridge = installFakeBridge();
+
+    const runtime: ChromeNamespace = {};
+
+    installNativeMessaging({ runtime });
+
+    const sendNativeMessage = runtime.sendNativeMessage as (
+      hostName: string,
+      message: unknown,
+    ) => Promise<unknown>;
+
+    const reply = sendNativeMessage("com.meru.test", { hello: "host" });
+
+    bridge.answerConnect();
+
+    await waitFor("the posted message", () => bridge.paths().includes(NATIVE_MESSAGING_PATHS.post));
+
+    bridge.sendFrame({ type: "message", message: { echo: { hello: "host" } } });
+
+    expect(await reply).toEqual({ echo: { hello: "host" } });
+
+    await waitFor("the stream cancel", () => bridge.isStreamCanceled());
+
+    expect(bridge.paths()).toEqual([
+      NATIVE_MESSAGING_PATHS.connect,
+      NATIVE_MESSAGING_PATHS.post,
+      NATIVE_MESSAGING_PATHS.disconnect,
+    ]);
+  });
+
+  test("fails with the error the bridge disconnected with", async () => {
+    const bridge = installFakeBridge();
+
+    const runtime: ChromeNamespace = {};
+
+    installNativeMessaging({ runtime });
+
+    const sendNativeMessage = runtime.sendNativeMessage as (
+      hostName: string,
+      message: unknown,
+    ) => Promise<unknown>;
+
+    const reply = sendNativeMessage("com.meru.test", { hello: "host" });
+
+    bridge.answerConnect();
+
+    await waitFor("the posted message", () => bridge.paths().includes(NATIVE_MESSAGING_PATHS.post));
+
+    bridge.sendFrame({ type: "disconnect", error: "Specified native messaging host not found." });
+
+    await expect(reply).rejects.toThrow("Specified native messaging host not found.");
+  });
+});

--- a/packages/electron-extensions/facade/api/native-messaging.ts
+++ b/packages/electron-extensions/facade/api/native-messaging.ts
@@ -117,7 +117,8 @@ function createPort(runtime: ChromeNamespace, hostName: string): NativeMessaging
 
       for (const frame of decoder.push(value) as NativeMessagingFrame[]) {
         // A port the extension disconnected hears nothing more, even while the
-        // host's last messages are still on their way
+        // host's last messages are still on their way. The reader is left
+        // open here because `disconnect` cancels it behind its own request
         if (isDisconnected) {
           return;
         }

--- a/packages/electron-extensions/facade/api/native-messaging.ts
+++ b/packages/electron-extensions/facade/api/native-messaging.ts
@@ -43,6 +43,8 @@ function createPort(runtime: ChromeNamespace, hostName: string): NativeMessaging
 
   let sendChain: Promise<unknown> = opened;
 
+  let cancelFrames = async () => {};
+
   const port: NativeMessagingPort = {
     name: hostName,
     onMessage,
@@ -63,9 +65,16 @@ function createPort(runtime: ChromeNamespace, hostName: string): NativeMessaging
 
       isDisconnected = true;
 
-      markOpened();
-
-      void postBridge(NATIVE_MESSAGING_PATHS.disconnect, { portId });
+      // Chrome delivers a port's traffic in order, so the disconnect goes out
+      // behind the connect and everything already posted. Sent unchained it
+      // overtakes them, and main closes the port before the messages arrive
+      sendChain = sendChain
+        .then(() => postBridge(NATIVE_MESSAGING_PATHS.disconnect, { portId }))
+        .catch(() => undefined)
+        // Main's stream cancel handler closes the port too, which is the
+        // backstop for a disconnect request that never landed
+        .then(() => cancelFrames())
+        .catch(() => undefined);
     },
   };
 
@@ -95,6 +104,8 @@ function createPort(runtime: ChromeNamespace, hostName: string): NativeMessaging
 
     const reader = response.body.getReader();
 
+    cancelFrames = () => reader.cancel();
+
     const decoder = new NativeMessageDecoder();
 
     for (;;) {
@@ -105,6 +116,12 @@ function createPort(runtime: ChromeNamespace, hostName: string): NativeMessaging
       }
 
       for (const frame of decoder.push(value) as NativeMessagingFrame[]) {
+        // A port the extension disconnected hears nothing more, even while the
+        // host's last messages are still on their way
+        if (isDisconnected) {
+          return;
+        }
+
         if (frame.type === "message") {
           onMessage.emit(frame.message, port);
         } else {

--- a/packages/electron-extensions/native-messaging/host.ts
+++ b/packages/electron-extensions/native-messaging/host.ts
@@ -129,7 +129,10 @@ export class NativeMessagingHost {
    * terminating the process covers the hosts that ignore it.
    */
   kill() {
-    if (this.isClosed) {
+    // Not `isClosed`: a host whose stdin broke is closed for reading and
+    // writing while its process is still running, and that is exactly the one
+    // that has to be killed
+    if (this.process.exitCode !== null || this.process.signalCode !== null) {
       return;
     }
 

--- a/packages/electron-extensions/native-messaging/native-messaging.test.ts
+++ b/packages/electron-extensions/native-messaging/native-messaging.test.ts
@@ -34,6 +34,12 @@ process.stdin.on("data", (chunk) => {
 });
 `;
 
+/** Closes its own stdin and keeps running, the way a host that stops reading does. */
+const STDIN_CLOSING_HOST_SOURCE = `
+require("node:fs").closeSync(0);
+setInterval(() => {}, 1000);
+`;
+
 let workDir: string;
 
 let requestHandler: ((request: GlobalRequest) => Promise<Response>) | undefined;
@@ -43,16 +49,7 @@ let session: Session;
 beforeEach(async () => {
   workDir = await mkdtemp(path.join(tmpdir(), "native-messaging-"));
 
-  const hostScriptPath = path.join(workDir, "host.js");
-
-  await writeFile(hostScriptPath, HOST_SOURCE);
-
-  await writeFile(
-    path.join(workDir, "host"),
-    `#!/bin/sh\nexec "${process.execPath}" "${hostScriptPath}" "$@"\n`,
-  );
-
-  await chmod(path.join(workDir, "host"), 0o755);
+  await writeHost("host", HOST_SOURCE);
 
   requestHandler = undefined;
 
@@ -75,7 +72,20 @@ afterEach(async () => {
   await rm(workDir, { recursive: true, force: true });
 });
 
-async function writeHostManifest(allowedExtensionId = EXTENSION_ID) {
+/** A host binary the manifest can point at, run through the shell the way a real one is. */
+async function writeHost(name: string, source: string) {
+  const scriptPath = path.join(workDir, `${name}.js`);
+
+  await writeFile(scriptPath, source);
+
+  const hostPath = path.join(workDir, name);
+
+  await writeFile(hostPath, `#!/bin/sh\nexec "${process.execPath}" "${scriptPath}" "$@"\n`);
+
+  await chmod(hostPath, 0o755);
+}
+
+async function writeHostManifest(allowedExtensionId = EXTENSION_ID, hostName = "host") {
   const manifestPath = getHostManifestSearchPaths(HOST_NAME, { homeDir: workDir })[0] as string;
 
   await mkdir(path.dirname(manifestPath), { recursive: true });
@@ -84,7 +94,7 @@ async function writeHostManifest(allowedExtensionId = EXTENSION_ID) {
     manifestPath,
     JSON.stringify({
       name: HOST_NAME,
-      path: path.join(workDir, "host"),
+      path: path.join(workDir, hostName),
       type: "stdio",
       allowed_origins: [`chrome-extension://${allowedExtensionId}/`],
     }),
@@ -270,6 +280,61 @@ describe("NativeMessaging", () => {
     await (response.body as ReadableStream<Uint8Array>).cancel();
 
     expect(logs.some(({ message }) => message === "Disconnected native messaging host")).toBe(true);
+
+    await waitForProcessExit(hostPid);
+
+    teardown();
+  });
+
+  test("kills a host that closed its own stdin and kept running", async () => {
+    await writeHost("stdin-closing-host", STDIN_CLOSING_HOST_SOURCE);
+
+    await writeHostManifest(EXTENSION_ID, "stdin-closing-host");
+
+    const logs: { message: string; details: Record<string, unknown> }[] = [];
+
+    const { teardown } = createNativeMessaging({
+      logger: {
+        info: (message, details) => {
+          logs.push({ message, details });
+        },
+        error: () => undefined,
+      },
+    });
+
+    const response = await connect();
+
+    const hostPid = logs.find(({ message }) => message === "Connected native messaging host")
+      ?.details.pid as number;
+
+    expect(hostPid).toBeGreaterThan(0);
+
+    const disconnected = readFrame(response);
+
+    let isDisconnected = false;
+
+    void disconnected.then(() => {
+      isDisconnected = true;
+    });
+
+    // The broken pipe surfaces on a write, and only once enough has been
+    // written for the pipe's buffer to stop absorbing it
+    for (let attempt = 0; attempt < 100 && !isDisconnected; attempt += 1) {
+      await requestHandler?.(
+        createRequest(NATIVE_MESSAGING_PATHS.post, {
+          token: BRIDGE_TOKEN,
+          portId: "port-1",
+          message: { hello: "h".repeat(64 * 1024) },
+        }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+
+    expect(await disconnected).toEqual({
+      type: "disconnect",
+      error: expect.stringContaining("EPIPE") as unknown as string,
+    });
 
     await waitForProcessExit(hostPid);
 


### PR DESCRIPTION
## Summary
Two fixes on the 1Password native messaging path, from the extensions review. A port's `disconnect()` no longer overtakes the messages queued ahead of it, which was silently dropping the last message an extension posted and could leak a host process. And a host whose stdin breaks is now actually killed, instead of being left running with its stdout pipe open once per reconnect attempt. Each fix comes with a test that fails on the code before it.

## Problem
Both are findings 1 and 2 of the pre-release extensions review, each reproduced by the reviewers.

`postMessage` chains its bridge POST on `sendChain`, which waits on the connect answer and on each prior post, while `disconnect()` fired its POST immediately and unchained. Chrome delivers a port's traffic in order and a message posted before `disconnect()` reaches the host, so three things went wrong. `port.postMessage(m); port.disconnect()` reached main as connect, disconnect, post: main closed the port and killed the host, and `handlePost` found no port and dropped `m` silently. `connectNative()` followed by `disconnect()` before the connect answered could be handled disconnect first, where `getPort` missed and `handleConnect` then registered the port and spawned a host that nothing closed until the stream was canceled. And `readFrames` kept emitting `onMessage` on a port the extension had already disconnected.

Separately, `NativeMessagingHost`'s stdin `error` handler called `close(error)`, and `kill()` returned early once `isClosed` was set, so neither `stdin.end()` nor `process.kill()` ran and `NativeMessaging.closePort`'s `port.host.kill()` did nothing. A host that closes its own stdin kept running with its stdout pipe open, and 1Password retries every 10 seconds while its host is unreachable.

## Solution
- The disconnect POST runs through `sendChain`, so it goes out behind the connect and everything already posted, and the stream reader is canceled afterwards so main's `cancel` handler closes the port as a backstop for a disconnect request that never landed.
- The `markOpened()` in `disconnect()` goes with it. `opened` already resolves from the connect response and from `readFrames` rejecting, and resolving it early is exactly what let the disconnect overtake the connect.
- `readFrames` stops emitting `onMessage` once the extension has disconnected, since the host's last messages are still on their way when the disconnect goes out, and Chrome stays quiet about a port the extension disconnected itself.
- `kill()` gates on the process not having exited rather than on `isClosed`. `isClosed` means nothing more will be read from or written to the host, which is exactly the state a host with a broken pipe is in while its process is still alive. Calling `kill()` before `close()` on the stdin path fixes the one path instead, and leaves the same trap set for the next one that closes without killing.
- The one path the wider gate reaches that the old one did not is a failed spawn, and it is inert. On Node 24.20, which Electron 43 bundles, the `error` event fires with `exitCode` already `-2` and no handle, so the guard still returns early; under Bun, where the tests run, `exitCode` stays `null`, `process.kill()` returns false with no handle, and `stdin.end()` on the never-connected pipe raises nothing the existing stdin handler does not already catch.

The review's two optional host items — Chrome's kill grace and escalation, and closing the port on `close` rather than `exit` — are deliberately not here. Both are review item 15, marked plausible and never reproduced, and a grace timer would put an asynchronous step into `closePort` on the hot path for a host that exits on stdin EOF anyway.

## Try it
Nothing to open: this is main-process and facade plumbing with no UI, and the ordering is only observable from inside an extension. `bun test packages/electron-extensions/native-messaging packages/electron-extensions/facade` covers both fixes, and reverting either source file turns its own tests red.

## Not verified
- No run against the real 1Password host or the packaged app. Both fixes are covered by unit tests only, one driving a fake bridge and one driving a real child process, and the second reaches the broken-pipe state through Bun's `child_process` rather than Electron's Node.
- Neither the facade change nor the kill gate is exercised by the end-to-end suite, which never disconnects a native messaging port or breaks a host's stdin.
- The runtime proxy's shim and relay client carry the same unchained-disconnect shape (review finding 25) and are untouched here.
