### PR TITLE
Record a bridge caller only when its token is known

### DIFF
--- a/packages/electron-extensions/bridge/bridge.test.ts
+++ b/packages/electron-extensions/bridge/bridge.test.ts
@@ -468,6 +468,68 @@ describe("ExtensionBridge", () => {
     expect(senderFrames).toEqual([undefined, newestFrame]);
   });
 
+  test("a tokenless flood evicts no honest caller's record", async () => {
+    const { session, stampHeaders, sendWithHeaders } = createSession();
+
+    const bridge = createBridge(session);
+
+    const senderFrames: (WebFrameMain | undefined)[] = [];
+
+    bridge.handle("/echo", ({ senderFrame, headers }) => {
+      senderFrames.push(senderFrame);
+
+      return new Response(null, { status: 204, headers });
+    });
+
+    const honestFrame = createFrame("https://accounts.google.com/");
+
+    const honestHeaders = stampHeaders(bridgeUrl("/echo", BRIDGE_TOKEN), { frame: honestFrame });
+
+    /*
+     * Everything else in the session reaches the listener too, and neither
+     * shape of it is recorded: a page sending no token at all, and one sending
+     * a value no loaded extension holds. The cap of each and twice the cap
+     * together, so the honest record surviving is the token condition holding
+     * rather than the flood falling short — without it that record is the
+     * oldest of 1025 and goes on the first eviction.
+     */
+    for (let stamped = 0; stamped < MAX_RECORDED_CALLER_FRAMES; stamped += 1) {
+      const floodFrame = createFrame("https://workspace-app.test/");
+
+      stampHeaders(bridgeUrl("/echo", undefined), { frame: floodFrame });
+
+      stampHeaders(bridgeUrl("/echo", "guessed"), { frame: floodFrame });
+    }
+
+    await sendWithHeaders("/echo", "{}", honestHeaders, BRIDGE_TOKEN);
+
+    expect(senderFrames).toEqual([honestFrame]);
+  });
+
+  test("an unrecorded caller's own stamp is stripped anyway", () => {
+    const { session, stampHeaders } = createSession();
+
+    createBridge(session);
+
+    /*
+     * Nothing replaces it, so the strip is the whole of what keeps a forged
+     * value from reaching the handler as if the main process had written it.
+     * Both shapes the listener declines to record, the second being the page
+     * that guesses the token and the header alike.
+     */
+    const forgedHeaders = { "X-Extension-Bridge-Caller": "guessed" };
+
+    const frame = createFrame("https://workspace-app.test/");
+
+    expect(stampHeaders(bridgeUrl("/echo", undefined), { frame, headers: forgedHeaders })).toEqual(
+      {},
+    );
+
+    expect(stampHeaders(bridgeUrl("/echo", "guessed"), { frame, headers: forgedHeaders })).toEqual(
+      {},
+    );
+  });
+
   test("a frame destroyed since its request was stamped is not handed over", async () => {
     const { session, stampHeaders, sendWithHeaders } = createSession();
 

--- a/packages/electron-extensions/bridge/bridge.ts
+++ b/packages/electron-extensions/bridge/bridge.ts
@@ -38,16 +38,18 @@ export const MAX_BRIDGE_REQUEST_BYTES = 64 * 1024 * 1024;
 export const MAX_CONCURRENT_BRIDGE_BODY_READS = 16;
 
 /**
- * The header the bridge stamps onto every request from a frame, carrying the
- * nonce its caller record is filed under. `protocol.handle` hands the bridge
- * only the session, but the session's `webRequest` sees the same request first
- * and Chromium tells it the frame that made it — so the bridge's own
- * `onBeforeSendHeaders` listener records that frame under a fresh nonce and
+ * The header the bridge stamps onto an authenticated request from a frame,
+ * carrying the nonce its caller record is filed under. `protocol.handle` hands
+ * the bridge only the session, but the session's `webRequest` sees the same
+ * request first and Chromium tells it the frame that made it — so the bridge's
+ * own `onBeforeSendHeaders` listener records that frame under a fresh nonce and
  * writes the nonce into the request the handler is about to receive (measured
  * on Electron 43.2.0: the listener runs before the handler, its callback gating
- * the request, and the stamped header arrives intact). Whatever a caller puts
- * in the header itself is dropped before the stamp goes on, so the nonce is
- * only ever the main process's own word.
+ * the request, and the stamped header arrives intact). A request the listener
+ * declines to record — one carrying no token a loaded extension holds — reaches
+ * the handler without the header, and is refused there for the same reason.
+ * Whatever a caller puts in the header itself is dropped either way, so the
+ * nonce is only ever the main process's own word.
  */
 export const EXTENSION_BRIDGE_CALLER_HEADER = "x-extension-bridge-caller";
 
@@ -55,14 +57,13 @@ export const EXTENSION_BRIDGE_CALLER_HEADER = "x-extension-bridge-caller";
  * Bounds the caller records that were stamped but never consumed — a request
  * canceled between its headers and the handler leaves its record behind.
  *
- * A record goes in for every request the filter matches, whatever token the
- * request turns out to carry, so every document in the session reaches it: a
- * page with no token at all is recorded and then refused by the handler. A
- * document making enough concurrent bridge requests can therefore evict an
- * honest caller's record that was still coming, which costs that caller its
- * frame and leaves it delivering a sender of `id` alone — refused rather than
- * misattributed. Ordinary traffic never approaches this, and the eviction is
- * oldest-first.
+ * A record only ever goes in for a request whose token names a loaded
+ * extension, which the listener reads off the URL the same way the handler
+ * does, so what the cap bounds is the loaded extensions' own in-flight calls.
+ * Everything else in the session — a workspace app, an XSS in a mail page —
+ * holds no token and is never recorded, so no volume of its requests can evict
+ * an honest caller's record that was still coming. The eviction is oldest-first
+ * and ordinary traffic never approaches this.
  */
 export const MAX_RECORDED_CALLER_FRAMES = 1024;
 
@@ -119,9 +120,13 @@ export class ExtensionBridge {
   }
 
   setupSession(session: Session, sessionOptions: ExtensionBridgeSession) {
-    const callerFramesByNonce = new Map<string, WebFrameMain>();
+    const sessionState: ExtensionBridgeSessionState = {
+      ...sessionOptions,
+      callerFramesByNonce: new Map(),
+      bodyReadCount: 0,
+    };
 
-    this.sessions.set(session, { ...sessionOptions, callerFramesByNonce, bodyReadCount: 0 });
+    this.sessions.set(session, sessionState);
 
     // A blocking callback is what puts the record in the map before the handler
     // reads it. That ordering is measured on Electron 43.2.0 rather than
@@ -137,7 +142,7 @@ export class ExtensionBridge {
     session.webRequest.onBeforeSendHeaders(
       { urls: [`${EXTENSION_BRIDGE_SCHEME}://*/*`] },
       (details, callback) => {
-        callback({ requestHeaders: this.stampCaller(callerFramesByNonce, details) });
+        callback({ requestHeaders: this.stampCaller(sessionState, details) });
       },
     );
 
@@ -161,12 +166,27 @@ export class ExtensionBridge {
    * as the initiator goes on record under a fresh nonce, and the nonce rides
    * the request to `handleRequest`.
    *
+   * A record is minted only for a token that names a loaded extension, read off
+   * the URL exactly as `handleRequest` reads it, which is what keeps
+   * `MAX_RECORDED_CALLER_FRAMES` a bound on the extensions' own calls rather
+   * than on every document in the session. That is a condition on recording and
+   * not a gate on the request: an unknown token is stripped but not stamped,
+   * and goes on to the handler to be refused, since refusing here would buy no
+   * memory (see
+   * `MAX_BRIDGE_REQUEST_BYTES`) and would hand the page a network error where it
+   * expects a 403 — and a frameless caller never reaches this listener at all,
+   * so the handler's own check is the boundary either way.
+   *
    * The strip loop earns its place on case: a caller writing
    * `X-Extension-Bridge-Caller` and a stamp written in lower case are two keys
    * on the same object and both reach the handler, where the header lookup is
-   * case-insensitive and may read either. Removing the loop is caught by
-   * `a stamp a caller wrote itself names no frame`. It covers frame requests only, because
-   * this listener is the one thing a frameless caller never reaches: measured
+   * case-insensitive and may read either. It runs ahead of both conditions, so
+   * the caller that is stripped and then not stamped — no token, or one no
+   * extension holds — does not get its own value through in place of a real
+   * stamp. Removing the loop is caught by `a stamp a caller wrote itself names
+   * no frame` and by `an unrecorded caller's own stamp is stripped anyway`. It
+   * covers frame requests only, because this listener is the one thing a
+   * frameless caller never reaches: measured
    * on Electron 43.2.0, a service worker's and a dedicated worker's requests
    * skip `onBeforeSendHeaders` entirely and arrive at the handler with whatever
    * headers they set. What makes that safe is not the stripping but the nonce:
@@ -176,7 +196,7 @@ export class ExtensionBridge {
    * shim, which only ever runs in one.
    */
   private stampCaller(
-    callerFramesByNonce: Map<string, WebFrameMain>,
+    sessionState: ExtensionBridgeSessionState,
     details: OnBeforeSendHeadersListenerDetails,
   ) {
     const requestHeaders: Record<string, string> = {};
@@ -190,6 +210,14 @@ export class ExtensionBridge {
     if (!details.frame || details.frame.isDestroyed()) {
       return requestHeaders;
     }
+
+    const bridgeToken = new URL(details.url).searchParams.get(EXTENSION_BRIDGE_TOKEN_PARAM);
+
+    if (bridgeToken === null || !sessionState.getExtensionId(bridgeToken)) {
+      return requestHeaders;
+    }
+
+    const { callerFramesByNonce } = sessionState;
 
     const callerNonce = randomUUID();
 


### PR DESCRIPTION
## Summary
The bridge's `onBeforeSendHeaders` listener minted a nonce and recorded the initiating frame for every request matching its scheme filter, before anything knew whether the request carried a valid token — so a page holding no token at all could flood the record store and evict an honest caller's record that was still in flight. Now that #1008 put the token on the query string, the listener reads it off `details.url` and records only a caller whose token names a loaded extension. Nothing changes for an authenticated caller, and the listener still does not gate the request.

## Problem
`stampCaller` runs for every request the filter matches. Every document in an account session can reach the bridge scheme — a workspace app, an XSS in a mail page — and each of its requests got a `randomUUID` nonce and a record in `callerFramesByNonce`, which is capped at `MAX_RECORDED_CALLER_FRAMES` (1024) with oldest-first eviction. Enough concurrent tokenless requests therefore evicted a real extension caller's record before its request reached the handler, and that caller then delivered a sender of `id` alone, which the extension refuses. Only the runtime proxy's routes read the frame, so the failure is a refused message rather than a misattributed one — an availability corner rather than a spoofing one, recorded as a residual on #1008.

Before #1008 the listener could not tell the two apart, because the token was in the request body and the body is not visible there.

## Solution
- `stampCaller` reads `EXTENSION_BRIDGE_TOKEN_PARAM` off `details.url` and returns without minting when the token is absent or names no loaded extension. `setupSession` now builds the session state first and closes the listener over it, so the listener can reach `getExtensionId` where it only reached `callerFramesByNonce` before.
- `MAX_RECORDED_CALLER_FRAMES` becomes a bound on the loaded extensions' own in-flight calls. That closes the eviction rather than bounding it: nothing an untokened page sends is recorded at all.
- The stamp still goes in unconditionally for a valid token, before the handler runs, because that ordering is what binds a relayed sender to the tab that sent it.
- The strip loop that removes a caller-written `x-extension-bridge-caller` header runs ahead of both conditions, so a caller that writes the header itself and is then not stamped does not get its forged value through in place of a real stamp. A new test pins that, since the existing `a stamp a caller wrote itself names no frame` only covers the valid-token path.

**Why not cancel the request here instead.** It would buy no memory: measured on Electron 43.2.0, eight 32 MiB posts from a tokenless page grew main's RSS by 225 MiB with the listener canceling every one, against 230 MiB refusing in the handler without reading and 391 MiB reading first — the upload is materialized by Chromium before the listener's callback decides. It would also change what the page sees from a 403 to a network error. And a frameless caller — a service worker, a dedicated worker — never reaches this listener at all, so the handler's token check has to stay the real boundary regardless; making the listener look like a gate would only mislead.

**Why reading the token here is not a new exposure.** Measured on Electron 43.2.0 while reviewing #1008: a fetch of this scheme leaves no `PerformanceResourceTiming` entry at all, from the page's own world or from an isolated world, where an ordinary http fetch from the page's world does.

## Not verified
- Nothing here has been exercised in a running app. The listener is driven by `bridge.test.ts` and `runtime-proxy.test.ts` against a fake session, not against real Electron `webRequest` details.
- The e2e suite needs `MERU_TEST_LICENSE_KEY` and was not run locally; CI runs it on this PR.
- The two Electron 43.2.0 measurements quoted above were made during #1008's review and were not repeated here.
- `new URL(details.url)` in the listener is unguarded, and a throw there would leave `callback` uncalled and the request hanging, where the handler's existing unguarded parse only fails the request. Judged unreachable by reasoning rather than measurement: the scheme is registered `standard: true`, so Chromium canonicalizes the URL and rejects an invalid one in the renderer before `webRequest` ever sees it, and no URL was found that Chromium accepts and Node's parser rejects.