### PR TITLE
Tear a port down when the bridge refuses a post

### DIFF
--- a/packages/electron-extensions/facade/api/native-messaging.test.ts
+++ b/packages/electron-extensions/facade/api/native-messaging.test.ts
@@ -228,6 +228,73 @@ describe("facade connectNative", () => {
     await waitFor("the stream cancel", () => bridge.isStreamCanceled());
   });
 
+  test("tears a port down once however many posts the bridge refuses", async () => {
+    const bridge = installFakeBridge();
+
+    const { port } = connectNative();
+
+    let disconnectCount = 0;
+
+    port.onDisconnect.addListener(() => {
+      disconnectCount += 1;
+    });
+
+    bridge.answerConnect();
+
+    bridge.refuse(NATIVE_MESSAGING_PATHS.post, 429);
+
+    port.postMessage({ hello: "host" });
+
+    port.postMessage({ hello: "again" });
+
+    await waitFor("the disconnect request", () =>
+      bridge.paths().includes(NATIVE_MESSAGING_PATHS.disconnect),
+    );
+
+    // The second post was queued before the first was refused, so it still
+    // goes out, and the disconnect goes out behind it exactly once
+    expect(bridge.paths()).toEqual([
+      NATIVE_MESSAGING_PATHS.connect,
+      NATIVE_MESSAGING_PATHS.post,
+      NATIVE_MESSAGING_PATHS.post,
+      NATIVE_MESSAGING_PATHS.disconnect,
+    ]);
+
+    expect(disconnectCount).toBe(1);
+  });
+
+  test("stays quiet about a post refused after the extension disconnected", async () => {
+    const bridge = installFakeBridge();
+
+    const { port } = connectNative();
+
+    let isDisconnectEmitted = false;
+
+    port.onDisconnect.addListener(() => {
+      isDisconnectEmitted = true;
+    });
+
+    bridge.answerConnect();
+
+    bridge.refuse(NATIVE_MESSAGING_PATHS.post, 429);
+
+    port.postMessage({ hello: "host" });
+
+    port.disconnect();
+
+    await waitFor("the stream cancel", () => bridge.isStreamCanceled());
+
+    expect(bridge.paths()).toEqual([
+      NATIVE_MESSAGING_PATHS.connect,
+      NATIVE_MESSAGING_PATHS.post,
+      NATIVE_MESSAGING_PATHS.disconnect,
+    ]);
+
+    // Chrome stays quiet about a port the extension disconnected itself, and
+    // the refusal arriving afterwards changes nothing
+    expect(isDisconnectEmitted).toBe(false);
+  });
+
   test("refuses to post on a disconnected port", () => {
     installFakeBridge();
 

--- a/packages/electron-extensions/facade/api/native-messaging.test.ts
+++ b/packages/electron-extensions/facade/api/native-messaging.test.ts
@@ -36,6 +36,8 @@ function installFakeBridge() {
 
   let answerConnect = () => {};
 
+  const refusals = new Map<string, number>();
+
   const connectAnswered = new Promise<void>((resolve) => {
     answerConnect = resolve;
   });
@@ -44,6 +46,12 @@ function installFakeBridge() {
     const { pathname: path } = new URL(url);
 
     requests.push({ path, body: JSON.parse(init.body as string) });
+
+    const refusalStatus = refusals.get(path);
+
+    if (refusalStatus !== undefined) {
+      return new Response(null, { status: refusalStatus });
+    }
 
     if (path !== NATIVE_MESSAGING_PATHS.connect) {
       return new Response(null, { status: 204 });
@@ -67,6 +75,9 @@ function installFakeBridge() {
     requests,
     paths: () => requests.map(({ path }) => path),
     answerConnect,
+    refuse: (path: string, status: number) => {
+      refusals.set(path, status);
+    },
     sendFrame: (frame: NativeMessagingFrame) => {
       controller?.enqueue(encodeNativeMessage(frame));
     },
@@ -176,6 +187,45 @@ describe("facade connectNative", () => {
 
     // Chrome stays quiet about a port the extension disconnected itself
     expect(isDisconnectEmitted).toBe(false);
+  });
+
+  test("tears the port down when the bridge refuses a post", async () => {
+    const bridge = installFakeBridge();
+
+    const { runtime, port } = connectNative();
+
+    let disconnectError: string | undefined;
+
+    port.onDisconnect.addListener(() => {
+      disconnectError = (runtime.lastError as { message?: string } | undefined)?.message;
+    });
+
+    bridge.answerConnect();
+
+    // What a session already at its cap of bodies read at once answers
+    bridge.refuse(NATIVE_MESSAGING_PATHS.post, 429);
+
+    port.postMessage({ hello: "host" });
+
+    await waitFor("the disconnect request", () =>
+      bridge.paths().includes(NATIVE_MESSAGING_PATHS.disconnect),
+    );
+
+    expect(disconnectError).toBe("The native messaging bridge answered 429");
+
+    // Main closed nothing, so the port's own disconnect is what closes its
+    // record there and kills the host
+    expect(bridge.paths()).toEqual([
+      NATIVE_MESSAGING_PATHS.connect,
+      NATIVE_MESSAGING_PATHS.post,
+      NATIVE_MESSAGING_PATHS.disconnect,
+    ]);
+
+    expect(() => {
+      port.postMessage({ hello: "again" });
+    }).toThrow("Attempting to use a disconnected port object");
+
+    await waitFor("the stream cancel", () => bridge.isStreamCanceled());
   });
 
   test("refuses to post on a disconnected port", () => {

--- a/packages/electron-extensions/facade/api/native-messaging.ts
+++ b/packages/electron-extensions/facade/api/native-messaging.ts
@@ -12,6 +12,11 @@ const DISCONNECTED_PORT_ERROR = "Attempting to use a disconnected port object";
 
 const BRIDGE_CLOSED_ERROR = "The native messaging bridge closed the connection.";
 
+/** What a refused bridge call reads as, whether it refused the connect or a post. */
+function bridgeAnsweredError(status: number) {
+  return `The native messaging bridge answered ${status}`;
+}
+
 type NativeMessagingPort = {
   name: string;
   postMessage: (message: unknown) => void;
@@ -56,6 +61,11 @@ function createPort(runtime: ChromeNamespace, hostName: string): NativeMessaging
 
       sendChain = sendChain
         .then(() => postBridge(NATIVE_MESSAGING_PATHS.post, { portId, message }))
+        .then((response) => {
+          if (!response.ok) {
+            refusePost(response.status);
+          }
+        })
         .catch(() => undefined);
     },
     disconnect() {
@@ -65,17 +75,21 @@ function createPort(runtime: ChromeNamespace, hostName: string): NativeMessaging
 
       isDisconnected = true;
 
-      // Chrome delivers a port's traffic in order, so the disconnect goes out
-      // behind the connect and everything already posted. Sent unchained it
-      // overtakes them, and main closes the port before the messages arrive
-      sendChain = sendChain
-        .then(() => postBridge(NATIVE_MESSAGING_PATHS.disconnect, { portId }))
-        .catch(() => undefined)
-        // Main's stream cancel handler closes the port too, which is the
-        // backstop for a disconnect request that never landed
-        .then(() => cancelFrames())
-        .catch(() => undefined);
+      sendDisconnect();
     },
+  };
+
+  // Chrome delivers a port's traffic in order, so the disconnect goes out
+  // behind the connect and everything already posted. Sent unchained it
+  // overtakes them, and main closes the port before the messages arrive
+  const sendDisconnect = () => {
+    sendChain = sendChain
+      .then(() => postBridge(NATIVE_MESSAGING_PATHS.disconnect, { portId }))
+      .catch(() => undefined)
+      // Main's stream cancel handler closes the port too, which is the
+      // backstop for a disconnect request that never landed
+      .then(() => cancelFrames())
+      .catch(() => undefined);
   };
 
   // Chrome stays quiet about a port the extension disconnected itself
@@ -93,11 +107,30 @@ function createPort(runtime: ChromeNamespace, hostName: string): NativeMessaging
     });
   };
 
+  /**
+   * A post the bridge refused, which is what a session at its cap of bodies
+   * read at once gets. Chrome has no answer for one message being refused, so
+   * this takes the nearest one it has: the port goes away with `lastError`
+   * set, and everything posted after it throws. Main has closed nothing on its
+   * side — the refusal is settled before the request reaches its handler — so
+   * the disconnect still goes out, behind whatever was queued ahead of it, to
+   * close the port's record there and kill its host.
+   */
+  const refusePost = (status: number) => {
+    if (isDisconnected) {
+      return;
+    }
+
+    disconnected(bridgeAnsweredError(status));
+
+    sendDisconnect();
+  };
+
   const readFrames = async () => {
     const response = await postBridge(NATIVE_MESSAGING_PATHS.connect, { portId, hostName });
 
     if (!response.ok || !response.body) {
-      throw new Error(`The native messaging bridge answered ${response.status}`);
+      throw new Error(bridgeAnsweredError(response.status));
     }
 
     markOpened();

--- a/packages/electron-extensions/runtime-proxy/relay-client.test.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.test.ts
@@ -573,11 +573,17 @@ describe("createRelayClient", () => {
 
     const { chrome } = createWorkerChrome();
 
-    const browser: ChromeNamespace = { runtime: chrome.runtime };
+    // Two distinct runtime objects, as Electron builds them, so a `lastError`
+    // set on only the one the port happened to be created under would show
+    const browser: ChromeNamespace = {
+      runtime: { id: EXTENSION_ID, onMessage: createNativeEvent(), onConnect: createNativeEvent() },
+    };
 
     startClient([chrome, browser]);
 
     const runtime = chrome.runtime as ChromeNamespace;
+
+    const browserRuntime = browser.runtime as ChromeNamespace;
 
     type RefusedPort = {
       postMessage: (message: unknown) => void;
@@ -604,8 +610,12 @@ describe("createRelayClient", () => {
 
     let lastErrorDuringListener: unknown;
 
+    let browserLastErrorDuringListener: unknown;
+
     port?.onDisconnect.addListener(() => {
       lastErrorDuringListener = runtime.lastError;
+
+      browserLastErrorDuringListener = browserRuntime.lastError;
     });
 
     // What a session already at its cap of bodies read at once answers
@@ -619,7 +629,12 @@ describe("createRelayClient", () => {
     );
 
     expect(lastErrorDuringListener).toEqual({ message: "The runtime proxy bridge answered 429" });
+    expect(browserLastErrorDuringListener).toEqual({
+      message: "The runtime proxy bridge answered 429",
+    });
+
     expect(runtime.lastError).toBeUndefined();
+    expect(browserRuntime.lastError).toBeUndefined();
 
     expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerPortDisconnect)[0]?.body).toEqual({
       portId: "port-1",

--- a/packages/electron-extensions/runtime-proxy/relay-client.test.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.test.ts
@@ -47,12 +47,20 @@ function stubBridge() {
 
   const streamControllers: ReadableStreamDefaultController<Uint8Array>[] = [];
 
+  const refusals = new Map<string, number>();
+
   globalThis.fetch = (async (url: string, init: RequestInit) => {
     const { pathname: pathName } = new URL(url);
 
     const body = JSON.parse(init.body as string) as Record<string, unknown>;
 
     posts.push({ pathName, body });
+
+    const refusalStatus = refusals.get(pathName);
+
+    if (refusalStatus !== undefined) {
+      return new Response(null, { status: refusalStatus });
+    }
 
     if (pathName === RUNTIME_PROXY_PATHS.workerJobs) {
       const stream = new ReadableStream<Uint8Array>({
@@ -69,6 +77,9 @@ function stubBridge() {
 
   return {
     posts,
+    refuse: (pathName: string, status: number) => {
+      refusals.set(pathName, status);
+    },
     postsTo: (pathName: string) => posts.filter((post) => post.pathName === pathName),
     waitForStream: async (streamCount = 1) => {
       await waitFor(() => streamControllers.length >= streamCount, `${streamCount} job streams`);
@@ -555,6 +566,68 @@ describe("createRelayClient", () => {
     expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerPortDisconnect)[0]?.body).toEqual({
       portId: "port-1",
     });
+  });
+
+  test("a refused post tears the worker port down with lastError set", async () => {
+    const stub = stubBridge();
+
+    const { chrome } = createWorkerChrome();
+
+    const browser: ChromeNamespace = { runtime: chrome.runtime };
+
+    startClient([chrome, browser]);
+
+    const runtime = chrome.runtime as ChromeNamespace;
+
+    type RefusedPort = {
+      postMessage: (message: unknown) => void;
+      onDisconnect: WrappedEvent;
+    };
+
+    let port: RefusedPort | undefined;
+
+    (runtime.onConnect as WrappedEvent).addListener((connectedPort) => {
+      port = connectedPort as RefusedPort;
+    });
+
+    await stub.waitForStream();
+
+    stub.pushJob({
+      type: "connect",
+      jobId: "job-1",
+      portId: "port-1",
+      name: "relay",
+      sender: SENDER,
+    });
+
+    await waitFor(() => port !== undefined, "the port");
+
+    let lastErrorDuringListener: unknown;
+
+    port?.onDisconnect.addListener(() => {
+      lastErrorDuringListener = runtime.lastError;
+    });
+
+    // What a session already at its cap of bodies read at once answers
+    stub.refuse(RUNTIME_PROXY_PATHS.workerPortPost, 429);
+
+    port?.postMessage("refused");
+
+    await waitFor(
+      () => stub.postsTo(RUNTIME_PROXY_PATHS.workerPortDisconnect).length === 1,
+      "the disconnect post",
+    );
+
+    expect(lastErrorDuringListener).toEqual({ message: "The runtime proxy bridge answered 429" });
+    expect(runtime.lastError).toBeUndefined();
+
+    expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerPortDisconnect)[0]?.body).toEqual({
+      portId: "port-1",
+    });
+
+    expect(() => port?.postMessage("too late")).toThrow(
+      "Attempting to use a disconnected port object",
+    );
   });
 
   test("parks a fresh job stream when the previous one ends", async () => {

--- a/packages/electron-extensions/runtime-proxy/relay-client.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.ts
@@ -1,6 +1,7 @@
 import { postBridge } from "../facade/lib/bridge";
 import type { ChromeEventListener, ChromeNamespace } from "../facade/lib/chrome";
 import { createEvent } from "../facade/lib/event";
+import { withLastError } from "../facade/lib/last-error";
 import { NativeMessageDecoder } from "../native-messaging/framing";
 import {
   MAX_RUNTIME_PROXY_FRAME_BYTES,
@@ -21,6 +22,11 @@ const DEFAULT_RETRY_DELAY_MS = 1000;
  * runs for hours does not grow a set for as long as it lives.
  */
 const MAX_REMEMBERED_JOB_IDS = 1000;
+
+/** What a refused bridge call reads as, whatever the call was. */
+function bridgeAnsweredError(status: number) {
+  return `The runtime proxy bridge answered ${status}`;
+}
 
 type WorkerPort = {
   externalPort: Record<string, unknown>;
@@ -61,10 +67,31 @@ export function createRelayClient({
 
   const handledJobIds = new Set<string>();
 
+  const wrappedRuntimes: ChromeNamespace[] = [];
+
   let isStopped = false;
 
   const postToBridge = (pathName: string, body: Record<string, unknown>) =>
     postBridge(pathName, body).catch(() => undefined);
+
+  /**
+   * `lastError` around an emit, set on every runtime object this client
+   * wrapped: Electron builds `chrome` and `browser` as two objects, one client
+   * serves both, and a listener reads whichever one it was written against.
+   */
+  const withRuntimesLastError = (error: string, emit: () => void) => {
+    let run = emit;
+
+    for (const runtime of wrappedRuntimes) {
+      const nextRun = run;
+
+      run = () => {
+        withLastError(runtime, error, nextRun);
+      };
+    }
+
+    run();
+  };
 
   /**
    * Wraps a native event with one that also mirrors its listeners here. The
@@ -185,19 +212,45 @@ export function createRelayClient({
         // Chained so two posts arrive in the order they were written
         sendChain = sendChain
           .then(() => postBridge(RUNTIME_PROXY_PATHS.workerPortPost, { portId, message }))
+          .then((response) => {
+            // A post the bridge refused, which is what a session at its cap of
+            // bodies read at once gets. Chrome has no answer for one message
+            // being refused, so this takes the nearest one it has: the port
+            // goes away with `lastError` set and later posts throw
+            if (!response.ok) {
+              tearDown(bridgeAnsweredError(response.status));
+            }
+          })
           .catch(() => undefined);
       },
       disconnect() {
-        if (isDisconnected) {
-          return;
-        }
-
-        isDisconnected = true;
-
-        ports.delete(portId);
-
-        void postToBridge(RUNTIME_PROXY_PATHS.workerPortDisconnect, { portId });
+        tearDown();
       },
+    };
+
+    /**
+     * Closes the port from this side: main hears the disconnect and drops its
+     * end, and later posts throw. An error means the port went away rather
+     * than being disconnected, so the extension's own listeners hear it with
+     * `lastError` set; Chrome stays quiet about a port the worker closed
+     * itself, so without one nothing is emitted.
+     */
+    const tearDown = (error?: string) => {
+      if (isDisconnected) {
+        return;
+      }
+
+      isDisconnected = true;
+
+      ports.delete(portId);
+
+      void postToBridge(RUNTIME_PROXY_PATHS.workerPortDisconnect, { portId });
+
+      if (error !== undefined) {
+        withRuntimesLastError(error, () => {
+          onDisconnect.emit(externalPort);
+        });
+      }
     };
 
     return {
@@ -320,7 +373,7 @@ export function createRelayClient({
         const response = await postBridge(RUNTIME_PROXY_PATHS.workerJobs, {});
 
         if (!response.ok || !response.body) {
-          throw new Error(`The runtime proxy bridge answered ${response.status}`);
+          throw new Error(bridgeAnsweredError(response.status));
         }
 
         const reader = response.body.getReader();
@@ -360,6 +413,8 @@ export function createRelayClient({
       if (!runtime) {
         return;
       }
+
+      wrappedRuntimes.push(runtime);
 
       mirrorEvent(runtime, "onMessage", messageListeners);
 

--- a/packages/electron-extensions/runtime-proxy/shim.test.ts
+++ b/packages/electron-extensions/runtime-proxy/shim.test.ts
@@ -23,6 +23,18 @@ afterEach(() => {
 
 type RecordedRequest = { pathName: string; body: Record<string, unknown> };
 
+async function waitFor(condition: () => boolean, what: string) {
+  const deadline = Date.now() + 1000;
+
+  while (!condition()) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for ${what}`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}
+
 function stubFetch(respond: (pathName: string, body: Record<string, unknown>) => Response) {
   const requests: RecordedRequest[] = [];
 
@@ -303,6 +315,55 @@ describe("shimmed connect", () => {
     expect(requests.some(({ pathName }) => pathName === RUNTIME_PROXY_PATHS.portDisconnect)).toBe(
       true,
     );
+
+    expect(() => port.postMessage("too late")).toThrow(
+      "Attempting to use a disconnected port object",
+    );
+  });
+
+  test("a refused post tears the port down and tells the relay", async () => {
+    const respondWithStream = respondWithPortStream({});
+
+    const refusals = new Map<string, number>();
+
+    const requests = stubFetch((pathName) => {
+      const refusalStatus = refusals.get(pathName);
+
+      // What a session already at its cap of bodies read at once answers
+      return refusalStatus === undefined
+        ? respondWithStream(pathName)
+        : new Response(null, { status: refusalStatus });
+    });
+
+    const runtime = createShimmedRuntime();
+
+    const port = (runtime.connect as Connect)();
+
+    let lastErrorDuringListener: unknown;
+
+    port.onDisconnect.addListener(() => {
+      lastErrorDuringListener = runtime.lastError;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    refusals.set(RUNTIME_PROXY_PATHS.portPost, 429);
+
+    port.postMessage("refused");
+
+    await waitFor(
+      () => requests.some(({ pathName }) => pathName === RUNTIME_PROXY_PATHS.portDisconnect),
+      "the disconnect post",
+    );
+
+    expect(lastErrorDuringListener).toEqual({ message: "The runtime proxy bridge answered 429" });
+    expect(runtime.lastError).toBeUndefined();
+
+    expect(requests.map(({ pathName }) => pathName)).toEqual([
+      RUNTIME_PROXY_PATHS.connect,
+      RUNTIME_PROXY_PATHS.portPost,
+      RUNTIME_PROXY_PATHS.portDisconnect,
+    ]);
 
     expect(() => port.postMessage("too late")).toThrow(
       "Attempting to use a disconnected port object",

--- a/packages/electron-extensions/runtime-proxy/shim.ts
+++ b/packages/electron-extensions/runtime-proxy/shim.ts
@@ -16,6 +16,11 @@ import {
 
 const DISCONNECTED_PORT_ERROR = "Attempting to use a disconnected port object";
 
+/** What a refused bridge call reads as, whatever the call was. */
+function bridgeAnsweredError(status: number) {
+  return `The runtime proxy bridge answered ${status}`;
+}
+
 /**
  * What a shimmed context can say about where it runs, read from its own
  * globals. The same two facts serve a content script and an extension page: the
@@ -107,7 +112,7 @@ function createProxiedSendMessage(
         });
 
         if (!response.ok) {
-          throw new Error(`The runtime proxy bridge answered ${response.status}`);
+          throw new Error(bridgeAnsweredError(response.status));
         }
 
         result = (await response.json()) as RuntimeProxySendMessageResult;
@@ -181,6 +186,11 @@ function createProxiedPort(
 
       sendChain = sendChain
         .then(() => postBridge(RUNTIME_PROXY_PATHS.portPost, { portId, message }))
+        .then((response) => {
+          if (!response.ok) {
+            refusePost(response.status);
+          }
+        })
         .catch(() => undefined);
     },
     disconnect() {
@@ -192,8 +202,12 @@ function createProxiedPort(
 
       markOpened();
 
-      void postBridge(RUNTIME_PROXY_PATHS.portDisconnect, { portId });
+      sendDisconnect();
     },
+  };
+
+  const sendDisconnect = () => {
+    void postBridge(RUNTIME_PROXY_PATHS.portDisconnect, { portId });
   };
 
   // Chrome stays quiet about a port the content script disconnected itself
@@ -211,6 +225,24 @@ function createProxiedPort(
     });
   };
 
+  /**
+   * A post the bridge refused, which is what a session at its cap of bodies
+   * read at once gets. Chrome has no answer for one message being refused, so
+   * this takes the nearest one it has: the port goes away with `lastError`
+   * set, and everything posted after it throws. Main has closed nothing on its
+   * side — the refusal is settled before the request reaches its handler — so
+   * the disconnect still goes out to close the port's record there.
+   */
+  const refusePost = (status: number) => {
+    if (isDisconnected) {
+      return;
+    }
+
+    disconnected(bridgeAnsweredError(status));
+
+    sendDisconnect();
+  };
+
   const readFrames = async () => {
     const response = await postBridge(RUNTIME_PROXY_PATHS.connect, {
       portId,
@@ -219,7 +251,7 @@ function createProxiedPort(
     });
 
     if (!response.ok || !response.body) {
-      throw new Error(`The runtime proxy bridge answered ${response.status}`);
+      throw new Error(bridgeAnsweredError(response.status));
     }
 
     markOpened();


### PR DESCRIPTION
## Summary
A port's `postMessage` swallowed a non-ok bridge response, so a refused post dropped the message with no `runtime.lastError` and no `onDisconnect` — silently, on all three port implementations. A refused post now tears the port down: `onDisconnect` fires with `lastError`, later posts throw, and the port's own disconnect request still goes out so main releases its record and any native host. The residual [PR #1008](https://github.com/zoidsh/meru/pull/1008) left open, overlapping finding 1 of the [3.60 extensions review](https://github.com/zoidsh/docs/blob/main/meru/extensions-review-3.60.md); unit tests only, no run against the real 1Password host.

## Problem
`facade/api/native-messaging.ts`, `runtime-proxy/shim.ts` and `runtime-proxy/relay-client.ts` each chain a port's posts on `sendChain` as `.then(() => postBridge(…)).catch(() => undefined)`. None of them looks at `response.ok`. The `.catch` was there for a fetch that throws, which the bridge in-process never does, and until [PR #1008](https://github.com/zoidsh/meru/pull/1008) there was nothing for the bridge to refuse a post with — every non-connect call it answered was a 2xx or an outright bug.

PR #1008 gave it one. A session at `MAX_CONCURRENT_BRIDGE_BODY_READS` (16 bodies read at once) is answered 429 from the URL, before the body is touched. On a port that 429 landed in the swallowing `.catch`: the message never reached the host, the extension was told nothing, and the port stayed open posting into a refusal it could not see. The same hole covers 403, 404 and a handler that throws, none of which a port can recover from either.

## Solution
- A post whose response is not ok tears the port down. `onDisconnect` fires with `runtime.lastError` set to `The native messaging bridge answered <status>` (the runtime proxy says `runtime proxy bridge`, matching what its connect path already throws), and every later post throws the disconnected-port error.
- The port's own disconnect request still goes out afterwards. Main closed nothing — the refusal is settled before the request reaches its handler — so its port record and, for native messaging, the host process it spawned are only released if the page side asks. In the facade that disconnect rides `sendChain` behind whatever was already queued and cancels the reader after it, which is the ordering [PR #1009](https://github.com/zoidsh/meru/pull/1009) established; extracting it as `sendDisconnect` is what lets both callers keep it.
- On the relay client's worker port, `disconnect()` and the refusal path became one `tearDown(error?)`: same bookkeeping, and `onDisconnect` emitted only when there is an error, since Chrome stays quiet about a port the worker closed itself. Its `lastError` is set on every runtime object the client wrapped, because one relay client serves both `chrome` and `browser` and the listener reads whichever it was written against.

**Tear-down rather than a retry.** Chrome has no analog for a single `postMessage` being refused by the transport; the nearest honest behavior is the one this code already has when the stream ends — the port goes away with `lastError` set. A retry after a short delay was the alternative, and it would hide the only condition that triggers this: the cap is 16 concurrent body reads per session and each port serializes its own posts behind `sendChain`, so a port reaching it means a page flooding the bridge from somewhere else, not honest load. It would also hold the port's whole send chain for the delay, since everything posted after waits behind the retry.

**Any non-ok status, not just 429.** 403 (unknown token), 404 (unregistered path) and a handler that threw are equally unrecoverable for a port, and each dropped a message just as silently. `readFrames` already treats any non-ok connect this way.

**Finding 25 is still open, and this change leans on it.** The shim's and relay client's `disconnect()` still post unchained, so `postMessage(x); disconnect()` can still drop `x` on those two. This change does not touch that shape — it only routes the existing post through a named `sendDisconnect`/`tearDown` — and the fix belongs with the rest of finding 25. What is new is that on those two the disconnect now fires at the one moment the session is known to be refusing, and neither has a backstop for it being refused in turn: the shim never cancels its reader and the worker port has no stream, so a refused disconnect leaves main's port record open until the page unloads. Native messaging is covered either way, because its disconnect is followed by the reader cancel and main's stream `cancel` handler closes the port and kills the host. Chaining the disconnect and canceling the shim's reader after it — finding 25's fix — closes this too, which is an argument for doing that one next rather than a reason to widen this PR.

Found by a review pass over this branch, along with two test gaps the second commit fills: the relay client's test wrapped one runtime object twice, so it would have passed an implementation that set `lastError` on only one of `chrome` and `browser`, and nothing pinned what happens when the tear-down is reentered — two posts both refused, or a refusal arriving after the extension already disconnected.

**Rebased onto [PR #1013](https://github.com/zoidsh/meru/pull/1013).** That change minifies these three bundles and lowered their budgets to 9 KB, 6 KB and 6 KB, so the comments this PR adds no longer ship: measured after the rebase, the facade is 7.1 KB, the relay client 4.8 KB and the shim 4.5 KB. An earlier commit here raised the two proxy ceilings, which were 15 KB against unminified bundles this change pushed over; it is gone, and no budget moves.

## Try it
Nothing to open: this is facade and worker plumbing with no UI, and a refused post is only observable from inside an extension. `bun test packages/electron-extensions` covers it; reverting any one of the three source files turns that file's new test red, which is how each was checked.

## Not verified
- No run against the real 1Password host, the packaged app, or a real 429. Every test drives a fake bridge or a stubbed `fetch` shaped to answer 429, so what is verified is the client's reaction to the status, not that the cap produces it under load.
- A disconnect request that is itself refused is only handled on the native messaging port, through the reader cancel PR #1009 added; that cancel reaching main's stream handler is that PR's measurement rather than this one's.
- The runtime proxy is off by default and has never run against 1Password, so both proxy changes are unexercised outside their unit tests.
- Whether a 429 can be reached at all in ordinary use is still the open question from PR #1008: `MAX_CONCURRENT_BRIDGE_BODY_READS` at 16 is a judgment call that has not been measured against a real 1Password load with many inline-menu frames. If it turns out to be reachable honestly, this change converts a silent drop into a visible disconnect, which is the point, but the cap is then the thing to revisit.


