### PR TITLE
Three measured extension performance wins

### DIFF
--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, readdir, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { deriveExtension, pruneDerivedExtensions } from "./index";
@@ -335,6 +336,24 @@ describe("deriveExtension", () => {
     expect(
       JSON.parse(await readFile(path.join(derivedDir, "manifest.json"), "utf8")).content_scripts,
     ).toEqual(contentScripts);
+  });
+
+  test("digests the source tree the way a stamp already on disk was written", async () => {
+    const derivedDir = await derive();
+
+    const fileNames = ["background/background.js", "manifest.json", "popup.html"];
+
+    const fileEntries = await Promise.all(
+      fileNames.map(async (fileName) => {
+        const stats = await stat(path.join(sourceDir, ...fileName.split("/")));
+
+        return `${fileName}\0${stats.size}\0${stats.mtimeMs}`;
+      }),
+    );
+
+    expect(JSON.parse(await readFile(`${derivedDir}.json`, "utf8")).sourceTree).toBe(
+      createHash("sha256").update(fileEntries.sort().join("\n")).digest("hex"),
+    );
   });
 
   test("stamps a copy without matches as it did before they existed", async () => {

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -77,25 +77,37 @@ function hash(value: string) {
  * Digests the source tree from each file's path, size and mtime — never its
  * contents, since an extension runs to tens of megabytes and this happens on
  * every launch, and an edit always moves one of the two.
+ *
+ * Every entry is stat'd at once rather than one after another: this runs per
+ * extension on every launch and Gmail's first navigation waits behind it, and
+ * an extension of a few thousand files spent that wait on a round trip to the
+ * disk per file. The digest is the same either way — the lines are sorted
+ * before they are hashed — so a stamp written by an earlier version still
+ * matches and no profile re-derives.
  */
 async function hashSourceTree(sourceDir: string) {
   const entryNames = await readdir(sourceDir, { recursive: true });
 
-  const fileEntries: string[] = [];
+  const fileEntries = await Promise.all(
+    entryNames.map(async (entryName) => {
+      const stats = await stat(path.join(sourceDir, entryName));
 
-  for (const entryName of entryNames) {
-    const stats = await stat(path.join(sourceDir, entryName));
+      if (!stats.isFile()) {
+        return undefined;
+      }
 
-    if (!stats.isFile()) {
-      continue;
-    }
+      const relativePath = entryName.split(path.sep).join("/");
 
-    const relativePath = entryName.split(path.sep).join("/");
+      return `${relativePath}\0${stats.size}\0${stats.mtimeMs}`;
+    }),
+  );
 
-    fileEntries.push(`${relativePath}\0${stats.size}\0${stats.mtimeMs}`);
-  }
-
-  return hash(fileEntries.sort().join("\n"));
+  return hash(
+    fileEntries
+      .filter((fileEntry) => fileEntry !== undefined)
+      .sort()
+      .join("\n"),
+  );
 }
 
 async function readStamp(stampPath: string) {

--- a/packages/electron-extensions/native-messaging/framing.test.ts
+++ b/packages/electron-extensions/native-messaging/framing.test.ts
@@ -65,6 +65,34 @@ describe("NativeMessageDecoder", () => {
     );
   });
 
+  test("refuses an oversized message whose length arrives across two chunks", () => {
+    const announcement = new Uint8Array(4);
+
+    new DataView(announcement.buffer).setUint32(0, MAX_NATIVE_MESSAGE_BYTES + 1, true);
+
+    const decoder = new NativeMessageDecoder();
+
+    expect(decoder.push(announcement.subarray(0, 3))).toEqual([]);
+
+    expect(() => decoder.push(announcement.subarray(3))).toThrow(
+      `Native message of ${MAX_NATIVE_MESSAGE_BYTES + 1} bytes exceeds the ${MAX_NATIVE_MESSAGE_BYTES} byte limit`,
+    );
+  });
+
+  test("assembles a message out of many small chunks", () => {
+    const message = { chunked: "x".repeat(5000) };
+
+    const frame = encodeNativeMessage(message);
+
+    const chunks: Uint8Array[] = [];
+
+    for (let offset = 0; offset < frame.byteLength; offset += 64) {
+      chunks.push(frame.subarray(offset, offset + 64));
+    }
+
+    expect(decodeAll(chunks)).toEqual([message]);
+  });
+
   test("accepts a message right at the cap", () => {
     const message = "a".repeat(MAX_NATIVE_MESSAGE_BYTES - 2);
 

--- a/packages/electron-extensions/native-messaging/framing.ts
+++ b/packages/electron-extensions/native-messaging/framing.ts
@@ -32,49 +32,118 @@ export function encodeNativeMessage(message: unknown): Uint8Array {
  * Reassembles messages from however the bytes arrive. A message that claims to
  * be larger than the cap is refused before a byte of it is buffered, so a host
  * cannot grow the decoder's memory by announcing a huge length.
+ *
+ * The chunks are kept as they arrive and joined once, when a whole frame is in
+ * hand, so every byte is copied exactly once. Growing one buffer instead copied
+ * everything already held on every chunk, which is quadratic in the frame: a
+ * 1 MiB message arriving in 64 KB chunks copied about 8 MB, and the runtime
+ * proxy reuses this decoder under a cap of 64 MiB.
  */
 export class NativeMessageDecoder {
-  private buffered = new Uint8Array(0);
+  private chunks: Uint8Array[] = [];
+
+  private bufferedBytes = 0;
+
+  /** The announced body length once its prefix is read and within the cap. */
+  private pendingMessageBytes: number | undefined;
 
   constructor(private maxMessageBytes = MAX_NATIVE_MESSAGE_BYTES) {}
 
   /** Throws when the stream is unusable, which leaves the caller to end it. */
   push(chunk: Uint8Array): unknown[] {
-    const combined = new Uint8Array(this.buffered.byteLength + chunk.byteLength);
+    if (chunk.byteLength > 0) {
+      this.chunks.push(chunk);
 
-    combined.set(this.buffered);
-
-    combined.set(chunk, this.buffered.byteLength);
-
-    this.buffered = combined;
+      this.bufferedBytes += chunk.byteLength;
+    }
 
     const messages: unknown[] = [];
 
-    while (this.buffered.byteLength >= LENGTH_PREFIX_BYTES) {
-      const messageBytes = new DataView(
-        this.buffered.buffer,
-        this.buffered.byteOffset,
-        LENGTH_PREFIX_BYTES,
-      ).getUint32(0, true);
+    while (true) {
+      if (this.pendingMessageBytes === undefined) {
+        if (this.bufferedBytes < LENGTH_PREFIX_BYTES) {
+          break;
+        }
 
-      if (messageBytes > this.maxMessageBytes) {
-        throw new Error(
-          `Native message of ${messageBytes} bytes exceeds the ${this.maxMessageBytes} byte limit`,
-        );
+        const prefix = this.take(LENGTH_PREFIX_BYTES);
+
+        const messageBytes = new DataView(
+          prefix.buffer,
+          prefix.byteOffset,
+          LENGTH_PREFIX_BYTES,
+        ).getUint32(0, true);
+
+        if (messageBytes > this.maxMessageBytes) {
+          throw new Error(
+            `Native message of ${messageBytes} bytes exceeds the ${this.maxMessageBytes} byte limit`,
+          );
+        }
+
+        this.pendingMessageBytes = messageBytes;
       }
 
-      if (this.buffered.byteLength < LENGTH_PREFIX_BYTES + messageBytes) {
+      if (this.bufferedBytes < this.pendingMessageBytes) {
         break;
       }
 
-      const body = this.buffered.subarray(LENGTH_PREFIX_BYTES, LENGTH_PREFIX_BYTES + messageBytes);
+      const body = this.take(this.pendingMessageBytes);
+
+      this.pendingMessageBytes = undefined;
 
       messages.push(this.parse(body));
-
-      this.buffered = this.buffered.slice(LENGTH_PREFIX_BYTES + messageBytes);
     }
 
     return messages;
+  }
+
+  /**
+   * Takes the next `byteLength` bytes off the front of the chunks, joining only
+   * as many as it takes. A chunk holding the whole run is handed over as a view
+   * of itself, and one holding more keeps its remainder as a view.
+   */
+  private take(byteLength: number): Uint8Array {
+    const firstChunk = this.chunks[0];
+
+    if (firstChunk && firstChunk.byteLength >= byteLength) {
+      if (firstChunk.byteLength === byteLength) {
+        this.chunks.shift();
+      } else {
+        this.chunks[0] = firstChunk.subarray(byteLength);
+      }
+
+      this.bufferedBytes -= byteLength;
+
+      return firstChunk.subarray(0, byteLength);
+    }
+
+    const taken = new Uint8Array(byteLength);
+
+    let takenBytes = 0;
+
+    // Never runs out, since the caller asks for no more than `bufferedBytes`
+    for (let chunk = this.chunks.shift(); chunk; chunk = this.chunks.shift()) {
+      const wantedBytes = byteLength - takenBytes;
+
+      if (chunk.byteLength > wantedBytes) {
+        taken.set(chunk.subarray(0, wantedBytes), takenBytes);
+
+        this.chunks.unshift(chunk.subarray(wantedBytes));
+
+        break;
+      }
+
+      taken.set(chunk, takenBytes);
+
+      takenBytes += chunk.byteLength;
+
+      if (takenBytes === byteLength) {
+        break;
+      }
+    }
+
+    this.bufferedBytes -= byteLength;
+
+    return taken;
   }
 
   private parse(body: Uint8Array) {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -92,8 +92,18 @@ function buildAppFiles() {
       }),
     );
 
-  // Runs inside extensions rather than in Meru, so it is bundled like a preload
-  // and copied into every extension the loader derives
+  /*
+   * Runs inside extensions rather than in Meru, so it is bundled like a preload
+   * and copied into every extension the loader derives.
+   *
+   * Minified where the app's own bundles are not: one of these loads in every
+   * extension context — the service worker, each popup and options page, and
+   * every inline-menu iframe a page gets — and the facade alone was 26.9 kB
+   * against 7.2 kB. Minified in a development build too, so the bytes a
+   * developer runs are the bytes that ship. The derive writes the token in
+   * front of whatever it is handed, and names the file itself, so nothing
+   * downstream reads the output's contents.
+   */
   const buildExtensionScript = (inputPath: string, outputFileName: string) =>
     rolldown({
       ...rolldownOptions,
@@ -108,6 +118,7 @@ function buildAppFiles() {
         file: path.join(process.cwd(), "build-js", outputFileName),
         codeSplitting: false,
         format: "iife",
+        minify: true,
       }),
     );
 

--- a/tests/bundle-budget.json
+++ b/tests/bundle-budget.json
@@ -1,8 +1,8 @@
 {
   "app.js": 2294784,
-  "extensions-chrome-facade.js": 25600,
-  "extensions-runtime-proxy-relay.js": 15360,
-  "extensions-runtime-proxy-shim.js": 15360,
+  "extensions-chrome-facade.js": 9216,
+  "extensions-runtime-proxy-relay.js": 6144,
+  "extensions-runtime-proxy-shim.js": 6144,
   "fixture-extension/background.js": 4096,
   "fixture-extension/probe.js": 7168,
   "preload-gmail.js": 108544,


### PR DESCRIPTION
## Summary
Three quick wins from the "Memory and performance" section of the 3.60 extensions review, each measured here: the derive's source-tree hash stats in parallel (93 ms → 13 ms for 3000 files), the native-messaging decoder joins chunks once per frame instead of recopying a growing buffer (64 MiB in 64 KB chunks: 18.5 s → 0.23 s), and the three scripts that load in every extension context ship minified (26.9 kB → 7.2 kB for the facade). Behavior-preserving throughout, since this is going in right before a release; the derive digest is byte-identical, so no profile re-derives on the upgrade. The runtime proxy's end-to-end suite could not be run here — see **Not verified**.

## Problem
All three sit on paths that run per extension, per context, or per chunk, and none of them had to.

`hashSourceTree` awaited one `stat` per file over a `readdir({recursive: true})` listing. The derive stamp is what decides whether a copy is current, so this runs per extension on every launch, and Gmail's first navigation waits behind the extension loads. 1Password's tree is thousands of files.

`NativeMessageDecoder.push` allocated a new buffer and copied everything already held on every chunk, which is quadratic in the frame size: a 1 MiB host message arriving in 64 KB chunks copied about 8 MB. The runtime proxy reuses the same decoder under a 64 MiB cap, where a frame near the cap costs about a thousand copies of a growing buffer.

The facade, the runtime-proxy shim and the relay shipped unminified. One of the three loads in every extension context — the service worker, each popup and options page, and every inline-menu iframe 1Password puts in a page — so those bytes are paid per context rather than once.

## Solution
- **Derive.** `hashSourceTree` stats every entry at once. Measured on this machine with a synthetic 3000-file tree, through `deriveExtension` on the launch path where the stamp already matches: median 93 ms before, 13 ms after, warm cache. The digest has to come out identical or every profile re-derives and pays a full copy for nothing, and it does — the lines were already sorted before hashing, so only the order they are produced in changes. The new test pins the digest to sha256 over the sorted `path\0size\0mtime` lines, and it passes against the previous implementation as well as this one.
- **Framing.** The decoder keeps chunks as they arrive and joins them once, when a whole frame is in hand, so every byte is copied at most once — and not at all where a single chunk holds the frame, which is the ordinary case. 64 MiB in 64 KB chunks went from 18.5 s to 0.23 s, 16 MiB from 1.08 s to 25 ms, 1 MiB from 7.5 ms to 3.6 ms. The cap is still checked from the announced length before any of the body is buffered, which is what stops a host growing the decoder's memory by announcing a huge frame; the length prefix is consumed as soon as it is whole, so the check happens on the chunk that completes it whether that is the first or the fourth. A new test covers a prefix split across two chunks, and the existing split and coalesced cases stay green.
- **Bundles.** `minify: true` on the three extension scripts only, and the three bundle budgets come down to lock the win in. Not the app's own bundle: it is read once by the main process, where the size buys nothing and minifying costs readable stack traces. Minified in development builds too rather than gating on `--dev`, so the bytes a developer runs are the bytes that ship and anything the minifier breaks shows up in daily use rather than only in a release build.

Two things the review flagged as needing checking before committing to minification, both checked. The derive prepends `globalThis.<token global> = "…";` to whatever it is handed rather than replacing a placeholder, so there is nothing for minification to rename; the property name survives as a dotted access in all three bundles, which rolldown does not mangle, and running the minified facade against bare `chrome` and `browser` objects installs its namespaces and builds `extension-bridge://bridge/web-navigation/get-all-frames?token=…` from the prepended token. The `web_accessible_resources` refusal in `derive/web-accessible.ts` matches manifest patterns against the derive's own file names (`chrome-facade.js`), which the build output's contents never touch.

`MAX_RUNTIME_PROXY_FRAME_BYTES` stays at 64 MiB, decided rather than overlooked. The review recommends a few MB, but the proxy's frame sizes were sized in [PR #985](https://github.com/zoidsh/meru/pull/985) and nobody has measured what 1Password sends over runtime messaging; the decoder fix is what made the cap dangerous in the first place, and a 64 MiB frame now costs 0.23 s of copying rather than 18.5 s. The proxy is off by default, so the question can wait for the measurement that would settle it.

`derivePages` still walks the derived tree with a second recursive `readdir`. Reusing the hash's listing would mean handing it the source's names and trusting the copy to match, and it only runs on the re-copy path, so it is left alone. The reflink copy, the menu icon cache and the relay client's retry delay stay out of scope and are recorded in the review doc.

## Not verified
- `tests/extension-proxy.e2e.ts` was not run. It launches through `useProApp`, which needs `MERU_TEST_LICENSE_KEY`, and this machine has no license key. The minified facade was instead exercised directly against stub `chrome`/`browser` globals as described above; the shim and relay bundles were exercised the same way in review — each executed behind the prepended token line against a stub `chrome` and a capturing `fetch`, building their `runtime-proxy/` URLs with the token intact — but never against a real worker.
- No measurement against a real 1Password tree or a real native-messaging host: both benchmarks are synthetic, on a warm ext4 cache on this machine.
- The framing change was not exercised through a live host process, only through the unit suite and the benchmark.

