### PR TITLE
Chain a proxy port's disconnect behind what it already sent

### DIFF
--- a/packages/electron-extensions/runtime-proxy/relay-client.test.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.test.ts
@@ -568,6 +568,52 @@ describe("createRelayClient", () => {
     });
   });
 
+  test("a message posted before a disconnect goes out ahead of it", async () => {
+    const stub = stubBridge();
+
+    const { chrome } = createWorkerChrome();
+
+    startClient([chrome]);
+
+    type OrderedPort = { postMessage: (message: unknown) => void; disconnect: () => void };
+
+    let port: OrderedPort | undefined;
+
+    ((chrome.runtime as ChromeNamespace).onConnect as WrappedEvent).addListener((connectedPort) => {
+      port = connectedPort as OrderedPort;
+    });
+
+    await stub.waitForStream();
+
+    stub.pushJob({
+      type: "connect",
+      jobId: "job-1",
+      portId: "port-1",
+      name: "relay",
+      sender: SENDER,
+    });
+
+    await waitFor(() => port !== undefined, "the port");
+
+    port?.postMessage("first");
+
+    port?.disconnect();
+
+    await waitFor(
+      () => stub.postsTo(RUNTIME_PROXY_PATHS.workerPortDisconnect).length === 1,
+      "the disconnect post",
+    );
+
+    const portPaths: string[] = [
+      RUNTIME_PROXY_PATHS.workerPortPost,
+      RUNTIME_PROXY_PATHS.workerPortDisconnect,
+    ];
+
+    expect(
+      stub.posts.map(({ pathName }) => pathName).filter((pathName) => portPaths.includes(pathName)),
+    ).toEqual(portPaths);
+  });
+
   test("a refused post tears the worker port down with lastError set", async () => {
     const stub = stubBridge();
 

--- a/packages/electron-extensions/runtime-proxy/relay-client.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.ts
@@ -234,6 +234,12 @@ export function createRelayClient({
      * than being disconnected, so the extension's own listeners hear it with
      * `lastError` set; Chrome stays quiet about a port the worker closed
      * itself, so without one nothing is emitted.
+     *
+     * The disconnect rides `sendChain` like every post, so it lands behind
+     * what was written before it. Sent unchained it overtakes them, and main
+     * closes the port before the messages arrive. Unlike the shim's port there
+     * is no stream to cancel behind it, so a disconnect the bridge refuses in
+     * turn leaves main's record open; nothing this side holds can close it.
      */
     const tearDown = (error?: string) => {
       if (isDisconnected) {
@@ -244,7 +250,9 @@ export function createRelayClient({
 
       ports.delete(portId);
 
-      void postToBridge(RUNTIME_PROXY_PATHS.workerPortDisconnect, { portId });
+      sendChain = sendChain.then(() =>
+        postToBridge(RUNTIME_PROXY_PATHS.workerPortDisconnect, { portId }),
+      );
 
       if (error !== undefined) {
         withRuntimesLastError(error, () => {

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
@@ -393,7 +393,8 @@ export class RuntimeProxy {
         this.ports.set(port.id, port);
       },
       cancel: () => {
-        // The content script's context went away with its page
+        // The content script's context went away with its page, or the shim
+        // canceled its reader behind a disconnect this bridge refused
         if (port) {
           this.closeShimPort(port, { notifyWorker: true });
         }

--- a/packages/electron-extensions/runtime-proxy/shim.test.ts
+++ b/packages/electron-extensions/runtime-proxy/shim.test.ts
@@ -35,7 +35,9 @@ async function waitFor(condition: () => boolean, what: string) {
   }
 }
 
-function stubFetch(respond: (pathName: string, body: Record<string, unknown>) => Response) {
+function stubFetch(
+  respond: (pathName: string, body: Record<string, unknown>) => Response | Promise<Response>,
+) {
   const requests: RecordedRequest[] = [];
 
   globalThis.fetch = (async (url: string, init: RequestInit) => {
@@ -324,12 +326,24 @@ describe("shimmed connect", () => {
   test("a message posted before a disconnect goes out ahead of it, and the reader is canceled after", async () => {
     const events: string[] = [];
 
-    stubFetch((pathName) => {
+    let answerConnect = () => {};
+
+    // The connect is held unanswered, which is the window an unchained
+    // disconnect overtakes it in. A stub that answers in the same tick closes
+    // that window and would pass whether the disconnect waits on `opened` or
+    // resolves it itself
+    const connectAnswered = new Promise<void>((resolve) => {
+      answerConnect = resolve;
+    });
+
+    stubFetch(async (pathName) => {
       events.push(`request:${pathName}`);
 
       if (pathName !== RUNTIME_PROXY_PATHS.connect) {
         return new Response(null, { status: 204 });
       }
+
+      await connectAnswered;
 
       const stream = new ReadableStream<Uint8Array>({
         cancel: () => {
@@ -344,11 +358,15 @@ describe("shimmed connect", () => {
 
     const port = (runtime.connect as Connect)();
 
-    // Both written before the connect has answered, which is where an
-    // unchained disconnect overtakes the post and the connect itself
     port.postMessage("first");
 
     port.disconnect();
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(events).toEqual([`request:${RUNTIME_PROXY_PATHS.connect}`]);
+
+    answerConnect();
 
     await waitFor(() => events.includes("cancel"), "the reader cancel");
 

--- a/packages/electron-extensions/runtime-proxy/shim.test.ts
+++ b/packages/electron-extensions/runtime-proxy/shim.test.ts
@@ -321,6 +321,79 @@ describe("shimmed connect", () => {
     );
   });
 
+  test("a message posted before a disconnect goes out ahead of it, and the reader is canceled after", async () => {
+    const events: string[] = [];
+
+    stubFetch((pathName) => {
+      events.push(`request:${pathName}`);
+
+      if (pathName !== RUNTIME_PROXY_PATHS.connect) {
+        return new Response(null, { status: 204 });
+      }
+
+      const stream = new ReadableStream<Uint8Array>({
+        cancel: () => {
+          events.push("cancel");
+        },
+      });
+
+      return new Response(stream, { status: 200 });
+    });
+
+    const runtime = createShimmedRuntime();
+
+    const port = (runtime.connect as Connect)();
+
+    // Both written before the connect has answered, which is where an
+    // unchained disconnect overtakes the post and the connect itself
+    port.postMessage("first");
+
+    port.disconnect();
+
+    await waitFor(() => events.includes("cancel"), "the reader cancel");
+
+    expect(events).toEqual([
+      `request:${RUNTIME_PROXY_PATHS.connect}`,
+      `request:${RUNTIME_PROXY_PATHS.portPost}`,
+      `request:${RUNTIME_PROXY_PATHS.portDisconnect}`,
+      "cancel",
+    ]);
+  });
+
+  test("a port the content script disconnected hears no more messages", async () => {
+    let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+
+    stubFetch(
+      respondWithPortStream({
+        enqueue: (controller) => {
+          streamController = controller;
+        },
+      }),
+    );
+
+    const runtime = createShimmedRuntime();
+
+    const port = (runtime.connect as Connect)();
+
+    let messagesHeard = 0;
+
+    port.onMessage.addListener(() => {
+      messagesHeard += 1;
+    });
+
+    await waitFor(() => streamController !== undefined, "the port stream");
+
+    port.disconnect();
+
+    // Still on its way when the content script hung up, the way the worker's
+    // last messages are
+    streamController?.enqueue(encodeFrame({ type: "message", message: "late" }));
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(messagesHeard).toBe(0);
+  });
+
   test("a refused post tears the port down and tells the relay", async () => {
     const respondWithStream = respondWithPortStream({});
 

--- a/packages/electron-extensions/runtime-proxy/shim.ts
+++ b/packages/electron-extensions/runtime-proxy/shim.ts
@@ -175,6 +175,8 @@ function createProxiedPort(
 
   let sendChain: Promise<unknown> = opened;
 
+  let cancelFrames = async () => {};
+
   const port = {
     name,
     onMessage,
@@ -200,14 +202,21 @@ function createProxiedPort(
 
       isDisconnected = true;
 
-      markOpened();
-
       sendDisconnect();
     },
   };
 
+  // Chrome delivers a port's traffic in order, so the disconnect goes out
+  // behind the connect and everything already posted. Sent unchained it
+  // overtakes them, and main closes the port before the messages arrive
   const sendDisconnect = () => {
-    void postBridge(RUNTIME_PROXY_PATHS.portDisconnect, { portId });
+    sendChain = sendChain
+      .then(() => postBridge(RUNTIME_PROXY_PATHS.portDisconnect, { portId }))
+      .catch(() => undefined)
+      // Main closes the port from its stream's `cancel` handler too, which is
+      // the backstop for a disconnect request that never landed
+      .then(() => cancelFrames())
+      .catch(() => undefined);
   };
 
   // Chrome stays quiet about a port the content script disconnected itself
@@ -231,7 +240,8 @@ function createProxiedPort(
    * this takes the nearest one it has: the port goes away with `lastError`
    * set, and everything posted after it throws. Main has closed nothing on its
    * side — the refusal is settled before the request reaches its handler — so
-   * the disconnect still goes out to close the port's record there.
+   * the disconnect still goes out, behind whatever was queued ahead of it, to
+   * close the port's record there.
    */
   const refusePost = (status: number) => {
     if (isDisconnected) {
@@ -258,6 +268,8 @@ function createProxiedPort(
 
     const reader = response.body.getReader();
 
+    cancelFrames = () => reader.cancel();
+
     const decoder = new NativeMessageDecoder(MAX_RUNTIME_PROXY_FRAME_BYTES);
 
     for (;;) {
@@ -268,6 +280,14 @@ function createProxiedPort(
       }
 
       for (const frame of decoder.push(value) as RuntimeProxyPortFrame[]) {
+        // A port the content script disconnected hears nothing more, even
+        // while the worker's last messages are still on their way. The reader
+        // is left open here because `disconnect` cancels it behind its own
+        // request
+        if (isDisconnected) {
+          return;
+        }
+
         if (frame.type === "message") {
           onMessage.emit(frame.message, port);
         } else {


### PR DESCRIPTION
## Summary
`postMessage(x); disconnect()` dropped `x` on both of the runtime proxy's ports, the shim's and the relay client's: the disconnect went out unchained and overtook the queued post, and on the shim the connect itself. Both now send the disconnect through `sendChain`, and the shim cancels its frame reader behind the request so a disconnect the bridge refuses in turn still closes main's port record. Finding 25 of the [3.60 extensions review](https://github.com/zoidsh/docs/blob/main/meru/extensions-review-3.60.md), the same shape [PR #1009](https://github.com/zoidsh/meru/pull/1009) fixed on the native messaging port; unit tests only, and the runtime proxy is off by default.

## Problem
Both proxy ports chain `postMessage` on `sendChain` so two posts arrive in the order they were written, and neither chained `disconnect()`. It posted immediately, and two fetches have no order between them, so `postMessage(x); disconnect()` delivered the disconnect first, main closed the port, and `x` was dropped with nothing said. Chrome delivers a port's traffic in order.

The shim was the worse of the two, because its `sendChain` starts at the connect: `disconnect()` also called `markOpened()`, resolving the gate that everything posted before the connect answers waits behind. So `connect(); postMessage(x); disconnect()` — what an extension writes when it wants one round trip — sent the disconnect before the connect it belongs to, at which point main has no port to close and the post that follows lands on a port record that nothing will ever close. The shim's frame loop also kept emitting `onMessage` on a port the content script had already disconnected.

[PR #1012](https://github.com/zoidsh/meru/pull/1012) gave this a second edge. It makes a port whose post the bridge refuses tear itself down, and the disconnect it then sends is what releases main's record. On the native messaging port that is safe even when the disconnect is refused too, because the reader cancel behind it makes main's stream `cancel` handler close the port. Neither proxy port had that backstop: the shim never canceled its reader, so a refused disconnect left main's `ProxyPort` open until the extension's worker next stopped, which is what `invalidateWorkerStream` closes every port on, or until the page unloaded and Electron canceled the body itself.

## Solution
- Both ports send the disconnect through `sendChain`, so it lands behind the connect and everything already posted. On the shim that meant dropping the `markOpened()` from `disconnect()` — resolving `opened` early is exactly what let the disconnect overtake the connect. The gate still resolves on every path `readFrames()` settles on, since `disconnected()` calls `markOpened()` and both its branches end there, so a connect that is refused or fails does not strand the disconnect. A connect fetch that never answers at all does strand it, and harmlessly: main builds its port record synchronously as it answers, so a request that never got that far left nothing to close.
- The shim cancels its frame reader behind the disconnect request, as `sendDisconnect` does in `native-messaging.ts`. Main's `cancel` handler on the port stream calls `closeShimPort`, which is guarded on `isClosed`, so the cancel is a no-op after a disconnect that landed and the backstop after one that did not.
- The shim's frame loop stops emitting once `isDisconnected`, so a message still on its way from the worker is not delivered to a port the content script hung up. The relay client needs no equivalent: `tearDown` removes the port from `ports` and `handleJob` looks it up there, so a later `portMessage` job finds nothing.

**The relay client's worker port stays best-effort, deliberately.** It posts `workerPortDisconnect` and has no stream to cancel, so there is nothing to put behind a disconnect the bridge refuses; main's record would stay until the shim side closes it or the worker next stops. Chaining still fixes the ordering bug, which is what finding 25 is about, and the missing backstop is recorded in the `tearDown` comment rather than invented — giving the worker port a stream of its own to cancel is a protocol change, not part of this fix.

**The ordering PR #1012's tests pin is unchanged.** A refused post still goes out as connect, post, disconnect: `refusePost` and `tearDown` run inside the `.then` of the post they refused, so chaining the disconnect puts it exactly where it already was. Those tests were left as they are and still pass.

## Try it
Nothing to open: the runtime proxy is off by default, has no UI, and a port's send ordering is only observable from inside an extension. `bun test packages/electron-extensions` covers it. Each new test was checked against the partial fix it is meant to catch, not only against a full revert: keeping `markOpened()` in the shim's `disconnect()`, dropping the reader cancel, dropping the frame-loop gate, and leaving the relay client's disconnect unchained each turn one red.

## Not verified
- Unit tests against a stubbed `fetch` only. No run against the real 1Password extension, the packaged app, or the proxy turned on; the runtime proxy has never run against 1Password at all.
- That main's port-stream `cancel` handler fires when the shim's reader is canceled is read from `runtime-proxy.ts`, not measured in Electron. It is the same handler finding 26 flags as unmeasured for the page-unload case; this change gives it a caller that is explicit rather than relying on Electron canceling the body itself.
- The worker port's refused disconnect leaves main's record open until something else closes it, as above. Not fixed and not reproduced — a refused disconnect needs the bridge's concurrency cap reached, which PR #1008 left open as an unmeasured judgment call.
