### PR TITLE
Four relay fixes in the runtime proxy

### DIFF
--- a/packages/electron-extensions/runtime-proxy/relay-client.test.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.test.ts
@@ -427,6 +427,34 @@ describe("createRelayClient", () => {
     });
   });
 
+  // Chrome fails a `sendResponse` it cannot clone right away. A reply the
+  // bridge cannot serialize would otherwise post nothing at all, leaving the
+  // caller on the relay's in-flight timeout, minutes away
+  test("a reply that cannot be serialized answers closed rather than nothing", async () => {
+    const stub = stubBridge();
+
+    const { chrome } = createWorkerChrome();
+
+    startClient([chrome]);
+
+    const runtime = chrome.runtime as ChromeNamespace;
+
+    (runtime.onMessage as WrappedEvent).addListener((_message, _sender, sendResponse) => {
+      (sendResponse as (response: unknown) => void)({ vaultId: 1n });
+    });
+
+    await stub.waitForStream();
+
+    stub.pushJob({ type: "sendMessage", jobId: "job-1", message: "unlock", sender: SENDER });
+
+    await waitFor(() => stub.postsTo(RUNTIME_PROXY_PATHS.workerReply).length === 1, "the reply");
+
+    expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerReply)[0]?.body).toEqual({
+      jobId: "job-1",
+      result: { status: "closed" },
+    });
+  });
+
   test("builds a port for a connect job and carries it both ways", async () => {
     const stub = stubBridge();
 

--- a/packages/electron-extensions/runtime-proxy/relay-client.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.ts
@@ -278,10 +278,28 @@ export function createRelayClient({
     };
   };
 
+  /**
+   * A reply the bridge cannot carry is still a reply: `postBridge` serializes
+   * synchronously and throws on what `JSON.stringify` refuses — a `BigInt`, a
+   * cycle, a `toJSON` of the extension's own that throws — and an escaping
+   * throw would leave the caller waiting on the relay's in-flight timeout,
+   * minutes away, where Chrome fails a `sendResponse` it cannot clone at once.
+   */
   const postReply = (
     jobId: string,
     result: RuntimeProxySendMessageResult | RuntimeProxyConnectResult,
-  ) => postToBridge(RUNTIME_PROXY_PATHS.workerReply, { jobId, result });
+  ) => {
+    try {
+      return postToBridge(RUNTIME_PROXY_PATHS.workerReply, { jobId, result });
+    } catch (error) {
+      console.error("[runtime-proxy-relay] could not serialize the reply", error);
+
+      return postToBridge(RUNTIME_PROXY_PATHS.workerReply, {
+        jobId,
+        result: { status: "closed" },
+      });
+    }
+  };
 
   /**
    * Whether this job is new here. The relay redelivers anything it has no ack

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
@@ -922,6 +922,27 @@ describe("RuntimeProxy", () => {
 
     expect(await shimResponse.json()).toEqual({ status: "noListener" });
   });
+
+  test("a session adopted after the worker session went away is woken", async () => {
+    const harness = createHarness();
+
+    // A wake is pending on the session that is about to go
+    harness.sendShimMessage("wakes the old session");
+
+    await waitFor(() => harness.workerSession.workerStarts.length === 1, "the first wake");
+
+    harness.proxy.teardownSession(harness.workerSession.session);
+
+    const adoptedSession = createFakeSession();
+
+    harness.proxy.setWorkerSession(adoptedSession.session);
+
+    harness.sendShimMessage("wakes the adopted session");
+
+    await waitFor(() => adoptedSession.workerStarts.length === 1, "the adopted session's wake");
+
+    expect(adoptedSession.workerStarts).toEqual([EXTENSION_SCOPE]);
+  });
 });
 
 // The shim maps the relay's failure statuses onto Chrome's error strings; the

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
@@ -128,6 +128,14 @@ function createFakeSession() {
         listener({ versionId, runningStatus: "stopping" });
       }
     },
+    /** The second half of a stop: Chromium reports both, in this order. */
+    reportWorkerStopped: (versionId: number) => {
+      scopesByVersionId.delete(versionId);
+
+      for (const listener of statusListeners) {
+        listener({ versionId, runningStatus: "stopped" });
+      }
+    },
     /**
      * Sends a request the way Electron carries one: the bridge's headers
      * listener runs first — recording `callerFrame` when the request has one,
@@ -758,6 +766,65 @@ describe("RuntimeProxy", () => {
     harness.workerSession.reportWorkerStopping(1);
 
     expect(await shimPort.waitForFrames(1)).toEqual([{ type: "disconnect", error: undefined }]);
+  });
+
+  test("a stop of a worker that is not an extension's settles nothing", async () => {
+    const harness = createHarness();
+
+    harness.workerSession.reportWorkerRunning(1);
+
+    // The account's own worker in the session that keeps the extension —
+    // Gmail's, which idle-stops routinely and owes the relay nothing
+    harness.workerSession.reportWorkerRunning(2, "https://mail.google.com/mail/");
+
+    const workerStream = await harness.openWorkerStream();
+
+    const shimPort = await harness.connectShimPort("port-6");
+
+    const [connectJob] = await workerStream.waitForJobs(1);
+
+    if (connectJob?.type !== "connect") {
+      throw new Error("Expected a connect job");
+    }
+
+    await harness.ackJob(connectJob.jobId);
+
+    await harness.replyToJob(connectJob.jobId, { status: "connected" });
+
+    const shimResponse = harness.sendShimMessage("awaiting a reply");
+
+    const [, messageJob] = await workerStream.waitForJobs(2);
+
+    if (messageJob?.type !== "sendMessage") {
+      throw new Error("Expected a sendMessage job");
+    }
+
+    await harness.ackJob(messageJob.jobId);
+
+    harness.workerSession.reportWorkerStopping(2);
+
+    harness.workerSession.reportWorkerStopped(2);
+
+    expect(workerStream.isEnded()).toBe(false);
+
+    expect(shimPort.frames).toEqual([]);
+
+    // The acked message would have been failed as a closed port by a stop that
+    // settled every stream; the extension's own worker answers it instead
+    await harness.replyToJob(messageJob.jobId, { status: "replied", reply: "unlocked" });
+
+    expect(await (await shimResponse).json()).toEqual({ status: "replied", reply: "unlocked" });
+  });
+
+  test("a stop of a version never seen starting still settles every stream", async () => {
+    const harness = createHarness();
+
+    const workerStream = await harness.openWorkerStream();
+
+    // Nothing names this version, so nothing rules out the extension's worker
+    harness.workerSession.reportWorkerStopping(9);
+
+    await waitFor(() => workerStream.isEnded(), "the parked stream to be invalidated");
   });
 
   test("a torn-down shim session closes its ports and tells the worker", async () => {

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
@@ -584,6 +584,8 @@ export class RuntimeProxy {
       }
     }
 
+    const requeuedJobs: RelayJob[] = [];
+
     for (const job of this.inFlightJobs.values()) {
       if (job.extensionId !== extensionId) {
         continue;
@@ -605,8 +607,16 @@ export class RuntimeProxy {
 
       job.state = "queued";
 
-      this.queue(extensionId).push(job);
+      requeuedJobs.push(job);
     }
+
+    // At the front, in the order they were handed over: a job that reached a
+    // stream always predates anything still queued, since the queue only fills
+    // while no stream is parked and a parked stream is flushed synchronously.
+    // A port's messages must not overtake the connect that opens it, and the
+    // shim can have both in flight at once — its `connect` resolves on the
+    // bridge's answer, which is given before the worker has seen the job
+    this.queue(extensionId).unshift(...requeuedJobs);
 
     const requeuedConnectPortIds = new Set(
       this.queue(extensionId)
@@ -703,8 +713,9 @@ export class RuntimeProxy {
         // The stream stopped taking frames under us; its worker is gone. The
         // jobs after this one were handed to nobody and are in neither the
         // queue nor `inFlightJobs`, so they go back before the invalidation —
-        // which settles this one from `inFlightJobs` and reads the queue to
-        // tell a port whose connect is waiting from one that has to be closed
+        // which settles this one from `inFlightJobs`, puts it back ahead of
+        // them, and reads the queue to tell a port whose connect is waiting
+        // from one that has to be closed
         queue.push(...jobs.slice(index + 1));
 
         this.invalidateWorkerStream(extensionId);

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
@@ -148,8 +148,14 @@ export class RuntimeProxy {
 
   private removeWorkerSessionListener: (() => void) | undefined;
 
-  /** Scopes seen starting, the only way to name a worker once it is stopping. */
-  private scopesByVersionId = new Map<number, string>();
+  /**
+   * Scopes seen starting, the only way to name a worker once it is stopping.
+   * A version whose scope is not an extension's — the account's own page
+   * workers, Gmail's included — is recorded as `null`: the scope itself is of
+   * no use here, but knowing the version tells its stop apart from the stop of
+   * a worker this proxy never saw start.
+   */
+  private scopesByVersionId = new Map<number, string | null>();
 
   private workerStreams = new Map<string, WorkerStream>();
 
@@ -499,7 +505,10 @@ export class RuntimeProxy {
       try {
         const { scope } = this.workerSession.serviceWorkers.getInfoFromVersionID(versionId);
 
-        this.scopesByVersionId.set(versionId, scope);
+        this.scopesByVersionId.set(
+          versionId,
+          scope.startsWith(EXTENSION_SCHEME_PREFIX) ? scope : null,
+        );
       } catch {
         // A worker gone again before it was asked about names no stream
       }
@@ -511,17 +520,27 @@ export class RuntimeProxy {
       return;
     }
 
+    const isKnownVersion = this.scopesByVersionId.has(versionId);
+
     const scope = this.scopesByVersionId.get(versionId);
 
     if (runningStatus === "stopped") {
       this.scopesByVersionId.delete(versionId);
     }
 
-    if (scope?.startsWith(EXTENSION_SCHEME_PREFIX)) {
+    if (scope) {
       const extensionId = scope.slice(EXTENSION_SCHEME_PREFIX.length).replace(/\/.*$/, "");
 
       this.invalidateWorkerStream(extensionId);
 
+      return;
+    }
+
+    // A worker that is not an extension's owes the relay nothing. Gmail's own
+    // worker idle-stops routinely in this session, and settling every stream on
+    // it would disconnect every relayed port and fail every message awaiting a
+    // reply, twice per stop
+    if (isKnownVersion) {
       return;
     }
 

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
@@ -686,7 +686,9 @@ export class RuntimeProxy {
 
     const queue = this.queue(extensionId);
 
-    for (const job of queue.splice(0)) {
+    const jobs = queue.splice(0);
+
+    for (const [index, job] of jobs.entries()) {
       job.state = "handed";
 
       job.attempts += 1;
@@ -698,7 +700,13 @@ export class RuntimeProxy {
       try {
         stream.controller.enqueue(encodeNativeMessage(this.toJobFrame(job)));
       } catch {
-        // The stream stopped taking frames under us; its worker is gone
+        // The stream stopped taking frames under us; its worker is gone. The
+        // jobs after this one were handed to nobody and are in neither the
+        // queue nor `inFlightJobs`, so they go back before the invalidation —
+        // which settles this one from `inFlightJobs` and reads the queue to
+        // tell a port whose connect is waiting from one that has to be closed
+        queue.push(...jobs.slice(index + 1));
+
         this.invalidateWorkerStream(extensionId);
 
         return;

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
@@ -313,6 +313,17 @@ export class RuntimeProxy {
         this.failQueuedJobs(extensionId, "noListener");
       }
 
+      // The bookkeeping of the session that just went is worse than useless to
+      // the next one: a pending wake would make `wakeWorker` return early for a
+      // session that was never asked to start the worker, and its timer would
+      // then fail that session's queue; a version id means nothing outside the
+      // session that issued it
+      for (const extensionId of this.wakes.keys()) {
+        this.clearWake(extensionId);
+      }
+
+      this.scopesByVersionId.clear();
+
       return;
     }
 


### PR DESCRIPTION
## Summary
Four main-process relay fixes from the extension review — rows 24, 27, 28 and 29 of the review doc — so the shared-instance proxy is usable when its flag turns on. The one that matters is row 24: Gmail's own service worker idle-stopping in the worker session tore down every relayed port, routinely, and twice per stop. Nothing here changes behavior with the flag off, and the end-to-end suite could not be run on this machine.

## Problem
The relay is gated off by default and has never run against 1Password, so these are the review's reading of the code rather than field reports. Each is a way the relay settles work it should have carried:

- **Row 24.** `handleRunningStatusChanged` recorded the scope of every service worker version starting in the worker session, Gmail's included, and on stop a scope that was known but not an extension's fell through to the "cannot be pinned to a scope" branch that invalidates every stream. Gmail's worker idle-stops as a matter of course, and each stop sent `disconnect` to every established relayed port, failed every acked `sendMessage` awaiting a reply as `The message port closed before a response was received.`, re-handed the un-acked jobs with `attempts += 1`, and left the live relay client to re-park only after its retry delay. `stopping` and `stopped` both fire, so it happened twice per stop.
- **Row 27.** The worker branch of `teardownSession` invalidated the streams and failed the queued jobs but kept `wakes`, timers and all, and `scopesByVersionId`. A session adopted as the worker within `wakeTimeoutMs` then found `wakeWorker` returning early on the departed session's wake, so nothing called `startWorkerForScope` on it, and the stale timer failed every job queued for it as a missing receiving end.
- **Row 28.** `flushQueuedJobs` took the whole queue with `splice(0)` before handing any of it over. An `enqueue` that threw mid-loop left the jobs after it in neither the queue nor `inFlightJobs`, and a `sendMessage` among them had nothing left to settle it.
- **Row 29.** `postBridge` serializes with `JSON.stringify`, synchronously, and the worker's `postReply` called it inside a `.then`. A reply carrying a `BigInt` or a cycle threw there, no reply was posted, and the caller waited out the relay's five-minute in-flight timeout for the `closed` it was always going to get. Chrome fails a `sendResponse` it cannot clone at once.

## Solution
- Row 24 records a non-extension scope as `null` rather than dropping it, so its stop is still a *known* version, and returns on a known version that is not an extension's. Dropping those scopes outright was the review's phrasing, but it makes Gmail's stop indistinguishable from the stop of a worker the proxy never saw start, which is the case the fall-through exists for and which still settles every stream.
- Row 27 clears every wake and the version map in that branch.
- Row 28 iterates by index and pushes the un-handed remainder back in order. It goes back *before* the invalidation rather than after, because that pass reads the queue to tell a port whose connect is still waiting from one it has to close. `invalidateWorkerStream` then puts the jobs it took back at the *front* rather than pushing each: a job that reached a stream always predates anything still queued, since the queue only fills while no stream is parked and a parked stream is flushed synchronously. Pushing inverted the two, and a port's connect and its posts can be among them together — the shim's `connect` resolves on the bridge's answer, which `handleConnect` gives as soon as the job is queued rather than when the worker takes it — so the posts would have reached a worker with no such port yet and been dropped. Caught in review; the front is order-preserving on every path into that method, not only this one.
- Row 29 wraps the reply post and sends `{status: "closed"}` in its place, logging the error. It sits in `postReply` rather than `sendResponse` so it covers every reply the worker posts, and only the `sendMessage` reply can carry a payload that fails.

Tests: the fake session grows a `reportWorkerStopped`, since a real stop reports both statuses. Rows 24, 27 and 29 each get a test that fails without its fix — a non-extension worker stopping while a port is open and an acked message is awaiting its reply, a session adopted after the worker session went away being woken, and a reply carrying a `BigInt` answering `closed`. A stop of a version never seen starting gets one too, pinning the fall-through that row 24 narrows. Row 28 has none: the only multi-job flush is onto a stream created in the same synchronous path, so a mid-flush `enqueue` failure cannot be produced through the public surface without a seam built for the test.

## Try it
Nothing to open. The proxy is off by default and needs `MERU_EXTENSIONS_FIXTURE=1 MERU_EXTENSIONS_SHARED_INSTANCE=1` on a development build; row 24's own trigger is Gmail's worker idle-stopping, which Playwright's CDP debugger disables.

## Not verified
- `tests/extension-proxy.e2e.ts` was not run: it needs `MERU_TEST_LICENSE_KEY` from `.env.test.local`, which is not on this machine. `bun test`, `bun run types`, `bun run lint` and `bun run fmt:check` all pass.
- Row 28's fix is reasoned rather than exercised, for the reason above. The re-queue ordering that came out of review is in the same position: the reviewer confirmed both the loss and the fix against a stream whose controller throws, which is a seam the tests don't have.
- None of this has run against 1Password, which is still the pass that answers the whole feature.
