### PR TITLE
Pin a departing page's port disconnect, and fill the relayed sender

### DIFF
--- a/packages/electron-extensions/bridge/bridge.test.ts
+++ b/packages/electron-extensions/bridge/bridge.test.ts
@@ -16,8 +16,8 @@ const EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
 
 const BRIDGE_TOKEN = "bridge-token";
 
-function createFrame(url: string): WebFrameMain {
-  return { url, parent: null, isDestroyed: () => false } as unknown as WebFrameMain;
+function createFrame(url: string, frameToken = `token-${url}`): WebFrameMain {
+  return { url, parent: null, frameToken, isDestroyed: () => false } as unknown as WebFrameMain;
 }
 
 /** What the facade builds, plus the case it never builds: no token at all. */
@@ -317,6 +317,71 @@ describe("ExtensionBridge", () => {
     });
 
     await request("/echo", {}, { frame, token: BRIDGE_TOKEN });
+
+    expect(handledSenderFrame).toBe(frame);
+  });
+
+  test("a frame that navigated between the stamp and the handler names no sender frame", async () => {
+    const { session, stampHeaders, sendWithHeaders } = createSession();
+
+    const bridge = createBridge(session);
+
+    /*
+     * What Electron hands back after a cross-document navigation: the same
+     * `WebFrameMain`, alive, re-pointed at the new `RenderFrameHost` and
+     * reading as the page it now shows. Only the frame token says the document
+     * that made the request has gone.
+     */
+    const frame = createFrame("https://accounts.google.com/", "document-1");
+
+    const navigatingFrame = frame as unknown as { url: string; frameToken: string };
+
+    let handledSenderFrame: WebFrameMain | undefined;
+
+    bridge.handle("/echo", ({ senderFrame, headers }) => {
+      handledSenderFrame = senderFrame;
+
+      return new Response(null, { status: 204, headers });
+    });
+
+    const stampedHeaders = stampHeaders(bridgeUrl("/echo", BRIDGE_TOKEN), {
+      frame,
+      token: BRIDGE_TOKEN,
+    });
+
+    navigatingFrame.url = "https://accounts.google.com/signin";
+
+    navigatingFrame.frameToken = "document-2";
+
+    await sendWithHeaders("/echo", "{}", stampedHeaders, BRIDGE_TOKEN);
+
+    expect(handledSenderFrame).toBeUndefined();
+  });
+
+  test("a same-document navigation keeps its frame, since the document is the same", async () => {
+    const { session, stampHeaders, sendWithHeaders } = createSession();
+
+    const bridge = createBridge(session);
+
+    // A `pushState`: the `RenderFrameHost`, and so the token, are untouched
+    const frame = createFrame("https://mail.google.com/mail/u/0/", "document-1");
+
+    let handledSenderFrame: WebFrameMain | undefined;
+
+    bridge.handle("/echo", ({ senderFrame, headers }) => {
+      handledSenderFrame = senderFrame;
+
+      return new Response(null, { status: 204, headers });
+    });
+
+    const stampedHeaders = stampHeaders(bridgeUrl("/echo", BRIDGE_TOKEN), {
+      frame,
+      token: BRIDGE_TOKEN,
+    });
+
+    (frame as unknown as { url: string }).url = "https://mail.google.com/mail/u/0/#inbox";
+
+    await sendWithHeaders("/echo", "{}", stampedHeaders, BRIDGE_TOKEN);
 
     expect(handledSenderFrame).toBe(frame);
   });

--- a/packages/electron-extensions/bridge/bridge.ts
+++ b/packages/electron-extensions/bridge/bridge.ts
@@ -88,9 +88,21 @@ type ExtensionBridgeSession = {
   getExtensionId: (bridgeToken: string) => string | undefined;
 };
 
+/**
+ * A frame recorded as a caller, with the token of the document it was showing
+ * at the time. Electron keeps one `WebFrameMain` per frame tree node and
+ * re-points it at the new `RenderFrameHost` when the frame navigates, so the
+ * instance outliving the request says nothing about the document that made it;
+ * the token is what changes underneath.
+ */
+type RecordedCallerFrame = {
+  frame: WebFrameMain;
+  frameToken: string;
+};
+
 type ExtensionBridgeSessionState = ExtensionBridgeSession & {
   /** The frames recorded as callers of in-flight requests, by stamped nonce. */
-  callerFramesByNonce: Map<string, WebFrameMain>;
+  callerFramesByNonce: Map<string, RecordedCallerFrame>;
   /** Authenticated bodies being read right now, against the concurrency cap. */
   bodyReadCount: number;
 };
@@ -221,7 +233,10 @@ export class ExtensionBridge {
 
     const callerNonce = randomUUID();
 
-    callerFramesByNonce.set(callerNonce, details.frame);
+    callerFramesByNonce.set(callerNonce, {
+      frame: details.frame,
+      frameToken: details.frame.frameToken,
+    });
 
     if (callerFramesByNonce.size > MAX_RECORDED_CALLER_FRAMES) {
       const oldestNonce = callerFramesByNonce.keys().next().value;
@@ -237,8 +252,18 @@ export class ExtensionBridge {
   }
 
   /**
-   * The frame recorded for the request's stamped nonce, consumed on the way
-   * out so a nonce answers exactly once, and only while the frame is alive.
+   * The frame recorded for the request's stamped nonce, consumed on the way out
+   * so a nonce answers exactly once, and only while the frame is alive and
+   * still showing the document that made the request.
+   *
+   * The token is the second half of that. A `WebFrameMain` survives its own
+   * document: Electron tracks one per frame tree node and re-points it at the
+   * new `RenderFrameHost`, so a frame that navigated between the stamp and the
+   * handler is alive, reads as the new document's URL and title, and would
+   * otherwise be handed over as the sender of a message the old document sent.
+   * A cross-document navigation swaps the `RenderFrameHost` and so the token; a
+   * same-document one — `pushState`, a hash change — keeps both, which is the
+   * case that must still go through.
    */
   private takeCallerFrame(sessionState: ExtensionBridgeSessionState, request: GlobalRequest) {
     const callerNonce = request.headers.get(EXTENSION_BRIDGE_CALLER_HEADER);
@@ -247,11 +272,15 @@ export class ExtensionBridge {
       return undefined;
     }
 
-    const callerFrame = sessionState.callerFramesByNonce.get(callerNonce);
+    const recorded = sessionState.callerFramesByNonce.get(callerNonce);
 
     sessionState.callerFramesByNonce.delete(callerNonce);
 
-    return callerFrame && !callerFrame.isDestroyed() ? callerFrame : undefined;
+    if (!recorded || recorded.frame.isDestroyed()) {
+      return undefined;
+    }
+
+    return recorded.frame.frameToken === recorded.frameToken ? recorded.frame : undefined;
   }
 
   /**

--- a/packages/electron-extensions/fixture/probes.ts
+++ b/packages/electron-extensions/fixture/probes.ts
@@ -37,6 +37,12 @@ export type ProbeResults = {
   workerClosedPort: boolean;
   /** Whether the worker's event log recorded this context closing its own port. */
   selfCloseSeenByWorker: boolean;
+  /**
+   * The name of a port this context opened and deliberately left open, or
+   * `null` if it never came up. Nothing in this context will ever close it, so
+   * the worker hearing it disconnect means the context itself went away.
+   */
+  openPortName: string | null;
 };
 
 function delay(durationMs: number) {
@@ -196,6 +202,20 @@ async function probeSelfClose(runtime: FixtureRuntime, contextId: string): Promi
   return false;
 }
 
+/**
+ * Opens a port, proves it is live, and leaves it open — what a page that
+ * navigates away without disconnecting leaves behind. Its name goes into the
+ * results so a test can watch the worker's log for the disconnect that the
+ * context going away should produce.
+ */
+async function probeOpenPort(runtime: FixtureRuntime, contextId: string): Promise<string | null> {
+  const portName = `left-open:${contextId}`;
+
+  const port = runtime.connect({ name: portName });
+
+  return (await portRoundTrip(port, contextId)) ? portName : null;
+}
+
 export async function runProbes(): Promise<ProbeResults> {
   const runtime = getChromeRuntime();
 
@@ -217,5 +237,6 @@ export async function runProbes(): Promise<ProbeResults> {
     port: await probePort(runtime, contextId),
     workerClosedPort: await probeWorkerClosedPort(runtime, contextId),
     selfCloseSeenByWorker: await probeSelfClose(runtime, contextId),
+    openPortName: await probeOpenPort(runtime, contextId),
   };
 }

--- a/packages/electron-extensions/runtime-proxy/bridge-protocol.ts
+++ b/packages/electron-extensions/runtime-proxy/bridge-protocol.ts
@@ -112,6 +112,12 @@ export type RuntimeProxyTab = {
   highlighted: boolean;
   pinned: boolean;
   incognito: boolean;
+  status: "loading" | "complete";
+  groupId: number;
+  selected: boolean;
+  audible: boolean;
+  discarded: boolean;
+  autoDiscardable: boolean;
 };
 
 /**
@@ -129,6 +135,12 @@ export type RuntimeProxySender = {
   origin?: string;
   frameId?: number;
   tab?: RuntimeProxyTab;
+  /**
+   * Always `"active"`: the frame is the one Chromium recorded as the request's
+   * caller and the sender is built while it is alive, so it is never a
+   * prerendered or back-forward-cached document.
+   */
+  documentLifecycle?: "active";
 };
 
 /**

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
@@ -186,6 +186,7 @@ function createPage(shimSession: Session, contentsId = 7, url = PAGE_URL) {
     session: shimSession,
     isDestroyed: () => false,
     isLoading: () => false,
+    isCurrentlyAudible: () => false,
     getURL: () => url,
     getTitle: () => "Sign in",
   } as unknown as WebContents;

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
@@ -185,6 +185,7 @@ function createPage(shimSession: Session, contentsId = 7, url = PAGE_URL) {
     id: contentsId,
     session: shimSession,
     isDestroyed: () => false,
+    isLoading: () => false,
     getURL: () => url,
     getTitle: () => "Sign in",
   } as unknown as WebContents;

--- a/packages/electron-extensions/runtime-proxy/sender.test.ts
+++ b/packages/electron-extensions/runtime-proxy/sender.test.ts
@@ -27,12 +27,14 @@ function createContents(
   url: string,
   contentsSession: Session = session,
   isLoading = false,
+  isCurrentlyAudible = false,
 ) {
   return {
     id: contentsId,
     session: contentsSession,
     isDestroyed: () => false,
     isLoading: () => isLoading,
+    isCurrentlyAudible: () => isCurrentlyAudible,
     getURL: () => url,
     getTitle: () => title,
   } as unknown as WebContents;
@@ -205,6 +207,24 @@ describe("reconstructSender", () => {
     });
 
     expect(sender.tab?.status).toBe("loading");
+  });
+
+  test("a tab playing audio says so, the way Chrome's own tab does", () => {
+    const pageUrl = "https://mail.google.com/mail/u/0/";
+
+    const frame = createFrame(pageUrl, 12);
+
+    const contents = createContents(7, "Gmail", pageUrl, session, false, true);
+
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: pageUrl, isTopFrame: true },
+      senderFrame: frame as unknown as WebFrameMain,
+      getWebContentsFromFrame: contentsOf([[frame, contents]]),
+    });
+
+    expect(sender.tab?.audible).toBe(true);
   });
 
   test("a same-document navigation since the report still delivers the frame's own URL", () => {

--- a/packages/electron-extensions/runtime-proxy/sender.test.ts
+++ b/packages/electron-extensions/runtime-proxy/sender.test.ts
@@ -26,11 +26,13 @@ function createContents(
   title: string,
   url: string,
   contentsSession: Session = session,
+  isLoading = false,
 ) {
   return {
     id: contentsId,
     session: contentsSession,
     isDestroyed: () => false,
+    isLoading: () => isLoading,
     getURL: () => url,
     getTitle: () => title,
   } as unknown as WebContents;
@@ -75,6 +77,7 @@ describe("reconstructSender", () => {
       id: EXTENSION_ID,
       url: "https://accounts.google.com/signin",
       origin: "https://accounts.google.com",
+      documentLifecycle: "active",
       frameId: 0,
       tab: {
         id: 7,
@@ -84,8 +87,14 @@ describe("reconstructSender", () => {
         index: -1,
         active: true,
         highlighted: true,
+        selected: true,
         pinned: false,
         incognito: false,
+        status: "complete",
+        groupId: -1,
+        audible: false,
+        discarded: false,
+        autoDiscardable: true,
       },
     });
   });
@@ -154,6 +163,7 @@ describe("reconstructSender", () => {
       id: EXTENSION_ID,
       url: popupUrl,
       origin: `chrome-extension://${EXTENSION_ID}`,
+      documentLifecycle: "active",
     });
   });
 
@@ -179,6 +189,45 @@ describe("reconstructSender", () => {
     expect(sender.origin).toBe(`chrome-extension://${EXTENSION_ID}`);
   });
 
+  test("a tab still loading says so, which is the one tab field with a source", () => {
+    const pageUrl = "https://accounts.google.com/signin";
+
+    const frame = createFrame(pageUrl, 12);
+
+    const contents = createContents(7, "Sign in", pageUrl, session, true);
+
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: pageUrl, isTopFrame: true },
+      senderFrame: frame as unknown as WebFrameMain,
+      getWebContentsFromFrame: contentsOf([[frame, contents]]),
+    });
+
+    expect(sender.tab?.status).toBe("loading");
+  });
+
+  test("a same-document navigation since the report still delivers the frame's own URL", () => {
+    // What Gmail does constantly, and what the exact-URL check used to answer
+    // with `id` alone: the shim read `location.href`, the page pushStated, and
+    // the request reached the bridge against a frame at the newer URL
+    const frame = createFrame("https://mail.google.com/mail/u/0/#inbox", 12);
+
+    const contents = createContents(7, "Gmail", "https://mail.google.com/mail/u/0/#inbox");
+
+    const sender = reconstructSender({
+      session,
+      extensionId: EXTENSION_ID,
+      report: { url: "https://mail.google.com/mail/u/0/", isTopFrame: true },
+      senderFrame: frame as unknown as WebFrameMain,
+      getWebContentsFromFrame: contentsOf([[frame, contents]]),
+    });
+
+    // The frame's URL, never the report's: the report buys no field of its own
+    expect(sender.url).toBe("https://mail.google.com/mail/u/0/#inbox");
+    expect(sender.origin).toBe("https://mail.google.com");
+  });
+
   test("a request the bridge recorded no frame for delivers the id alone", () => {
     const sender = reconstructSender({
       session,
@@ -193,7 +242,7 @@ describe("reconstructSender", () => {
     expect(sender).toEqual({ id: EXTENSION_ID });
   });
 
-  test("a report the caller's frame does not back is not honored", () => {
+  test("a report from another origin is not honored", () => {
     const frame = createFrame("https://accounts.google.com/", 12);
 
     const contents = createContents(7, "Sign in", "https://accounts.google.com/");

--- a/packages/electron-extensions/runtime-proxy/sender.ts
+++ b/packages/electron-extensions/runtime-proxy/sender.ts
@@ -57,8 +57,18 @@ function createTabDetails(contents: WebContents): RuntimeProxyTab {
     // The page is speaking, which is the closest this layer has to "in front"
     active: true,
     highlighted: true,
+    selected: true,
     pinned: false,
     incognito: false,
+    status: contents.isLoading() ? "loading" : "complete",
+    // Tab groups are Chrome UI the embedder has none of, which is what
+    // Chrome's own `TAB_GROUP_ID_NONE` says
+    groupId: -1,
+    // Nothing here plays audio through an extension's eyes, and Meru never
+    // discards a page out from under one
+    audible: false,
+    discarded: false,
+    autoDiscardable: true,
   };
 }
 
@@ -83,14 +93,22 @@ export type ReconstructSenderOptions = {
  * The sender is built from the frame the bridge recorded as the request's
  * caller, never from any frame that merely resembles the report: with one URL
  * open in two tabs of a session, the message is attributed to the tab that
- * sent it. The shim's self-report still has to match that frame — same URL,
+ * sent it. The shim's self-report still has to match that frame — same origin,
  * same side of the top-frame line — and a report the caller's own frame does
  * not back delivers as `id` alone rather than as the URL it asked for: an
  * extension checking `sender.origin` against its own — which is what 1Password
  * does before it will answer — then refuses it, which is the right way for an
- * unverifiable claim to end. A mismatch is a document that navigated between
- * the shim reading `location.href` and the request being handled, or a report
- * that was never true, and neither is delivered.
+ * unverifiable claim to end.
+ *
+ * Origin rather than the exact URL, because the exact URL made a same-document
+ * navigation — a `pushState` between the shim reading `location.href` and the
+ * bridge handling the request — deliver as `id` alone, and Gmail pushStates
+ * constantly. Nothing is given up: the sender's `url` and `origin` are read off
+ * the frame either way, so the report buys no field of its own, and a context
+ * can no more claim a foreign origin than it could a foreign URL — the caller
+ * stamp is a frame Chromium recorded, not a claim. What the check still catches
+ * is a report from a context of some other origin entirely, which is a report
+ * that was never true.
  *
  * A top-level extension page is no tab, so it stops there. Chrome gives an
  * action popup's messages a sender of `id`, `url` and `origin` alone, and that
@@ -112,7 +130,10 @@ export function reconstructSender({
     return { id: extensionId };
   }
 
-  if (senderFrame.url !== report.url || (senderFrame.parent === null) !== report.isTopFrame) {
+  if (
+    getOrigin(senderFrame.url) !== getOrigin(report.url) ||
+    (senderFrame.parent === null) !== report.isTopFrame
+  ) {
     return { id: extensionId };
   }
 
@@ -126,6 +147,12 @@ export function reconstructSender({
     id: extensionId,
     url: senderFrame.url,
     origin: getOrigin(senderFrame.url),
+    // A live caller frame is by definition the active document of its frame.
+    // `documentId` has no Electron source — nothing exposes Chromium's
+    // per-document token — and stays absent rather than being invented, as
+    // does `tlsChannelId`, which Chrome fills only for an extension that asked
+    // for it in its manifest
+    documentLifecycle: "active",
   };
 
   const isExtensionPage =

--- a/packages/electron-extensions/runtime-proxy/sender.ts
+++ b/packages/electron-extensions/runtime-proxy/sender.ts
@@ -61,12 +61,13 @@ function createTabDetails(contents: WebContents): RuntimeProxyTab {
     pinned: false,
     incognito: false,
     status: contents.isLoading() ? "loading" : "complete",
+    // What Chromium derives Chrome's own `audible` from; Gmail's notification
+    // sounds and Meet's audio make this a real value rather than a constant
+    audible: contents.isCurrentlyAudible(),
     // Tab groups are Chrome UI the embedder has none of, which is what
     // Chrome's own `TAB_GROUP_ID_NONE` says
     groupId: -1,
-    // Nothing here plays audio through an extension's eyes, and Meru never
-    // discards a page out from under one
-    audible: false,
+    // Meru never discards a page out from under an extension
     discarded: false,
     autoDiscardable: true,
   };
@@ -103,12 +104,27 @@ export type ReconstructSenderOptions = {
  * Origin rather than the exact URL, because the exact URL made a same-document
  * navigation — a `pushState` between the shim reading `location.href` and the
  * bridge handling the request — deliver as `id` alone, and Gmail pushStates
- * constantly. Nothing is given up: the sender's `url` and `origin` are read off
- * the frame either way, so the report buys no field of its own, and a context
- * can no more claim a foreign origin than it could a foreign URL — the caller
- * stamp is a frame Chromium recorded, not a claim. What the check still catches
- * is a report from a context of some other origin entirely, which is a report
- * that was never true.
+ * constantly. What the report is held to is therefore the sending document's
+ * origin rather than its URL. The URL it does deliver is still the frame's own,
+ * never the report's, so the report buys no field of its own; a context can no
+ * more claim a foreign origin than it could a foreign URL, since the caller
+ * stamp is a frame Chromium recorded rather than a claim.
+ *
+ * What keeps that from being a hole is the bridge, not this check. A
+ * `WebFrameMain` outlives the document that made the request — Electron
+ * re-points one frame instance at each new `RenderFrameHost` — so on its own,
+ * origin equality would let a cross-document navigation to another page of the
+ * same origin through and attribute the old document's message to the new one.
+ * The caller stamp is gated on the frame's token for exactly that reason
+ * (`bridge/bridge.ts`), so a frame here is the document that spoke, and the
+ * only mismatch left for this check to absorb is the same-document one.
+ *
+ * Two URLs with no origin of their own — `about:blank`, `data:`, `file:`, an
+ * empty URL — compare equal here, since `getOrigin` answers `"null"` for each.
+ * Harmless while the frame is the sending document and every field is read off
+ * it, but it means an opaque-origin report is not really checked; the honest
+ * source would be `WebFrameMain.origin` against the shim's `location.origin`,
+ * and what Electron serializes there for extension origins is unverified.
  *
  * A top-level extension page is no tab, so it stops there. Chrome gives an
  * action popup's messages a sender of `id`, `url` and `origin` alone, and that

--- a/tests/extension-proxy.e2e.ts
+++ b/tests/extension-proxy.e2e.ts
@@ -196,6 +196,43 @@ async function readProbeResults(webContentsId: number, frameUrlPrefix?: string) 
   return JSON.parse(serializedResults as unknown as string) as ProbeResults;
 }
 
+/** Navigates a probe window that is already open, the way a page leaves. */
+async function navigateProbeWindow(webContentsId: number, url: string) {
+  await meru.app.evaluate(
+    async ({ webContents }, { webContentsId: contentsId, url: nextUrl }) => {
+      await webContents.fromId(contentsId)?.loadURL(nextUrl);
+    },
+    { webContentsId, url },
+  );
+}
+
+/**
+ * The worker's port event log, read through an extension page of the worker's
+ * own session — natively, with no proxy in the path, so what it reports is the
+ * worker's own view. A context that has gone away cannot report for itself,
+ * which is the whole point of asking the worker instead.
+ */
+async function readWorkerPortEvents(webContentsId: number) {
+  return meru.app.evaluate(
+    ({ webContents }, { webContentsId: contentsId }) => {
+      const contents = webContents.fromId(contentsId);
+
+      if (!contents) {
+        return [];
+      }
+
+      return contents.mainFrame.executeJavaScript(
+        `new Promise((resolve) => {
+          chrome.runtime.sendMessage({ type: "read-events" }, (reply) => {
+            resolve(reply && reply.events ? reply.events : []);
+          });
+        })`,
+      ) as Promise<string[]>;
+    },
+    { webContentsId },
+  );
+}
+
 function popupUrl(context: string) {
   return `chrome-extension://${FIXTURE_EXTENSION_ID}/popup.html?context=${context}`;
 }
@@ -347,6 +384,38 @@ test("ports relay both ways and both ends observe a disconnect", async () => {
   // The shim closing a port reaches the worker end as that port's
   // onDisconnect, observed through the worker's own event log
   expect(page.selfCloseSeenByWorker).toBe(true);
+});
+
+test("a page navigating away disconnects the port it left open", async () => {
+  /*
+   * The one path that closes a shim port whose page went away without
+   * disconnecting is `ReadableStream.cancel` on the connect response, and that
+   * it fires at all is Electron's behavior rather than this layer's — which is
+   * why it is pinned here rather than assumed. Without it the worker never
+   * hears `onDisconnect` and both port maps grow by one per navigation.
+   *
+   * The shim cannot cover for it. A bridge POST started from the departing
+   * context — a `pagehide` handler, `keepalive` or not — never reaches main:
+   * an unload-time request on this scheme is dropped with the frame, measured
+   * with this same case and the cancel handler compiled out.
+   */
+  const observerPopupId = await openProbeWindow(WORKER_PARTITION, popupUrl("navigation-observer"));
+
+  const pageId = await openProbeWindow(SHIM_PARTITION, `${serverOrigin}/plain`);
+
+  const page = await readProbeResults(pageId);
+
+  expect(page.openPortName).toBe(`left-open:${page.contextId}`);
+
+  const openPortDisconnect = `disconnect:${page.openPortName}`;
+
+  // Nothing in the page closes this port, so the worker has no business
+  // seeing it disconnect while the page is still there
+  expect(await readWorkerPortEvents(observerPopupId)).not.toContain(openPortDisconnect);
+
+  await navigateProbeWindow(pageId, "about:blank");
+
+  await expect.poll(() => readWorkerPortEvents(observerPopupId)).toContain(openPortDisconnect);
 });
 
 test("a message is attributed to the frame that sent it, an embedded extension frame included", async () => {


### PR DESCRIPTION
## Summary
Rows 26 and 30 of the runtime proxy review, the shim and sender side. The disconnect a page leaving takes its port with is now pinned by an end-to-end case, which measured that Electron's `ReadableStream.cancel` does fire and that the shim can never cover for it if a future Electron stops. The relayed `MessageSender` gains the fields Chrome's carries, and the check against the shim's self-report relaxes from exact URL to origin equality — which needed the bridge's caller stamp bound to the document that made the request, since a `WebFrameMain` outlives its own document.

## Problem
**Row 26.** The only path that closes a shim port whose page navigated away without calling `disconnect()` is `ReadableStream.cancel` on the connect response in `handleConnect`. Whether Electron cancels a response body when the frame that asked for it is destroyed was unmeasured, and the e2e suite never navigated a page with an open port. If it does not fire, the worker never hears `onDisconnect` for a per-page port, `RuntimeProxy.ports` and the relay client's map grow by one per navigation for the life of the worker, and a worker-side `postMessage` to the dead port succeeds silently. Chrome disconnects a port when its frame unloads.

**Row 30.** The worker-side `sender` and `port.sender` carried no [`documentLifecycle`](https://developer.chrome.com/docs/extensions/reference/api/runtime#type-MessageSender), and `tab` was missing `status`, `groupId`, `selected`, `audible`, `discarded` and `autoDiscardable` from [`chrome.tabs.Tab`](https://developer.chrome.com/docs/extensions/reference/api/tabs#type-Tab) — all of it observable by an extension inspecting its sender. Separately, the sender was delivered only when the shim's reported URL matched the caller frame's exactly, so a same-document navigation between the shim reading `location.href` and the bridge handling the request delivered `id` alone; an extension checking `sender.origin` against its own, which is what 1Password does before it will answer, then refuses the message. Gmail `pushState`s constantly.

## Solution
- The fixture leaves one port open per context and reports its name. The new e2e case navigates the page and reads the worker's own event log through a popup of the *worker* session — natively, with no proxy in the path, so what it reports is the worker's view rather than the proxy's.
- `documentLifecycle: "active"`, since a live caller frame is by definition its frame's active document. `tab.status` and `tab.audible` are read off the `WebContents` — `isLoading()` and `isCurrentlyAudible()`, the latter being what Chromium derives Chrome's own field from, and Gmail's notification sounds make it a real value rather than a constant. `selected`, `pinned`, `discarded` and `autoDiscardable` carry the values Chrome gives an active foreground tab, and `groupId` Chrome's own `TAB_GROUP_ID_NONE`. `documentId` stays absent because nothing in Electron exposes Chromium's per-document token, and `tlsChannelId` because Chrome fills it only for an extension that asked for it in its manifest — inventing either is worse than omitting it.
- The report check is now origin equality, with `isTopFrame` still exact. The URL delivered is still the frame's own, never the report's, so the report buys no field of its own.

**Origin equality needed the caller stamp fixed first, which is the third commit.** A `WebFrameMain` outlives the document that made a request: Electron keeps one per frame tree node and re-points it at the new `RenderFrameHost` on navigation, so a frame recorded at the stamp is still alive at the handler and reads as whatever the frame shows by then. Exact URL equality hid that — a navigated frame no longer matched the report, so the sender came out as `id` alone. Origin equality would not have: a cross-document navigation to another page of the same origin, `mail/u/0` to `mail/u/1` between the stamp and the handler, would deliver the new document's URL and tab title, and `documentLifecycle: "active"` for a document pending deletion, as the sender of a message the old document sent. Chrome captures the sender at send time and has no such window. So `stampCaller` now records the frame's token beside it and `takeCallerFrame` refuses the frame when the token changed: a cross-document navigation swaps the `RenderFrameHost` and so the token, a same-document one keeps both. Gating the frame rather than tightening the URL check back up is what keeps both properties — the frame is the document that spoke, and a `pushState` in flight still delivers.

**A `pagehide` disconnect was written and then deleted, which is the other part worth knowing.** The plan for row 26 was for the shim to track its open ports and post `portDisconnect` for each on `pagehide` with `keepalive: true`, so the disconnect no longer depended on Electron's cancel semantics. It cannot work. Measured on Electron 43.2.0, packaged Linux build, by compiling each half out in turn with this same e2e case: the cancel path alone delivers the disconnect promptly; the `pagehide` path alone delivers nothing, `keepalive: true` and `false` alike. `pagehide` itself does fire in a content script's isolated world — a `localStorage` marker written by the departing context was read by the next page's content script — so what fails is the request. Chromium's keepalive path covers HTTP(S), not a `protocol.handle` scheme, and an unload-time request on that scheme is dropped with the frame. That generalizes past this row: **nothing on the extension bridge can ever be sent from `pagehide` or `unload`**, so any future design wanting a last word from a departing context has to send it earlier or let main observe the departure. Inert code that reads as a safety net is worse than none, because the next reader trusts it, so the handler, the port registry and the `keepalive` option are all gone and the measurement lives here, in the test's own comment, and in the feature doc.

## Try it
No preview deployment for the desktop app. `xvfb-run -a bun run test:e2e -- extension-proxy` runs the five proxy cases, the new one being "a page navigating away disconnects the port it left open"; it builds the app first, and `MERU_SKIP_BUILD=1` runs against a build already in `dist`.

## Not verified
- Nothing here has run against 1Password itself, which is what would say whether the relaxed origin check and the filled sender are enough for a real extension's `sender.origin` gate. The e2e suite's fixture is the only extension exercised.
- The measurements are from Electron 43.2.0 on Linux only. Whether macOS and Windows cancel a destroyed frame's response body on the same schedule is untested, though the e2e case now fails loudly on any platform where it stops.
- The token gate is unit-tested against a frame whose token changes, not against a real cross-document navigation in the packaged app — that a navigation swaps `frameToken` is Chromium's `RenderDocument` behavior, taken from the documentation rather than measured here. If some navigation kept its token, that request delivers what it delivered before this PR.
- Two URLs with no origin of their own — `about:blank`, `data:`, `file:`, an empty URL — compare equal in the report check, since both sides go through the same `getOrigin` and it answers `"null"` for each. Harmless while the frame is the sending document and every field is read off it; the honest source would be `WebFrameMain.origin` against the shim's `location.origin`, and what Electron serializes there for extension origins is unverified. Left as a follow-up.
- `chrome.runtime.getManifest()` in a content-script-only copy still returns a manifest without `background`, so an extension inspecting itself still sees a different extension per account. Left out deliberately: `getManifest` is synchronous, so the worker role's derived manifest has to be carried into the shim's globals the way the bridge token already is, which is a derive change rather than a shim one. Handed to its own session.