### PR TITLE
Shim getManifest in content-script-only copies

### DIFF
--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -516,6 +516,46 @@ describe("deriveExtension for a shared instance", () => {
     });
   });
 
+  test("the two roles' manifests differ in the keys the shim lays over, and no others", async () => {
+    const { derivedDir: workerDir } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      sharedInstance: { role: "worker", relayScriptPath },
+    });
+
+    const { derivedDir: shimDir } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      sharedInstance: { role: "contentScriptOnly", shimScriptPath },
+    });
+
+    const readManifest = async (derivedDir: string) =>
+      JSON.parse(await readFile(path.join(derivedDir, "manifest.json"), "utf8")) as Record<
+        string,
+        unknown
+      >;
+
+    const workerManifest = await readManifest(workerDir);
+
+    const shimManifest = await readManifest(shimDir);
+
+    const differingKeys = [
+      ...new Set([...Object.keys(workerManifest), ...Object.keys(shimManifest)]),
+    ]
+      .filter(
+        (manifestKey) =>
+          JSON.stringify(workerManifest[manifestKey]) !== JSON.stringify(shimManifest[manifestKey]),
+      )
+      .sort();
+
+    // The shim answers the worker role's manifest by laying exactly these two
+    // keys over its own context's native answer, so a third difference would
+    // stop being answered without anything else failing
+    expect(differingKeys).toEqual(["background", "content_scripts"]);
+  });
+
   test("the shim's manifest is derived without a worker copy on disk", async () => {
     const { derivedDir } = await deriveExtension({
       sourceDir,

--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { RUNTIME_PROXY_MANIFEST_GLOBAL } from "../runtime-proxy/bridge-protocol";
 import { deriveExtension, pruneDerivedExtensions } from "./index";
 
 let workDir: string;
@@ -459,6 +460,104 @@ describe("deriveExtension for a shared instance", () => {
 
     expect(shimSource).toContain(bridgeToken);
     expect(shimSource).toEndWith("// shim\n");
+  });
+
+  /**
+   * The manifest the derive left on the shim's globals, read back the way the
+   * shim itself reads it: the preamble is one assignment per line, ahead of the
+   * bundle.
+   */
+  async function readShimManifest(derivedDir: string) {
+    const shimSource = await readFile(
+      path.join(derivedDir, "chrome-runtime-proxy-shim.js"),
+      "utf8",
+    );
+
+    const assignment = shimSource
+      .split("\n")
+      .find((line) => line.startsWith(`globalThis.${RUNTIME_PROXY_MANIFEST_GLOBAL} = `));
+
+    if (!assignment) {
+      throw new Error("The shim carries no manifest");
+    }
+
+    return JSON.parse(
+      assignment.slice(`globalThis.${RUNTIME_PROXY_MANIFEST_GLOBAL} = `.length, -1),
+    );
+  }
+
+  test("the content-script-only copy's shim carries the worker copy's own manifest", async () => {
+    const { derivedDir: workerDir } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      sharedInstance: { role: "worker", relayScriptPath },
+    });
+
+    const { derivedDir: shimDir } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      sharedInstance: { role: "contentScriptOnly", shimScriptPath },
+    });
+
+    const workerManifest = JSON.parse(
+      await readFile(path.join(workerDir, "manifest.json"), "utf8"),
+    );
+
+    // Byte for byte what the one worker's own `getManifest` answers, which is
+    // the whole point: the shim's `background` key and its unshimmed
+    // `content_scripts` are the worker copy's, not this copy's
+    expect(await readShimManifest(shimDir)).toEqual(workerManifest);
+
+    expect(workerManifest.background).toEqual({
+      service_worker: "chrome-facade-service-worker.js",
+      type: "module",
+    });
+  });
+
+  test("the shim's manifest is derived without a worker copy on disk", async () => {
+    const { derivedDir } = await deriveExtension({
+      sourceDir,
+      derivedExtensionsDir,
+      facadeScriptPath,
+      sharedInstance: { role: "contentScriptOnly", shimScriptPath },
+    });
+
+    // The session that adopts the worker role derives its copy when it is set
+    // up, which can be after this one and need not happen at all
+    expect((await readdir(derivedExtensionsDir)).sort()).toEqual(
+      [path.basename(derivedDir), `${path.basename(derivedDir)}.json`].sort(),
+    );
+
+    expect(await readShimManifest(derivedDir)).toMatchObject({
+      background: { service_worker: "chrome-facade-service-worker.js" },
+      content_scripts: [{ matches: ["https://*/*"], js: ["content.js"] }],
+    });
+  });
+
+  test("the shim's manifest follows a changed clamp", async () => {
+    const deriveClampedTo = async (matches: string[]) =>
+      (
+        await deriveExtension({
+          sourceDir,
+          derivedExtensionsDir,
+          facadeScriptPath,
+          getContentScriptMatches: () => matches,
+          sharedInstance: { role: "contentScriptOnly", shimScriptPath },
+        })
+      ).derivedDir;
+
+    const derivedDir = await deriveClampedTo(["https://mail.google.com/*"]);
+
+    expect((await readShimManifest(derivedDir)).content_scripts).toEqual([
+      { matches: ["https://mail.google.com/*"], js: ["content.js"] },
+    ]);
+
+    expect(
+      (await readShimManifest(await deriveClampedTo(["https://accounts.google.com/*"])))
+        .content_scripts,
+    ).toEqual([{ matches: ["https://accounts.google.com/*"], js: ["content.js"] }]);
   });
 
   test("the content-script-only copy's pages run the shim and may reach the bridge", async () => {

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { cp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { EXTENSION_BRIDGE_SCHEME, EXTENSION_BRIDGE_TOKEN_GLOBAL } from "../bridge/protocol";
+import { RUNTIME_PROXY_MANIFEST_GLOBAL } from "../runtime-proxy/bridge-protocol";
 import { getExtensionIdFromManifestKey } from "./extension-id";
 import { allowPageConnectSource, injectPageScripts } from "./html";
 import {
@@ -168,6 +169,43 @@ async function derivePages(
 }
 
 /**
+ * The manifest the worker role's copy carries, which is what the one shared
+ * worker's own `chrome.runtime.getManifest()` returns and therefore the answer
+ * every session has to agree on. The content-script-only copy embeds it in its
+ * shim so that a context inspecting the extension does not find a `background`
+ * key missing where the worker session finds one.
+ *
+ * Recomputed from the source manifest rather than read back off the worker
+ * copy's directory: `deriveManifest` is pure, and the worker copy is derived by
+ * whichever session adopted that role — a directory that may not exist yet when
+ * this copy is derived, and does not exist at all on a launch where no session
+ * has adopted it.
+ *
+ * Nothing has to invalidate it, since the shim script it rides in is rewritten
+ * on every launch, below. Everything it is computed from — the source manifest,
+ * the stripped keys, the clamp — is in the stamp regardless, so a copy is never
+ * kept over a change to any of them either.
+ */
+function deriveWorkerRoleManifest({
+  sourceManifest,
+  strippedManifestKeys,
+  contentScriptMatches,
+}: {
+  sourceManifest: ExtensionManifest;
+  strippedManifestKeys: string[];
+  contentScriptMatches: string[] | undefined;
+}) {
+  return deriveManifest(sourceManifest, {
+    facadeFileName: FACADE_FILE_NAME,
+    serviceWorkerFileName: SERVICE_WORKER_FILE_NAME,
+    bridgeConnectSource: `${EXTENSION_BRIDGE_SCHEME}:`,
+    strippedManifestKeys,
+    contentScriptMatches,
+    sharedInstance: { role: "worker", relayFileName: RUNTIME_PROXY_RELAY_FILE_NAME },
+  }).manifest;
+}
+
+/**
  * Copies an unpacked extension into a directory the loader owns and adds the
  * `chrome.*` facade to it: the service worker gets a wrapper that pulls the
  * facade in ahead of the extension's background script, and every extension
@@ -254,14 +292,22 @@ export async function deriveExtension({
   // Always, so a rebuilt facade reaches copies that are otherwise up to date
   const bridgeToken = randomUUID();
 
-  const writeTokenCarryingScript = async (fileName: string, scriptPath: string) =>
-    writeFile(
+  const writeTokenCarryingScript = async (
+    fileName: string,
+    scriptPath: string,
+    extraGlobals: Record<string, unknown> = {},
+  ) => {
+    const globals = { [EXTENSION_BRIDGE_TOKEN_GLOBAL]: bridgeToken, ...extraGlobals };
+
+    const preamble = Object.entries(globals)
+      .map(([globalName, value]) => `globalThis.${globalName} = ${JSON.stringify(value)};\n`)
+      .join("");
+
+    await writeFile(
       path.join(derivedDir, fileName),
-      `globalThis.${EXTENSION_BRIDGE_TOKEN_GLOBAL} = ${JSON.stringify(bridgeToken)};\n${await readFile(
-        scriptPath,
-        "utf8",
-      )}`,
+      `${preamble}${await readFile(scriptPath, "utf8")}`,
     );
+  };
 
   await writeTokenCarryingScript(FACADE_FILE_NAME, facadeScriptPath);
 
@@ -272,7 +318,13 @@ export async function deriveExtension({
   }
 
   if (sharedInstance?.role === "contentScriptOnly") {
-    await writeTokenCarryingScript(RUNTIME_PROXY_SHIM_FILE_NAME, sharedInstance.shimScriptPath);
+    await writeTokenCarryingScript(RUNTIME_PROXY_SHIM_FILE_NAME, sharedInstance.shimScriptPath, {
+      [RUNTIME_PROXY_MANIFEST_GLOBAL]: deriveWorkerRoleManifest({
+        sourceManifest,
+        strippedManifestKeys,
+        contentScriptMatches,
+      }),
+    });
   }
 
   return { derivedDir, bridgeToken, extensionId };

--- a/packages/electron-extensions/fixture/_locales/en/messages.json
+++ b/packages/electron-extensions/fixture/_locales/en/messages.json
@@ -1,0 +1,9 @@
+{
+  "extName": {
+    "message": "Meru fixture",
+    "description": "The fixture extension's name, localized so the end-to-end suite covers a manifest Chromium rewrites at load."
+  },
+  "extDescription": {
+    "message": "Meru's own test extension. It ships inside the app, loads only in development or behind the end-to-end flag, and its content scripts match loopback pages alone."
+  }
+}

--- a/packages/electron-extensions/fixture/chrome.ts
+++ b/packages/electron-extensions/fixture/chrome.ts
@@ -33,6 +33,7 @@ export type FixturePort = {
 };
 
 export type FixtureManifest = {
+  [manifestKey: string]: unknown;
   background?: unknown;
 };
 

--- a/packages/electron-extensions/fixture/fixture.test.ts
+++ b/packages/electron-extensions/fixture/fixture.test.ts
@@ -11,6 +11,8 @@ import { FIXTURE_EXTENSION_ID } from "./id";
  */
 type FixtureManifestFile = {
   key?: string;
+  name?: string;
+  default_locale?: string;
   background?: { service_worker?: string };
   action?: { default_popup?: string };
   content_scripts?: { matches?: string[]; js?: string[] }[];
@@ -45,6 +47,24 @@ describe("the fixture manifest", () => {
     expect(web_accessible_resources?.map((resource) => resource.matches)).toEqual([
       LOOPBACK_MATCHES,
     ]);
+  });
+
+  test("names itself out of `_locales`, so a localized manifest is covered", async () => {
+    const { name, default_locale } = await readManifest();
+
+    // Chromium substitutes this at load and adds `current_locale`, and the
+    // derive never sees either — which is exactly what the runtime proxy's
+    // `getManifest` overlay is here to survive. 1Password's own manifest is
+    // `__MSG_extName__` too, so this is the shape that ships
+    expect(name).toBe("__MSG_extName__");
+
+    expect(default_locale).toBe("en");
+
+    const messages = JSON.parse(
+      await readFile(path.join(import.meta.dir, "_locales", "en", "messages.json"), "utf8"),
+    );
+
+    expect(messages.extName?.message).toBe("Meru fixture");
   });
 
   test("carries the surface the runtime proxy tests drive", async () => {

--- a/packages/electron-extensions/fixture/manifest.json
+++ b/packages/electron-extensions/fixture/manifest.json
@@ -1,8 +1,9 @@
 {
   "manifest_version": 3,
-  "name": "Meru fixture",
+  "name": "__MSG_extName__",
   "version": "1.0.0",
-  "description": "Meru's own test extension. It ships inside the app, loads only in development or behind the end-to-end flag, and its content scripts match loopback pages alone.",
+  "description": "__MSG_extDescription__",
+  "default_locale": "en",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjpdyC58E6LINMdwynN1Cr88rSysuYHtG0mRMs0o1Vhh3IdBugheaJhpWozxKi75SL2eOZI3hW0oiMnhxJW5mmPWdoRL90KXX+4FxREbGJXpmAtUgWs4yBDjeePSSBffHTd4vDtByrQ/0PHmoP1fRlWUU85oJoT1y26ZGQ9FQUvnx9PYG2rviHgF8in9dsopZ8QQHCQZe7qis4Ms8zoQcf0IzKNPEn3y7L6y9LbMGp9wDAtSGqXM9EoddVQnIekv62bM43TqFJVmFc2ZrsvWV2LT0rE5HY3crZ4XLYHdh0nXPuqecmAcIl4ZpG9FGNxCDLrBhmtqSvWQ6Xq8V8ckldQIDAQAB",
   "permissions": ["storage"],
   "background": {

--- a/packages/electron-extensions/fixture/probes.ts
+++ b/packages/electron-extensions/fixture/probes.ts
@@ -5,6 +5,7 @@
  * to read — the tests assert on the whole outcome objects.
  */
 import {
+  type FixtureManifest,
   type FixtureMessageSender,
   type FixturePort,
   type FixtureRuntime,
@@ -57,11 +58,14 @@ export type ProbeResults = {
   documentUrl: string;
   extensionId: string;
   /**
-   * Whether this context's copy of the extension still carries a `background`
-   * key: `true` is the full copy, `false` the content-script-only one, and
-   * `null` a context where `getManifest` does not exist.
+   * Whole, what this context's `chrome.runtime.getManifest()` answers, and
+   * `null` in a context that has no such method. Every session has to answer
+   * the same manifest even though they load different copies: the
+   * content-script-only copy is derived without a `background` key, and the
+   * shim is what puts the worker copy's manifest back in front of the
+   * extension.
    */
-  manifestHasBackground: boolean | null;
+  manifest: FixtureManifest | null;
   echo: EchoOutcome;
   port: PortOutcome;
   /**
@@ -524,7 +528,7 @@ export async function runProbes(): Promise<ProbeResults> {
     contextId,
     documentUrl: contextGlobals.location.href,
     extensionId: runtime.id,
-    manifestHasBackground: manifest ? manifest.background !== undefined : null,
+    manifest: manifest ?? null,
     echo,
     port,
     workerStampInLocal,

--- a/packages/electron-extensions/runtime-proxy/bridge-protocol.ts
+++ b/packages/electron-extensions/runtime-proxy/bridge-protocol.ts
@@ -33,6 +33,18 @@ import type {
  */
 export const RUNTIME_PROXY_RELAY_START_GLOBAL = "__meruRuntimeProxyStartRelay";
 
+/**
+ * Where the derived content-script-only copy leaves the manifest the shim
+ * answers `chrome.runtime.getManifest()` with: the *worker* role's derived
+ * manifest, since the worker copy is the one instance every session shares and
+ * what its `getManifest` returns is the answer they all have to agree on.
+ *
+ * It rides the shim's own script the way the bridge token rides the facade's,
+ * because `getManifest` is synchronous — there is no asking the bridge for it —
+ * and the shim runs in isolated worlds the facade never reaches.
+ */
+export const RUNTIME_PROXY_MANIFEST_GLOBAL = "__meruRuntimeProxyManifest";
+
 /** What every extension URL starts with, from a worker scope to a page's own. */
 export const EXTENSION_SCHEME_PREFIX = "chrome-extension://";
 

--- a/packages/electron-extensions/runtime-proxy/shim.test.ts
+++ b/packages/electron-extensions/runtime-proxy/shim.test.ts
@@ -482,8 +482,73 @@ describe("shimmed connect", () => {
   });
 });
 
+describe("shimmed getManifest", () => {
+  const WORKER_MANIFEST = {
+    name: "Test Extension",
+    version: "1.0.0",
+    manifest_version: 3,
+    background: { service_worker: "chrome-facade-service-worker.js", type: "module" },
+    content_scripts: [{ matches: ["https://mail.google.com/*"], js: ["content.js"] }],
+  };
+
+  function createRuntime(nativeManifest?: unknown) {
+    const runtime: ChromeNamespace = { id: EXTENSION_ID };
+
+    if (nativeManifest !== undefined) {
+      runtime.getManifest = () => nativeManifest;
+    }
+
+    installRuntimeProxyShim({ runtime }, { workerManifest: WORKER_MANIFEST });
+
+    return runtime.getManifest as () => unknown;
+  }
+
+  test("answers the worker copy's manifest rather than this copy's", () => {
+    // The copy this context runs in is the one the derive took `background`
+    // off, so its own answer is the per-account difference being closed
+    const getManifest = createRuntime({ ...WORKER_MANIFEST, background: undefined });
+
+    expect(getManifest()).toEqual(WORKER_MANIFEST);
+  });
+
+  test("hands out a fresh copy every call, the way Chrome does", () => {
+    const getManifest = createRuntime();
+
+    const first = getManifest() as { content_scripts: unknown[] };
+
+    expect(first).not.toBe(getManifest());
+    expect(first.content_scripts).not.toBe(
+      (getManifest() as { content_scripts: unknown[] }).content_scripts,
+    );
+
+    first.content_scripts.push({ matches: ["https://evil.example/*"] });
+
+    expect(getManifest()).toEqual(WORKER_MANIFEST);
+  });
+
+  test("installs over itself without changing what it answers", () => {
+    const runtime: ChromeNamespace = { id: EXTENSION_ID };
+
+    installRuntimeProxyShim({ runtime }, { workerManifest: WORKER_MANIFEST });
+
+    installRuntimeProxyShim({ runtime }, { workerManifest: WORKER_MANIFEST });
+
+    expect((runtime.getManifest as () => unknown)()).toEqual(WORKER_MANIFEST);
+  });
+
+  test("leaves the native answer alone when the derive embedded none", () => {
+    const nativeGetManifest = () => ({ name: "Native" });
+
+    const runtime: ChromeNamespace = { id: EXTENSION_ID, getManifest: nativeGetManifest };
+
+    installRuntimeProxyShim({ runtime });
+
+    expect(runtime.getManifest).toBe(nativeGetManifest);
+  });
+});
+
 describe("installRuntimeProxyShim", () => {
-  test("shadows only sendMessage and connect, and leaves the rest native", () => {
+  test("shadows only what it proxies, and leaves the rest native", () => {
     const nativeSendMessage = () => undefined;
 
     const getUrl = (resourcePath: string) => `chrome-extension://${EXTENSION_ID}/${resourcePath}`;

--- a/packages/electron-extensions/runtime-proxy/shim.test.ts
+++ b/packages/electron-extensions/runtime-proxy/shim.test.ts
@@ -483,67 +483,119 @@ describe("shimmed connect", () => {
 });
 
 describe("shimmed getManifest", () => {
+  /** What the derive embedded: the worker role's copy of the manifest file. */
   const WORKER_MANIFEST = {
-    name: "Test Extension",
+    name: "__MSG_extName__",
     version: "1.0.0",
     manifest_version: 3,
+    default_locale: "en",
     background: { service_worker: "chrome-facade-service-worker.js", type: "module" },
     content_scripts: [{ matches: ["https://mail.google.com/*"], js: ["content.js"] }],
   };
 
-  function createRuntime(nativeManifest?: unknown) {
-    const runtime: ChromeNamespace = { id: EXTENSION_ID };
+  /**
+   * What Chromium answers in this copy: the manifest it localized as it loaded
+   * it — `__MSG_extName__` substituted out of `_locales`, `current_locale`
+   * added — with no `background` and the shim in front of every content script,
+   * which is what the derive left this copy.
+   */
+  const NATIVE_MANIFEST = {
+    name: "1Password – Password Manager",
+    version: "1.0.0",
+    manifest_version: 3,
+    default_locale: "en",
+    current_locale: "en",
+    content_scripts: [
+      {
+        matches: ["https://mail.google.com/*"],
+        js: ["chrome-runtime-proxy-shim.js", "content.js"],
+      },
+    ],
+  };
 
-    if (nativeManifest !== undefined) {
-      runtime.getManifest = () => nativeManifest;
-    }
+  /** The same localization, in the copy that kept its worker. */
+  const WORKER_SESSION_NATIVE_MANIFEST = {
+    ...NATIVE_MANIFEST,
+    background: WORKER_MANIFEST.background,
+    content_scripts: WORKER_MANIFEST.content_scripts,
+  };
 
-    installRuntimeProxyShim({ runtime }, { workerManifest: WORKER_MANIFEST });
+  function createRuntime(
+    nativeManifest: unknown = NATIVE_MANIFEST,
+    workerManifest: unknown = WORKER_MANIFEST,
+  ) {
+    const runtime: ChromeNamespace = {
+      id: EXTENSION_ID,
+      getManifest: () => structuredClone(nativeManifest),
+    };
 
-    return runtime.getManifest as () => unknown;
+    installRuntimeProxyShim({ runtime }, { workerManifest });
+
+    return runtime.getManifest as () => Record<string, unknown>;
   }
 
-  test("answers the worker copy's manifest rather than this copy's", () => {
-    // The copy this context runs in is the one the derive took `background`
-    // off, so its own answer is the per-account difference being closed
-    const getManifest = createRuntime({ ...WORKER_MANIFEST, background: undefined });
+  test("answers what the worker session's own getManifest answers", () => {
+    expect(createRuntime()()).toEqual(WORKER_SESSION_NATIVE_MANIFEST);
+  });
 
-    expect(getManifest()).toEqual(WORKER_MANIFEST);
+  test("keeps the localization Chromium did, which the derive never sees", () => {
+    // The manifest file names the extension `__MSG_extName__`, as 1Password's
+    // does; Chromium substitutes it out of `_locales` at load and adds
+    // `current_locale`, and the derive runs nowhere near either
+    const manifest = createRuntime()();
+
+    expect(manifest.name).toBe("1Password – Password Manager");
+    expect(manifest.current_locale).toBe("en");
+  });
+
+  test("drops background when the worker role's manifest carries none", () => {
+    const manifest = createRuntime(NATIVE_MANIFEST, {
+      ...WORKER_MANIFEST,
+      background: undefined,
+    })();
+
+    expect("background" in manifest).toBe(false);
   });
 
   test("hands out a fresh copy every call, the way Chrome does", () => {
     const getManifest = createRuntime();
 
-    const first = getManifest() as { content_scripts: unknown[] };
+    const first = getManifest();
 
     expect(first).not.toBe(getManifest());
-    expect(first.content_scripts).not.toBe(
-      (getManifest() as { content_scripts: unknown[] }).content_scripts,
-    );
+    expect(first.background).not.toBe(getManifest().background);
 
-    first.content_scripts.push({ matches: ["https://evil.example/*"] });
+    (first.content_scripts as unknown[]).push({ matches: ["https://evil.example/*"] });
 
-    expect(getManifest()).toEqual(WORKER_MANIFEST);
+    expect(getManifest()).toEqual(WORKER_SESSION_NATIVE_MANIFEST);
   });
 
   test("installs over itself without changing what it answers", () => {
-    const runtime: ChromeNamespace = { id: EXTENSION_ID };
+    const runtime: ChromeNamespace = { id: EXTENSION_ID, getManifest: () => NATIVE_MANIFEST };
 
     installRuntimeProxyShim({ runtime }, { workerManifest: WORKER_MANIFEST });
 
     installRuntimeProxyShim({ runtime }, { workerManifest: WORKER_MANIFEST });
 
-    expect((runtime.getManifest as () => unknown)()).toEqual(WORKER_MANIFEST);
+    expect((runtime.getManifest as () => unknown)()).toEqual(WORKER_SESSION_NATIVE_MANIFEST);
   });
 
   test("leaves the native answer alone when the derive embedded none", () => {
-    const nativeGetManifest = () => ({ name: "Native" });
+    const nativeGetManifest = () => NATIVE_MANIFEST;
 
     const runtime: ChromeNamespace = { id: EXTENSION_ID, getManifest: nativeGetManifest };
 
     installRuntimeProxyShim({ runtime });
 
     expect(runtime.getManifest).toBe(nativeGetManifest);
+  });
+
+  test("gives a context Chrome answers no manifest in one of its own", () => {
+    const runtime: ChromeNamespace = { id: EXTENSION_ID };
+
+    installRuntimeProxyShim({ runtime }, { workerManifest: WORKER_MANIFEST });
+
+    expect(runtime.getManifest).toBeUndefined();
   });
 });
 

--- a/packages/electron-extensions/runtime-proxy/shim.ts
+++ b/packages/electron-extensions/runtime-proxy/shim.ts
@@ -311,6 +311,56 @@ function getEmbeddedWorkerManifest() {
   return (globalThis as unknown as Record<string, unknown>)[RUNTIME_PROXY_MANIFEST_GLOBAL];
 }
 
+/**
+ * The only keys the worker role's derived manifest and this copy's differ in:
+ * `deriveManifest` deletes `background` for the content-script-only role and
+ * prepends the shim to every `content_scripts` entry, and leaves the rest of
+ * the rewrite the same for both. `deriveManifest`'s own tests pin that, since
+ * a third difference would silently stop being answered here.
+ */
+const WORKER_ROLE_MANIFEST_KEYS = ["background", "content_scripts"];
+
+/**
+ * Answers what the one worker's own `getManifest` answers, by laying the two
+ * keys the roles differ in over this context's native answer.
+ *
+ * An overlay rather than the embedded manifest outright, because the native
+ * answer is not the manifest file: Chromium localizes a manifest as it loads
+ * it — `__MSG_name__` and its siblings substituted out of `_locales`, and a
+ * `current_locale` key added — and `getManifest` returns that. 1Password's
+ * manifest names itself `__MSG_extName__`, so handing back what the derive
+ * wrote would trade the `background` difference for a name and a locale that
+ * differ instead. The derive cannot do the substitution itself: the UI locale
+ * is a runtime fact of the browser process, not of the copy on disk.
+ *
+ * Both copies are localized by the same browser process from the same
+ * `_locales`, so everything the overlay leaves alone already agrees.
+ */
+function createProxiedGetManifest(nativeGetManifest: NativeMethod, workerManifest: unknown) {
+  return () => {
+    const manifest = { ...(nativeGetManifest() as Record<string, unknown>) };
+
+    const workerManifestKeys = workerManifest as Record<string, unknown>;
+
+    for (const manifestKey of WORKER_ROLE_MANIFEST_KEYS) {
+      if (workerManifestKeys[manifestKey] === undefined) {
+        delete manifest[manifestKey];
+
+        continue;
+      }
+
+      manifest[manifestKey] = workerManifestKeys[manifestKey];
+    }
+
+    // Chrome hands out a new object per call and says nothing about what an
+    // extension may do with it, so an extension that mutates what it got — or
+    // that is handed the same object twice and compares the two — must see
+    // exactly what it sees in Chrome. The native answer is already fresh; the
+    // two keys laid over it are not
+    return structuredClone(manifest);
+  };
+}
+
 export type InstallRuntimeProxyShimOptions = {
   getSenderReport?: () => RuntimeProxySenderReport;
   /**
@@ -334,8 +384,11 @@ export type InstallRuntimeProxyShimOptions = {
  * one the derive took the `background` key off, so an extension inspecting
  * itself would otherwise find no service worker where the worker session's copy
  * finds one — a per-account difference with nothing behind it, since the worker
- * every session reaches is the same worker. It answers the worker role's
- * derived manifest, which is what that worker's own `getManifest` returns.
+ * every session reaches is the same worker. It answers what the worker's own
+ * `getManifest` answers, by laying the worker role's `background` and
+ * `content_scripts` over this context's native answer rather than replacing it
+ * outright; see `createProxiedGetManifest` for why the native answer is the
+ * base.
  *
  * `onMessage` and `onConnect` are left native, which is what bounds the shim:
  * an extension page hears what it opened a port for, and not what the worker
@@ -366,11 +419,11 @@ export function installRuntimeProxyShim(
     getSenderReport,
   );
 
-  if (workerManifest !== undefined) {
-    // Chrome hands out a new object per call and says nothing about what an
-    // extension may do with it, so an extension that mutates what it got — or
-    // that is handed the same object twice and compares the two — must see
-    // exactly what it sees in Chrome
-    runtime.getManifest = () => structuredClone(workerManifest);
+  const nativeGetManifest = getNativeMethod(runtime, "getManifest");
+
+  // With no native answer to lay the two keys over there is nothing to
+  // correct, and a context Chrome gives no `getManifest` must not gain one
+  if (workerManifest !== undefined && nativeGetManifest) {
+    runtime.getManifest = createProxiedGetManifest(nativeGetManifest, workerManifest);
   }
 }

--- a/packages/electron-extensions/runtime-proxy/shim.ts
+++ b/packages/electron-extensions/runtime-proxy/shim.ts
@@ -7,6 +7,7 @@ import {
   MAX_RUNTIME_PROXY_FRAME_BYTES,
   PORT_CLOSED_ERROR,
   RECEIVING_END_ERROR,
+  RUNTIME_PROXY_MANIFEST_GLOBAL,
   RUNTIME_PROXY_PATHS,
   type RuntimeProxyPortFrame,
   type RuntimeProxySenderReport,
@@ -300,8 +301,23 @@ function createProxiedConnect(
   };
 }
 
+/**
+ * The worker role's derived manifest, as the derive left it on this context's
+ * globals. Absent — a shim bundle running outside a derived copy, in a test or
+ * from a copy an older derive wrote — means there is nothing better than the
+ * native answer to give, so `getManifest` is left alone.
+ */
+function getEmbeddedWorkerManifest() {
+  return (globalThis as unknown as Record<string, unknown>)[RUNTIME_PROXY_MANIFEST_GLOBAL];
+}
+
 export type InstallRuntimeProxyShimOptions = {
   getSenderReport?: () => RuntimeProxySenderReport;
+  /**
+   * What `getManifest` answers, in place of the one the derive left on the
+   * globals. Only tests pass it.
+   */
+  workerManifest?: unknown;
 };
 
 /**
@@ -311,8 +327,15 @@ export type InstallRuntimeProxyShimOptions = {
  * worker to receive them. It runs before any of the extension's own code — the
  * derive prepends it to every `content_scripts` entry and writes it into every
  * extension page ahead of the page's own scripts — so the extension only ever
- * sees the shadowed functions. Everything else on `chrome.runtime`, `getURL`
- * and `id` above all, stays exactly as Electron made it.
+ * sees the shadowed functions. `getURL` and `id` stay exactly as Electron made
+ * them.
+ *
+ * `getManifest` is shadowed as well, for a different reason: this copy is the
+ * one the derive took the `background` key off, so an extension inspecting
+ * itself would otherwise find no service worker where the worker session's copy
+ * finds one — a per-account difference with nothing behind it, since the worker
+ * every session reaches is the same worker. It answers the worker role's
+ * derived manifest, which is what that worker's own `getManifest` returns.
  *
  * `onMessage` and `onConnect` are left native, which is what bounds the shim:
  * an extension page hears what it opened a port for, and not what the worker
@@ -320,7 +343,10 @@ export type InstallRuntimeProxyShimOptions = {
  */
 export function installRuntimeProxyShim(
   extensionApi: ChromeNamespace,
-  { getSenderReport = getContextSenderReport }: InstallRuntimeProxyShimOptions = {},
+  {
+    getSenderReport = getContextSenderReport,
+    workerManifest = getEmbeddedWorkerManifest(),
+  }: InstallRuntimeProxyShimOptions = {},
 ) {
   const runtime = extensionApi.runtime as ChromeNamespace | undefined;
 
@@ -339,4 +365,12 @@ export function installRuntimeProxyShim(
     getNativeMethod(runtime, "connect"),
     getSenderReport,
   );
+
+  if (workerManifest !== undefined) {
+    // Chrome hands out a new object per call and says nothing about what an
+    // extension may do with it, so an extension that mutates what it got — or
+    // that is handed the same object twice and compares the two — must see
+    // exactly what it sees in Chrome
+    runtime.getManifest = () => structuredClone(workerManifest);
+  }
 }

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -160,6 +160,10 @@ function buildAppFiles() {
       copyFixtureFile("manifest.json"),
       copyFixtureFile("popup.html"),
       copyFixtureFile("fixture-frame.html"),
+      // Chromium substitutes the manifest's `__MSG_*__` names out of these as
+      // it loads the copy, which is what the proxy's `getManifest` overlay is
+      // held against
+      copyFixtureFile(path.join("_locales", "en", "messages.json")),
     ]);
   };
 

--- a/tests/extension-proxy.e2e.ts
+++ b/tests/extension-proxy.e2e.ts
@@ -263,12 +263,16 @@ test("both sessions' popups reach the one worker the first session keeps", async
 
   const shimPopup = await readProbeResults(shimPopupId);
 
-  // Which copy each session got, read from the manifest each context sees:
-  // the worker session keeps the whole extension, every other session a copy
-  // with no background at all
-  expect(workerPopup.manifestHasBackground).toBe(true);
+  // The two sessions load different copies — the worker session the whole
+  // extension, every other session one derived with no `background` at all —
+  // and `getManifest` is where that would otherwise show. The worker session's
+  // answer is native and therefore the ground truth; the shim session's is the
+  // shim's, and the two agreeing is the claim
+  expect(workerPopup.manifest).toMatchObject({
+    background: { service_worker: "chrome-facade-service-worker.js" },
+  });
 
-  expect(shimPopup.manifestHasBackground).toBe(false);
+  expect(shimPopup.manifest).toEqual(workerPopup.manifest);
 
   expect(workerPopup.extensionId).toBe(FIXTURE_EXTENSION_ID);
 
@@ -324,7 +328,11 @@ test("content scripts inject into the shim session and round-trip, a strict page
 
   const cspPage = await readProbeResults(cspPageId);
 
-  expect(plainPage.manifestHasBackground).toBe(false);
+  // A content script's isolated world answers the worker copy's manifest too,
+  // which is the same shim in the other place it runs
+  expect(plainPage.manifest).toMatchObject({
+    background: { service_worker: "chrome-facade-service-worker.js" },
+  });
 
   expect(plainPage.echo).toEqual(
     echoReply(plainPage, expect.any(String), {

--- a/tests/extension-proxy.e2e.ts
+++ b/tests/extension-proxy.e2e.ts
@@ -270,6 +270,11 @@ test("both sessions' popups reach the one worker the first session keeps", async
   // shim's, and the two agreeing is the claim
   expect(workerPopup.manifest).toMatchObject({
     background: { service_worker: "chrome-facade-service-worker.js" },
+    // Chromium localized the manifest as it loaded the copy, which the derive
+    // never sees: the file says `__MSG_extName__` and carries no
+    // `current_locale`
+    name: "Meru fixture",
+    current_locale: expect.any(String),
   });
 
   expect(shimPopup.manifest).toEqual(workerPopup.manifest);
@@ -321,6 +326,8 @@ test("content scripts inject into the shim session and round-trip, a strict page
 
   const cspPageId = await openProbeWindow(SHIM_PARTITION, cspPageUrl);
 
+  const workerPageId = await openProbeWindow(WORKER_PARTITION, plainPageUrl);
+
   // The results existing at all is the injection claim: the only thing that
   // writes them into a loopback page is the fixture's content script, and the
   // only copy in this session is the content-script-only one
@@ -329,10 +336,10 @@ test("content scripts inject into the shim session and round-trip, a strict page
   const cspPage = await readProbeResults(cspPageId);
 
   // A content script's isolated world answers the worker copy's manifest too,
-  // which is the same shim in the other place it runs
-  expect(plainPage.manifest).toMatchObject({
-    background: { service_worker: "chrome-facade-service-worker.js" },
-  });
+  // which is the same shim in the other place it runs — held against the
+  // worker session's own content script rather than a shape, so the
+  // localization Chromium did is part of what has to agree
+  expect(plainPage.manifest).toEqual((await readProbeResults(workerPageId)).manifest);
 
   expect(plainPage.echo).toEqual(
     echoReply(plainPage, expect.any(String), {


### PR DESCRIPTION
## Summary
`chrome.runtime.getManifest()` now answers the same manifest in every account session under the shared extension instance. The derive embeds the worker role's derived manifest in the content-script-only copy's shim script, next to the bridge token, and the shim lays the two keys the roles differ in over the context's own native answer, cloned per call. Nothing changes when `sharedInstance` is off; the worker session stays native.

## Problem
The derive takes the whole `background` key off the copy that every session but the worker's loads, so an extension calling `getManifest()` in a content-script-only session found no service worker where the worker session's copy found one. That is a per-account difference with nothing behind it — the worker every session reaches is the same worker — and one more thing an extension can notice about which account it happens to be running in. It was the last item on the shared instance's conformance list that is a derive change rather than a transport one.

## Solution
- `deriveExtension` for the `contentScriptOnly` role computes the **worker** role's derived manifest and writes it onto the shim's globals as `__meruRuntimeProxyManifest`, the way `EXTENSION_BRIDGE_TOKEN_GLOBAL` already rides the facade's and the shim's own script. It travels that way rather than over the bridge because `getManifest` is synchronous, and the shim runs in isolated worlds the facade never reaches.
- The *derived* manifest, not the source one, because the derived manifest is what the one worker's own `getManifest` returns — down to `background.service_worker` naming Meru's generated wrapper.
- **The shim overlays rather than replaces**, and only `background` and `content_scripts`. What Chromium answers is not the manifest file: `file_util::LoadExtension` runs `extension_l10n_util::LocalizeManifest`, which substitutes `__MSG_*__` in `name`, `description`, `action.default_title` and their siblings out of `_locales` and unconditionally sets `current_locale` to the browser UI locale, and `getManifest` returns that dictionary. 1Password's manifest is `"name": "__MSG_extName__"` across eleven locales, so answering what the derive wrote would have traded the `background` difference for a name and a locale that differ instead. The derive cannot do the substitution — the UI locale is a runtime fact of the browser process, not of the copy on disk — and does not have to: both copies are localized by the same process from the same `_locales`, so everything the overlay leaves alone already agrees. Caught in review; the first commit had this wrong.
- Those two keys are the whole difference between the roles' derived manifests, and a derive test pins that, so a third one fails rather than silently stopping being answered.
- The embedded manifest is recomputed from the source manifest rather than read back off the worker copy's directory. The worker copy is derived by whichever session adopted that role, so it may not exist yet when this copy is derived, and on a launch where no session adopts the role it never exists at all. `deriveManifest` is pure, so recomputing agrees with the copy by construction.
- `DERIVE_VERSION` deliberately does not move, and the stamp gains no field. The shim script is rewritten on **every** launch, the way the facade's token is, so the embedded manifest cannot go stale; and the three things the rewrite reads that aren't constants — the source manifest, `strippedManifestKeys`, the content-script clamp — are already in the stamp, so no kept copy can carry a stale one either. A bump would re-copy every derived extension on upgrade and buy nothing.
- `structuredClone` per call, since Chrome returns a new object each time and says nothing about what an extension may do with the one it got. With no manifest on the globals — an older copy, or a test — `getManifest` is left native, and with no native `getManifest` to overlay the shim installs nothing, since a context Chrome answers none in must not gain one.
- The fixture extension gained a `default_locale` and a `_locales/en/messages.json` and names itself `__MSG_extName__`, because the end-to-end equality assertion passed over the localization bug: a manifest Chromium does not rewrite cannot show it. The probe now reports the whole manifest instead of a `manifestHasBackground` boolean, and the content-script assertion compares against the worker session's own content script rather than a shape.

Two behavior notes the diff doesn't say out loud. **Key order still differs**: Chromium's manifest dictionary is key-sorted, so a native `Object.keys` comes back alphabetical while the overlay's re-added `background` lands last — only enumeration can see it, and no fix is worth the cost. And **`deriveWorkerRoleManifest` runs the worker role's `web_accessible_resources` refusal on every content-script-only derive**, warm path included, so a source whose only exposing pattern names the relay file now throws there where it previously succeeded. Harmless in practice, since the worker session already refuses that source on the same launch, but it is new.

## Try it
No preview deployment for the desktop app. `xvfb-run -a bun run test:e2e tests/extension-proxy.e2e.ts` drives it: "both sessions' popups reach the one worker the first session keeps" asserts `shimPopup.manifest` equals `workerPopup.manifest` and that the worker's carries the localized `name` and a `current_locale`; "content scripts inject into the shim session and round-trip" asserts a shim-session content script's isolated world equals a worker-session one's. Both fail on `main` — before this change the shim session reported no `background` at all.

## Not verified
- Never run against 1Password itself, which is true of the shared instance as a whole. The localization claim is held against Chromium's source and against the fixture, not against 1Password's own `_locales`.
- `bun test`, `bun run types`, `bun run lint`, `bun run fmt:check` and `tests/extension-proxy.e2e.ts` all pass locally under xvfb.