### PR TITLE
Schedule extension alarms in main and deliver onAlarm over the bridge

### DIFF
--- a/packages/electron-extensions/alarms/alarms.test.ts
+++ b/packages/electron-extensions/alarms/alarms.test.ts
@@ -177,6 +177,49 @@ describe("Alarms", () => {
     expect(await readJson(send(ALARMS_PATHS.getAll))).toEqual([]);
   });
 
+  test("refuses a name long enough to make its own deliveries unreadable", async () => {
+    setup(new Alarms());
+
+    const longName = "a".repeat(513);
+
+    expect(
+      (await send(ALARMS_PATHS.create, { name: longName, alarmInfo: { delayInMinutes: 1 } }))
+        .status,
+    ).toBe(400);
+    expect(await readJson(send(ALARMS_PATHS.getAll))).toEqual([]);
+  });
+
+  test("refuses a delay large enough to overflow the time it is due", async () => {
+    setup(new Alarms());
+
+    const status = (
+      await send(ALARMS_PATHS.create, { name: "overflow", alarmInfo: { delayInMinutes: 1e305 } })
+    ).status;
+
+    expect(status).toBe(400);
+    expect(await readJson(send(ALARMS_PATHS.getAll))).toEqual([]);
+  });
+
+  test("caps how many alarms one extension may hold, and still replaces its own", async () => {
+    setup(new Alarms());
+
+    for (let index = 0; index < 500; index += 1) {
+      await send(ALARMS_PATHS.create, { name: `poll-${index}`, alarmInfo: { delayInMinutes: 60 } });
+    }
+
+    expect(
+      (await send(ALARMS_PATHS.create, { name: "one-too-many", alarmInfo: { delayInMinutes: 60 } }))
+        .status,
+    ).toBe(400);
+
+    // Replacing an alarm it already holds keeps working at the cap
+    expect(
+      (await send(ALARMS_PATHS.create, { name: "poll-0", alarmInfo: { delayInMinutes: 120 } }))
+        .status,
+    ).toBe(204);
+    expect(await readJson(send(ALARMS_PATHS.getAll))).toBeArrayOfSize(500);
+  });
+
   test("replaces an alarm created again under the same name", async () => {
     setup(new Alarms());
 

--- a/packages/electron-extensions/alarms/alarms.test.ts
+++ b/packages/electron-extensions/alarms/alarms.test.ts
@@ -1,0 +1,367 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { OnBeforeSendHeadersListenerDetails, Session, WebFrameMain } from "electron";
+import { ExtensionBridge } from "../bridge/bridge";
+import { getExtensionBridgeUrl } from "../bridge/protocol";
+import { NativeMessageDecoder } from "../native-messaging/framing";
+import { Alarms } from "./alarms";
+import { ALARMS_PATHS, type AlarmDetails, type AlarmFrame } from "./bridge-protocol";
+
+const EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
+
+const BRIDGE_TOKEN = "bridge-token";
+
+type BeforeSendHeadersListener = (
+  details: OnBeforeSendHeadersListenerDetails,
+  callback: (response: { requestHeaders?: Record<string, string> }) => void,
+) => void;
+
+let requestHandler: ((request: GlobalRequest) => Promise<Response>) | undefined;
+
+let beforeSendHeadersListener: BeforeSendHeadersListener | null = null;
+
+let startedWorkerScopes: string[];
+
+let session: Session;
+
+/** A page's frame, which is what tells a page's stream from the worker's. */
+function createFrame(): WebFrameMain {
+  return {
+    url: `chrome-extension://${EXTENSION_ID}/popup.html`,
+    parent: null,
+    frameToken: "frame-token",
+    isDestroyed: () => false,
+  } as unknown as WebFrameMain;
+}
+
+beforeEach(() => {
+  requestHandler = undefined;
+
+  beforeSendHeadersListener = null;
+
+  startedWorkerScopes = [];
+
+  session = {
+    protocol: {
+      handle: (_scheme: string, handler: (request: GlobalRequest) => Promise<Response>) => {
+        requestHandler = handler;
+      },
+      unhandle: () => {
+        requestHandler = undefined;
+      },
+    },
+    webRequest: {
+      onBeforeSendHeaders: (filter: unknown, listener?: BeforeSendHeadersListener | null) => {
+        beforeSendHeadersListener = listener ?? (filter as BeforeSendHeadersListener | null);
+      },
+    },
+    serviceWorkers: {
+      startWorkerForScope: async (scope: string) => {
+        startedWorkerScopes.push(scope);
+      },
+    },
+  } as unknown as Session;
+});
+
+function setup(alarms: Alarms) {
+  const bridge = new ExtensionBridge();
+
+  alarms.registerRoutes(bridge);
+
+  bridge.setupSession(session, {
+    getExtensionId: (bridgeToken) => (bridgeToken === BRIDGE_TOKEN ? EXTENSION_ID : undefined),
+  });
+}
+
+/**
+ * A bridge call as the facade makes it. Without a frame the request reaches the
+ * handler unstamped, which is exactly what a service worker's request looks
+ * like — the `webRequest` listener a page's request passes through is one a
+ * worker never reaches.
+ */
+function send(pathName: string, body: Record<string, unknown> = {}, frame?: WebFrameMain) {
+  const url = getExtensionBridgeUrl(pathName, BRIDGE_TOKEN);
+
+  let requestHeaders: Record<string, string> = {};
+
+  if (frame) {
+    beforeSendHeadersListener?.(
+      { url, frame, requestHeaders } as OnBeforeSendHeadersListenerDetails,
+      ({ requestHeaders: stampedHeaders }) => {
+        requestHeaders = stampedHeaders ?? requestHeaders;
+      },
+    );
+  }
+
+  return requestHandler?.(
+    new Request(url, { method: "POST", headers: requestHeaders, body: JSON.stringify(body) }),
+  ) as Promise<Response>;
+}
+
+/** Parks an events stream and reads the alarms as they arrive. */
+async function park(frame?: WebFrameMain) {
+  const response = await send(ALARMS_PATHS.events, {}, frame);
+
+  const reader = (response.body as ReadableStream<Uint8Array>).getReader();
+
+  const decoder = new NativeMessageDecoder();
+
+  const delivered: AlarmDetails[] = [];
+
+  const read = async () => {
+    for (;;) {
+      const { value, done } = await reader.read();
+
+      if (done) {
+        return;
+      }
+
+      for (const frameRead of decoder.push(value) as AlarmFrame[]) {
+        delivered.push(frameRead.alarm);
+      }
+    }
+  };
+
+  void read();
+
+  return {
+    delivered,
+    cancel: () => reader.cancel(),
+  };
+}
+
+/** Lets the timers a due alarm rides on run, and the stream reads behind them. */
+function settle() {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 20);
+  });
+}
+
+async function readJson(response: Promise<Response>) {
+  return (await response).json();
+}
+
+describe("Alarms", () => {
+  test("creates an alarm and reads it back", async () => {
+    setup(new Alarms());
+
+    await send(ALARMS_PATHS.create, { name: "watchtower", alarmInfo: { delayInMinutes: 60 } });
+
+    const alarm = (await readJson(send(ALARMS_PATHS.get, { name: "watchtower" }))) as AlarmDetails;
+
+    expect(alarm.name).toBe("watchtower");
+    expect(alarm.scheduledTime).toBeGreaterThan(Date.now());
+    expect(await readJson(send(ALARMS_PATHS.getAll))).toBeArrayOfSize(1);
+  });
+
+  test("answers null for an alarm that is not there", async () => {
+    setup(new Alarms());
+
+    expect(await readJson(send(ALARMS_PATHS.get, { name: "missing" }))).toBeNull();
+    expect(await readJson(send(ALARMS_PATHS.getAll))).toEqual([]);
+  });
+
+  test("takes a create with no name as the alarm named empty", async () => {
+    setup(new Alarms());
+
+    await send(ALARMS_PATHS.create, { alarmInfo: { delayInMinutes: 60 } });
+
+    const alarm = (await readJson(send(ALARMS_PATHS.get, {}))) as AlarmDetails;
+
+    expect(alarm.name).toBe("");
+  });
+
+  test("refuses a create that names no time at all", async () => {
+    setup(new Alarms());
+
+    expect((await send(ALARMS_PATHS.create, { name: "empty", alarmInfo: {} })).status).toBe(400);
+    expect(await readJson(send(ALARMS_PATHS.getAll))).toEqual([]);
+  });
+
+  test("replaces an alarm created again under the same name", async () => {
+    setup(new Alarms());
+
+    await send(ALARMS_PATHS.create, { name: "poll", alarmInfo: { delayInMinutes: 60 } });
+    await send(ALARMS_PATHS.create, { name: "poll", alarmInfo: { delayInMinutes: 120 } });
+
+    const alarms = (await readJson(send(ALARMS_PATHS.getAll))) as AlarmDetails[];
+
+    expect(alarms).toBeArrayOfSize(1);
+    expect(alarms[0]?.scheduledTime).toBeGreaterThan(Date.now() + 90 * 60_000);
+  });
+
+  test("clears one alarm and says whether there was one", async () => {
+    setup(new Alarms());
+
+    await send(ALARMS_PATHS.create, { name: "poll", alarmInfo: { delayInMinutes: 60 } });
+
+    expect(await readJson(send(ALARMS_PATHS.clear, { name: "poll" }))).toBe(true);
+    expect(await readJson(send(ALARMS_PATHS.clear, { name: "poll" }))).toBe(false);
+  });
+
+  test("clears every alarm and answers true either way", async () => {
+    setup(new Alarms());
+
+    await send(ALARMS_PATHS.create, { name: "poll", alarmInfo: { delayInMinutes: 60 } });
+
+    expect(await readJson(send(ALARMS_PATHS.clearAll))).toBe(true);
+    expect(await readJson(send(ALARMS_PATHS.getAll))).toEqual([]);
+    expect(await readJson(send(ALARMS_PATHS.clearAll))).toBe(true);
+  });
+
+  test("delivers a due alarm to the worker's parked stream", async () => {
+    setup(new Alarms());
+
+    const workerStream = await park();
+
+    await send(ALARMS_PATHS.create, { name: "lockMonitor", alarmInfo: { when: Date.now() - 1 } });
+
+    await settle();
+
+    expect(workerStream.delivered).toEqual([
+      { name: "lockMonitor", scheduledTime: expect.any(Number) },
+    ]);
+  });
+
+  test("delivers to an extension page alongside the worker", async () => {
+    setup(new Alarms());
+
+    const workerStream = await park();
+
+    const pageStream = await park(createFrame());
+
+    await send(ALARMS_PATHS.create, { name: "poll", alarmInfo: { when: Date.now() - 1 } });
+
+    await settle();
+
+    expect(workerStream.delivered).toBeArrayOfSize(1);
+    expect(pageStream.delivered).toBeArrayOfSize(1);
+  });
+
+  test("clears a one-shot alarm once it has fired and keeps a periodic one", async () => {
+    setup(new Alarms());
+
+    await park();
+
+    const firedAt = Date.now() - 1;
+
+    await send(ALARMS_PATHS.create, { name: "once", alarmInfo: { when: firedAt } });
+    await send(ALARMS_PATHS.create, {
+      name: "repeating",
+      alarmInfo: { when: firedAt, periodInMinutes: 1 },
+    });
+
+    await settle();
+
+    const alarms = (await readJson(send(ALARMS_PATHS.getAll))) as AlarmDetails[];
+
+    expect(alarms.map(({ name }) => name)).toEqual(["repeating"]);
+    // Advanced by a period from when it was due, rather than left where it was
+    expect(alarms[0]?.scheduledTime).toBe(firedAt + 60_000);
+  });
+
+  test("hands a periodic alarm's listener the time it was due", async () => {
+    setup(new Alarms());
+
+    const workerStream = await park();
+
+    const dueAt = Date.now() - 1;
+
+    await send(ALARMS_PATHS.create, {
+      name: "keepalive",
+      alarmInfo: { when: dueAt, periodInMinutes: 1 },
+    });
+
+    await settle();
+
+    expect(workerStream.delivered).toEqual([
+      { name: "keepalive", scheduledTime: dueAt, periodInMinutes: 1 },
+    ]);
+  });
+
+  test("drops an alarm with no worker parked, and wakes nothing", async () => {
+    setup(new Alarms());
+
+    await send(ALARMS_PATHS.create, { name: "poll", alarmInfo: { when: Date.now() - 1 } });
+
+    await settle();
+
+    expect(startedWorkerScopes).toEqual([]);
+
+    // Nothing was queued for the worker that starts afterwards
+    const workerStream = await park();
+
+    await settle();
+
+    expect(workerStream.delivered).toEqual([]);
+  });
+
+  test("does not count an extension page as a worker to deliver to", async () => {
+    setup(new Alarms({ shouldWakeWorker: () => true }));
+
+    await park(createFrame());
+
+    await send(ALARMS_PATHS.create, { name: "poll", alarmInfo: { when: Date.now() - 1 } });
+
+    await settle();
+
+    expect(startedWorkerScopes).toEqual([`chrome-extension://${EXTENSION_ID}/`]);
+  });
+
+  test("wakes a stopped worker and delivers what came due while it started", async () => {
+    setup(new Alarms({ shouldWakeWorker: () => true }));
+
+    await send(ALARMS_PATHS.create, { name: "lockMonitor", alarmInfo: { when: Date.now() - 1 } });
+
+    await settle();
+
+    expect(startedWorkerScopes).toEqual([`chrome-extension://${EXTENSION_ID}/`]);
+
+    const workerStream = await park();
+
+    await settle();
+
+    expect(workerStream.delivered.map(({ name }) => name)).toEqual(["lockMonitor"]);
+  });
+
+  test("drops what a woken worker never came back for", async () => {
+    setup(new Alarms({ shouldWakeWorker: () => true, wakeTimeoutMs: 10 }));
+
+    await send(ALARMS_PATHS.create, { name: "poll", alarmInfo: { when: Date.now() - 1 } });
+
+    await settle();
+
+    const workerStream = await park();
+
+    await settle();
+
+    expect(workerStream.delivered).toEqual([]);
+  });
+
+  test("stops delivering to a stream its context canceled", async () => {
+    setup(new Alarms());
+
+    const workerStream = await park();
+
+    await workerStream.cancel();
+
+    await send(ALARMS_PATHS.create, { name: "poll", alarmInfo: { when: Date.now() - 1 } });
+
+    await settle();
+
+    expect(workerStream.delivered).toEqual([]);
+  });
+
+  test("forgets a session's alarms when it is torn down", async () => {
+    const alarms = new Alarms();
+
+    setup(alarms);
+
+    await send(ALARMS_PATHS.create, { name: "poll", alarmInfo: { delayInMinutes: 60 } });
+
+    alarms.teardownSession(session);
+
+    setup(alarms);
+
+    expect(await readJson(send(ALARMS_PATHS.getAll))).toEqual([]);
+  });
+});

--- a/packages/electron-extensions/alarms/alarms.ts
+++ b/packages/electron-extensions/alarms/alarms.ts
@@ -32,6 +32,19 @@ const DEFAULT_WAKE_TIMEOUT_MS = 10_000;
  */
 const MAX_PENDING_ALARMS = 32;
 
+/**
+ * How long an alarm's name may be, matching Chrome's own cap.
+ *
+ * It is also what keeps a delivery frame inside the decoder's limit at the far
+ * end: the name is the only part of an `Alarm` an extension chooses the size
+ * of, and a name near the frame cap would make every delivery of that alarm
+ * unreadable rather than merely large.
+ */
+const MAX_ALARM_NAME_LENGTH = 512;
+
+/** How many alarms one extension may hold at once, as Chrome caps it. */
+const MAX_ALARMS_PER_EXTENSION = 500;
+
 /** Whether a fired alarm may start this extension's stopped service worker. */
 export type AlarmWakePolicy = (details: { session: Session; extensionId: string }) => boolean;
 
@@ -200,11 +213,23 @@ export class Alarms {
   ) {
     const schedule = createAlarmSchedule(alarmInfo, Date.now());
 
-    if (!schedule) {
+    if (!schedule || name.length > MAX_ALARM_NAME_LENGTH) {
       return false;
     }
 
     const entry = this.getExtensionAlarms(session, extensionId);
+
+    // Replacing one of the extension's own alarms is always allowed; only
+    // growing the set past the cap is not
+    if (!entry.alarms.has(name) && entry.alarms.size >= MAX_ALARMS_PER_EXTENSION) {
+      this.logger?.error("Refused an alarm past the per-extension cap", {
+        extensionId,
+        name,
+        alarms: entry.alarms.size,
+      });
+
+      return false;
+    }
 
     this.removeAlarm(entry, name);
 

--- a/packages/electron-extensions/alarms/alarms.ts
+++ b/packages/electron-extensions/alarms/alarms.ts
@@ -73,6 +73,12 @@ type ScheduledAlarm = AlarmSchedule & {
  * than the facade's: a service worker's request reaches the handler with no
  * caller stamp, having skipped the `webRequest` listener that mints one, so a
  * frameless caller is the worker (see `stampCaller` in `bridge/bridge.ts`).
+ *
+ * A page whose frame died between the stamp and the handler arrives frameless
+ * too, and is filed as a worker for the life of that stream. It costs nothing:
+ * with waking off the flag is never read, and with it on the worst of it is one
+ * wake skipped while a stream Electron is about to cancel still stands in for a
+ * worker.
  */
 type AlarmStream = {
   controller: ReadableStreamDefaultController<Uint8Array>;
@@ -478,6 +484,17 @@ export class Alarms {
    * The stream a context parks to hear `onAlarm`. It is opened by the first
    * listener the context adds and lives as long as the context does, so its
    * cancel is how a closed page or a stopped worker is noticed.
+   *
+   * That cancel is the only thing pruning a dead context's stream, and it is
+   * enough because Electron fires it on frame destruction, on navigation and on
+   * worker death — measured for the native messaging port streams this shape
+   * comes from. The runtime proxy invalidates its own worker streams from the
+   * session's `running-status-changed` events instead, and needs to: a job it
+   * hands over has to be known delivered, so a stream that merely looks live
+   * costs it a lost message. Nothing here is owed that. A dead stream that has
+   * not been canceled yet only means one delivery enqueued into a buffer
+   * nothing reads, and the alarm behind it is one this code would have dropped
+   * anyway.
    */
   private handleEvents(
     session: Session,

--- a/packages/electron-extensions/alarms/alarms.ts
+++ b/packages/electron-extensions/alarms/alarms.ts
@@ -1,0 +1,526 @@
+import type { Session } from "electron";
+import type { ExtensionBridge } from "../bridge/bridge";
+import type { ExtensionsLogger } from "../logger";
+import { encodeNativeMessage } from "../native-messaging/framing";
+import {
+  ALARMS_PATHS,
+  type AlarmCreateInfo,
+  type AlarmDetails,
+  type AlarmFrame,
+  type AlarmsCreateRequest,
+  type AlarmsNameRequest,
+} from "./bridge-protocol";
+import {
+  type AlarmSchedule,
+  createAlarmSchedule,
+  getNextScheduledTime,
+  MAX_TIMER_DELAY_MS,
+} from "./schedule";
+
+const EXTENSION_SCHEME_PREFIX = "chrome-extension://";
+
+/** How long a woken worker has to park its stream before the alarm is dropped. */
+const DEFAULT_WAKE_TIMEOUT_MS = 10_000;
+
+/**
+ * How many alarms an extension being woken may have waiting at once.
+ *
+ * Only ever reached with waking turned on, and then only by an extension whose
+ * worker will not start: every alarm that comes due while it is down joins the
+ * queue. The oldest goes, since an alarm's whole content is that it came due
+ * and the newest one says that best.
+ */
+const MAX_PENDING_ALARMS = 32;
+
+/** Whether a fired alarm may start this extension's stopped service worker. */
+export type AlarmWakePolicy = (details: { session: Session; extensionId: string }) => boolean;
+
+export type AlarmsOptions = {
+  /**
+   * Which extensions a due alarm may wake a stopped service worker for. Without
+   * it none are woken and an alarm reaches only the contexts already running,
+   * which is what Meru ships: waking an extension whose alarm runs on a minute
+   * keeps its worker resident for as long as the account is open, and no
+   * curated extension has been measured to need it (see the alarms notes in the
+   * feature docs).
+   */
+  shouldWakeWorker?: AlarmWakePolicy;
+  /** How long a wake is waited on before the alarms behind it are dropped. */
+  wakeTimeoutMs?: number;
+  logger?: ExtensionsLogger;
+};
+
+type ScheduledAlarm = AlarmSchedule & {
+  name: string;
+  timer: NodeJS.Timeout;
+};
+
+/**
+ * A context's parked events stream. `isWorker` is the bridge's own word rather
+ * than the facade's: a service worker's request reaches the handler with no
+ * caller stamp, having skipped the `webRequest` listener that mints one, so a
+ * frameless caller is the worker (see `stampCaller` in `bridge/bridge.ts`).
+ */
+type AlarmStream = {
+  controller: ReadableStreamDefaultController<Uint8Array>;
+  isWorker: boolean;
+};
+
+type Wake = {
+  timer: NodeJS.Timeout | undefined;
+};
+
+type ExtensionAlarms = {
+  alarms: Map<string, ScheduledAlarm>;
+  streams: Set<AlarmStream>;
+  /** Alarms that came due with the worker down, held while it is woken. */
+  pendingAlarms: AlarmDetails[];
+  wake: Wake | undefined;
+};
+
+/**
+ * `chrome.alarms` for extensions loaded into Electron sessions, scheduled here
+ * and delivered over the extension bridge.
+ *
+ * Electron ships Chromium's alarm manager and it works: alarms are scheduled,
+ * they come due, and their `scheduledTime` advances. What never happens is the
+ * delivery — Electron dispatches no `EventRouter` event into an extension
+ * service worker, so `onAlarm` fires in extension pages and never in the worker
+ * that MV3 puts every background handler in (measured 2 September 2026 on
+ * 43.2.0; see finding 31 of the 3.60 extensions review). 1Password's seven
+ * alarms are therefore dead, `lockMonitor` and `purge-login-detection-data`
+ * among them.
+ *
+ * The facade replaces the whole namespace rather than filling in around it, in
+ * every context and not only the worker: Electron's own alarms live in
+ * Chromium's store, and leaving pages on that store while the worker used this
+ * one would mean a page's `getAll` could not see what the worker scheduled and
+ * its `clear` would silently clear nothing.
+ *
+ * Alarms live in memory for as long as the session does. Chrome persists them
+ * across a browser restart and this does not, which costs nothing measured:
+ * what an alarm has to outlive is the service worker, and main outlives it
+ * either way, while every alarm 1Password owns is created again at each worker
+ * boot.
+ */
+export class Alarms {
+  private shouldWakeWorker: AlarmWakePolicy | undefined;
+
+  private wakeTimeoutMs: number;
+
+  private logger: ExtensionsLogger | undefined;
+
+  private sessions = new Map<Session, Map<string, ExtensionAlarms>>();
+
+  constructor({ shouldWakeWorker, wakeTimeoutMs, logger }: AlarmsOptions = {}) {
+    this.shouldWakeWorker = shouldWakeWorker;
+
+    this.wakeTimeoutMs = wakeTimeoutMs ?? DEFAULT_WAKE_TIMEOUT_MS;
+
+    this.logger = logger;
+  }
+
+  registerRoutes(bridge: ExtensionBridge) {
+    bridge.handle(ALARMS_PATHS.create, ({ session, extensionId, body, headers }) => {
+      const { name, alarmInfo } = body as unknown as AlarmsCreateRequest;
+
+      const created = this.create(
+        session,
+        extensionId,
+        readName(name),
+        alarmInfo as AlarmCreateInfo | undefined,
+      );
+
+      // Chrome refuses a `create` naming no time at all, and says so by
+      // throwing in the extension rather than by making a silent alarm
+      return new Response(null, { status: created ? 204 : 400, headers });
+    });
+
+    bridge.handle(ALARMS_PATHS.get, ({ session, extensionId, body, headers }) =>
+      Response.json(
+        this.get(session, extensionId, readName((body as unknown as AlarmsNameRequest).name)),
+        { headers },
+      ),
+    );
+
+    bridge.handle(ALARMS_PATHS.getAll, ({ session, extensionId, headers }) =>
+      Response.json(this.getAll(session, extensionId), { headers }),
+    );
+
+    bridge.handle(ALARMS_PATHS.clear, ({ session, extensionId, body, headers }) =>
+      Response.json(
+        this.clear(session, extensionId, readName((body as unknown as AlarmsNameRequest).name)),
+        { headers },
+      ),
+    );
+
+    bridge.handle(ALARMS_PATHS.clearAll, ({ session, extensionId, headers }) =>
+      Response.json(this.clearAll(session, extensionId), { headers }),
+    );
+
+    bridge.handle(ALARMS_PATHS.events, ({ session, extensionId, senderFrame, headers }) =>
+      this.handleEvents(session, extensionId, senderFrame === undefined, headers),
+    );
+  }
+
+  teardownSession(session: Session) {
+    const extensions = this.sessions.get(session);
+
+    if (!extensions) {
+      return;
+    }
+
+    this.sessions.delete(session);
+
+    for (const entry of extensions.values()) {
+      for (const alarm of entry.alarms.values()) {
+        clearTimeout(alarm.timer);
+      }
+
+      this.clearWake(entry);
+
+      entry.pendingAlarms.length = 0;
+
+      for (const stream of entry.streams) {
+        closeStream(stream);
+      }
+    }
+  }
+
+  /**
+   * Chrome makes an alarm with the name the extension gave, `""` when it gave
+   * none, and one name holds one alarm: creating over a live alarm replaces it
+   * rather than adding a second.
+   */
+  create(
+    session: Session,
+    extensionId: string,
+    name: string,
+    alarmInfo: AlarmCreateInfo | undefined,
+  ) {
+    const schedule = createAlarmSchedule(alarmInfo, Date.now());
+
+    if (!schedule) {
+      return false;
+    }
+
+    const entry = this.getExtensionAlarms(session, extensionId);
+
+    this.removeAlarm(entry, name);
+
+    this.armAlarm(session, extensionId, entry, { name, ...schedule });
+
+    return true;
+  }
+
+  get(session: Session, extensionId: string, name: string) {
+    const alarm = this.sessions.get(session)?.get(extensionId)?.alarms.get(name);
+
+    // JSON has no `undefined`, and the facade reads `null` back as Chrome's own
+    // answer for an alarm that is not there
+    return alarm ? toAlarmDetails(alarm) : null;
+  }
+
+  getAll(session: Session, extensionId: string) {
+    const entry = this.sessions.get(session)?.get(extensionId);
+
+    return [...(entry?.alarms.values() ?? [])].map(toAlarmDetails);
+  }
+
+  clear(session: Session, extensionId: string, name: string) {
+    const entry = this.sessions.get(session)?.get(extensionId);
+
+    return entry ? this.removeAlarm(entry, name) : false;
+  }
+
+  /** Chrome answers `true` whether or not there was anything to clear. */
+  clearAll(session: Session, extensionId: string) {
+    const entry = this.sessions.get(session)?.get(extensionId);
+
+    if (entry) {
+      for (const alarm of entry.alarms.values()) {
+        clearTimeout(alarm.timer);
+      }
+
+      entry.alarms.clear();
+    }
+
+    return true;
+  }
+
+  private getExtensionAlarms(session: Session, extensionId: string) {
+    let extensions = this.sessions.get(session);
+
+    if (!extensions) {
+      extensions = new Map();
+
+      this.sessions.set(session, extensions);
+    }
+
+    let entry = extensions.get(extensionId);
+
+    if (!entry) {
+      entry = { alarms: new Map(), streams: new Set(), pendingAlarms: [], wake: undefined };
+
+      extensions.set(extensionId, entry);
+    }
+
+    return entry;
+  }
+
+  private removeAlarm(entry: ExtensionAlarms, name: string) {
+    const alarm = entry.alarms.get(name);
+
+    if (!alarm) {
+      return false;
+    }
+
+    clearTimeout(alarm.timer);
+
+    entry.alarms.delete(name);
+
+    return true;
+  }
+
+  /**
+   * Puts the alarm in its map with a timer running against it. A wait longer
+   * than a timer can hold is served by re-arming on the same record, so the
+   * alarm the extension sees is one alarm however many timers it took.
+   */
+  private armAlarm(
+    session: Session,
+    extensionId: string,
+    entry: ExtensionAlarms,
+    alarm: Omit<ScheduledAlarm, "timer">,
+  ) {
+    const remainingMs = Math.max(alarm.scheduledTime - Date.now(), 0);
+
+    const isLastLeg = remainingMs <= MAX_TIMER_DELAY_MS;
+
+    const scheduled: ScheduledAlarm = {
+      ...alarm,
+      timer: setTimeout(
+        () => {
+          if (isLastLeg) {
+            this.fireAlarm(session, extensionId, entry, alarm.name);
+          } else {
+            this.armAlarm(session, extensionId, entry, alarm);
+          }
+        },
+        isLastLeg ? remainingMs : MAX_TIMER_DELAY_MS,
+      ),
+    };
+
+    entry.alarms.set(alarm.name, scheduled);
+  }
+
+  /**
+   * Chrome hands the listener the time the alarm was due rather than the time
+   * it was delivered, and a periodic alarm is due again before its listener has
+   * run — so the record is advanced first and what was delivered is a copy.
+   */
+  private fireAlarm(session: Session, extensionId: string, entry: ExtensionAlarms, name: string) {
+    const alarm = entry.alarms.get(name);
+
+    if (!alarm) {
+      return;
+    }
+
+    const delivered = toAlarmDetails(alarm);
+
+    const nextScheduledTime = getNextScheduledTime(alarm, Date.now());
+
+    if (nextScheduledTime === undefined) {
+      entry.alarms.delete(name);
+    } else {
+      this.armAlarm(session, extensionId, entry, {
+        name,
+        scheduledTime: nextScheduledTime,
+        periodInMinutes: alarm.periodInMinutes,
+      });
+    }
+
+    this.deliverAlarm(session, extensionId, entry, delivered);
+  }
+
+  /**
+   * Every context of the extension that parked a stream hears the alarm, the
+   * way Chrome dispatches `onAlarm` to the worker and to any extension page
+   * open alongside it.
+   *
+   * An alarm that finds no worker parked is dropped, unless this extension is
+   * one waking is turned on for: Chrome's alarm wakes the worker it delivers
+   * to, and where Meru chooses not to wake, dropping is the honest half of that
+   * — queueing would deliver a stack of alarms whenever the worker next came up
+   * for its own reasons, which is a thing Chrome never does.
+   */
+  private deliverAlarm(
+    session: Session,
+    extensionId: string,
+    entry: ExtensionAlarms,
+    alarm: AlarmDetails,
+  ) {
+    const frame = encodeNativeMessage({ type: "alarm", alarm } satisfies AlarmFrame);
+
+    // Deleting the current entry mid-iteration is safe on a Set, and the
+    // survivors are what the wake below is decided on
+    for (const stream of entry.streams) {
+      try {
+        stream.controller.enqueue(frame);
+      } catch {
+        // A stream whose context went away without canceling
+        entry.streams.delete(stream);
+      }
+    }
+
+    // Read off what survived the delivery, so a worker stream that turned out
+    // to be dead is a worker to wake rather than one already reached
+    let hasWorker = false;
+
+    for (const stream of entry.streams) {
+      hasWorker ||= stream.isWorker;
+    }
+
+    if (hasWorker || !this.shouldWakeWorker?.({ session, extensionId })) {
+      return;
+    }
+
+    entry.pendingAlarms.push(alarm);
+
+    while (entry.pendingAlarms.length > MAX_PENDING_ALARMS) {
+      entry.pendingAlarms.shift();
+    }
+
+    this.wakeWorker(session, extensionId, entry);
+  }
+
+  /**
+   * `startWorkerForScope` starts the extension's worker, or does nothing when
+   * it is already running and simply has not parked its stream yet. Either way
+   * the alarms behind it wait for a worker stream, bounded by the wake timeout.
+   * The API is experimental on Electron 43, and the call is typed against
+   * Electron's own `Session`, so its going away is a type error rather than a
+   * silent nothing.
+   */
+  private wakeWorker(session: Session, extensionId: string, entry: ExtensionAlarms) {
+    if (entry.wake) {
+      return;
+    }
+
+    const wake: Wake = { timer: undefined };
+
+    entry.wake = wake;
+
+    wake.timer = setTimeout(() => {
+      if (entry.wake !== wake) {
+        return;
+      }
+
+      entry.wake = undefined;
+
+      if (entry.pendingAlarms.length > 0) {
+        this.logger?.info("Dropped alarms for a worker that did not wake", {
+          extensionId,
+          alarms: entry.pendingAlarms.length,
+        });
+
+        entry.pendingAlarms.length = 0;
+      }
+    }, this.wakeTimeoutMs);
+
+    Promise.resolve()
+      .then(() =>
+        session.serviceWorkers.startWorkerForScope(`${EXTENSION_SCHEME_PREFIX}${extensionId}/`),
+      )
+      .catch((error: unknown) => {
+        this.logger?.error("Failed to wake a service worker for an alarm", {
+          extensionId,
+          error,
+        });
+      });
+  }
+
+  /** Ends the wait for a worker, leaving what is waiting on it to the caller. */
+  private clearWake(entry: ExtensionAlarms) {
+    if (entry.wake?.timer) {
+      clearTimeout(entry.wake.timer);
+    }
+
+    entry.wake = undefined;
+  }
+
+  /**
+   * The stream a context parks to hear `onAlarm`. It is opened by the first
+   * listener the context adds and lives as long as the context does, so its
+   * cancel is how a closed page or a stopped worker is noticed.
+   */
+  private handleEvents(
+    session: Session,
+    extensionId: string,
+    isWorker: boolean,
+    headers: Record<string, string>,
+  ) {
+    const entry = this.getExtensionAlarms(session, extensionId);
+
+    let stream: AlarmStream | undefined;
+
+    const body = new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        stream = { controller, isWorker };
+
+        entry.streams.add(stream);
+      },
+      cancel: () => {
+        if (stream) {
+          entry.streams.delete(stream);
+        }
+      },
+    });
+
+    if (stream && isWorker) {
+      this.flushPendingAlarms(entry, stream);
+    }
+
+    return new Response(body, {
+      headers: { ...headers, "content-type": "application/octet-stream" },
+    });
+  }
+
+  /** What came due while the worker was being woken, in the order it came due. */
+  private flushPendingAlarms(entry: ExtensionAlarms, stream: AlarmStream) {
+    this.clearWake(entry);
+
+    const pendingAlarms = entry.pendingAlarms.splice(0);
+
+    for (const alarm of pendingAlarms) {
+      try {
+        stream.controller.enqueue(
+          encodeNativeMessage({ type: "alarm", alarm } satisfies AlarmFrame),
+        );
+      } catch {
+        entry.streams.delete(stream);
+
+        return;
+      }
+    }
+  }
+}
+
+/** Chrome takes a missing name as `""`, which is an ordinary alarm name. */
+function readName(name: unknown) {
+  return typeof name === "string" ? name : "";
+}
+
+function toAlarmDetails({ name, scheduledTime, periodInMinutes }: ScheduledAlarm): AlarmDetails {
+  return periodInMinutes === undefined
+    ? { name, scheduledTime }
+    : { name, scheduledTime, periodInMinutes };
+}
+
+function closeStream(stream: AlarmStream) {
+  try {
+    stream.controller.close();
+  } catch {
+    // Already closed with its context, which is the ordinary way one ends
+  }
+}

--- a/packages/electron-extensions/alarms/bridge-protocol.ts
+++ b/packages/electron-extensions/alarms/bridge-protocol.ts
@@ -1,0 +1,50 @@
+/**
+ * What `chrome.alarms` says over the extension bridge (`bridge/protocol.ts`),
+ * shared by the facade and the main process.
+ *
+ * The methods are ordinary bridge POSTs. Delivery is the half that needs more
+ * than a POST: `onAlarm` has to reach a context that asked for nothing, so a
+ * context holding listeners parks a streaming response at `events` and main
+ * writes a frame to it every time one of that extension's alarms comes due —
+ * the same length-prefixed JSON framing native messaging uses
+ * (`native-messaging/framing.ts`).
+ */
+
+export const ALARMS_PATHS = {
+  create: "/alarms/create",
+  get: "/alarms/get",
+  getAll: "/alarms/get-all",
+  clear: "/alarms/clear",
+  clearAll: "/alarms/clear-all",
+  events: "/alarms/events",
+} as const;
+
+/** Chrome's `Alarm`, which is the whole of what `onAlarm` hands a listener. */
+export type AlarmDetails = {
+  name: string;
+  /** Epoch milliseconds, as Chrome reports it — kept even once it is past. */
+  scheduledTime: number;
+  periodInMinutes?: number;
+};
+
+/** What the extension handed to `create`, taken as untrusted. */
+export type AlarmCreateInfo = {
+  when?: unknown;
+  delayInMinutes?: unknown;
+  periodInMinutes?: unknown;
+};
+
+export type AlarmsCreateRequest = {
+  name: unknown;
+  alarmInfo: unknown;
+};
+
+export type AlarmsNameRequest = {
+  name: unknown;
+};
+
+/** Frames on the events response body. Only one kind so far. */
+export type AlarmFrame = {
+  type: "alarm";
+  alarm: AlarmDetails;
+};

--- a/packages/electron-extensions/alarms/schedule.test.ts
+++ b/packages/electron-extensions/alarms/schedule.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import {
+  createAlarmSchedule,
+  getAlarmClampWarning,
+  getNextScheduledTime,
+  MIN_ALARM_PERIOD_MINUTES,
+} from "./schedule";
+
+const NOW = 1_700_000_000_000;
+
+const MS_PER_MINUTE = 60_000;
+
+describe("createAlarmSchedule", () => {
+  test("takes an absolute time as given", () => {
+    expect(createAlarmSchedule({ when: NOW + 5 * MS_PER_MINUTE }, NOW)).toEqual({
+      scheduledTime: NOW + 5 * MS_PER_MINUTE,
+      periodInMinutes: undefined,
+    });
+  });
+
+  test("keeps an absolute time already past, which Chrome fires at once", () => {
+    const schedule = createAlarmSchedule({ when: NOW - MS_PER_MINUTE }, NOW);
+
+    expect(schedule?.scheduledTime).toBe(NOW - MS_PER_MINUTE);
+  });
+
+  test("counts a delay from now", () => {
+    expect(createAlarmSchedule({ delayInMinutes: 2 }, NOW)?.scheduledTime).toBe(
+      NOW + 2 * MS_PER_MINUTE,
+    );
+  });
+
+  test("starts a period-only alarm one period out", () => {
+    expect(createAlarmSchedule({ periodInMinutes: 3 }, NOW)).toEqual({
+      scheduledTime: NOW + 3 * MS_PER_MINUTE,
+      periodInMinutes: 3,
+    });
+  });
+
+  test("floors a delay and a period at the minimum", () => {
+    expect(createAlarmSchedule({ delayInMinutes: 0.1, periodInMinutes: 0.2 }, NOW)).toEqual({
+      scheduledTime: NOW + MIN_ALARM_PERIOD_MINUTES * MS_PER_MINUTE,
+      periodInMinutes: MIN_ALARM_PERIOD_MINUTES,
+    });
+  });
+
+  test("refuses a create that names no time at all", () => {
+    expect(createAlarmSchedule({}, NOW)).toBeUndefined();
+    expect(createAlarmSchedule(undefined, NOW)).toBeUndefined();
+  });
+
+  test("ignores what it cannot read as a number", () => {
+    expect(createAlarmSchedule({ delayInMinutes: "5" }, NOW)).toBeUndefined();
+    expect(createAlarmSchedule({ when: Number.NaN }, NOW)).toBeUndefined();
+  });
+});
+
+describe("getNextScheduledTime", () => {
+  test("has no next time for a one-shot alarm", () => {
+    expect(getNextScheduledTime({ scheduledTime: NOW }, NOW)).toBeUndefined();
+  });
+
+  test("counts from when the alarm was due, not from when it ran", () => {
+    // A delivery 900 ms late must not push the next one 900 ms out
+    expect(getNextScheduledTime({ scheduledTime: NOW, periodInMinutes: 1 }, NOW + 900)).toBe(
+      NOW + MS_PER_MINUTE,
+    );
+  });
+
+  test("fires once and carries on after a machine sleeps through several periods", () => {
+    const sleptThrough = NOW + 10.5 * MS_PER_MINUTE;
+
+    expect(getNextScheduledTime({ scheduledTime: NOW, periodInMinutes: 1 }, sleptThrough)).toBe(
+      NOW + 11 * MS_PER_MINUTE,
+    );
+  });
+});
+
+describe("getAlarmClampWarning", () => {
+  test("says nothing about an alarm at or above the minimum", () => {
+    expect(getAlarmClampWarning("lockMonitor", { periodInMinutes: 1 })).toBeUndefined();
+    expect(
+      getAlarmClampWarning("lockMonitor", { periodInMinutes: MIN_ALARM_PERIOD_MINUTES }),
+    ).toBeUndefined();
+  });
+
+  test("names the alarm and the period it will really run at", () => {
+    const warning = getAlarmClampWarning("poll", { periodInMinutes: 0.1 });
+
+    expect(warning).toContain("poll");
+    expect(warning).toContain(String(MIN_ALARM_PERIOD_MINUTES));
+  });
+
+  test("names both fields when both are below the minimum", () => {
+    const warning = getAlarmClampWarning("poll", { delayInMinutes: 0.1, periodInMinutes: 0.2 });
+
+    expect(warning).toContain("delayInMinutes");
+    expect(warning).toContain("periodInMinutes");
+  });
+});

--- a/packages/electron-extensions/alarms/schedule.ts
+++ b/packages/electron-extensions/alarms/schedule.ts
@@ -75,7 +75,11 @@ export function createAlarmSchedule(
     return undefined;
   }
 
-  return { scheduledTime: now + startInMinutes * MS_PER_MINUTE, periodInMinutes };
+  const scheduledTime = now + startInMinutes * MS_PER_MINUTE;
+
+  // A delay large enough to overflow gives an alarm due at `Infinity`, which no
+  // timer can hold and which JSON reports back as `null`
+  return Number.isFinite(scheduledTime) ? { scheduledTime, periodInMinutes } : undefined;
 }
 
 /**

--- a/packages/electron-extensions/alarms/schedule.ts
+++ b/packages/electron-extensions/alarms/schedule.ts
@@ -1,0 +1,121 @@
+/**
+ * When an alarm is due, worked out the way Chrome works it out. Shared by the
+ * facade and the main process: main schedules from it, and the facade warns
+ * from it in the extension's own console, which is where Chrome puts the
+ * warning and the only place the extension's author would ever see it.
+ */
+
+import type { AlarmCreateInfo } from "./bridge-protocol";
+
+const MS_PER_MINUTE = 60_000;
+
+/**
+ * Chrome's floor on how often an alarm may fire, 30 seconds since Chrome 120.
+ *
+ * Chrome applies it to packed extensions and lets an unpacked one fire as
+ * often as it likes. Every extension Meru loads is unpacked in the narrow
+ * sense that it is a directory — the loader unpacks a signed Web Store package
+ * and derives a copy of it (`derive/`) — so "unpacked" here describes how Meru
+ * loads an extension rather than where it came from, and the author wrote
+ * against the clamped behavior. Clamping is therefore the honest reading.
+ */
+export const MIN_ALARM_PERIOD_MINUTES = 0.5;
+
+/**
+ * `setTimeout` counts its delay into a signed 32-bit integer, and anything past
+ * that fires immediately instead — so a long wait is served by re-arming across
+ * several of these rather than by one timer.
+ */
+export const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
+
+export type AlarmSchedule = {
+  scheduledTime: number;
+  periodInMinutes?: number;
+};
+
+/** Chrome ignores what it cannot read as a finite number. */
+function readNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function clampMinutes(minutes: number | undefined) {
+  if (minutes === undefined) {
+    return undefined;
+  }
+
+  return Math.max(minutes, MIN_ALARM_PERIOD_MINUTES);
+}
+
+/**
+ * When the alarm first fires and how often after, or `undefined` for a
+ * `create` Chrome refuses — one naming no time at all.
+ *
+ * `when` is an absolute time and is taken as given, including one already past,
+ * which Chrome fires at once. A delay or a period is a length of time and is
+ * floored at the minimum. An alarm with a period and no start begins one period
+ * out, the way Chrome starts it.
+ */
+export function createAlarmSchedule(
+  alarmInfo: AlarmCreateInfo | undefined,
+  now: number,
+): AlarmSchedule | undefined {
+  const periodInMinutes = clampMinutes(readNumber(alarmInfo?.periodInMinutes));
+
+  const when = readNumber(alarmInfo?.when);
+
+  if (when !== undefined) {
+    return { scheduledTime: when, periodInMinutes };
+  }
+
+  const delayInMinutes = clampMinutes(readNumber(alarmInfo?.delayInMinutes));
+
+  const startInMinutes = delayInMinutes ?? periodInMinutes;
+
+  if (startInMinutes === undefined) {
+    return undefined;
+  }
+
+  return { scheduledTime: now + startInMinutes * MS_PER_MINUTE, periodInMinutes };
+}
+
+/**
+ * When a periodic alarm that has just fired is due again.
+ *
+ * Counted from the time it was due rather than from now, so an alarm on a
+ * minute stays on the minute rather than drifting by however late each delivery
+ * ran. A machine that slept through several periods comes back with that count
+ * already past: Chrome fires once and carries on from the present rather than
+ * firing once per period it missed, so the next time is walked forward to the
+ * first one still ahead.
+ */
+export function getNextScheduledTime(schedule: AlarmSchedule, now: number) {
+  const periodMs = (schedule.periodInMinutes ?? 0) * MS_PER_MINUTE;
+
+  if (periodMs <= 0) {
+    return undefined;
+  }
+
+  const elapsedPeriods = Math.floor((now - schedule.scheduledTime) / periodMs);
+
+  return schedule.scheduledTime + periodMs * Math.max(elapsedPeriods + 1, 1);
+}
+
+/**
+ * What Chrome would have warned about this `create`, or `undefined` when it
+ * would have said nothing. A clamped alarm still gets made — the warning is the
+ * whole of what the extension is told, so it has to name the alarm and the
+ * period it will actually run at.
+ */
+export function getAlarmClampWarning(name: string, alarmInfo: AlarmCreateInfo | undefined) {
+  const belowMinimum = (["delayInMinutes", "periodInMinutes"] as const).filter((field) => {
+    const minutes = readNumber(alarmInfo?.[field]);
+
+    return minutes !== undefined && minutes < MIN_ALARM_PERIOD_MINUTES;
+  });
+
+  if (belowMinimum.length === 0) {
+    return undefined;
+  }
+
+  return `Alarm "${name}" asked for ${belowMinimum.join(" and ")} below the ${MIN_ALARM_PERIOD_MINUTES} minute minimum, and will fire every ${MIN_ALARM_PERIOD_MINUTES} minutes instead.`;
+}

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -7,6 +7,7 @@ import {
   type ExtensionAction,
   readExtensionActionIcon,
 } from "./action";
+import { Alarms, type AlarmWakePolicy } from "./alarms/alarms";
 import { ExtensionBridge } from "./bridge/bridge";
 import { deriveExtension, type SharedInstanceDeriveOptions } from "./derive";
 import type { ExtensionsLogger } from "./logger";
@@ -92,6 +93,12 @@ export type ExtensionsOptions = {
    */
   isNativeMessagingHostAllowed?: NativeMessagingHostPolicy;
   /**
+   * Which extensions a due alarm may start a stopped service worker for. Without
+   * it an alarm reaches only the contexts already running, which is what Meru
+   * ships: a worker woken every minute is a worker that never idles out.
+   */
+  shouldWakeWorkerForAlarm?: AlarmWakePolicy;
+  /**
    * Lets one extension instance serve every session
    * (`createSharedExtensionInstance` in `runtime-proxy/`). Without it every
    * session runs its own.
@@ -140,6 +147,8 @@ export class Extensions {
 
   private webNavigation: WebNavigation;
 
+  private alarms: Alarms;
+
   private serviceWorkerConsoleListeners = new Map<
     Session,
     (event: ElectronEvent, messageDetails: MessageDetails) => void
@@ -152,6 +161,7 @@ export class Extensions {
     strippedManifestKeys,
     getContentScriptMatches,
     isNativeMessagingHostAllowed,
+    shouldWakeWorkerForAlarm,
     sharedInstance,
     logger,
   }: ExtensionsOptions) {
@@ -181,6 +191,10 @@ export class Extensions {
     this.webNavigation = new WebNavigation();
 
     this.webNavigation.registerRoutes(this.bridge);
+
+    this.alarms = new Alarms({ shouldWakeWorker: shouldWakeWorkerForAlarm, logger });
+
+    this.alarms.registerRoutes(this.bridge);
 
     this.sharedInstance?.install({ bridge: this.bridge, logger });
   }
@@ -405,6 +419,8 @@ export class Extensions {
     this.bridge.teardownSession(session);
 
     this.nativeMessaging.teardownSession(session);
+
+    this.alarms.teardownSession(session);
 
     this.sharedInstance?.teardownSession(session);
 

--- a/packages/electron-extensions/facade/api/alarms.test.ts
+++ b/packages/electron-extensions/facade/api/alarms.test.ts
@@ -25,6 +25,8 @@ function installFakeBridge() {
 
   let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
 
+  let canceledStreamCount = 0;
+
   let markParked = () => {};
 
   const parked = new Promise<void>((resolve) => {
@@ -54,6 +56,9 @@ function installFakeBridge() {
 
         markParked();
       },
+      cancel: () => {
+        canceledStreamCount += 1;
+      },
     });
 
     return new Response(body);
@@ -72,6 +77,15 @@ function installFakeBridge() {
     fire: (alarm: AlarmDetails) => {
       controller?.enqueue(encodeNativeMessage({ type: "alarm", alarm } satisfies AlarmFrame));
     },
+    /** A frame announcing more bytes than the decoder will ever buffer. */
+    breakStream: () => {
+      const oversizedFrame = new Uint8Array(4);
+
+      new DataView(oversizedFrame.buffer).setUint32(0, 2 ** 30, true);
+
+      controller?.enqueue(oversizedFrame);
+    },
+    canceledStreamCount: () => canceledStreamCount,
   };
 }
 
@@ -133,6 +147,41 @@ describe("alarms", () => {
     await methodOf(createAlarms(), "create")({ delayInMinutes: 1 });
 
     expect(bridge.requests[0]?.body).toEqual({ name: "", alarmInfo: { delayInMinutes: 1 } });
+  });
+
+  test("takes an explicit undefined name as the alarm named empty", async () => {
+    const bridge = installFakeBridge();
+
+    // What a wrapper forwarding an optional name passes; reading the first
+    // argument alone drops the alarmInfo and the alarm with it
+    await methodOf(createAlarms(), "create")(undefined, { delayInMinutes: 1 });
+
+    expect(bridge.requests[0]?.body).toEqual({ name: "", alarmInfo: { delayInMinutes: 1 } });
+  });
+
+  test("parks one replacement stream when a frame is too large to decode", async () => {
+    const bridge = installFakeBridge();
+
+    const alarms = createAlarms();
+
+    eventOf(alarms, "onAlarm").addListener(() => {});
+
+    await bridge.parked;
+
+    const error = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      bridge.breakStream();
+
+      await settle();
+
+      // The refused frame must take its stream with it: a reader left open
+      // leaves main writing to a stream nothing reads while the retry parks
+      // another
+      expect(bridge.canceledStreamCount()).toBe(1);
+    } finally {
+      error.mockRestore();
+    }
   });
 
   test("warns in the extension's own console about a period it will not get", async () => {

--- a/packages/electron-extensions/facade/api/alarms.test.ts
+++ b/packages/electron-extensions/facade/api/alarms.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { ALARMS_PATHS, type AlarmDetails, type AlarmFrame } from "../../alarms/bridge-protocol";
+import { encodeNativeMessage } from "../../native-messaging/framing";
+import type { ChromeEvent, ChromeNamespace } from "../lib/chrome";
+import { createAlarms, installAlarms } from "./alarms";
+
+type BridgeRequest = { path: string; body: Record<string, unknown> };
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+/**
+ * The main-process end of the bridge, with the events stream left open so the
+ * test can push alarms down it the way a due alarm does.
+ */
+function installFakeBridge() {
+  const requests: BridgeRequest[] = [];
+
+  const answers = new Map<string, unknown>();
+
+  const refusals = new Map<string, number>();
+
+  let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+
+  let markParked = () => {};
+
+  const parked = new Promise<void>((resolve) => {
+    markParked = resolve;
+  });
+
+  globalThis.fetch = (async (url: string, init: RequestInit) => {
+    const { pathname: path } = new URL(url);
+
+    requests.push({ path, body: JSON.parse(init.body as string) });
+
+    const refusalStatus = refusals.get(path);
+
+    if (refusalStatus !== undefined) {
+      return new Response(null, { status: refusalStatus });
+    }
+
+    if (path !== ALARMS_PATHS.events) {
+      return answers.has(path)
+        ? Response.json(answers.get(path))
+        : new Response(null, { status: 204 });
+    }
+
+    const body = new ReadableStream<Uint8Array>({
+      start: (streamController) => {
+        controller = streamController;
+
+        markParked();
+      },
+    });
+
+    return new Response(body);
+  }) as unknown as typeof fetch;
+
+  return {
+    requests,
+    paths: () => requests.map(({ path }) => path),
+    parked,
+    answer: (path: string, result: unknown) => {
+      answers.set(path, result);
+    },
+    refuse: (path: string, status: number) => {
+      refusals.set(path, status);
+    },
+    fire: (alarm: AlarmDetails) => {
+      controller?.enqueue(encodeNativeMessage({ type: "alarm", alarm } satisfies AlarmFrame));
+    },
+  };
+}
+
+function methodOf(alarms: ChromeNamespace, name: string) {
+  return alarms[name] as (...callArguments: unknown[]) => Promise<unknown>;
+}
+
+function eventOf(alarms: ChromeNamespace, name: string) {
+  return alarms[name] as ChromeEvent;
+}
+
+/** Lets the bridge calls and the stream reads behind a listener settle. */
+function settle() {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 10);
+  });
+}
+
+describe("installAlarms", () => {
+  test("replaces the alarms Electron implements", () => {
+    const nativeAlarms = { create: () => {} };
+
+    const extensionApi: ChromeNamespace = { alarms: nativeAlarms };
+
+    const alarms = createAlarms();
+
+    installAlarms(extensionApi, alarms);
+
+    expect(extensionApi.alarms).toBe(alarms);
+  });
+
+  test("adds no alarms to a context Chromium gives none", () => {
+    // A content script, which has no alarms in Chrome either
+    const extensionApi: ChromeNamespace = { runtime: {} };
+
+    installAlarms(extensionApi, createAlarms());
+
+    expect(extensionApi.alarms).toBeUndefined();
+  });
+});
+
+describe("alarms", () => {
+  test("creates an alarm over the bridge", async () => {
+    const bridge = installFakeBridge();
+
+    await methodOf(createAlarms(), "create")("lockMonitor", { periodInMinutes: 1 });
+
+    expect(bridge.requests).toEqual([
+      {
+        path: ALARMS_PATHS.create,
+        body: { name: "lockMonitor", alarmInfo: { periodInMinutes: 1 } },
+      },
+    ]);
+  });
+
+  test("takes a create with no name as the alarm named empty", async () => {
+    const bridge = installFakeBridge();
+
+    await methodOf(createAlarms(), "create")({ delayInMinutes: 1 });
+
+    expect(bridge.requests[0]?.body).toEqual({ name: "", alarmInfo: { delayInMinutes: 1 } });
+  });
+
+  test("warns in the extension's own console about a period it will not get", async () => {
+    installFakeBridge();
+
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await methodOf(createAlarms(), "create")("poll", { periodInMinutes: 0.1 });
+
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0]?.[0]).toContain("poll");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test("reads an alarm back, and undefined for one that is not there", async () => {
+    const bridge = installFakeBridge();
+
+    const alarm: AlarmDetails = { name: "poll", scheduledTime: 1, periodInMinutes: 1 };
+
+    bridge.answer(ALARMS_PATHS.get, alarm);
+    bridge.answer(ALARMS_PATHS.getAll, [alarm]);
+
+    expect(await methodOf(createAlarms(), "get")("poll")).toEqual(alarm);
+    expect(await methodOf(createAlarms(), "getAll")()).toEqual([alarm]);
+
+    bridge.answer(ALARMS_PATHS.get, null);
+
+    expect(await methodOf(createAlarms(), "get")("missing")).toBeUndefined();
+  });
+
+  test("answers a callback call instead of returning a promise", async () => {
+    const bridge = installFakeBridge();
+
+    bridge.answer(ALARMS_PATHS.clear, true);
+
+    const { promise, resolve } = Promise.withResolvers<unknown>();
+
+    const returnValue = methodOf(createAlarms(), "clear")("poll", resolve);
+
+    expect(returnValue).toBeUndefined();
+    expect(await promise).toBe(true);
+  });
+
+  test("answers Chrome's own empty result when the bridge refuses", async () => {
+    const bridge = installFakeBridge();
+
+    for (const path of [ALARMS_PATHS.get, ALARMS_PATHS.getAll, ALARMS_PATHS.clear]) {
+      bridge.refuse(path, 403);
+    }
+
+    const alarms = createAlarms();
+
+    // Never a rejection: Chrome's alarms have no failure of their own to report
+    expect(await methodOf(alarms, "get")("poll")).toBeUndefined();
+    expect(await methodOf(alarms, "getAll")()).toEqual([]);
+    expect(await methodOf(alarms, "clear")("poll")).toBe(false);
+  });
+
+  test("parks no stream until something listens", async () => {
+    const bridge = installFakeBridge();
+
+    await methodOf(createAlarms(), "create")("poll", { periodInMinutes: 1 });
+
+    expect(bridge.paths()).not.toContain(ALARMS_PATHS.events);
+  });
+
+  test("delivers a fired alarm to every listener", async () => {
+    const bridge = installFakeBridge();
+
+    const alarms = createAlarms();
+
+    const delivered: unknown[] = [];
+
+    eventOf(alarms, "onAlarm").addListener((alarm) => {
+      delivered.push(alarm);
+    });
+
+    eventOf(alarms, "onAlarm").addListener((alarm) => {
+      delivered.push(alarm);
+    });
+
+    await bridge.parked;
+
+    const alarm: AlarmDetails = { name: "lockMonitor", scheduledTime: 1, periodInMinutes: 1 };
+
+    bridge.fire(alarm);
+
+    await settle();
+
+    expect(delivered).toEqual([alarm, alarm]);
+  });
+
+  test("parks one stream however many listeners are added", async () => {
+    const bridge = installFakeBridge();
+
+    const alarms = createAlarms();
+
+    eventOf(alarms, "onAlarm").addListener(() => {});
+    eventOf(alarms, "onAlarm").addListener(() => {});
+
+    await bridge.parked;
+
+    await settle();
+
+    expect(bridge.paths().filter((path) => path === ALARMS_PATHS.events)).toBeArrayOfSize(1);
+  });
+
+  test("keeps a removed listener from hearing anything", async () => {
+    const bridge = installFakeBridge();
+
+    const alarms = createAlarms();
+
+    let firedCount = 0;
+
+    const listener = () => {
+      firedCount += 1;
+    };
+
+    eventOf(alarms, "onAlarm").addListener(listener);
+
+    await bridge.parked;
+
+    expect(eventOf(alarms, "onAlarm").hasListener(listener)).toBe(true);
+
+    eventOf(alarms, "onAlarm").removeListener(listener);
+
+    bridge.fire({ name: "poll", scheduledTime: 1 });
+
+    await settle();
+
+    expect(firedCount).toBe(0);
+    expect(eventOf(alarms, "onAlarm").hasListeners()).toBe(false);
+  });
+});

--- a/packages/electron-extensions/facade/api/alarms.ts
+++ b/packages/electron-extensions/facade/api/alarms.ts
@@ -24,15 +24,24 @@ function delay(delayMs: number) {
 /**
  * Chrome takes `create(alarmInfo)` as well as `create(name, alarmInfo)`, and an
  * alarm made without a name is the alarm named `""`.
+ *
+ * An explicit `undefined` or `null` where the name goes is Chrome leaving the
+ * parameter out rather than passing it, so `create(undefined, alarmInfo)` is
+ * the alarm named `""` — not, as reading the first argument alone would have
+ * it, a create carrying no `alarmInfo` at all. A wrapper forwarding an optional
+ * name is how an extension gets there.
  */
 function parseCreateArguments(callArguments: unknown[]) {
   const [firstArgument, secondArgument] = callArguments;
 
-  if (typeof firstArgument === "string") {
-    return { name: firstArgument, alarmInfo: secondArgument as AlarmCreateInfo | undefined };
-  }
+  const hasName = typeof firstArgument === "string";
 
-  return { name: "", alarmInfo: firstArgument as AlarmCreateInfo | undefined };
+  return {
+    name: hasName ? firstArgument : "",
+    alarmInfo: (hasName || secondArgument !== undefined ? secondArgument : firstArgument) as
+      | AlarmCreateInfo
+      | undefined,
+  };
 }
 
 function readName(callArguments: unknown[]) {
@@ -106,18 +115,25 @@ export function createAlarms(): ChromeNamespace {
 
     const decoder = new NativeMessageDecoder();
 
-    for (;;) {
-      const { value, done } = await reader.read();
+    // A frame the decoder refuses throws out of the loop, and a reader left
+    // open then means main keeps this stream in its delivery set and writes to
+    // it forever while the retry parks another one
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
 
-      if (done) {
-        return;
-      }
+        if (done) {
+          return;
+        }
 
-      for (const frame of decoder.push(value) as AlarmFrame[]) {
-        if (frame.type === "alarm") {
-          emitAlarm(frame.alarm satisfies AlarmDetails);
+        for (const frame of decoder.push(value) as AlarmFrame[]) {
+          if (frame.type === "alarm") {
+            emitAlarm(frame.alarm satisfies AlarmDetails);
+          }
         }
       }
+    } finally {
+      await reader.cancel().catch(() => undefined);
     }
   };
 

--- a/packages/electron-extensions/facade/api/alarms.ts
+++ b/packages/electron-extensions/facade/api/alarms.ts
@@ -1,0 +1,195 @@
+import {
+  ALARMS_PATHS,
+  type AlarmCreateInfo,
+  type AlarmDetails,
+  type AlarmFrame,
+} from "../../alarms/bridge-protocol";
+import { getAlarmClampWarning } from "../../alarms/schedule";
+import { NativeMessageDecoder } from "../../native-messaging/framing";
+import { postBridge } from "../lib/bridge";
+import type { ChromeEventListener, ChromeNamespace } from "../lib/chrome";
+import { createEvent } from "../lib/event";
+import { defineMember, readMember } from "../lib/fill";
+import { createBridgedMethod } from "../lib/method";
+
+/** How long a dropped events stream waits before it is parked again. */
+const RETRY_DELAY_MS = 1000;
+
+function delay(delayMs: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
+
+/**
+ * Chrome takes `create(alarmInfo)` as well as `create(name, alarmInfo)`, and an
+ * alarm made without a name is the alarm named `""`.
+ */
+function parseCreateArguments(callArguments: unknown[]) {
+  const [firstArgument, secondArgument] = callArguments;
+
+  if (typeof firstArgument === "string") {
+    return { name: firstArgument, alarmInfo: secondArgument as AlarmCreateInfo | undefined };
+  }
+
+  return { name: "", alarmInfo: firstArgument as AlarmCreateInfo | undefined };
+}
+
+function readName(callArguments: unknown[]) {
+  const [name] = callArguments;
+
+  return typeof name === "string" ? name : "";
+}
+
+/**
+ * A call the main process answers, with the answer Chrome gives for "nothing
+ * there" standing in whenever the bridge cannot be reached — `undefined` for a
+ * `get`, an empty list for a `getAll`, `false` for a `clear`.
+ *
+ * Chrome's alarms have no failure of their own to report and no `lastError` on
+ * any of these, so a bridge that is gone is told as an empty answer rather than
+ * as a rejection the extension has no handler for.
+ */
+function createAlarmQuery<QueryResult>(pathName: string, emptyResult: QueryResult) {
+  return createBridgedMethod(async (callArguments) => {
+    try {
+      const response = await postBridge(pathName, { name: readName(callArguments) });
+
+      if (!response.ok) {
+        return emptyResult;
+      }
+
+      const result = (await response.json()) as QueryResult | null;
+
+      // JSON carries no `undefined`, so a missing alarm arrives as `null`
+      return result ?? emptyResult;
+    } catch {
+      return emptyResult;
+    }
+  });
+}
+
+/**
+ * `chrome.alarms`, scheduled in the main process and delivered over the
+ * extension bridge (`alarms/alarms.ts`).
+ *
+ * Electron's own alarms are replaced rather than filled in around, because they
+ * are half working in a way that filling cannot reach: Chromium schedules them
+ * and fires them, and dispatches `onAlarm` into extension pages but never into
+ * an extension service worker, which is where MV3 puts every background handler
+ * (measured 2 September 2026 on Electron 43.2.0). An extension whose alarms all
+ * live in the worker — 1Password's seven do — has a namespace that answers
+ * every call and never fires.
+ *
+ * The events stream is parked by the first `onAlarm` listener rather than at
+ * startup, so a context that never listens never opens one.
+ */
+export function createAlarms(): ChromeNamespace {
+  const { emit: emitAlarm, addListener: addAlarmListener, ...alarmEvent } = createEvent();
+
+  let isListening = false;
+
+  /**
+   * Reads the parked stream until it ends, which is what a torn-down session
+   * and a refused request both look like from here. Ending is not the same as
+   * being done: the context is still live and still holds listeners, so the
+   * stream is parked again behind a delay for as long as the context lasts.
+   */
+  const readAlarmStream = async () => {
+    const response = await postBridge(ALARMS_PATHS.events, {});
+
+    if (!response.ok || !response.body) {
+      throw new Error(`The alarms bridge answered ${response.status}`);
+    }
+
+    const reader = response.body.getReader();
+
+    const decoder = new NativeMessageDecoder();
+
+    for (;;) {
+      const { value, done } = await reader.read();
+
+      if (done) {
+        return;
+      }
+
+      for (const frame of decoder.push(value) as AlarmFrame[]) {
+        if (frame.type === "alarm") {
+          emitAlarm(frame.alarm satisfies AlarmDetails);
+        }
+      }
+    }
+  };
+
+  const listenForAlarms = async () => {
+    if (isListening) {
+      return;
+    }
+
+    isListening = true;
+
+    for (;;) {
+      try {
+        await readAlarmStream();
+      } catch (error) {
+        console.error("[chrome-facade] alarms stream failed", error);
+      }
+
+      await delay(RETRY_DELAY_MS);
+    }
+  };
+
+  return {
+    create: createBridgedMethod(async (callArguments) => {
+      const { name, alarmInfo } = parseCreateArguments(callArguments);
+
+      const clampWarning = getAlarmClampWarning(name, alarmInfo);
+
+      if (clampWarning) {
+        console.warn(`[chrome-facade] ${clampWarning}`);
+      }
+
+      try {
+        await postBridge(ALARMS_PATHS.create, { name, alarmInfo });
+      } catch {
+        // Chrome's `create` reports nothing and answers nothing
+      }
+
+      return undefined;
+    }),
+
+    get: createAlarmQuery<AlarmDetails | undefined>(ALARMS_PATHS.get, undefined),
+    getAll: createAlarmQuery<AlarmDetails[]>(ALARMS_PATHS.getAll, []),
+    clear: createAlarmQuery<boolean>(ALARMS_PATHS.clear, false),
+    clearAll: createAlarmQuery<boolean>(ALARMS_PATHS.clearAll, false),
+
+    onAlarm: {
+      ...alarmEvent,
+      addListener(listener: ChromeEventListener, ...eventOptions: unknown[]) {
+        addAlarmListener(listener, ...eventOptions);
+
+        void listenForAlarms();
+      },
+    },
+  };
+}
+
+/**
+ * Replaces Electron's `alarms` with the facade's, in every context that has one
+ * — the service worker, where delivery is broken, and extension pages, where it
+ * works. Both, because one store is the whole point: an alarm the worker
+ * created has to be what a page's `getAll` sees and what its `clear` clears,
+ * and Electron's alarms live in Chromium's own store where nothing here can
+ * reach them.
+ *
+ * A context Chromium gives no `alarms` at all keeps none. That is what tells a
+ * content script apart from a privileged context, and Chrome exposes no alarms
+ * to a content script either.
+ */
+export function installAlarms(extensionApi: ChromeNamespace, alarms: ChromeNamespace) {
+  if (readMember(extensionApi, "alarms") === undefined) {
+    return;
+  }
+
+  defineMember(extensionApi, "alarms", alarms);
+}

--- a/packages/electron-extensions/facade/install.test.ts
+++ b/packages/electron-extensions/facade/install.test.ts
@@ -12,6 +12,7 @@ function createNativeChrome(): ChromeNamespace {
     runtime: { id: "aeblfdkhhhdcdjpifhhbdiojplfjncoa", getURL: (pathname: string) => pathname },
     storage: { local: { get: () => Promise.resolve({}) } },
     tabs: { query: () => Promise.resolve([]) },
+    alarms: { create: () => {}, onAlarm: { addListener: () => {} } },
     webRequest: { onBeforeRequest: undefined, onAuthRequired: undefined },
   };
 }
@@ -186,6 +187,33 @@ describe("installChromeFacade", () => {
     expect(eventOf(namespaceOf(chrome, "windows"), "onFocusChanged").hasListener(listener)).toBe(
       true,
     );
+  });
+
+  test("takes over the alarms Electron half implements", () => {
+    const chrome = createNativeChrome();
+
+    const { alarms } = chrome;
+
+    installChromeFacade(chrome);
+
+    // Electron schedules these and delivers `onAlarm` to no service worker,
+    // which is a gap filling cannot reach — see `api/alarms.ts`
+    expect(chrome.alarms).not.toBe(alarms);
+    expect(namespaceOf(chrome, "alarms").getAll).toBeFunction();
+  });
+
+  test("shares one alarms between the chrome and browser globals", () => {
+    const facade = createChromeFacade();
+
+    const chrome = createNativeChrome();
+    const browser = createNativeChrome();
+
+    installChromeFacade(chrome, facade);
+    installChromeFacade(browser, facade);
+
+    // One namespace means one set of `onAlarm` listeners and one parked stream,
+    // whichever global the extension reached it through
+    expect(chrome.alarms).toBe(browser.alarms);
   });
 
   test("runs twice without replacing what the first run added", () => {

--- a/packages/electron-extensions/facade/install.ts
+++ b/packages/electron-extensions/facade/install.ts
@@ -1,3 +1,4 @@
+import { createAlarms, installAlarms } from "./api/alarms";
 import { createCommands } from "./api/commands";
 import { createContextMenus } from "./api/context-menus";
 import { installNativeMessaging } from "./api/native-messaging";
@@ -12,13 +13,15 @@ import { fillMissing } from "./lib/fill";
 
 /**
  * Everything the facade has to offer, built without looking at what Electron
- * implements: noop namespaces for what Electron is missing entirely, and the
- * odd member for a namespace it ships half-finished. Promoting one of these to
- * a real implementation later means backing it with an embedder transport —
- * where the facade is installed and how it is merged stay the same.
+ * implements: noop namespaces for what Electron is missing entirely, the odd
+ * member for a namespace it ships half-finished, and — for `alarms` — a real
+ * implementation backed by the embedder's bridge. Promoting a namespace to one
+ * of those does not change where the facade is installed, only whether it is
+ * filled in around or taken over; `installChromeFacade` holds that list.
  */
 export function createChromeFacade(): ChromeNamespace {
   return {
+    alarms: createAlarms(),
     commands: createCommands(),
     contextMenus: createContextMenus(),
     notifications: createNotifications(),
@@ -37,15 +40,22 @@ export function createChromeFacade(): ChromeNamespace {
  * implements is left exactly as it is, and only the gaps around it are filled
  * (see the noop-first decision in the feature docs).
  *
- * Native messaging is the one exception, and it is one because filling gaps
- * cannot help there: Electron implements `connectNative` and refuses every host
- * from it (see `api/native-messaging.ts`).
+ * Two namespaces are the exception, and they are because filling gaps cannot
+ * help there: Electron implements `connectNative` and refuses every host from
+ * it (`api/native-messaging.ts`), and it implements `alarms` and delivers
+ * `onAlarm` nowhere a background handler can hear it (`api/alarms.ts`). Both
+ * are taken over rather than filled, which is why `alarms` is lifted out of the
+ * fill below — it is a real implementation and not a gap to leave alone.
  */
 export function installChromeFacade(
   extensionApi: ChromeNamespace,
   facade: ChromeNamespace = createChromeFacade(),
 ) {
-  fillMissing(extensionApi, facade);
+  const { alarms, ...fillableFacade } = facade;
+
+  fillMissing(extensionApi, fillableFacade);
 
   installNativeMessaging(extensionApi);
+
+  installAlarms(extensionApi, alarms as ChromeNamespace);
 }

--- a/packages/electron-extensions/facade/lib/fill.ts
+++ b/packages/electron-extensions/facade/lib/fill.ts
@@ -6,7 +6,7 @@ import type { ChromeNamespace } from "./chrome";
  * that logs and gives back `undefined`, and nothing here should ride on that
  * staying an ordinary property.
  */
-function read(target: ChromeNamespace, name: string) {
+export function readMember(target: ChromeNamespace, name: string) {
   try {
     return target[name];
   } catch {
@@ -14,7 +14,7 @@ function read(target: ChromeNamespace, name: string) {
   }
 }
 
-function define(target: ChromeNamespace, name: string, value: unknown) {
+export function defineMember(target: ChromeNamespace, name: string, value: unknown) {
   try {
     Object.defineProperty(target, name, {
       value,
@@ -39,10 +39,10 @@ function isNamespace(value: unknown): value is ChromeNamespace {
 export function fillMissing(target: ChromeNamespace, facade: ChromeNamespace) {
   for (const [name, facadeValue] of Object.entries(facade)) {
     try {
-      const nativeValue = read(target, name);
+      const nativeValue = readMember(target, name);
 
       if (nativeValue === undefined) {
-        define(target, name, facadeValue);
+        defineMember(target, name, facadeValue);
 
         continue;
       }

--- a/packages/electron-extensions/index.ts
+++ b/packages/electron-extensions/index.ts
@@ -1,4 +1,5 @@
 export type { ExtensionAction } from "./action";
+export type { AlarmWakePolicy } from "./alarms/alarms";
 export { registerExtensionBridgeScheme } from "./bridge/scheme";
 export { compareExtensionVersions, verifyCrx } from "./crx";
 export type { VerifiedCrx } from "./crx";

--- a/tests/bundle-budget.json
+++ b/tests/bundle-budget.json
@@ -1,5 +1,5 @@
 {
-  "app.js": 2294784,
+  "app.js": 2312192,
   "extensions-chrome-facade.js": 9216,
   "extensions-runtime-proxy-relay.js": 12288,
   "extensions-runtime-proxy-shim.js": 12288,


### PR DESCRIPTION
## Summary
Builds a facade `chrome.alarms` that schedules in the main process and delivers `onAlarm` over the extension bridge, so 1Password's worker-side alarms actually fire in Meru. Measured against the real extension: a 30-second control alarm delivered six times over 180 seconds and two of 1Password's own alarms three times each, against zero deliveries of each before. Two divergences from Chrome are deliberate and explained under Solution — alarms do not survive a relaunch, and a due alarm does not wake a stopped worker.

## Problem
On Electron 43.2.0 Chromium's alarm manager schedules extension alarms and fires them, and then dispatches `onAlarm` to no service worker — which is where MV3 puts every background handler. Finding 31 of the 3.60 extensions review measured it on the shipping path: a control alarm's `scheduledTime` advanced five times over 180 seconds while `onAlarm` fired zero times in a worker held demonstrably alive, and a stopped worker was never woken either. The events do fire in extension *pages*; it is dispatch into the worker specifically that is missing.

All seven of 1Password 8.12.34.34's alarms are therefore dead. `lockMonitor` (1 min, polls the desktop app's lock state) and `unlockedSessionKeepalive` (1 min, refreshes the session) both have a `setInterval` twin, which is why nothing looks broken today — the interval covers the worker-alive case and the alarm was the half meant to survive the worker stopping. `purge-login-detection-data` (1 min) has no twin at all.

## Solution
- `packages/electron-extensions/alarms/` schedules alarms in the main process, one timer per alarm, and delivers each due alarm as a frame on a stream that every listening extension context parks at the bridge — the shape `connectNative` already had.
- `facade/api/alarms.ts` replaces the namespace in the extension, bridging the five methods and feeding `onAlarm` from that stream. The stream is parked by the first listener rather than at startup, so a context that never listens never opens one.
- Chrome's own rules are mirrored where they are cheap: `delayInMinutes` and `periodInMinutes` floor at half a minute with a warning in the extension's own console, a `when` already past fires at once, creating over a live alarm replaces it, and a periodic alarm's next time is counted from when it was due rather than from when its listener ran. Chrome's caps come too — 500 alarms per extension, and 512 characters of name, which is also what keeps a delivery frame inside the transport's own limit.

**Replacing rather than filling, and in every context.** The facade's rule everywhere else is to fill only the gaps and leave what Electron implements alone. Alarms cannot be fixed that way — the namespace is present and answers every call, and only the delivery is missing. Shadowing only the worker was the alternative, since Electron's alarms do work in pages; it was rejected because Electron's alarms live in Chromium's own store, so pages and worker would then hold separate stores and a page's `getAll` could not see what the worker scheduled, while its `clear` of that name would silently clear nothing.

**In memory rather than persisted.** Chrome persists alarms across a browser restart and this does not. What an alarm has to outlive is the service worker, and the main process outlives it either way; every alarm 1Password owns is created again at each worker boot, so no curated extension has one that nothing recreates. Persisting would need a store in the session partition, a schema and an eviction rule for alarms whose extension is gone, and would buy none of them anything today.

**Delivered to a running worker, not waking a stopped one.** Waking is what Chrome's contract actually promises, and it is what would make `lockMonitor` mean something. It is off because 1Password's alarms run on a minute against a worker that idles out in thirty seconds, so waking would keep the worker resident for as long as the account is open, at the 80–110 MB per account the memory audit measures — spent to refresh a lock state whose real enforcement lives in the desktop app. The mechanism is built and unused behind `shouldWakeWorkerForAlarm` on the loader, for a standalone password manager whose vault timeout lives in the extension rather than in a desktop app; no catalog entry sets it, so it is plumbing landing ahead of its consumer. An alarm that comes due with no worker parked is dropped rather than queued, since a queue would deliver a stack of alarms whenever the worker next came up for its own reasons, which Chrome never does.

`lib/method.ts` is untouched: a bridged callback-style failure still sets no `runtime.lastError` (finding 18 of the same review). The alarms methods sidestep it by answering Chrome's own "nothing there" values on a bridge failure — `undefined` for a `get`, `[]` for a `getAll`, `false` for a `clear` — which is what Chrome gives, since its alarms have no failure of their own to report.

`tests/bundle-budget.json` raises the `app.js` ceiling from 2,294,784 to 2,312,192. The main-process bundle ships unminified with its comments intact, so a namespace costs its explanation in bytes as well as its code: `alarms/` adds 16.3 KiB against the 3.1 KiB of room the old ceiling left, and the new one leaves 3,870 bytes — the slack main was already carrying. Raised rather than absorbed by cutting comments, which is what the budget file asks for.

The second commit is four fixes from an adversarial review of the first: a frame the decoder refused threw out of the read loop with the reader still open, so main kept writing to a stream nothing read while the retry parked another; `create(undefined, alarmInfo)` dropped the alarm, where Chrome takes an explicit `undefined` for an optional parameter as the parameter being left out; and the two caps above, plus a guard on a delay large enough to overflow the time it is due.

## Try it
No preview deployment for a desktop app, so this is a local run:

```sh
bun run extensions:download && bun run build:js
mkdir -p /tmp/meru-alarms && echo '{"trial.expired": true}' > /tmp/meru-alarms/config.json
xvfb-run -a node_modules/.bin/electron . --no-sandbox --user-data-dir=/tmp/meru-alarms
```

Append a probe to the gitignored `extensions/1password/background/background.js` that registers `chrome.alarms.onAlarm` and creates an alarm on a `periodInMinutes` of 0.5, and read `/tmp/meru-alarms/logs/main.log`, into which the loader already pipes the worker console. Keep the worker alive with a *native* call such as `chrome.storage.local.get` rather than a facade one — see Not verified. Expect a delivery every 30 seconds, plus `trelica-job` and `purge-login-detection-data` on the minute. Restore the bundle afterwards.

## Not verified
- `lockMonitor` and `unlockedSessionKeepalive`, the two alarms that matter most, are still unmeasured. 1Password creates them only once its desktop app connects, and no machine here has one — the worker logs `NativeHostNotFound`. Their periods and handlers are read from the bundle; the delivery fix is measured on the control alarm and on the three alarms that are scheduled without the desktop app. A real-machine pass with the desktop app is what would close this.
- `bun run test:e2e` was not run: it needs `MERU_TEST_LICENSE_KEY`, which this sandbox does not have. `bun test`, `bun run types`, `bun run lint` and `bun run fmt:check` all pass.
- A facade call does not hold the service worker alive, and this is measured rather than reasoned: a bridged method is a `fetch` of a custom scheme, not an extension API call, so it does not reset Chromium's worker idle timer the way the native call it replaced did. A first probe using `chrome.alarms.getAll()` as its ten-second keepalive let the worker idle out after about thirty seconds. Nothing in this change depends on it, and no extension code was found relying on an alarms call to stay alive, but it is a behavior change the namespace's callers inherit.
- The waking path is exercised by unit tests only. No shipping configuration turns it on, so it has never run against a real stopped worker, and `startWorkerForScope` is experimental on Electron 43.
- Three divergences from Chrome are known and left alone, none of them reachable by a curated extension: `when` together with `delayInMinutes` takes the `when` where Chrome rejects the call; a `create` naming no time resolves rather than rejecting; and `get` reports the clamped `periodInMinutes` where Chrome reports the value as given. On the first two, Chromium validates in `AlarmsCreateFunction::Run` and answers `RespondNow(Error(...))`, which rejects the promise and sets `runtime.lastError` for a callback caller — it is not a synchronous throw at the call site, since `{}` is schema-valid with all three fields optional. Closing them therefore means giving the facade a local `lastError` path for callback callers rather than a cheap pre-flight throw, which is finding 18's territory and a change of its own.
- The adversarial review cleared, with scratch reproductions against a virtual clock, the multi-leg timer re-arm past a 32-bit delay, the Set mutation during delivery, the post-sleep period arithmetic against Chromium's own `OnAlarm`, teardown leaks, and the retry loop. The `senderFrame === undefined` worker discriminator can misfile a page whose frame died in the window before Electron cancels its stream; with waking off that flag is inert, and with it on the cost is a suppressed wake for that window.

