### PR TITLE
Clone rather than byte-copy the derive's source tree

### DIFF
--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
+import { constants } from "node:fs";
 import { cp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { EXTENSION_BRIDGE_SCHEME, EXTENSION_BRIDGE_TOKEN_GLOBAL } from "../bridge/protocol";
@@ -267,7 +268,13 @@ export async function deriveExtension({
 
     await rm(stampPath, { force: true });
 
-    await cp(sourceDir, derivedDir, { recursive: true });
+    // A copy-on-write clone where the filesystem has them — APFS, btrfs, XFS —
+    // and an ordinary byte copy everywhere else, which is what the flag asks
+    // for and `COPYFILE_FICLONE_FORCE` would fail at. It stays a copy either
+    // way: the derive writes the manifest, the facade and the shim into the
+    // directory it made, and a clone diverges from its source at the first
+    // write, which a link would not
+    await cp(sourceDir, derivedDir, { recursive: true, mode: constants.COPYFILE_FICLONE });
 
     const { manifest, serviceWorkerWrapper } = deriveManifest(sourceManifest, {
       facadeFileName: FACADE_FILE_NAME,


### PR DESCRIPTION
## Summary
`deriveExtension` copies the whole unpacked extension install with a plain recursive `cp`. Passing `mode: COPYFILE_FICLONE` asks the filesystem for a copy-on-write clone where it has them and falls back to an ordinary byte copy where it does not, so the copy stays a copy everywhere and gets close to free on APFS, btrfs and XFS. One option, no behavior change. The saving could not be measured here: this machine is ext4, where there is nothing to clone.

## Problem
The derive copies the entire install into `userData/derived-extensions` on first launch, again on every version change, and once per role when the shared instance is on — two full copies of the same tree for a single extension. 1Password is tens of megabytes, so that is tens of megabytes of real reads, real writes and real disk held, paid on the launch path before Gmail's first navigation.

The copy itself cannot go away. Chromium treats each directory as an extension root, the install directory is not the loader's to write to, and the derive writes into what it made: the rewritten manifest, the facade, the service worker wrapper, the proxy shim, and the scripts injected into every page.

## Solution
- Passes `mode: constants.COPYFILE_FICLONE` to the recursive `cp` at `derive/index.ts:270`.

A reflink is a copy in exactly the sense the derive needs: the two directories are independent files that happen to share extents until one of them is written, and the first write into the derived copy diverges it. A hard link or symlink would not — the derive would write the facade back into the user's verified install.

`COPYFILE_FICLONE_FORCE` is the flag that does not work here. It fails outright where cloning is unsupported, which is NTFS and ext4, so it would turn a free optimization into a launch-time error for most users. `COPYFILE_FICLONE` falls back to a normal copy instead, which is why it is safe to pass unconditionally with no platform check.

Verified that `fs.promises.cp` accepts `mode` alongside `recursive: true` on both runtimes that matter, with a throwaway script rather than from the docs: Node 24.20 (Electron 43 bundles Node 24) and Bun 1.4, which runs the tests. Both copied a nested tree with a symlink in it, and a write into the copy left the source untouched.

No test was added. A test that proves cloning happened needs a cloning filesystem, so it would pass or skip depending on the machine's disk and prove nothing on CI; the existing `packages/electron-extensions/derive` suite already covers that the copy is a copy, and passes (111 tests).

## Try it
Nothing to open — it is a one-option change on a filesystem call, with no user-visible surface. On a btrfs, XFS or APFS machine it is visible as `du -sh` of `userData/derived-extensions` no longer growing by the install's full size, and as a shorter first launch after an extension update.

## Not verified
- The clone path itself is unexercised. This machine's disk is ext4, so every run here took the fallback. Timing five runs of each over a 40 MB, 800-file tree gave a median of 394 ms plain against 430 ms cloned, then 408 ms against 320 ms on a second pass — noise in both directions, and exactly the no-change expected where the filesystem cannot clone. Nobody has run this on APFS, btrfs or XFS, so the size and time saved there is inferred from what a reflink is, not measured.
- Not run in a packaged app or against a real 1Password install; only the unit suite and the type, lint and format checks.
