### PR TITLE
Cache extension menu icons at 1x and 2x, and read each icon once

### DIFF
--- a/packages/app/extension-actions.ts
+++ b/packages/app/extension-actions.ts
@@ -1,6 +1,6 @@
 import { APP_TITLEBAR_HEIGHT } from "@meru/shared/constants";
 import type { ExtensionActionAnchorRect } from "@meru/shared/types";
-import { BrowserWindow, Menu, nativeImage, type WebContents } from "electron";
+import { BrowserWindow, Menu, type NativeImage, nativeImage, type WebContents } from "electron";
 import { accounts } from "./accounts";
 import { extensions } from "./extensions";
 import { ipc } from "./ipc";
@@ -13,18 +13,39 @@ import { WorkspaceApp } from "./workspace-app";
 const MENU_ICON_SIZE = 16;
 
 /**
- * Action icons are read at twice the size a menu draws them at, and a data URL
- * carries no scale factor for Electron to work that out from.
+ * A data URL carries no scale factor for Electron to work the density out
+ * from, so an icon built from one is drawn at 1x wherever it lands and comes
+ * out blurry on the 2x display that is the common case. Carrying a
+ * representation per factor is what tells Electron which pixels to draw.
+ */
+const MENU_ICON_SCALE_FACTORS = [1, 2];
+
+/**
+ * Action icons are read at twice the size a menu draws them at, so every
+ * representation scales down from the one source.
  */
 function createMenuIcon(iconDataUrl: string) {
-  const icon = nativeImage.createFromDataURL(iconDataUrl);
+  const sourceIcon = nativeImage.createFromDataURL(iconDataUrl);
 
   // An icon `nativeImage` cannot decode — an SVG one — comes back empty
-  if (icon.isEmpty()) {
-    return undefined;
+  if (sourceIcon.isEmpty()) {
+    return null;
   }
 
-  return icon.resize({ width: MENU_ICON_SIZE, height: MENU_ICON_SIZE });
+  const menuIcon = nativeImage.createEmpty();
+
+  for (const scaleFactor of MENU_ICON_SCALE_FACTORS) {
+    const size = MENU_ICON_SIZE * scaleFactor;
+
+    menuIcon.addRepresentation({
+      scaleFactor,
+      // The icon is built once per extension rather than once per menu open, so
+      // the slowest filter costs nothing a menu open pays for
+      dataURL: sourceIcon.resize({ width: size, height: size, quality: "best" }).toDataURL(),
+    });
+  }
+
+  return menuIcon;
 }
 
 /**
@@ -38,10 +59,40 @@ function createMenuIcon(iconDataUrl: string) {
 class ExtensionActions {
   popup = new Popup();
 
+  /**
+   * One menu icon per extension, built on the first menu that draws it: the
+   * menu is rebuilt on every open, and decoding a data URL and resizing it once
+   * per scale factor is far more than an open should cost. `null` is an icon
+   * `nativeImage` could not decode, kept so that decode isn't retried either.
+   *
+   * An action never changes while its extension runs, so loading and unloading
+   * are the only things the icons can go stale on, and `onActionsChanged` is
+   * exactly those.
+   */
+  private menuIcons = new Map<string, NativeImage | null>();
+
   init() {
     extensions.onActionsChanged(() => {
+      this.menuIcons.clear();
+
       this.broadcast();
     });
+  }
+
+  private getMenuIcon(extensionId: string, iconDataUrl: string | null) {
+    if (!iconDataUrl) {
+      return undefined;
+    }
+
+    let menuIcon = this.menuIcons.get(extensionId);
+
+    if (menuIcon === undefined) {
+      menuIcon = createMenuIcon(iconDataUrl);
+
+      this.menuIcons.set(extensionId, menuIcon);
+    }
+
+    return menuIcon ?? undefined;
   }
 
   /**
@@ -141,7 +192,7 @@ class ExtensionActions {
     const menu = Menu.buildFromTemplate(
       this.serialize(webContents).map(({ extensionId, title, iconDataUrl }) => ({
         label: title,
-        icon: iconDataUrl ? createMenuIcon(iconDataUrl) : undefined,
+        icon: this.getMenuIcon(extensionId, iconDataUrl),
         click: () => {
           this.openPopup(parentWindow, webContents, extensionId, anchorRect);
         },

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -713,6 +713,39 @@ describe("Extensions", () => {
     );
   });
 
+  test("reads a derived copy's icon again for a later session when the read failed", async () => {
+    let derivedDir = "";
+
+    const loadExtension = async (loadedDir: string) => {
+      derivedDir = loadedDir;
+
+      return createExtension("aaa", loadedDir, ACTION_MANIFEST);
+    };
+
+    const firstSession = createSession({ loadExtension });
+
+    const secondSession = createSession({ loadExtension });
+
+    const extensions = createExtensions([await createExtensionDir("one")], {
+      info: () => {},
+      error: () => {},
+    });
+
+    await extensions.setupSession(firstSession.session);
+
+    expect(extensions.getSessionActions(firstSession.session)[0]?.iconDataUrl).toBe(null);
+
+    // What a transient failure looks like from here: the file the first read
+    // could not find is there for the second
+    await writeFile(path.join(derivedDir, "icon-48.png"), "icon");
+
+    await extensions.setupSession(secondSession.session);
+
+    expect(extensions.getSessionActions(secondSession.session)[0]?.iconDataUrl).toBe(
+      `data:image/png;base64,${Buffer.from("icon").toString("base64")}`,
+    );
+  });
+
   test("has no actions for a session it loaded nothing into", async () => {
     const { session } = createSession();
 

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -681,6 +681,38 @@ describe("Extensions", () => {
     expect(extensions.getSessionActions(session)[0]?.iconDataUrl).toBe(null);
   });
 
+  test("reads a derived copy's icon once, however many sessions load it", async () => {
+    const extensionDir = await createExtensionDir("one");
+
+    await writeFile(path.join(extensionDir, "icon-48.png"), "icon");
+
+    let derivedDir = "";
+
+    const loadExtension = async (loadedDir: string) => {
+      derivedDir = loadedDir;
+
+      return createExtension("aaa", loadedDir, ACTION_MANIFEST);
+    };
+
+    const firstSession = createSession({ loadExtension });
+
+    const secondSession = createSession({ loadExtension });
+
+    const extensions = createExtensions([extensionDir]);
+
+    await extensions.setupSession(firstSession.session);
+
+    // The read the memo saves is the second session's, and taking the file away
+    // is what tells a memoized read apart from a repeated one
+    await rm(path.join(derivedDir, "icon-48.png"));
+
+    await extensions.setupSession(secondSession.session);
+
+    expect(extensions.getSessionActions(secondSession.session)[0]?.iconDataUrl).toBe(
+      `data:image/png;base64,${Buffer.from("icon").toString("base64")}`,
+    );
+  });
+
   test("has no actions for a session it loaded nothing into", async () => {
     const { session } = createSession();
 

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -409,6 +409,18 @@ export class Extensions {
       iconDataUrl = readExtensionActionIcon(extension);
 
       this.actionIconDataUrls.set(derivedDir, iconDataUrl);
+
+      // A failure must not be the answer for every later session, the way the
+      // derived copy's is not: a transient EMFILE or EIO on the first session's
+      // read would otherwise cost every account the icon until a restart, an
+      // account added mid-session included
+      const failedIconDataUrl = iconDataUrl;
+
+      iconDataUrl.catch(() => {
+        if (this.actionIconDataUrls.get(derivedDir) === failedIconDataUrl) {
+          this.actionIconDataUrls.delete(derivedDir);
+        }
+      });
     }
 
     return iconDataUrl;

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -141,6 +141,8 @@ export class Extensions {
 
   private derivedExtensions = new Map<string, ReturnType<typeof deriveExtension>>();
 
+  private actionIconDataUrls = new Map<string, Promise<string | null>>();
+
   private bridge: ExtensionBridge;
 
   private nativeMessaging: NativeMessaging;
@@ -392,12 +394,32 @@ export class Extensions {
     session.serviceWorkers.on("console-message", listener);
   }
 
+  /**
+   * The icon read off the derived copy every session loading it shares. Every
+   * account loads its own instance of the same copy, and each holds the data
+   * URL for as long as it holds the action, so reading per session would leave
+   * N accounts holding N copies of one base64 string.
+   */
+  private readActionIconDataUrl(extension: ActionExtension) {
+    const derivedDir = path.resolve(extension.path);
+
+    let iconDataUrl = this.actionIconDataUrls.get(derivedDir);
+
+    if (!iconDataUrl) {
+      iconDataUrl = readExtensionActionIcon(extension);
+
+      this.actionIconDataUrls.set(derivedDir, iconDataUrl);
+    }
+
+    return iconDataUrl;
+  }
+
   /** A broken icon costs the button its icon, not the extension its button. */
   private async createAction(extension: ActionExtension) {
     const action = createExtensionAction(extension);
 
     try {
-      action.iconDataUrl = await readExtensionActionIcon(extension);
+      action.iconDataUrl = await this.readActionIconDataUrl(extension);
     } catch (error) {
       this.logger?.error("Failed to read extension action icon", { id: extension.id, error });
     }


### PR DESCRIPTION
## Summary
The extensions menu rebuilt every action icon on every open, and built it at 1x, so the icons were blurry on a 2x display and paid a decode and a resize each time the menu opened. Each icon is now built once per extension with a 16 px representation at 1x and a 32 px one at 2x, and the icon file behind it is read and base64-encoded once per launch rather than once per account session. Both come from the "Memory and performance" section of the 3.60 extensions review.

## Problem
`createMenuIcon` in `packages/app/extension-actions.ts` decoded the action's data URL with `nativeImage.createFromDataURL` and resized it to 16 px every time `showMenu` built the menu. `resize({ width: 16, height: 16 })` produces a bitmap with no scale factor, and a data URL carries none for Electron to infer one from, so the result is drawn at 1x wherever it lands — blurry on the 2x display that is the common case. The rebuild is also pure repetition: an action never changes while its extension runs, because Electron implements no part of `chrome.action`.

Separately, `createAction` in `packages/electron-extensions/extensions.ts` called `readExtensionActionIcon` once per session. Every account loads its own instance of the same derived copy and holds the resulting data URL for as long as it holds the action, so N accounts read the same file N times and then held N copies of one base64 string.

## Solution
- `createMenuIcon` builds an empty `nativeImage` and adds one representation per scale factor, 16 px at 1x and 32 px at 2x, each scaled down from the one source. No second icon is read for the 2x representation: `resolveActionIconPath` already picks the smallest declared icon at 32 px or larger, and the largest declared otherwise, so the source is a 2x-sized image wherever the manifest offers one.
- `ExtensionActions` keeps a `Map` of extension id to icon and clears it in the existing `onActionsChanged` handler. That handler is enough on its own — an action changes only when an extension loads or a session tears down, and both emit it — so no new invalidation hook was added.
- A `null` entry is an icon `nativeImage` could not decode, which in practice means an SVG one. It is cached like any other so the failed decode isn't retried per open, and the menu item still gets no icon rather than an empty one, which is the fallback slice 10 settled on.
- `Extensions` memoizes `readExtensionActionIcon` per resolved derived directory, next to the existing `derivedExtensions` memo and keyed the same way, so a launch with a shared instance still reads once per role. A failed read is dropped from the memo the way the derive memo drops a failed copy, so a transient `EMFILE` or `EIO` on the first session's read doesn't cost every later session the icon until a restart; a permanently unreadable icon logs per session as it did before.
- The resize now asks for `quality: "best"`. It was `"good"` by default when it ran on every menu open; running once per extension per launch makes the slowest filter free at the point that matters.

## Try it
No preview deployment for a desktop app. Run `bun run dev` with an extension installed and `extensions.showTitlebarButton` on, then open the puzzle-icon button in the titlebar: the icons in the menu should be sharp on a HiDPI display where they were previously soft, and unchanged on a 1x one.

## Not verified
- The menu has not been looked at on a real 2x display — this sandbox has none. What is verified is one step short of that: under Electron with Xvfb, the built icon reports a logical size of 16×16, scale factors `[1, 2]`, and bitmaps of 1024 and 4096 bytes, meaning 16×16 and 32×32 pixels are both present for the menu to pick from. An SVG data URL still comes back empty from `createFromDataURL`, so the no-icon fallback is unchanged.
- The `nativeImage` half has no test. It is app code with no harness, matching the rest of `packages/app/extension-actions.ts`.

