### PR TITLE
Re-park the relay's job stream at once after a clean end

### DIFF
--- a/packages/electron-extensions/runtime-proxy/relay-client.test.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.test.ts
@@ -801,7 +801,7 @@ describe("how the job stream is parked again", () => {
 
     stub.refuse(RUNTIME_PROXY_PATHS.workerJobs, 503);
 
-    startRelayClient({ retryDelayMs: 300 });
+    startRelayClient({ retryDelayMs: 2000 });
 
     await stub.waitForPost(RUNTIME_PROXY_PATHS.workerJobs);
 
@@ -823,8 +823,9 @@ describe("how the job stream is parked again", () => {
 
     await stub.waitForStream(6);
 
-    // Nothing for the first end, then 16, 32, 64 and 128 as the floor doubles
-    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(240);
+    // Nothing for the first end, then 16, 32, 64 and 128 as the floor doubles,
+    // asserted with slack rather than as the 240 ms those four sum to
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(200);
   });
 
   test("a stream that lived out the window starts the backoff over", async () => {

--- a/packages/electron-extensions/runtime-proxy/relay-client.test.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.test.ts
@@ -7,7 +7,7 @@ import {
   type RuntimeProxyJob,
   type RuntimeProxySender,
 } from "./bridge-protocol";
-import { createRelayClient } from "./relay-client";
+import { createRelayClient, type CreateRelayClientOptions } from "./relay-client";
 
 const EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
 
@@ -763,6 +763,93 @@ describe("createRelayClient", () => {
     stub.pushJob({ type: "sendMessage", jobId: "job-1", message: "after restart", sender: SENDER });
 
     await waitFor(() => heard.length === 1, "the redelivered job");
+  });
+});
+
+describe("how the job stream is parked again", () => {
+  /** A client whose stream lifecycle is the whole of what a test watches. */
+  function startRelayClient(options: CreateRelayClientOptions) {
+    const client = createRelayClient(options);
+
+    client.wrapRuntime(createWorkerChrome().chrome);
+
+    client.start();
+
+    startedClients.push(client);
+
+    return client;
+  }
+
+  test("a stream that ended cleanly is parked again at once", async () => {
+    const stub = stubBridge();
+
+    startRelayClient({ retryDelayMs: 2000 });
+
+    const parked = await stub.waitForStream();
+
+    const endedAt = Date.now();
+
+    parked.close();
+
+    await stub.waitForStream(2);
+
+    expect(Date.now() - endedAt).toBeLessThan(500);
+  });
+
+  test("a refused stream is slept on rather than opened again at once", async () => {
+    const stub = stubBridge();
+
+    stub.refuse(RUNTIME_PROXY_PATHS.workerJobs, 503);
+
+    startRelayClient({ retryDelayMs: 300 });
+
+    await stub.waitForPost(RUNTIME_PROXY_PATHS.workerJobs);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerJobs)).toHaveLength(1);
+  });
+
+  test("a stream that keeps ending cleanly at once is backed off", async () => {
+    const stub = stubBridge();
+
+    startRelayClient({ retryDelayMs: 2000, cleanEndWindowMs: 10_000 });
+
+    const startedAt = Date.now();
+
+    for (let streamCount = 1; streamCount <= 5; streamCount += 1) {
+      (await stub.waitForStream(streamCount)).close();
+    }
+
+    await stub.waitForStream(6);
+
+    // Nothing for the first end, then 16, 32, 64 and 128 as the floor doubles
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(240);
+  });
+
+  test("a stream that lived out the window starts the backoff over", async () => {
+    const stub = stubBridge();
+
+    startRelayClient({ retryDelayMs: 2000, cleanEndWindowMs: 20 });
+
+    for (let streamCount = 1; streamCount <= 5; streamCount += 1) {
+      (await stub.waitForStream(streamCount)).close();
+    }
+
+    const lived = await stub.waitForStream(6);
+
+    await new Promise((resolve) => setTimeout(resolve, 40));
+
+    const endedAt = Date.now();
+
+    lived.close();
+
+    (await stub.waitForStream(7)).close();
+
+    await stub.waitForStream(8);
+
+    // The 256 and then 512 the backoff had reached would put this past 700ms
+    expect(Date.now() - endedAt).toBeLessThan(300);
   });
 });
 

--- a/packages/electron-extensions/runtime-proxy/relay-client.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.ts
@@ -26,6 +26,23 @@ import {
 const DEFAULT_RETRY_DELAY_MS = 1000;
 
 /**
+ * How long a job stream has to live for its clean end to read as main's own
+ * invalidation rather than a flap. Main ends a parked stream deliberately
+ * whenever it replaces one, so from here that end is the ordinary case and the
+ * jobs queued behind it are already waiting; only a stream that ends cleanly
+ * again and again the moment it is parked is main flapping.
+ */
+const DEFAULT_CLEAN_END_WINDOW_MS = 1000;
+
+/**
+ * What the second clean end inside the window sleeps, doubling per end up to
+ * `retryDelayMs`. Small enough that a single replaced stream costs nothing a
+ * queued message can feel, large enough that a flapping main cannot spin the
+ * worker.
+ */
+const CLEAN_END_BACKOFF_FLOOR_MS = 16;
+
+/**
  * How many job ids the client remembers to recognise a redelivery by. Far more
  * than a stream flap can put in flight at once, and bounded so a worker that
  * runs for hours does not grow a set for as long as it lives.
@@ -41,8 +58,10 @@ function bridgeAnsweredError(status: number) {
 const LOG_LABEL = "runtime-proxy-relay";
 
 export type CreateRelayClientOptions = {
-  /** How long a failed job stream waits before it is opened again. */
+  /** How long a job stream that failed waits before it is opened again. */
   retryDelayMs?: number;
+  /** How long a job stream has to live for its clean end to count as ordinary. */
+  cleanEndWindowMs?: number;
   /** How many handled job ids to remember before forgetting the oldest. */
   maxRememberedJobIds?: number;
   /**
@@ -72,6 +91,7 @@ export type CreateRelayClientOptions = {
  */
 export function createRelayClient({
   retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+  cleanEndWindowMs = DEFAULT_CLEAN_END_WINDOW_MS,
   maxRememberedJobIds = MAX_REMEMBERED_JOB_IDS,
   runStorageCall,
 }: CreateRelayClientOptions = {}) {
@@ -288,7 +308,14 @@ export function createRelayClient({
   };
 
   const runJobStream = async () => {
+    /** What the next clean end inside the window sleeps; 0 while none has. */
+    let cleanEndBackoffMs = 0;
+
     while (!isStopped) {
+      const parkedAt = Date.now();
+
+      let hasEndedCleanly = false;
+
       try {
         const response = await postBridge(RUNTIME_PROXY_PATHS.workerJobs, {});
 
@@ -311,12 +338,42 @@ export function createRelayClient({
             handleJob(job);
           }
         }
+
+        hasEndedCleanly = true;
       } catch (error) {
         console.error(`[${LOG_LABEL}] job stream failed`, error);
       }
 
-      if (!isStopped) {
-        await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+      if (isStopped) {
+        return;
+      }
+
+      /*
+       * A stream that ended cleanly is main having replaced it, which is what
+       * its own invalidation looks like from here — every job queued behind
+       * the replacement is waiting on this re-park, so sleeping on it is a
+       * delay paid for nothing. Only a bridge that refused or broke is a
+       * reason to wait, since re-parking on it at once would spin.
+       */
+      let delayMs = retryDelayMs;
+
+      if (hasEndedCleanly) {
+        if (Date.now() - parkedAt >= cleanEndWindowMs) {
+          cleanEndBackoffMs = 0;
+        }
+
+        delayMs = cleanEndBackoffMs;
+
+        cleanEndBackoffMs = Math.min(
+          cleanEndBackoffMs === 0 ? CLEAN_END_BACKOFF_FLOOR_MS : cleanEndBackoffMs * 2,
+          retryDelayMs,
+        );
+      } else {
+        cleanEndBackoffMs = 0;
+      }
+
+      if (delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
       }
     }
   };


### PR DESCRIPTION
## Summary
The runtime proxy's relay client slept one second after every job stream end, including the clean end that is main's own invalidation, so every job queued behind a replaced stream waited out that second for nothing. Now only a failed stream sleeps; a clean end re-parks at once, with a backoff so a flapping main cannot spin the worker. The runtime proxy is off by default (`MERU_EXTENSIONS_SHARED_INSTANCE`), so nothing changes for a shipping build with the flag off.

## Problem
The worker's relay client parks a long-poll stream at main to receive jobs, and when that stream ends it sleeps `retryDelayMs` — one second by default — before parking again. The sleep is right after an error, where a tight loop against a bridge that keeps refusing would spin. It is wrong after a clean end, which is what main's own invalidation looks like from the worker: main closes the parked stream deliberately whenever it replaces one, and `invalidateWorkerStream` re-queues everything the stream owed, so the jobs are already waiting when the worker goes to sleep for a second. Every `sendMessage`, `connect`, port message and `storage` call queued in that window pays the full second.

Invalidation is not rare. It happens on any `running-status-changed` stop that names an extension's scope, and, for a stop that cannot be pinned to a scope, on every stream at once. [PR #1016](https://github.com/zoidsh/meru/pull/1016) stopped Gmail's own worker idle-stops from triggering it, which took out the routine case, but the extension worker's own stops still do, and each one costs a second on top.

## Solution
- A stream that ended with `done` re-parks immediately; only a thrown error or a non-ok response sleeps `retryDelayMs`, since re-parking on a refusing bridge at once would spin.
- A backoff covers what the immediate re-park opens up: a main that flaps would otherwise be answered by a tight loop. Consecutive clean ends inside a window double the sleep from a 16 ms floor up to `retryDelayMs`, and a stream that lived out the window (1 second, `cleanEndWindowMs`) starts it over. The first clean end always re-parks with no sleep, so the ordinary invalidation pays nothing.
- The floor is a constant rather than another option, and the window is an option only because the tests need a stream to outlive it without spending a real second doing so.

A flat small delay on the clean path was the obvious alternative and was not taken: it would still charge the ordinary case — one replaced stream, which is what invalidation always looks like — for a flap that has not happened. The backoff charges only the second flap onward.

## Try it
Not runnable as a URL: this is main-process and worker-side code behind an off-by-default flag. `bun test packages/electron-extensions/runtime-proxy/relay-client.test.ts` covers it — four tests in `describe("how the job stream is parked again")` pin the immediate re-park on a clean end, the sleep on a refused stream, the doubling across repeated clean ends, and the reset after a stream that lived.

## Measured, for a follow-up
Port throughput is one serialized bridge round trip per message: each `postMessage` on both the shim and the relay client waits for the previous fetch's response. Measured on this machine against the fixture extension in a packaged Linux build, 200 messages per figure, warm, three runs — a shimmed session's extension page against the worker session's worker, and the same page in the worker session as the native baseline:

| | proxied (shim session) | native (worker session) |
| --- | --- | --- |
| port `postMessage`, fired back to back | 2.8–3.9 ms/message | 0.09–0.15 ms/message |
| port `postMessage`, one round trip at a time | 3.4–4.6 ms/message | 0.33–0.41 ms/message |
| `runtime.sendMessage`, sequential | 4.5–5.5 ms/call | 0.74–0.90 ms/call |

The burst is no faster per message than the strictly sequential loop, which is the serialization showing: the proxied path tops out around 300 messages a second however they are fired. Natively the burst is about 3x the sequential rate, because Chromium's posts pipeline. A per-port sequence number stamped by the sender and honored by main with a reorder buffer would let posts pipeline while keeping Chrome's in-order guarantee. Not built here.

## Not verified
- The change is exercised against a stubbed `fetch` only. No end-to-end run pins the latency win itself, because the e2e suite launches under a CDP debugger that disables Chromium's MV3 idle timer, so worker stops — and therefore stream invalidations — do not happen there to be measured.
- The backoff's ceiling and reset are pinned by timing assertions with wide margins rather than a fake clock; they are lower and upper bounds, not exact sleeps.
- `tests/extension-proxy.e2e.ts` passes on this branch (9 passed, 1 skipped). The `RuntimeProxy > Electron still ships the experimental APIs the proxy stands on` unit test fails in this sandbox both with and without the change — it needs a real Electron.