### PR TITLE
Dereference symlinks when copying the derive's source tree

### DIFF
--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -1,6 +1,17 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  symlink,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { RUNTIME_PROXY_MANIFEST_GLOBAL } from "../runtime-proxy/bridge-protocol";
@@ -363,6 +374,83 @@ describe("deriveExtension", () => {
     expect(JSON.parse(await readFile(`${derivedDir}.json`, "utf8"))).not.toHaveProperty(
       "contentScriptMatches",
     );
+  });
+
+  describe("a source tree with symlinks in it", () => {
+    let sharedDir: string;
+
+    beforeEach(async () => {
+      sharedDir = path.join(workDir, "shared");
+
+      await mkdir(sharedDir, { recursive: true });
+
+      await writeFile(path.join(sharedDir, "shared-popup.html"), "<html><head></head></html>");
+
+      await symlink(
+        path.join("..", "shared", "shared-popup.html"),
+        path.join(sourceDir, "linked-popup.html"),
+      );
+    });
+
+    test("never writes through a link into the file it points at", async () => {
+      await derive();
+
+      expect(await readFile(path.join(sharedDir, "shared-popup.html"), "utf8")).toBe(
+        "<html><head></head></html>",
+      );
+    });
+
+    test("copies a linked page as a file of the copy's own", async () => {
+      const derivedDir = await derive();
+
+      const linkedPagePath = path.join(derivedDir, "linked-popup.html");
+
+      expect((await lstat(linkedPagePath)).isSymbolicLink()).toBe(false);
+
+      expect(await readFile(linkedPagePath, "utf8")).toContain(
+        '<script src="/chrome-facade.js"></script>',
+      );
+    });
+
+    test("copies again when the file a link points at changed", async () => {
+      const derivedDir = await derive();
+
+      await writeFile(path.join(derivedDir, "background", "background.js"), "// stale\n");
+
+      const sharedPagePath = path.join(sharedDir, "shared-popup.html");
+
+      await writeFile(sharedPagePath, "<html><head><title>Edited</title></head></html>");
+
+      const editedAt = new Date(Date.now() + 60_000);
+
+      await utimes(sharedPagePath, editedAt, editedAt);
+
+      await derive();
+
+      // The whole copy was made again, which is what the stamp noticing an
+      // edit through the link means
+      expect(await readFile(path.join(derivedDir, "background", "background.js"), "utf8")).toBe(
+        "// background\n",
+      );
+      expect(await readFile(path.join(derivedDir, "linked-popup.html"), "utf8")).toContain(
+        "<title>Edited</title>",
+      );
+    });
+
+    test("fails the derive on a dangling link rather than half-copying", async () => {
+      const derivedDir = await derive();
+
+      await symlink(path.join("..", "shared", "gone.html"), path.join(sourceDir, "dangling.html"));
+
+      await expect(
+        deriveExtension({ sourceDir, derivedExtensionsDir, facadeScriptPath }),
+      ).rejects.toThrow(/ENOENT/);
+
+      // The digest is taken before anything is removed, so the copy that was
+      // already there survives a source the derive cannot read
+      expect(await readFile(path.join(derivedDir, "manifest.json"), "utf8")).toBeTruthy();
+      expect(await readFile(`${derivedDir}.json`, "utf8")).toBeTruthy();
+    });
   });
 
   test("reports no id for an extension without a key", async () => {

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -86,6 +86,11 @@ function hash(value: string) {
  * disk per file. The digest is the same either way — the lines are sorted
  * before they are hashed — so a stamp written by an earlier version still
  * matches and no profile re-derives.
+ *
+ * `stat` rather than `lstat` on purpose, so that a symlink is measured by the
+ * file it points at. The copy dereferences, so an edit to a linked file is an
+ * edit to what the copy holds and has to re-derive it; `lstat` would measure
+ * the link itself, which does not move when its target changes.
  */
 async function hashSourceTree(sourceDir: string) {
   const entryNames = await readdir(sourceDir, { recursive: true });
@@ -274,7 +279,19 @@ export async function deriveExtension({
     // way: the derive writes the manifest, the facade and the shim into the
     // directory it made, and a clone diverges from its source at the first
     // write, which a link would not
-    await cp(sourceDir, derivedDir, { recursive: true, mode: constants.COPYFILE_FICLONE });
+    //
+    // `dereference` for the same reason a clone is not a link. A symlink is
+    // copied as a symlink otherwise, and a relative one comes out rewritten
+    // to point back at the source tree, so the facade `derivePages` injects
+    // into a linked page is written through the link and into the directory
+    // the derive exists not to touch — a developer's unpacked tree with
+    // `popup.html -> ../shared/popup.html` in it. A packed install carries no
+    // symlinks, so this is a development case and no shipped extension's
+    await cp(sourceDir, derivedDir, {
+      recursive: true,
+      mode: constants.COPYFILE_FICLONE,
+      dereference: true,
+    });
 
     const { manifest, serviceWorkerWrapper } = deriveManifest(sourceManifest, {
       facadeFileName: FACADE_FILE_NAME,


### PR DESCRIPTION
## Summary
A symlink in an extension's source tree made the derive write into the directory it exists not to touch: `cp` copies a link as a link, and `derivePages` then injected the facade through it and into the file it pointed at. `dereference: true` on the same `cp` copies a linked file as a file, so the copy owns every byte it holds. A packed install carries no symlinks, so shipped 1Password is unaffected — this protects development only. Follow-up to #1024, found in its review.

## Problem
The derive's whole contract is that the directory the embedder handed over is never written to: it is a verified install, or a folder a developer is working in. `deriveExtension` copies it into `userData/derived-extensions` and then writes only into the copy — the rewritten manifest, the facade, the service worker wrapper, the shim, and a script tag into every page.

A symlink defeats that. Node's `cp` copies a link as a link and rewrites a relative target to an absolute path back into the source tree, so the derived copy's `popup.html` is a link into the user's own directory and `derivePages` writes the facade straight through it. Reproduced against `deriveExtension` itself: a source tree with `linked-popup.html -> ../shared/shared-popup.html` in it comes out of one derive with the *shared* file changed on disk from `<html><head></head></html>` to `<html><head><script src="/chrome-facade.js"></script></head></html>`.

The case that hits this is a developer's unpacked directory in `extensions/` sharing a page between two extensions, not a CRX install — a packed extension carries no symlinks at all. It is pre-existing rather than introduced by #1024; that PR's review is where it was found.

## Solution
- Adds `dereference: true` to the recursive `cp` in `derive/index.ts`, alongside the `COPYFILE_FICLONE` mode already there.
- Documents that `hashSourceTree` uses `stat` rather than `lstat` on purpose, and adds three tests for source trees with symlinks in them.

A link pointing outside the source tree becomes a copy of its target inside the derived directory. That is what Chromium would have read through the link anyway, so nothing the extension sees changes.

The stamp has to notice an edit to a linked file, since that file is now part of what the copy holds. It already does: `hashSourceTree` stats every entry with `stat`, which resolves links, so a link is measured by its target's size and mtime. That was incidental before and is load-bearing now, so it is written down and pinned by a test that touches the shared file and asserts the whole copy is made again.

`DERIVE_VERSION` is deliberately **not** bumped. Bumping it re-derives every profile on the upgrade — a full copy of every extension, for every user — to correct a case that only arises in an unpacked development tree. A copy already on disk cannot do the harm either, because `derivePages` runs only on the re-copy path, and a developer's source changes constantly, which is exactly what re-derives it with the fix in place.

A dangling link fails the derive rather than half-copying it, and did before this change: `hashSourceTree` stats every entry and throws `ENOENT` naming the missing path, which happens *before* the existing copy and its stamp are removed, so a source the derive cannot read leaves the previous copy intact. Dereferencing gives `cp` a second place to fail on the same link, so a test now pins that ordering.

## Try it
Nothing to open in the app. To see it, put a relative symlink to a file outside the tree into an unpacked extension in `extensions/`, run the app once, and check the file it points at — on main it has gained a `<script src="/chrome-facade.js">` tag, on this branch it is unchanged.

## Not verified
- Not run in a packaged app or against a real extension install; only the unit suite and the type, lint and format checks. Both are moot for the shipped path — the change is only reachable through a symlink, and packed installs have none.
- Windows is unexercised. Node's `cp` takes `dereference` on every platform, but nobody has run this on a Windows checkout, where a developer's symlink would be a junction or need developer mode to exist at all.
- A source tree containing a symlink loop still fails rather than hanging, and fails the same way it did before this change — `hashSourceTree`'s recursive `readdir` already followed symlinked directories, so it throws first (`ELOOP` under Bun, `ENAMETOOLONG` under Node). Probed directly rather than covered by a test.