### PR TITLE
Skip the derive's symlink tests where symlinks cannot be made

### DIFF
--- a/packages/electron-extensions/derive/index.test.ts
+++ b/packages/electron-extensions/derive/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import {
   lstat,
   mkdir,
@@ -53,6 +54,31 @@ async function writeSourceFile(fileName: string, content: string) {
 
 async function writeManifest(manifestSource: Record<string, unknown>) {
   await writeSourceFile("manifest.json", JSON.stringify(manifestSource));
+}
+
+/**
+ * Whether this machine can make a symlink at all, which on Windows means
+ * Developer Mode is on. The tests below have to create one to have anything to
+ * derive, and a test failing for the machine's reason rather than the code's is
+ * what teaches a developer to ignore a red suite. CI runs on Ubuntu, so main is
+ * still held to them.
+ */
+function canCreateSymlinks() {
+  const probeDir = mkdtempSync(path.join(tmpdir(), "electron-extensions-symlink-probe-"));
+
+  try {
+    symlinkSync(path.join(probeDir, "target"), path.join(probeDir, "link"));
+
+    return true;
+  } catch {
+    console.warn(
+      "Skipping the derive's symlink tests: this machine cannot create symlinks. Turn on Developer Mode on Windows.",
+    );
+
+    return false;
+  } finally {
+    rmSync(probeDir, { recursive: true, force: true });
+  }
 }
 
 beforeEach(async () => {
@@ -376,7 +402,7 @@ describe("deriveExtension", () => {
     );
   });
 
-  describe("a source tree with symlinks in it", () => {
+  describe.skipIf(!canCreateSymlinks())("a source tree with symlinks in it", () => {
     let sharedDir: string;
 
     beforeEach(async () => {


### PR DESCRIPTION
## Summary
The four symlink tests added in #1027 fail with `EPERM` on a Windows developer machine without Developer Mode, because creating a symlink there needs it. They now skip on such a machine, with a warning naming Developer Mode, instead of failing. Test-only; CI runs on Ubuntu and is unaffected.

## Problem
#1027 added a `describe` block for source trees with symlinks in them, and its setup creates one — there is no way to test the dereferencing copy without it. On Windows an unprivileged process cannot create a symlink unless Developer Mode is on, so on an ordinary Windows developer machine those four tests fail with `EPERM`.

That failure says nothing about the code. A suite that is red for the machine's reason rather than the code's is what teaches a developer to stop reading red, which costs more than the four tests are worth.

## Solution
- Probes symlink creation once, by making one in a scratch directory inside a `try`, and `describe.skipIf`s the block on the result.
- Warns once, naming Developer Mode, when the probe fails.

Skipped rather than made to pass: a test that quietly reports green on a machine where it never ran claims something that was not checked. A skip says what happened, and CI on Ubuntu still holds main to all four.

The probe makes a symlink rather than branching on `process.platform`, because Developer Mode is what decides this and not the platform — a Windows machine with it on runs the tests, and a hypothetical POSIX environment without the permission skips them.

Verified both ways on this Linux machine: the suite runs all 115 derive tests normally, and with the probe forced to fail it reports 111 pass and 4 skip with the warning printed once.

## Try it
Nothing to open. `bun test packages/electron-extensions/derive` on Linux or macOS runs all four; on Windows without Developer Mode it now prints the warning and skips them.

## Not verified
- Not run on Windows. The `EPERM` this guards against, and the skip it produces there, are both inferred from how Windows gates symlink creation — no Windows machine was available. On Linux the skip path was exercised by forcing the probe to fail rather than by hitting the real permission error.