### PR TITLE
Park a shimmed context's stream again at once after a clean end

### DIFF
--- a/packages/electron-extensions/runtime-proxy/clean-end-backoff.test.ts
+++ b/packages/electron-extensions/runtime-proxy/clean-end-backoff.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { createCleanEndBackoff } from "./clean-end-backoff";
+
+describe("createCleanEndBackoff", () => {
+  test("the first clean end waits for nothing, and the rest double to the ceiling", () => {
+    const backoff = createCleanEndBackoff({ ceilingMs: 1000, windowMs: 1000 });
+
+    const waits = Array.from({ length: 9 }, () => backoff.next(0));
+
+    expect(waits).toEqual([0, 16, 32, 64, 128, 256, 512, 1000, 1000]);
+  });
+
+  test("a stream that lived out the window starts the doubling over", () => {
+    const backoff = createCleanEndBackoff({ ceilingMs: 1000, windowMs: 1000 });
+
+    backoff.next(0);
+
+    backoff.next(0);
+
+    expect(backoff.next(0)).toBe(32);
+
+    // The one that lived pays nothing itself, and the one after it pays the
+    // floor rather than the 64 the doubling had reached
+    expect(backoff.next(1000)).toBe(0);
+
+    expect(backoff.next(0)).toBe(16);
+  });
+
+  test("a reset forgets the flapping the way a failed stream does", () => {
+    const backoff = createCleanEndBackoff({ ceilingMs: 1000 });
+
+    backoff.next(0);
+
+    backoff.next(0);
+
+    backoff.reset();
+
+    expect(backoff.next(0)).toBe(0);
+  });
+
+  test("a ceiling under the floor is the ceiling, not the floor", () => {
+    const backoff = createCleanEndBackoff({ ceilingMs: 5, windowMs: 1000 });
+
+    expect([backoff.next(0), backoff.next(0), backoff.next(0)]).toEqual([0, 5, 5]);
+  });
+});

--- a/packages/electron-extensions/runtime-proxy/clean-end-backoff.ts
+++ b/packages/electron-extensions/runtime-proxy/clean-end-backoff.ts
@@ -1,0 +1,63 @@
+/**
+ * How long the next park waits after a stream ended cleanly, shared by the two
+ * clients that keep a stream parked at the bridge — the worker's job stream
+ * (`relay-client.ts`) and a shimmed context's receive stream
+ * (`page-stream-client.ts`).
+ *
+ * A clean end is main having closed the stream deliberately, which for both is
+ * the ordinary case and not a failure: the jobs behind a replaced job stream
+ * are already queued, and an evicted page context hears nothing until it parks
+ * again. So the first clean end waits for nothing at all. What the immediate
+ * re-park opens up is a main that closes every stream as it arrives, which an
+ * unconditional re-park would answer with a tight loop, and that is what the
+ * doubling bounds — a client that keeps being closed at once ends up parking
+ * about as often as a flat wait would have let it.
+ *
+ * The wait is only ever paid by a stream that ended cleanly. A refused or
+ * broken one is its client's own business, and the two differ there: the job
+ * stream waits a flat delay, a page stream doubles up to half a minute.
+ */
+
+/** What the second clean end inside the window waits, doubling from there. */
+const FLOOR_MS = 16;
+
+/** How long a stream has to live for its clean end to count as ordinary. */
+export const DEFAULT_CLEAN_END_WINDOW_MS = 1000;
+
+export type CleanEndBackoffOptions = {
+  /** Where the doubling stops, which is the wait a flapping main settles at. */
+  ceilingMs: number;
+  /** How long a stream has to live for the doubling to start over. */
+  windowMs?: number;
+};
+
+export function createCleanEndBackoff({
+  ceilingMs,
+  windowMs = DEFAULT_CLEAN_END_WINDOW_MS,
+}: CleanEndBackoffOptions) {
+  let backoffMs = 0;
+
+  return {
+    /**
+     * What to wait before parking again, given how long the stream that just
+     * ended cleanly had lived. A stream that lived out the window starts the
+     * doubling over, so the wait decays to nothing as soon as one does.
+     */
+    next(livedMs: number) {
+      if (livedMs >= windowMs) {
+        backoffMs = 0;
+      }
+
+      const delayMs = backoffMs;
+
+      backoffMs = Math.min(backoffMs === 0 ? FLOOR_MS : backoffMs * 2, ceilingMs);
+
+      return delayMs;
+    },
+
+    /** Forgets the flapping, for a client whose stream failed instead. */
+    reset() {
+      backoffMs = 0;
+    },
+  };
+}

--- a/packages/electron-extensions/runtime-proxy/page-stream-client.test.ts
+++ b/packages/electron-extensions/runtime-proxy/page-stream-client.test.ts
@@ -6,7 +6,7 @@ import {
   type RuntimeProxySender,
   RUNTIME_PROXY_PATHS,
 } from "./bridge-protocol";
-import { createPageStreamClient } from "./page-stream-client";
+import { createPageStreamClient, type CreatePageStreamClientOptions } from "./page-stream-client";
 
 const EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
 
@@ -134,7 +134,7 @@ type Port = {
   onDisconnect: WrappedEvent;
 };
 
-function startClient() {
+function startClient(options: Partial<CreatePageStreamClientOptions> = {}) {
   const chrome: ChromeNamespace = {
     runtime: {
       id: EXTENSION_ID,
@@ -151,6 +151,7 @@ function startClient() {
       storageChanges.push({ area, changes });
     },
     retryDelayMs: 5,
+    ...options,
   });
 
   client.wrapRuntime(chrome);
@@ -479,6 +480,44 @@ describe("createPageStreamClient", () => {
      * a slow machine cannot fail it.
      */
     expect(Date.now() - startedAt).toBeGreaterThanOrEqual(60);
+  });
+
+  test("a stream that ended cleanly is parked again at once", async () => {
+    const stub = stubBridge();
+
+    startClient({ retryDelayMs: 2000 });
+
+    await stub.waitForStream();
+
+    const endedAt = Date.now();
+
+    stub.endStream();
+
+    await stub.waitForStream(2);
+
+    expect(Date.now() - endedAt).toBeLessThan(500);
+  });
+
+  test("a stream that keeps ending cleanly at once is backed off", async () => {
+    const stub = stubBridge();
+
+    startClient({ retryDelayMs: 2000, cleanEndWindowMs: 10_000 });
+
+    const startedAt = Date.now();
+
+    for (let streamCount = 1; streamCount <= 5; streamCount += 1) {
+      (await stub.waitForStream(streamCount)).close();
+    }
+
+    await stub.waitForStream(6);
+
+    /*
+     * Nothing for the first end, then 16, 32, 64 and 128 as the floor doubles,
+     * asserted with slack rather than as the 240 ms those four sum to. This is
+     * the case an unconditional re-park would turn into a hot loop: two live
+     * clients on one frame evict each other's context on every park.
+     */
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(200);
   });
 });
 

--- a/packages/electron-extensions/runtime-proxy/page-stream-client.ts
+++ b/packages/electron-extensions/runtime-proxy/page-stream-client.ts
@@ -8,6 +8,7 @@ import {
   type RuntimeProxySenderReport,
   RUNTIME_PROXY_PATHS,
 } from "./bridge-protocol";
+import { createCleanEndBackoff, DEFAULT_CLEAN_END_WINDOW_MS } from "./clean-end-backoff";
 import { dispatchMessage, mirrorEvent } from "./message-dispatch";
 import { createRelayedPort, type RelayedPort, type RelayedPortTransport } from "./relayed-port";
 import type { RuntimeProxyStorageAreaName, RuntimeProxyStorageChanges } from "./storage-protocol";
@@ -49,6 +50,8 @@ export type CreatePageStreamClientOptions = {
   retryDelayMs?: number;
   /** Where the backoff after repeated failures stops. */
   maxRetryDelayMs?: number;
+  /** How long a stream has to live for its clean end to count as ordinary. */
+  cleanEndWindowMs?: number;
 };
 
 /**
@@ -74,6 +77,7 @@ export function createPageStreamClient({
   onStorageChanged,
   retryDelayMs = DEFAULT_RETRY_DELAY_MS,
   maxRetryDelayMs = MAX_RETRY_DELAY_MS,
+  cleanEndWindowMs = DEFAULT_CLEAN_END_WINDOW_MS,
 }: CreatePageStreamClientOptions) {
   const messageListeners = new Set<ChromeEventListener>();
 
@@ -224,11 +228,27 @@ export function createPageStreamClient({
    * the relay drops this context — the worker's session went away and took the
    * relay's idea of this one with it — where the context itself is still very
    * much alive and still has to hear the worker that comes back.
+   *
+   * A clean end is the relay having dropped the context deliberately, and this
+   * context hears nothing at all until it parks again, so it parks at once
+   * rather than waiting. The backoff behind that is load-bearing here: a
+   * context evicted by another park of the same frame re-parks and evicts that
+   * one in turn, which is a flap between live clients rather than a flapping
+   * main, and an unconditional re-park would make it a hot loop.
    */
   const runPageStream = async () => {
     let failureCount = 0;
 
+    const cleanEndBackoff = createCleanEndBackoff({
+      ceilingMs: retryDelayMs,
+      windowMs: cleanEndWindowMs,
+    });
+
     while (!isStopped) {
+      const parkedAt = Date.now();
+
+      let hasEndedCleanly = false;
+
       try {
         const response = await postBridge(RUNTIME_PROXY_PATHS.pageStream, {
           sender: getSenderReport(),
@@ -255,18 +275,29 @@ export function createPageStreamClient({
             handleEnvelope(envelope);
           }
         }
+
+        hasEndedCleanly = true;
       } catch {
         // A refused or broken stream is a context that hears nothing until it
         // parks again, which is worth no more noise than the wait itself
         failureCount += 1;
       }
 
-      if (!isStopped) {
-        const delayMs = Math.min(
-          retryDelayMs * 2 ** Math.max(failureCount - 1, 0),
-          maxRetryDelayMs,
-        );
+      if (isStopped) {
+        return;
+      }
 
+      let delayMs: number;
+
+      if (hasEndedCleanly) {
+        delayMs = cleanEndBackoff.next(Date.now() - parkedAt);
+      } else {
+        cleanEndBackoff.reset();
+
+        delayMs = Math.min(retryDelayMs * 2 ** Math.max(failureCount - 1, 0), maxRetryDelayMs);
+      }
+
+      if (delayMs > 0) {
         await new Promise((resolve) => setTimeout(resolve, delayMs));
       }
     }

--- a/packages/electron-extensions/runtime-proxy/relay-client.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.ts
@@ -14,6 +14,7 @@ import {
   type RuntimeProxyWorkerConnectToTabResult,
   type RuntimeProxyWorkerSendToTabResult,
 } from "./bridge-protocol";
+import { createCleanEndBackoff, DEFAULT_CLEAN_END_WINDOW_MS } from "./clean-end-backoff";
 import { dispatchMessage, firstReply, mirrorEvent } from "./message-dispatch";
 import { getNativeMethod, type NativeMethod, parseSendMessageArguments } from "./native-api";
 import { createRelayedPort, type RelayedPort, type RelayedPortTransport } from "./relayed-port";
@@ -24,23 +25,6 @@ import {
 } from "./storage-protocol";
 
 const DEFAULT_RETRY_DELAY_MS = 1000;
-
-/**
- * How long a job stream has to live for its clean end to read as main's own
- * invalidation rather than a flap. Main ends a parked stream deliberately
- * whenever it replaces one, so from here that end is the ordinary case and the
- * jobs queued behind it are already waiting; only a stream that ends cleanly
- * again and again the moment it is parked is main flapping.
- */
-const DEFAULT_CLEAN_END_WINDOW_MS = 1000;
-
-/**
- * What the second clean end inside the window sleeps, doubling per end up to
- * `retryDelayMs`. Small enough that a single replaced stream costs nothing a
- * queued message can feel, large enough that a flapping main cannot spin the
- * worker.
- */
-const CLEAN_END_BACKOFF_FLOOR_MS = 16;
 
 /**
  * How many job ids the client remembers to recognise a redelivery by. Far more
@@ -308,8 +292,10 @@ export function createRelayClient({
   };
 
   const runJobStream = async () => {
-    /** What the next clean end inside the window sleeps; 0 while none has. */
-    let cleanEndBackoffMs = 0;
+    const cleanEndBackoff = createCleanEndBackoff({
+      ceilingMs: retryDelayMs,
+      windowMs: cleanEndWindowMs,
+    });
 
     while (!isStopped) {
       const parkedAt = Date.now();
@@ -355,21 +341,14 @@ export function createRelayClient({
        * delay paid for nothing. Only a bridge that refused or broke is a
        * reason to wait, since re-parking on it at once would spin.
        */
-      let delayMs = retryDelayMs;
+      let delayMs: number;
 
       if (hasEndedCleanly) {
-        if (Date.now() - parkedAt >= cleanEndWindowMs) {
-          cleanEndBackoffMs = 0;
-        }
-
-        delayMs = cleanEndBackoffMs;
-
-        cleanEndBackoffMs = Math.min(
-          cleanEndBackoffMs === 0 ? CLEAN_END_BACKOFF_FLOOR_MS : cleanEndBackoffMs * 2,
-          retryDelayMs,
-        );
+        delayMs = cleanEndBackoff.next(Date.now() - parkedAt);
       } else {
-        cleanEndBackoffMs = 0;
+        cleanEndBackoff.reset();
+
+        delayMs = retryDelayMs;
       }
 
       if (delayMs > 0) {


### PR DESCRIPTION
## Summary
The page stream client carried the same defect [PR #1026](https://github.com/zoidsh/meru/pull/1026) fixed in the relay client: every end of its parked receive stream waited a second, including the clean end that means the relay dropped this context deliberately. It now re-parks at once on a clean end, with the same flap backoff, which here is load-bearing rather than defensive. The rule moves into `clean-end-backoff.ts` so the two clients share one copy of it. The runtime proxy is off by default, so nothing changes for a shipping build with the flag off.

## Problem
Found by the reviewer of #1026, who noticed `page-stream-client.ts` sleeping `retryDelayMs` after a clean end the same way the relay client did.

A shimmed context parks a receive stream at the bridge and everything the worker addresses at it arrives there: a `tabs.sendMessage`, a `runtime.sendMessage` broadcast, the ports a `tabs.connect` opens, and `storage.onChanged`. When the stream ends the client waits `retryDelayMs` — one second — before parking again, and `failureCount` is reset on a successful park, so a clean end always paid the full second rather than any backed-off multiple of it.

A clean end is `PageStreams.closeContext`, and most of its callers are a context that is genuinely dying — a destroyed frame, a canceled body, a torn-down session — where nothing re-parks and the wait costs nothing. The case that matters is a live context evicted anyway: `dropContextsForFrame` drops a frame's earlier context when the URL is no longer the frame's, and the enqueue-failure path closes a context whose client is still there. Those contexts hear nothing at all until they park again, and they waited a second to do it.

That is a smaller prize than #1026's, where every job queued behind a replaced stream paid. Recorded rather than sold as more than it is.

## Solution
- A stream that ended cleanly parks again at once; a refused or broken one keeps the existing doubling to `maxRetryDelayMs`, half a minute, since a shimmed session whose worker session is gone is refused every park and dozens of frames retrying at a flat rate is idle load.
- The flap backoff comes with it, and here it is what makes the immediate re-park safe rather than a precaution against a misbehaving main. `dropContextsForFrame`'s own comment records the failure: the shim once ran three times per frame, each park evicting its siblings' contexts, which re-parked and evicted it in turn — a flap between live clients on one frame. An unconditional re-park would make that a hot loop. Doubling from a 16 ms floor, the clients settle at one park a second each, the same steady state the flat wait gave, and the wait decays to nothing as soon as a stream lives out the window.
- The rule itself moves to `clean-end-backoff.ts`, shared with the relay client, which is the only change to `relay-client.ts` — same behavior, same tests. The two clients park for different reasons and wait differently when a stream fails, but what a clean end costs is one rule, and it is subtle enough that two copies would drift. It costs about 150 bytes in each minified bundle, roughly what a second copy would.

A flat small delay on the clean path was the obvious alternative, rejected for the same reason as in #1026: it charges the ordinary single eviction for a flap that has not happened.

## Try it
Not runnable as a URL — main-process and content-script code behind an off-by-default flag. `bun test packages/electron-extensions/runtime-proxy` covers it: `clean-end-backoff.test.ts` pins the rule exactly (0, 16, 32, … to the ceiling, the reset by a stream that lived, and a ceiling under the floor), and `page-stream-client.test.ts` gains the immediate re-park and the flap backoff. Both new page-stream tests fail against main's client.

## Not verified
- No end-to-end coverage of the win itself. `tests/extension-proxy.e2e.ts` passes on this branch (9 passed, 1 skipped), but it never evicts a live context, so what it proves is that ordinary parking still works.
- The eviction path this helps is the one `dropContextsForFrame` calls the failure the install guard exists to prevent, so on a healthy build it should be rare. The measurable case is a URL change without a fresh document.
- `extensions-runtime-proxy-relay.js` is now 11.8 KB against its 12.0 KB budget. Under, and the budget test passes, but the headroom is thin enough that the next change to these bundles will likely have to raise the ceiling.