### PR TITLE
Ship the shared extension instance on by default

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -161,19 +161,21 @@ export const extensions = new Extensions({
   strippedManifestKeys: getStrippedManifestKeys(),
   getContentScriptMatches,
   // One shared extension instance across all account sessions — one 1Password
-  // sign-in instead of one per account. It has never been run against
-  // 1Password itself, so nothing loads it by default: development builds opt
-  // in with MERU_EXTENSIONS_SHARED_INSTANCE=1, the end-to-end suite does the
-  // same alongside the fixture flag — its packaged build is the only automated
-  // coverage the runtime proxy has — and deleting this one option removes the
-  // whole feature.
-  sharedInstance:
-    (is.dev || isFixtureExtensionEnabled()) && process.env.MERU_EXTENSIONS_SHARED_INSTANCE
-      ? createSharedExtensionInstance({
-          shimScriptPath: path.join(__dirname, "extensions-runtime-proxy-shim.js"),
-          relayScriptPath: path.join(__dirname, "extensions-runtime-proxy-relay.js"),
-        })
-      : undefined,
+  // sign-in instead of one per account, and one worker whatever the account
+  // count. It is how Meru runs extensions rather than something the user
+  // chooses: a per-account instance is the thing the feature exists to remove,
+  // so an off switch would only ever switch back to the worse sign-in and
+  // memory behavior, and `extensions.enabled` already turns extensions off
+  // entirely. Passed unconditionally rather than behind that master switch,
+  // which is read per session in `getExtensionDirs`: a session that loads no
+  // extension never adopts a role, so gating here would buy nothing and would
+  // read the switch once at launch, handing a full instance to any account
+  // added after extensions were turned on. Deleting this one option still
+  // removes the whole feature.
+  sharedInstance: createSharedExtensionInstance({
+    shimScriptPath: path.join(__dirname, "extensions-runtime-proxy-shim.js"),
+    relayScriptPath: path.join(__dirname, "extensions-runtime-proxy-relay.js"),
+  }),
   logger: {
     info: (message, details) => {
       log.info(message, details);

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -43,6 +43,7 @@ import { DoNotDisturb, doNotDisturb } from "./do-not-disturb";
 import { downloads } from "./downloads";
 import { extensionActions } from "./extension-actions";
 import {
+  extensions,
   extensionUpdater,
   getInstalledExtensions,
   installCuratedExtension,
@@ -88,6 +89,20 @@ class Ipc {
   renderer = new IpcEmitter<IpcRendererEvent>();
 
   init() {
+    // Removing the account whose session holds the one extension worker leaves
+    // the accounts left behind with content-script-only copies and nothing to
+    // reach, until a relaunch or until an account added later adopts the role.
+    // Offering the relaunch is the honest answer while the loader cannot hand
+    // the role to a surviving session; see the feature doc's "The worker
+    // session's removal".
+    extensions.onSharedInstanceWorkerLost(() => {
+      if (main.window.isDestroyed()) {
+        return;
+      }
+
+      ipc.renderer.send(main.window.webContents, "extensions.workerSessionLost");
+    });
+
     config.onDidAnyChange(() => {
       ipc.renderer.send(main.window.webContents, "config.configChanged", config.store);
 

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -6,6 +6,7 @@ import type { ClearStorageDataOptions, Extension, Session } from "electron";
 import { getExtensionBridgeUrl } from "./bridge/protocol";
 import { Extensions } from "./extensions";
 import { NATIVE_MESSAGING_PATHS } from "./native-messaging/bridge-protocol";
+import { createSharedExtensionInstance } from "./runtime-proxy";
 
 let workDir: string;
 
@@ -807,5 +808,163 @@ describe("Extensions", () => {
     expect(extensions.isLoadedExtensionUrl(session, "chrome-extension://aaa/popup.html")).toBe(
       false,
     );
+  });
+});
+
+describe("the shared instance losing its worker session", () => {
+  /*
+   * The real `createSharedExtensionInstance`, so what is under test is the
+   * answer it gives the loader rather than a fake agreeing with the loader.
+   * Its scripts have to exist, because the derive copies them into every copy.
+   */
+  async function createSharedInstance() {
+    const shimScriptPath = path.join(workDir, "shim.js");
+
+    const relayScriptPath = path.join(workDir, "relay.js");
+
+    await writeFile(shimScriptPath, "// shim\n");
+
+    await writeFile(relayScriptPath, "// relay\n");
+
+    return createSharedExtensionInstance({ shimScriptPath, relayScriptPath });
+  }
+
+  function createSharedExtensions(
+    extensionDirs: ConstructorParameters<typeof Extensions>[0]["extensionDirs"],
+    sharedInstance: ConstructorParameters<typeof Extensions>[0]["sharedInstance"],
+  ) {
+    return new Extensions({
+      extensionDirs,
+      facadeScriptPath,
+      derivedExtensionsDir: path.join(workDir, "derived"),
+      sharedInstance,
+    });
+  }
+
+  /** One extension id from both sessions, which is what a `manifest.key` buys. */
+  function createSharedSession() {
+    return createSession({
+      loadExtension: async (extensionDir: string) => createExtension("aaa", extensionDir),
+    });
+  }
+
+  test("firing once when other sessions still hold the extension", async () => {
+    const extensions = createSharedExtensions(
+      [await createExtensionDir("one")],
+      await createSharedInstance(),
+    );
+
+    let workerLostCount = 0;
+
+    extensions.onSharedInstanceWorkerLost(() => {
+      workerLostCount += 1;
+    });
+
+    const { session: workerSession } = createSharedSession();
+
+    const { session: shimSession } = createSharedSession();
+
+    await extensions.setupSession(workerSession);
+
+    await extensions.setupSession(shimSession);
+
+    extensions.teardownSession(workerSession);
+
+    expect(workerLostCount).toBe(1);
+  });
+
+  test("staying silent when a content-script-only session goes", async () => {
+    const extensions = createSharedExtensions(
+      [await createExtensionDir("one")],
+      await createSharedInstance(),
+    );
+
+    let workerLostCount = 0;
+
+    extensions.onSharedInstanceWorkerLost(() => {
+      workerLostCount += 1;
+    });
+
+    const { session: workerSession } = createSharedSession();
+
+    const { session: shimSession } = createSharedSession();
+
+    await extensions.setupSession(workerSession);
+
+    await extensions.setupSession(shimSession);
+
+    extensions.teardownSession(shimSession);
+
+    expect(workerLostCount).toBe(0);
+  });
+
+  test("staying silent when the worker session was the last one", async () => {
+    const extensions = createSharedExtensions(
+      [await createExtensionDir("one")],
+      await createSharedInstance(),
+    );
+
+    let workerLostCount = 0;
+
+    extensions.onSharedInstanceWorkerLost(() => {
+      workerLostCount += 1;
+    });
+
+    const { session: workerSession } = createSharedSession();
+
+    await extensions.setupSession(workerSession);
+
+    extensions.teardownSession(workerSession);
+
+    expect(workerLostCount).toBe(0);
+  });
+
+  test("an unsubscribed listener hears nothing", async () => {
+    const extensions = createSharedExtensions(
+      [await createExtensionDir("one")],
+      await createSharedInstance(),
+    );
+
+    let workerLostCount = 0;
+
+    const unsubscribe = extensions.onSharedInstanceWorkerLost(() => {
+      workerLostCount += 1;
+    });
+
+    unsubscribe();
+
+    const { session: workerSession } = createSharedSession();
+
+    const { session: shimSession } = createSharedSession();
+
+    await extensions.setupSession(workerSession);
+
+    await extensions.setupSession(shimSession);
+
+    extensions.teardownSession(workerSession);
+
+    expect(workerLostCount).toBe(0);
+  });
+
+  test("nothing fires without a shared instance, where every session runs its own", async () => {
+    const extensions = createExtensions([await createExtensionDir("one")]);
+
+    let workerLostCount = 0;
+
+    extensions.onSharedInstanceWorkerLost(() => {
+      workerLostCount += 1;
+    });
+
+    const { session: firstSession } = createSharedSession();
+
+    const { session: secondSession } = createSharedSession();
+
+    await extensions.setupSession(firstSession);
+
+    await extensions.setupSession(secondSession);
+
+    extensions.teardownSession(firstSession);
+
+    expect(workerLostCount).toBe(0);
   });
 });

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -39,6 +39,8 @@ const CONSOLE_ERROR_LEVEL = 3;
 
 export type ActionsChangedListener = (session: Session, actions: ExtensionAction[]) => void;
 
+export type SharedInstanceWorkerLostListener = () => void;
+
 export type ExtensionDirs = string[] | (() => Promise<string[]> | string[]);
 
 /**
@@ -55,7 +57,12 @@ export type SharedExtensionInstance = {
   install(context: { bridge: ExtensionBridge; logger?: ExtensionsLogger }): void;
   /** Called per session before its extensions derive. */
   adoptSession(session: Session): SharedInstanceDeriveOptions;
-  teardownSession(session: Session): void;
+  /**
+   * Whether that session was the one holding the worker, which is what the
+   * loader needs to tell an embedder that the sessions left behind have
+   * nothing to reach.
+   */
+  teardownSession(session: Session): boolean;
 };
 
 export type ExtensionsOptions = {
@@ -130,6 +137,8 @@ export class Extensions {
   private getContentScriptMatches: ExtensionsOptions["getContentScriptMatches"];
 
   private sharedInstance: SharedExtensionInstance | undefined;
+
+  private sharedInstanceWorkerLostListeners = new Set<SharedInstanceWorkerLostListener>();
 
   private logger: ExtensionsLogger | undefined;
 
@@ -456,7 +465,17 @@ export class Extensions {
 
     this.alarms.teardownSession(session);
 
-    this.sharedInstance?.teardownSession(session);
+    // This session is already out of `loadedExtensionIdsBySession`, so what is
+    // left in it is the sessions that keep their content-script-only copies
+    const workerRoleWasVacated = this.sharedInstance?.teardownSession(session) === true;
+
+    if (workerRoleWasVacated && this.loadedExtensionIdsBySession.size > 0) {
+      this.logger?.info("Shared extension instance lost its worker session", {
+        orphanedSessions: this.loadedExtensionIdsBySession.size,
+      });
+
+      this.emitSharedInstanceWorkerLost();
+    }
 
     const consoleListener = this.serviceWorkerConsoleListeners.get(session);
 
@@ -491,6 +510,30 @@ export class Extensions {
     return () => {
       this.actionsChangedListeners.delete(listener);
     };
+  }
+
+  /**
+   * Fires when the session holding the shared instance's worker is torn down
+   * while other sessions still have the extension loaded. Those sessions keep
+   * the content-script-only copies they were derived with, so their extensions
+   * have nothing to reach until the app restarts — or until a session set up
+   * later adopts the vacant role. An embedder that offers a relaunch is what
+   * stands between the user and a password manager that quietly stopped
+   * working. It does not fire when the torn-down session was the last one, as
+   * there is nothing left to be broken.
+   */
+  onSharedInstanceWorkerLost(listener: SharedInstanceWorkerLostListener) {
+    this.sharedInstanceWorkerLostListeners.add(listener);
+
+    return () => {
+      this.sharedInstanceWorkerLostListeners.delete(listener);
+    };
+  }
+
+  private emitSharedInstanceWorkerLost() {
+    for (const listener of this.sharedInstanceWorkerLostListeners) {
+      listener();
+    }
   }
 
   private emitActionsChanged(session: Session) {

--- a/packages/electron-extensions/runtime-proxy/index.test.ts
+++ b/packages/electron-extensions/runtime-proxy/index.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import type { Session } from "electron";
+import { createSharedExtensionInstance } from "./index";
+
+/**
+ * Role adoption alone, which needs no Electron: `install` is what builds the
+ * `RuntimeProxy`, and every method here guards on it, so a shared instance
+ * that was never installed hands out roles and nothing else.
+ */
+function createRoleAssigner() {
+  return createSharedExtensionInstance({
+    shimScriptPath: "/shim.js",
+    relayScriptPath: "/relay.js",
+  });
+}
+
+function createSession(label: string) {
+  return { label } as unknown as Session;
+}
+
+describe("createSharedExtensionInstance role adoption", () => {
+  test("the first session set up keeps the worker and every later one is content-script-only", () => {
+    const sharedInstance = createRoleAssigner();
+
+    expect(sharedInstance.adoptSession(createSession("first"))).toEqual({
+      role: "worker",
+      relayScriptPath: "/relay.js",
+    });
+
+    expect(sharedInstance.adoptSession(createSession("second"))).toEqual({
+      role: "contentScriptOnly",
+      shimScriptPath: "/shim.js",
+    });
+  });
+
+  test("a session asked twice keeps the role it has", () => {
+    const sharedInstance = createRoleAssigner();
+
+    const workerSession = createSession("worker");
+
+    expect(sharedInstance.adoptSession(workerSession).role).toBe("worker");
+    expect(sharedInstance.adoptSession(workerSession).role).toBe("worker");
+  });
+
+  test("tearing down a content-script-only session leaves the worker where it is", () => {
+    const sharedInstance = createRoleAssigner();
+
+    const workerSession = createSession("worker");
+
+    sharedInstance.adoptSession(workerSession);
+
+    const shimSession = createSession("shim");
+
+    sharedInstance.adoptSession(shimSession);
+
+    sharedInstance.teardownSession(shimSession);
+
+    expect(sharedInstance.adoptSession(createSession("third")).role).toBe("contentScriptOnly");
+  });
+
+  /*
+   * The behavior the feature doc records rather than one anybody wants: the
+   * surviving sessions keep the content-script-only copies they were derived
+   * with and have no worker to reach until the app restarts, because
+   * `adoptSession` is reached only from `Extensions.setupSession` and a
+   * session is set up once, when its account is constructed. What this pins is
+   * that the role is genuinely vacant afterwards, so the next session set up —
+   * an account added after the removal — picks it up.
+   */
+  test("tearing down the worker session vacates the role for the next session set up", () => {
+    const sharedInstance = createRoleAssigner();
+
+    const workerSession = createSession("worker");
+
+    sharedInstance.adoptSession(workerSession);
+
+    const shimSession = createSession("shim");
+
+    sharedInstance.adoptSession(shimSession);
+
+    sharedInstance.teardownSession(workerSession);
+
+    expect(sharedInstance.adoptSession(createSession("added-later")).role).toBe("worker");
+  });
+});

--- a/packages/electron-extensions/runtime-proxy/index.test.ts
+++ b/packages/electron-extensions/runtime-proxy/index.test.ts
@@ -61,11 +61,12 @@ describe("createSharedExtensionInstance role adoption", () => {
   /*
    * The behavior the feature doc records rather than one anybody wants: the
    * surviving sessions keep the content-script-only copies they were derived
-   * with and have no worker to reach until the app restarts, because
-   * `adoptSession` is reached only from `Extensions.setupSession` and a
-   * session is set up once, when its account is constructed. What this pins is
-   * that the role is genuinely vacant afterwards, so the next session set up —
-   * an account added after the removal — picks it up.
+   * with and have no worker to reach until a session set up later takes the
+   * role — an account added after the removal, or every account after a
+   * restart — because `adoptSession` is reached only from
+   * `Extensions.setupSession` and a session is set up once, when its account
+   * is constructed. What this pins is that the role is genuinely vacant
+   * afterwards, so the next session set up does pick it up.
    */
   test("tearing down the worker session vacates the role for the next session set up", () => {
     const sharedInstance = createRoleAssigner();

--- a/packages/electron-extensions/runtime-proxy/index.ts
+++ b/packages/electron-extensions/runtime-proxy/index.ts
@@ -71,13 +71,18 @@ export function createSharedExtensionInstance({
 
     teardownSession(session) {
       // A torn-down worker session orphans the content-script-only sessions
-      // until the next session adopts the worker role on a fresh instance;
-      // the proxy answers them "receiving end does not exist" in between
-      if (session === workerSession) {
+      // until the next session adopts the worker role — an account added after
+      // the removal, or a relaunch; the proxy answers them "receiving end does
+      // not exist" in between, which is why the loader passes this answer on
+      const wasWorkerSession = session === workerSession;
+
+      if (wasWorkerSession) {
         workerSession = undefined;
       }
 
       proxy?.teardownSession(session);
+
+      return wasWorkerSession;
     },
   };
 }

--- a/packages/renderer/lib/ipc.ts
+++ b/packages/renderer/lib/ipc.ts
@@ -1,6 +1,7 @@
 import { ipc } from "@meru/shared/renderer/ipc";
 import { navigate } from "wouter/use-hash-location";
 import { playNotificationSound } from "./notifications";
+import { restartRequiredToast } from "./toast";
 
 ipc.renderer.on("navigate", (_event, to) => {
   navigate(to);
@@ -46,4 +47,17 @@ ipc.renderer.on("taskbar.setOverlayIcon", (_event, unreadCount) => {
 
 ipc.renderer.on("notifications.playSound", (_event, { sound, volume }) => {
   playNotificationSound({ sound, volume });
+});
+
+/*
+ * The account that was just removed held the one extension instance every
+ * account shared, so the accounts left behind have extensions that can no
+ * longer reach it. A restart gives the instance to one of them. The message
+ * names no extension because main knows the sessions rather than what the user
+ * installed into them.
+ */
+ipc.renderer.on("extensions.workerSessionLost", () => {
+  restartRequiredToast(
+    "Extensions stopped working in your other accounts. Restart Meru to load them again.",
+  );
 });

--- a/packages/renderer/lib/toast.ts
+++ b/packages/renderer/lib/toast.ts
@@ -1,8 +1,8 @@
 import { ipc } from "@meru/shared/renderer/ipc";
 import { toast } from "sonner";
 
-export function restartRequiredToast() {
-  toast.info("Restart Meru to apply the changes.", {
+export function restartRequiredToast(message = "Restart Meru to apply the changes.") {
+  toast.info(message, {
     id: "restart-required",
     duration: Number.POSITIVE_INFINITY,
     action: {

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -307,6 +307,7 @@ export type IpcRendererEvent = {
   "tabs.changed": [accountsTabs: AccountTabsState[]];
   "bookmarks.changed": [bookmarks: BookmarkState[]];
   "extensions.actionsChanged": [actions: ExtensionActionState[]];
+  "extensions.workerSessionLost": [];
   "findInPage.activate": [];
   "findInPage.result": [result: { activeMatch: number; totalMatches: number }];
   "trial.daysLeftChanged": [daysLeft: number];

--- a/tests/extension-proxy.e2e.ts
+++ b/tests/extension-proxy.e2e.ts
@@ -32,6 +32,7 @@ import { FIXTURE_EXTENSION_ID } from "@meru/electron-extensions/fixture/id";
 import type { ProbeResults } from "@meru/electron-extensions/fixture/probes";
 import { expect, test } from "@playwright/test";
 import { useProApp } from "./lib/app";
+import { openSettingsPage } from "./lib/settings";
 
 /** The shape `accounts` is stored in, as in `pro.e2e.ts`. */
 function account(id: string, label: string, selected: boolean) {
@@ -746,4 +747,41 @@ test.skip("storage.onChanged fires in the shim session, for the worker's writes 
       areaName,
     });
   }
+});
+
+/*
+ * Removing the account whose session holds the worker leaves the accounts left
+ * behind with content-script-only copies and nothing to reach, until the app
+ * restarts or an account added later adopts the vacant role. The app cannot
+ * hand the role to a surviving session yet — see "The worker session's removal"
+ * in the feature doc for why that is a design change — so what it owes the user
+ * is the offer of a restart, and this is the whole chain that produces it: the
+ * loader noticing, the main process telling the renderer, and the toast.
+ */
+test("removing the worker account offers a restart to the accounts left behind", async () => {
+  await waitForFixture(WORKER_PARTITION);
+
+  await waitForFixture(SHIM_PARTITION);
+
+  const navigation = await meru.openSettings();
+
+  await openSettingsPage(meru, navigation, "Accounts");
+
+  /*
+   * The first row is the worker account, for the same reason the partition
+   * constants above say so: accounts are constructed in config order and roles
+   * are adopted in the order sessions are set up. Picking the wrong row fails
+   * this test rather than passing it quietly, because removing a shimmed
+   * session raises no toast at all.
+   */
+  await meru.renderer.getByRole("button", { name: "Remove account" }).first().click();
+
+  await meru.renderer
+    .getByRole("alertdialog")
+    .getByRole("button", { name: "Remove account" })
+    .click();
+
+  await expect(
+    meru.renderer.getByText("Extensions stopped working in your other accounts."),
+  ).toBeVisible();
 });

--- a/tests/extension-proxy.e2e.ts
+++ b/tests/extension-proxy.e2e.ts
@@ -4,9 +4,9 @@
  * shared extension instance has, since 1Password needs a real Google account,
  * the desktop app and a display.
  *
- * The launch carries both extension flags: `MERU_EXTENSIONS_FIXTURE` puts the
- * bundled fixture into every account session of this packaged build, and
- * `MERU_EXTENSIONS_SHARED_INSTANCE` turns on the shared instance, so the
+ * The launch carries one extension flag: `MERU_EXTENSIONS_FIXTURE` puts the
+ * bundled fixture into every account session of this packaged build. The
+ * shared instance needs no flag, because it is how Meru runs extensions — the
  * first account's session keeps the fixture's service worker while the second
  * account's session gets the content-script-only copy whose `chrome.runtime`
  * messaging the proxy relays. Two accounts need Pro, which is why this file
@@ -60,7 +60,7 @@ const meru = useProApp(
   {
     accounts: [account("worker-account", "Worker", true), account("shim-account", "Shim", false)],
   },
-  { env: { MERU_EXTENSIONS_FIXTURE: "1", MERU_EXTENSIONS_SHARED_INSTANCE: "1" } },
+  { env: { MERU_EXTENSIONS_FIXTURE: "1" } },
 );
 
 /**


### PR DESCRIPTION
## Summary
The runtime proxy — one extension instance serving every account session — is on for every launch, and the `MERU_EXTENSIONS_SHARED_INSTANCE` gate is deleted rather than replaced by a config key. One 1Password sign-in instead of one per account, and one service worker whatever the account count. Removing the account that holds the worker now offers a restart instead of silently breaking the others. It ships ahead of the real-machine pass against 1Password rather than after it, so that pass is now a release gate: [section 5 of the manual pass](https://github.com/zoidsh/docs/blob/main/meru/extensions-manual-pass.md), and 3.60 should not go out without it.

## Problem
`runtime-proxy/` has been complete since 26 August and shipped in nothing: `packages/app/extensions.ts` built the `sharedInstance` option only when `(is.dev || isFixtureExtensionEnabled()) && process.env.MERU_EXTENSIONS_SHARED_INSTANCE`, so every released build gave each account its own extension instance — its own 1Password sign-in and its own service worker. On a Mac with the 1Password desktop app connected those workers never idle out: two accounts measured at 116 MB and 89 MB still resident after three minutes, and about 230 MB attributable to the extension at rest.

Tim decided to flip it, and to flip it with no switch: a per-account instance is the thing the feature exists to remove, so an off switch would only ever be a switch back to the worse sign-in and memory behavior, and `extensions.enabled` already turns extensions off entirely. That supersedes the 25 August decision to ship it as a **Share extensions across accounts** setting.

## Solution
- `sharedInstance` is now passed unconditionally, and the environment variable is gone from the repository.
- `tests/extension-proxy.e2e.ts` drives the proxy through the ordinary path, carrying `MERU_EXTENSIONS_FIXTURE` alone — the packaged suite is now testing what ships rather than a flagged path.
- Removing the worker account raises a restart toast in the accounts left behind.

Passed unconditionally rather than behind `extensions.enabled`, which was the obvious gate. `extensions.enabled` is read per session in `getExtensionDirs`, and `setupSession` returns before `adoptSession` when a session has no extension directories, so gating the construction would buy nothing — while reading the switch once at module load would hand a full per-account instance to any account added after a user turned extensions on.

This closes row 22 of the 3.60 extensions review as a side effect: with the variable gone there is no pair of environment variables that puts a real 1Password install through the proxy in a packaged build. `MERU_EXTENSIONS_FIXTURE` stays, and stays a boolean that can only load the fixture the app already carries.

### The worker account's removal
Removing the account whose session holds the worker leaves every remaining account with a content-script-only copy and nothing to reach, because teardown clears the worker and `adoptSession` is reached only from `Extensions.setupSession`, which runs for a session once. What the accounts read is three different errors — "Receiving end does not exist" for messaging, "Could not reach the extension's storage." for `chrome.storage`, and Chrome's "Access to storage is not allowed from this context." for a content script's `session` area once the recorded access levels are cleared.

So the loader gains `onSharedInstanceWorkerLost`, fired only when the torn-down session held the worker *and* other sessions still have the extension loaded, `ipc.ts` forwards it to the main window, and the renderer raises the restart toast the install path already shows. The message names no extension, because what main knows is sessions rather than what the user installed into them.

**Handing the role to a surviving session instead was sized and rejected as more than this change.** Re-deriving a survivor into the worker role is the small half; the wall is the documents already open in that session, whose content scripts keep their shims for the life of the document while the relay refuses every shim-side route from the worker session — `sendMessage`, `connect` and the storage call answer 400, the port routes answer 204 having done nothing, and `PageStreams` answers 403 rather than letting the worker session park a stream — and the shim has no fallback to the natives it shadowed. The shape worth building is teaching the shim to unshim itself when the relay tells it its session became the worker session; the alternatives are reloading the adopted session's views from the embedder, or relaxing the relay's worker-session invariants. Written up under "The worker session's removal" in the feature doc, along with the fact that the sign-in does not survive the removal under any of them, because the store the worker keeps is its own session's.

## Try it
There is no preview deployment and no URL: this is a main-process change to an Electron app. `xvfb-run -a bun run test:e2e` is where you can watch it — `tests/extension-proxy.e2e.ts` now exercises the proxy with no flag set, and its last case removes the worker account and reads the toast. On a desktop, `bun run dev` with two accounts and 1Password in `extensions/` shows one worker rather than two.

## Not verified
- 1Password itself has still never been run against the proxy, on any branch. That is section 5 of the manual pass and it is a release gate, not a merge gate.
- **The single-account worker-only path has no end-to-end coverage.** Every launch now takes the worker role, which was previously the untested half: the relay client parks a job stream, `tabs.sendMessage` and `tabs.connect` take a bridge round trip before the native call, `hasListener` answers from the mirror set, and every storage change POSTs to main. The e2e suite always runs two accounts.
- **Whether the removed account's worker actually stops** was not measured. Its relay client re-parks `workerJobs` on a retry with a `console.error` each time until the worker dies, and nothing here confirms `removeExtension` and `clearData` end it promptly.
- `documentId` targeting matches nothing across the proxy, unchanged by this PR and unmeasured against 1Password.
- The worker-session removal behavior was read off the code, pinned in unit tests with fake sessions, and covered end to end for the toast only — not reproduced against a real extension losing its worker mid-session.
- Memory was not measured on this branch. The figures above are Tim's measurements on his Mac on 2 September 2026, recorded in the feature doc.