### PR TITLE
Cut three sources of noise from the extensions log

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -19,6 +19,7 @@ import { app } from "electron";
 import { serializeError } from "serialize-error";
 import { config } from "@/config";
 import { log } from "@/lib/log";
+import { serializeErrorDetails } from "@/lib/log-details";
 import { licenseKey } from "@/license-key";
 
 /** Where the curated extensions are installed, `<installDir>/<id>/<version>`. */
@@ -178,8 +179,8 @@ export const extensions = new Extensions({
     info: (message, details) => {
       log.info(message, details);
     },
-    error: (message, { error, ...details }) => {
-      log.error(message, { ...details, error: serializeError(error) });
+    error: (message, details) => {
+      log.error(message, serializeErrorDetails(details));
     },
   },
 });

--- a/packages/app/lib/load-failures.test.ts
+++ b/packages/app/lib/load-failures.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { isLoadFailureWorthLogging } from "./load-failures";
+
+describe("isLoadFailureWorthLogging", () => {
+  test("skips a subframe that cancelled its own load", () => {
+    expect(isLoadFailureWorthLogging(-3, false)).toBe(false);
+  });
+
+  test("keeps a main frame that aborted, which is the view going blank", () => {
+    expect(isLoadFailureWorthLogging(-3, true)).toBe(true);
+  });
+
+  test("keeps every other subframe failure", () => {
+    expect(isLoadFailureWorthLogging(-2, false)).toBe(true);
+    expect(isLoadFailureWorthLogging(-105, false)).toBe(true);
+  });
+});

--- a/packages/app/lib/load-failures.ts
+++ b/packages/app/lib/load-failures.ts
@@ -1,0 +1,18 @@
+/**
+ * `net::ERR_ABORTED`, which is not a failure: it is the page cancelling a load
+ * it started itself.
+ */
+const ERR_ABORTED = -3;
+
+/**
+ * Whether a `did-fail-load` says anything about why a view is empty.
+ *
+ * Gmail aborts its own subframes on every launch — the `mail/u/0/data?token=`
+ * poll, Drive's `auth_warmup`, the `accounts.google.com/ServiceLogin` frame —
+ * so a subframe carrying `ERR_ABORTED` is noise. Every other code, and every
+ * main frame whatever the code, still says something: a main frame that aborts
+ * is the view the user is looking at going blank.
+ */
+export function isLoadFailureWorthLogging(errorCode: number, isMainFrame: boolean) {
+  return isMainFrame || errorCode !== ERR_ABORTED;
+}

--- a/packages/app/lib/log-details.test.ts
+++ b/packages/app/lib/log-details.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { serializeErrorDetails } from "./log-details";
+
+describe("serializeErrorDetails", () => {
+  test("leaves the error key out when the caller passed none", () => {
+    const details = serializeErrorDetails({
+      sourceUrl: "chrome-extension://abc/background.js",
+      message: "Session does not exist for tab 3",
+    });
+
+    expect(details).toEqual({
+      sourceUrl: "chrome-extension://abc/background.js",
+      message: "Session does not exist for tab 3",
+    });
+    expect("error" in details).toBe(false);
+  });
+
+  test("serializes an error the caller did pass, alongside the rest", () => {
+    const details = serializeErrorDetails({
+      extensionDir: "/extensions/1password",
+      error: new Error("No manifest.json"),
+    });
+
+    expect(details.extensionDir).toBe("/extensions/1password");
+    expect(details.error).toMatchObject({ name: "Error", message: "No manifest.json" });
+  });
+
+  test("serializes a non-error value the caller did pass", () => {
+    expect(serializeErrorDetails({ error: "boom" }).error).toMatchObject({
+      name: "NonError",
+      message: "Non-error value: boom",
+    });
+  });
+});

--- a/packages/app/lib/log-details.ts
+++ b/packages/app/lib/log-details.ts
@@ -1,0 +1,19 @@
+import { serializeError } from "serialize-error";
+
+/**
+ * Serializes the `error` in a logger's details, leaving the key out entirely
+ * when the caller passed none.
+ *
+ * `serializeError(undefined)` does not answer `undefined`: it invents a
+ * `{ name: "NonError", message: "Non-error value: undefined" }` whose stack
+ * points at `serializeError` itself. Every log line from a caller that reports
+ * a message without an error — the extension loader's `Extension service worker
+ * error`, which forwards a worker's own `console.error` — then carried a stack
+ * from inside the logger, which is not where anything went wrong.
+ */
+export function serializeErrorDetails({
+  error,
+  ...details
+}: Record<string, unknown>): Record<string, unknown> {
+  return error === undefined ? details : { ...details, error: serializeError(error) };
+}

--- a/packages/app/lib/web-contents.ts
+++ b/packages/app/lib/web-contents.ts
@@ -7,17 +7,8 @@ import {
 import { setupWindowContextMenu } from "@/context-menu";
 import { ipc } from "@/ipc";
 import { shouldOpenDevToolsOnLaunch } from "./dev-tools";
+import { isLoadFailureWorthLogging } from "./load-failures";
 import { log } from "./log";
-
-/**
- * `net::ERR_ABORTED`, which is not a failure: it is the page cancelling a load
- * it started itself. Gmail does it to its own subframes on every launch — the
- * `mail/u/0/data?token=` poll, Drive's `auth_warmup`, the
- * `accounts.google.com/ServiceLogin` frame — so a subframe carrying this code
- * says nothing about why a view is empty. Every other code, and every main
- * frame whatever the code, still does.
- */
-const ERR_ABORTED = -3;
 
 /**
  * Says why a view is empty. A load that never arrives leaves nothing behind on
@@ -32,7 +23,7 @@ export function logLoadFailures(webContents: WebContents, name: string) {
   webContents.on(
     "did-fail-load",
     (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
-      if (!isMainFrame && errorCode === ERR_ABORTED) {
+      if (!isLoadFailureWorthLogging(errorCode, isMainFrame)) {
         return;
       }
 

--- a/packages/app/lib/web-contents.ts
+++ b/packages/app/lib/web-contents.ts
@@ -10,6 +10,16 @@ import { shouldOpenDevToolsOnLaunch } from "./dev-tools";
 import { log } from "./log";
 
 /**
+ * `net::ERR_ABORTED`, which is not a failure: it is the page cancelling a load
+ * it started itself. Gmail does it to its own subframes on every launch — the
+ * `mail/u/0/data?token=` poll, Drive's `auth_warmup`, the
+ * `accounts.google.com/ServiceLogin` frame — so a subframe carrying this code
+ * says nothing about why a view is empty. Every other code, and every main
+ * frame whatever the code, still does.
+ */
+const ERR_ABORTED = -3;
+
+/**
  * Says why a view is empty. A load that never arrives leaves nothing behind on
  * its own: the renderer that died, the frame that was refused and the error the
  * network stack gave up with are all only in these events.
@@ -22,6 +32,10 @@ export function logLoadFailures(webContents: WebContents, name: string) {
   webContents.on(
     "did-fail-load",
     (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+      if (!isMainFrame && errorCode === ERR_ABORTED) {
+        return;
+      }
+
       log.error(`${name} failed to load`, {
         errorCode,
         errorDescription,

--- a/packages/electron-extensions/facade/api/alarms.test.ts
+++ b/packages/electron-extensions/facade/api/alarms.test.ts
@@ -199,6 +199,31 @@ describe("alarms", () => {
     }
   });
 
+  test("warns once per alarm name, however often the extension recreates it", async () => {
+    installFakeBridge();
+
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const alarms = createAlarms();
+
+      const create = methodOf(alarms, "create");
+
+      await create("poll", { periodInMinutes: 0.1 });
+      await create("poll", { periodInMinutes: 0.1 });
+      await create("poll", { periodInMinutes: 0.2 });
+
+      expect(warn).toHaveBeenCalledTimes(1);
+
+      await create("sync", { delayInMinutes: 0.1 });
+
+      expect(warn).toHaveBeenCalledTimes(2);
+      expect(warn.mock.calls[1]?.[0]).toContain("sync");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   test("reads an alarm back, and undefined for one that is not there", async () => {
     const bridge = installFakeBridge();
 

--- a/packages/electron-extensions/facade/api/alarms.ts
+++ b/packages/electron-extensions/facade/api/alarms.ts
@@ -99,6 +99,18 @@ export function createAlarms(): ChromeNamespace {
   let isListening = false;
 
   /**
+   * The alarm names this context has already warned about, kept for as long as
+   * the namespace lives.
+   *
+   * A deliberate departure from Chrome, which warns on every `create`: an
+   * extension that recreates a debounce alarm on a timer repeats the line
+   * forever — 1Password remakes `sync-xam-backend-accounts` four to six times
+   * per worker boot, per account — and the second warning tells the extension
+   * nothing the first one did not.
+   */
+  const warnedAlarmNames = new Set<string>();
+
+  /**
    * Reads the parked stream until it ends, which is what a torn-down session
    * and a refused request both look like from here. Ending is not the same as
    * being done: the context is still live and still holds listeners, so the
@@ -161,7 +173,9 @@ export function createAlarms(): ChromeNamespace {
 
       const clampWarning = getAlarmClampWarning(name, alarmInfo);
 
-      if (clampWarning) {
+      if (clampWarning && !warnedAlarmNames.has(name)) {
+        warnedAlarmNames.add(name);
+
         console.warn(`[chrome-facade] ${clampWarning}`);
       }
 


### PR DESCRIPTION
## Summary
Three independent log fixes found in the 1Password manual pass on a Mac: a fabricated stack on every worker console error, a `did-fail-load` error line for Gmail's own aborted subframes on every launch, and the alarm clamp warning repeating once per `create`. All three are behavior-preserving — nothing but what reaches the log changes.

## Problem
The packaged log is hard to read during the manual pass, for three unrelated reasons.

Every `Extension service worker error` line carries a stack that points at the logger:

```
Extension service worker error {
  sourceUrl: 'chrome-extension://…/background.js',
  message: 'Session does not exist for tab 3',
  error: {
    name: 'NonError',
    message: 'Non-error value: undefined',
    stack: 'NonError: Non-error value: undefined\n    at serializeError (…/serialize-error/index.js:197:13)\n    at …/packages/app/extensions.ts:182'
  }
}
```

The loader reports a worker's own `console.error` as a message and a source URL with no `error` key, and the app's adapter called `serializeError(undefined)` regardless. That does not answer `undefined`: it invents a `NonError` whose stack is `serializeError`'s. Those lines are the ones the feature doc's `EventRouter` paragraph explains — Electron dispatches no `tabs.*` or `webNavigation.*` events into a worker, so 1Password logs `Session does not exist for <tab>` and friends throughout a normal working session, which makes this the most repeated line in the log.

The Gmail view logs an error on every launch for three subframes Gmail cancels itself:

```
Gmail view failed to load { errorCode: -3, errorDescription: 'ERR_ABORTED', validatedURL: 'https://mail.google.com/mail/u/0/data?token=…', isMainFrame: false }
Gmail view failed to load { errorCode: -3, errorDescription: 'ERR_ABORTED', validatedURL: 'https://drive.google.com/auth_warmup', isMainFrame: false }
Gmail view failed to load { errorCode: -3, errorDescription: 'ERR_ABORTED', validatedURL: 'https://accounts.google.com/ServiceLogin?…', isMainFrame: false }
```

Per account, per launch, and none of them a failure. The listener came in with the load-race diagnostics in #824, which are still wanted for the case they were added for.

And the facade's alarm clamp warning fires on every `create`, so 1Password's `sync-xam-backend-accounts` debounce alarm — recreated four to six times per worker boot — puts the same line in the log that many times per account.

## Solution
- The serialization moves out of the adapter into `serializeErrorDetails` in `packages/app/lib/log-details.ts`, which leaves the key out when the caller passed no error and keeps the shape for callers that did. The after line is the same as above without the `error` key. It is a helper rather than an inline `error === undefined` check because that gives it a test seam: `packages/app/extensions.ts` calls `app.getPath` at module scope, so nothing in it is testable without Electron. It is the only logger adapter in the app — the remaining `serializeError` calls all sit in a `catch`, where the value is always present.
- `did-fail-load` skips a subframe whose code is `-3`, through `isLoadFailureWorthLogging` in a new `packages/app/lib/load-failures.ts`. That is `net::ERR_ABORTED`, which Chromium reports when the page cancelled a load it started — a navigation replaced, an iframe removed, a fetch superseded — so it is the one code that means nothing failed, and the only one worth special-casing. A main frame that aborts still logs, whatever the code: that is the view the user is looking at going blank, which is the case #824 added these for. Every non-abort subframe failure still logs too. `did-fail-provisional-load` alongside it is left alone; no line from it turned up in the pass. The decision lives in its own module because `web-contents.ts` imports `electron`, `@/ipc` and `@/context-menu`, so testing the guard in place would have meant mocking four modules — which no test in this package does, and which leaks across a shared test process.
- The clamp warning is gated on a `Set` of names already warned about, living as long as the facade's namespace and so as long as the extension context. Chrome warns per call, and the doc comment says this is a deliberate departure — the second warning tells the extension nothing the first did not, while the log is what the difference is for.

## Try it
Nothing to open: the app is what runs it, and the three lines only appear with 1Password installed on a real machine. `bun test packages/electron-extensions packages/app` covers all three seams — `serializeErrorDetails` in `packages/app/lib/log-details.test.ts`, `isLoadFailureWorthLogging` in `packages/app/lib/load-failures.test.ts`, and warn-once in `packages/electron-extensions/facade/api/alarms.test.ts`.

## Not verified
- None of the three was observed fixed in a packaged log; all three were read off the log from the manual pass and fixed at the source, with the before line quoted above and the after line derived rather than captured. The next run of section 1 of the manual pass is what confirms them.

