### PR TITLE
Run the one extension worker on the default session

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -360,6 +360,20 @@ export const config = new Store<Config>({
         // @ts-expect-error
         store.delete("verificationCodes.confidence");
       }
+
+      /*
+       * The one extension worker moved to the default session in 3.60.0, so
+       * every account partition of a profile written before it holds a worker
+       * store nothing reads any more — a stale `chrome.storage` and, since only
+       * `chrome.storage` is proxied, a stale IndexedDB that a popup opened in
+       * that account would read directly.
+       *
+       * Scheduled rather than done here: a migration runs synchronously, at the
+       * store's construction, which is before `app.whenReady()` — there is no
+       * session to clear yet and no way to await one. `init` performs it and
+       * puts the flag back.
+       */
+      store.set("extensions.clearStaleAccountData", true);
     },
   },
 });

--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -151,6 +151,25 @@ function getContentScriptMatches(extensionId: string) {
     ?.contentScriptMatches;
 }
 
+/**
+ * Meru's own pages in the worker session, as match patterns, for the loader to
+ * warn about an extension whose content scripts reach them. The renderer and
+ * the popups beside it are all one origin, which `loadRenderer` decides: a
+ * `file://` document in a packaged build, unmatchable while the loader grants
+ * no file access, and the dev server in development — which is where an
+ * unpacked `extensions/` folder is loaded from, so it is the one that can
+ * actually be reached. The port is left off because a match pattern ignores it.
+ */
+function getWorkerSessionPagePatterns() {
+  if (!is.dev) {
+    return ["file:///*"];
+  }
+
+  const { protocol, hostname } = new URL(process.env.MERU_RENDERER_URL || "http://localhost:3000/");
+
+  return [`${protocol}//${hostname}/*`];
+}
+
 // Extension contexts reach the main process over the bridge's custom scheme,
 // and Electron only takes scheme privileges while modules are still loading
 registerExtensionBridgeScheme();
@@ -175,6 +194,7 @@ export const extensions = new Extensions({
   // The worker lives in the default session, which no account owns, so an
   // account session is never the one holding it — see
   // `setupExtensionsWorkerSession` below.
+  workerSessionPagePatterns: getWorkerSessionPagePatterns(),
   sharedInstance: createSharedExtensionInstance({
     shimScriptPath: path.join(__dirname, "extensions-runtime-proxy-shim.js"),
     relayScriptPath: path.join(__dirname, "extensions-runtime-proxy-relay.js"),
@@ -303,13 +323,25 @@ export async function uninstallCuratedExtension(extensionId: string) {
    * deletes an extension's storage on uninstall too, with nothing further
    * asked.
    *
+   * Unloaded from the worker session first, because the delete has to land on
+   * a store nothing is writing: the copy otherwise stays loaded until the
+   * restart the settings page asks for, and a worker still running writes part
+   * of its store back behind the delete — into the directory a reinstall under
+   * the same id reads, so the reinstall comes back signed in, which is the one
+   * outcome this call exists to prevent. On Windows it is worse than a race,
+   * the delete failing outright against LevelDB files Chromium still holds
+   * open.
+   *
+   * The accounts' content-script-only copies are left where they are. They
+   * hold no store, and unloading them would only take away the content scripts
+   * of documents already open, which the restart does anyway.
+   *
    * It clears every extension's store in that session rather than this one's,
    * which is exact while the catalog holds a single entry and is why a second
-   * curated extension needs a per-id clear before it lands. The extension also
-   * stays loaded until the restart the settings page asks for, so a worker
-   * still running can write part of its store back; what it writes is orphaned
-   * at the next launch, where the extension is not loaded at all.
+   * curated extension needs a per-id clear before it lands.
    */
+  extensions.unloadExtension(session.defaultSession, extensionId);
+
   await extensions.clearSessionData(session.defaultSession);
 
   log.info("Uninstalled extension", { extensionId });

--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -153,21 +153,37 @@ function getContentScriptMatches(extensionId: string) {
 
 /**
  * Meru's own pages in the worker session, as match patterns, for the loader to
- * warn about an extension whose content scripts reach them. The renderer and
- * the popups beside it are all one origin, which `loadRenderer` decides: a
- * `file://` document in a packaged build, unmatchable while the loader grants
- * no file access, and the dev server in development — which is where an
- * unpacked `extensions/` folder is loaded from, so it is the one that can
- * actually be reached. The port is left off because a match pattern ignores it.
+ * warn about an extension whose content scripts reach them. The renderer, the
+ * bookmarks and downloads popups and the desktop-sources page are all one
+ * origin, which `loadRenderer` decides: a `file://` document in a packaged
+ * build, unmatchable while the loader grants no file access, and the dev
+ * server in development — which is where an unpacked `extensions/` folder is
+ * loaded from, so it is the one that can actually be reached.
+ *
+ * The port is left off because Chrome's grammar has no place for one: a
+ * pattern carrying a port is not a narrower pattern but an invalid one, which
+ * Chromium refuses as it loads the manifest.
+ *
+ * A `MERU_RENDERER_URL` that will not parse gives no patterns rather than
+ * throwing. It is read at module scope, where a throw would take the launch
+ * with it, and `loadRenderer` hands the same value to `loadUrl`, so a bad one
+ * is already a page that does not load — the warning going quiet is the
+ * smaller half of that.
  */
 function getWorkerSessionPagePatterns() {
   if (!is.dev) {
     return ["file:///*"];
   }
 
-  const { protocol, hostname } = new URL(process.env.MERU_RENDERER_URL || "http://localhost:3000/");
+  try {
+    const { protocol, hostname } = new URL(
+      process.env.MERU_RENDERER_URL || "http://localhost:3000/",
+    );
 
-  return [`${protocol}//${hostname}/*`];
+    return [`${protocol}//${hostname}/*`];
+  } catch {
+    return [];
+  }
 }
 
 // Extension contexts reach the main process over the bridge's custom scheme,
@@ -235,6 +251,43 @@ export function setupExtensionsWorkerSession() {
   extensions.setupSession(session.defaultSession).catch((error: unknown) => {
     log.error("Failed to set up extensions worker session", { error: serializeError(error) });
   });
+}
+
+/**
+ * Clears what the accounts' own partitions still hold from before the one
+ * worker moved to the default session, once, on the first launch after the
+ * upgrade. Each partition of such a profile keeps that account's own worker
+ * store — a `chrome.storage` nothing reads any more, and an IndexedDB that is
+ * worse than unread: only `chrome.storage` is proxied, so an extension page
+ * opened in that account reads its stale database directly where every other
+ * account reads an empty one.
+ *
+ * The 3.60.0 migration schedules this rather than doing it, running
+ * synchronously and before the app is ready. Runs before `accounts.init()`
+ * constructs any of these sessions, so nothing has the files open;
+ * `fromPartition` makes an empty session where the account has never run,
+ * which has nothing to clear and costs a directory that is not there.
+ *
+ * The flag goes back before the work rather than after it: a clear that throws
+ * is one directory the user can live with, where a flag left set would clear
+ * every account's extension storage on every launch from here on.
+ */
+export async function clearStaleAccountExtensionData() {
+  if (!config.get("extensions.clearStaleAccountData")) {
+    return;
+  }
+
+  config.set("extensions.clearStaleAccountData", false);
+
+  await Promise.all(
+    config
+      .get("accounts")
+      .map((account) =>
+        extensions.clearSessionData(session.fromPartition(`persist:${account.id}`)),
+      ),
+  );
+
+  log.info("Cleared stale account extension data");
 }
 
 /**
@@ -328,9 +381,13 @@ export async function uninstallCuratedExtension(extensionId: string) {
    * restart the settings page asks for, and a worker still running writes part
    * of its store back behind the delete — into the directory a reinstall under
    * the same id reads, so the reinstall comes back signed in, which is the one
-   * outcome this call exists to prevent. On Windows it is worse than a race,
-   * the delete failing outright against LevelDB files Chromium still holds
-   * open.
+   * outcome this call exists to prevent.
+   *
+   * How much of the Windows half it fixes is reasoned rather than measured:
+   * `removeExtension` terminates the worker asynchronously and says nothing
+   * about closing the LevelDB handle, so a delete failing against files
+   * Chromium still holds open stays possible there, which is what
+   * `clearSessionData` retries for.
    *
    * The accounts' content-script-only copies are left where they are. They
    * hold no store, and unloading them would only take away the content scripts

--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -15,7 +15,7 @@ import {
 import { curatedExtensions, isCuratedExtensionId } from "@meru/shared/extensions";
 import { ms } from "@meru/shared/ms";
 import type { ExtensionUpdateResult, InstalledExtensionState } from "@meru/shared/types";
-import { app } from "electron";
+import { app, session } from "electron";
 import { serializeError } from "serialize-error";
 import { config } from "@/config";
 import { log } from "@/lib/log";
@@ -161,21 +161,24 @@ export const extensions = new Extensions({
   derivedExtensionsDir: DERIVED_EXTENSIONS_DIR,
   strippedManifestKeys: getStrippedManifestKeys(),
   getContentScriptMatches,
-  // One shared extension instance across all account sessions — one 1Password
-  // sign-in instead of one per account, and one worker whatever the account
-  // count. It is how Meru runs extensions rather than something the user
-  // chooses: a per-account instance is the thing the feature exists to remove,
-  // so an off switch would only ever switch back to the worse sign-in and
-  // memory behavior, and `extensions.enabled` already turns extensions off
-  // entirely. Passed unconditionally rather than behind that master switch,
-  // which is read per session in `getExtensionDirs`: a session that loads no
-  // extension never adopts a role, so gating here would buy nothing and would
-  // read the switch once at launch, handing a full instance to any account
-  // added after extensions were turned on. Deleting this one option still
-  // removes the whole feature.
+  // One shared extension instance across every session — one 1Password sign-in
+  // instead of one per account, and one worker whatever the account count. It
+  // is how Meru runs extensions rather than something the user chooses: a
+  // per-account instance is the thing the feature exists to remove, so an off
+  // switch would only ever switch back to the worse sign-in and memory
+  // behavior, and `extensions.enabled` already turns extensions off entirely.
+  // Passed unconditionally rather than behind that master switch, which is read
+  // per session in `getExtensionDirs`: a session that loads no extension never
+  // adopts a role, so gating here would buy nothing and would read the switch
+  // once at launch. Deleting this one option still removes the whole feature.
+  //
+  // The worker lives in the default session, which no account owns, so an
+  // account session is never the one holding it — see
+  // `setupExtensionsWorkerSession` below.
   sharedInstance: createSharedExtensionInstance({
     shimScriptPath: path.join(__dirname, "extensions-runtime-proxy-shim.js"),
     relayScriptPath: path.join(__dirname, "extensions-runtime-proxy-relay.js"),
+    getWorkerSession: () => session.defaultSession,
   }),
   logger: {
     info: (message, details) => {
@@ -186,6 +189,33 @@ export const extensions = new Extensions({
     },
   },
 });
+
+/**
+ * Loads the extensions into the session the one worker runs in, which is
+ * Electron's default session: no account owns it, so removing an account is a
+ * non-event for the worker and the one 1Password sign-in outlives every
+ * removal, and every account session is content-script-only from its first
+ * load rather than whichever came first keeping the whole extension.
+ *
+ * Called before `accounts.init()` constructs any account session, and awaited
+ * by nothing: role adoption no longer turns on the order sessions are set up,
+ * so what starting first buys is only that the worker is loading while the
+ * accounts come up rather than after them. The load is reported the way an
+ * account's is, since a worker that failed to load must not take the launch
+ * with it — the accounts' copies are still there, reaching a worker that will
+ * not answer.
+ *
+ * The store the worker keeps lands in `userData` itself, that being what
+ * `getStoragePath()` answers for the default session where an account's
+ * answers `userData/Partitions/<accountId>` — every directory name
+ * `clearSessionData` already looks for, at a root that carries nothing else of
+ * the kind.
+ */
+export function setupExtensionsWorkerSession() {
+  extensions.setupSession(session.defaultSession).catch((error: unknown) => {
+    log.error("Failed to set up extensions worker session", { error: serializeError(error) });
+  });
+}
 
 /**
  * What is on disk, which config alone can't tell: an install carries a version,

--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -294,6 +294,24 @@ export async function uninstallCuratedExtension(extensionId: string) {
 
   await uninstallExtension({ installDir: INSTALL_DIR, extensionId });
 
+  /*
+   * And what the extension wrote, which lives in the default session with the
+   * worker. Removing an account used to clear that account's copy of the
+   * store, so uninstalling and then removing every account left nothing
+   * behind; with one store in a session no removal touches, nothing but a full
+   * app reset would reach it and a reinstall would come back signed in. Chrome
+   * deletes an extension's storage on uninstall too, with nothing further
+   * asked.
+   *
+   * It clears every extension's store in that session rather than this one's,
+   * which is exact while the catalog holds a single entry and is why a second
+   * curated extension needs a per-id clear before it lands. The extension also
+   * stays loaded until the restart the settings page asks for, so a worker
+   * still running can write part of its store back; what it writes is orphaned
+   * at the next launch, where the extension is not loaded at all.
+   */
+  await extensions.clearSessionData(session.defaultSession);
+
   log.info("Uninstalled extension", { extensionId });
 }
 

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -12,6 +12,7 @@ import {
   extensionUpdater,
   pruneDerivedExtensionCopies,
   pruneInstalledExtensionVersions,
+  setupExtensionsWorkerSession,
 } from "@/extensions";
 import { ipc } from "@/ipc";
 import { initLinuxWindowControls } from "@/lib/linux";
@@ -52,6 +53,13 @@ async function resetApp() {
       ]);
     }),
   );
+
+  // The one extension worker runs in the default session, so its
+  // `chrome.storage` and its IndexedDB are the only account data no account
+  // partition holds. Deliberately without a `clearStorageData()` beside it:
+  // the default session's storage path is `userData` itself, where that would
+  // reach far past the extensions
+  await extensions.clearSessionData(session.defaultSession);
 
   config.clear();
 
@@ -123,6 +131,10 @@ async function init() {
   await pruneInstalledExtensionVersions();
 
   await pruneDerivedExtensionCopies();
+
+  // Before the accounts, so the one worker is loading while their
+  // content-script-only copies come up rather than after them
+  setupExtensionsWorkerSession();
 
   accounts.init();
 

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -8,6 +8,7 @@ import { config } from "@/config";
 import { downloads } from "@/downloads";
 import { extensionActions } from "@/extension-actions";
 import {
+  clearStaleAccountExtensionData,
   extensions,
   extensionUpdater,
   pruneDerivedExtensionCopies,
@@ -131,6 +132,9 @@ async function init() {
   await pruneInstalledExtensionVersions();
 
   await pruneDerivedExtensionCopies();
+
+  // Before the accounts too, so no session of theirs holds the files open
+  await clearStaleAccountExtensionData();
 
   // Before the accounts, so the one worker is loading while their
   // content-script-only copies come up rather than after them

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -43,7 +43,6 @@ import { DoNotDisturb, doNotDisturb } from "./do-not-disturb";
 import { downloads } from "./downloads";
 import { extensionActions } from "./extension-actions";
 import {
-  extensions,
   extensionUpdater,
   getInstalledExtensions,
   installCuratedExtension,
@@ -89,20 +88,6 @@ class Ipc {
   renderer = new IpcEmitter<IpcRendererEvent>();
 
   init() {
-    // Removing the account whose session holds the one extension worker leaves
-    // the accounts left behind with content-script-only copies and nothing to
-    // reach, until a relaunch or until an account added later adopts the role.
-    // Offering the relaunch is the honest answer while the loader cannot hand
-    // the role to a surviving session; see the feature doc's "The worker
-    // session's removal".
-    extensions.onSharedInstanceWorkerLost(() => {
-      if (main.window.isDestroyed()) {
-        return;
-      }
-
-      ipc.renderer.send(main.window.webContents, "extensions.workerSessionLost");
-    });
-
     config.onDidAnyChange(() => {
       ipc.renderer.send(main.window.webContents, "config.configChanged", config.store);
 

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -182,10 +182,10 @@ async function derivePages(
  * key missing where the worker session finds one.
  *
  * Recomputed from the source manifest rather than read back off the worker
- * copy's directory: `deriveManifest` is pure, and the worker copy is derived by
- * whichever session adopted that role — a directory that may not exist yet when
- * this copy is derived, and does not exist at all on a launch where no session
- * has adopted it.
+ * copy's directory: `deriveManifest` is pure, and the worker copy belongs to
+ * the one session the embedder named — a directory that may not exist yet when
+ * this copy is derived, and does not exist at all on a launch where that
+ * session was never set up.
  *
  * Nothing has to invalidate it, since the shim script it rides in is rewritten
  * on every launch, below. Everything it is computed from — the source manifest,

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -3,7 +3,7 @@ import fs, { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os, { tmpdir } from "node:os";
 import path from "node:path";
 import type { ClearStorageDataOptions, Extension, Session } from "electron";
-import { getExtensionBridgeUrl } from "./bridge/protocol";
+import { EXTENSION_BRIDGE_SCHEME, getExtensionBridgeUrl } from "./bridge/protocol";
 import { Extensions } from "./extensions";
 import { NATIVE_MESSAGING_PATHS } from "./native-messaging/bridge-protocol";
 import { createSharedExtensionInstance } from "./runtime-proxy";
@@ -92,6 +92,8 @@ function createSession({
 
   const sessionEvents: string[] = [];
 
+  const beforeSendHeadersFilters: unknown[] = [];
+
   let requestHandler: ((request: GlobalRequest) => Promise<Response>) | undefined;
 
   const serviceWorkerConsoleListeners = new Set<
@@ -124,7 +126,9 @@ function createSession({
     },
     getStoragePath: () => storagePath,
     webRequest: {
-      onBeforeSendHeaders: () => undefined,
+      onBeforeSendHeaders: (filterOrListener: unknown) => {
+        beforeSendHeadersFilters.push(filterOrListener);
+      },
     },
     serviceWorkers: {
       on: (
@@ -147,6 +151,7 @@ function createSession({
     removedExtensionIds,
     handledSchemes,
     sessionEvents,
+    beforeSendHeadersFilters,
     serviceWorkerConsoleListeners,
     emitServiceWorkerConsole: (messageDetails: Record<string, unknown>) => {
       for (const listener of serviceWorkerConsoleListeners) {
@@ -811,13 +816,13 @@ describe("Extensions", () => {
   });
 });
 
-describe("the shared instance losing its worker session", () => {
+describe("the shared instance's worker session", () => {
   /*
    * The real `createSharedExtensionInstance`, so what is under test is the
    * answer it gives the loader rather than a fake agreeing with the loader.
    * Its scripts have to exist, because the derive copies them into every copy.
    */
-  async function createSharedInstance() {
+  async function createSharedInstance(workerSession: Session) {
     const shimScriptPath = path.join(workDir, "shim.js");
 
     const relayScriptPath = path.join(workDir, "relay.js");
@@ -826,145 +831,309 @@ describe("the shared instance losing its worker session", () => {
 
     await writeFile(relayScriptPath, "// relay\n");
 
-    return createSharedExtensionInstance({ shimScriptPath, relayScriptPath });
+    return createSharedExtensionInstance({
+      shimScriptPath,
+      relayScriptPath,
+      getWorkerSession: () => workerSession,
+    });
   }
 
   function createSharedExtensions(
     extensionDirs: ConstructorParameters<typeof Extensions>[0]["extensionDirs"],
     sharedInstance: ConstructorParameters<typeof Extensions>[0]["sharedInstance"],
+    logger?: ConstructorParameters<typeof Extensions>[0]["logger"],
   ) {
     return new Extensions({
       extensionDirs,
       facadeScriptPath,
       derivedExtensionsDir: path.join(workDir, "derived"),
       sharedInstance,
+      logger,
     });
   }
 
-  /** One extension id from both sessions, which is what a `manifest.key` buys. */
+  /**
+   * One extension id from every session, which is what a `manifest.key` buys,
+   * and the derived directory each session was handed — which is where the
+   * copy's own manifest is read from, rather than from anything the loader
+   * says about it.
+   */
   function createSharedSession() {
-    return createSession({
-      loadExtension: async (extensionDir: string) => createExtension("aaa", extensionDir),
+    const loadedDerivedDirs: string[] = [];
+
+    const created = createSession({
+      loadExtension: async (derivedDir: string) => {
+        loadedDerivedDirs.push(derivedDir);
+
+        return createExtension("aaa", derivedDir);
+      },
     });
+
+    return { ...created, loadedDerivedDirs };
   }
 
-  test("firing once when other sessions still hold the extension", async () => {
+  async function readDerivedManifest(derivedDir: string) {
+    return JSON.parse(await readFile(path.join(derivedDir, "manifest.json"), "utf8")) as {
+      background?: unknown;
+    };
+  }
+
+  /*
+   * The invariant the whole design rests on: the worker is the session the
+   * embedder named, so no other session ever carries a `background` key — not
+   * the one that came first, and not one set up long afterwards, which is what
+   * an account added while the app runs is.
+   */
+  test("every session but the named worker is content-script-only from its first load", async () => {
+    const workerSession = createSharedSession();
+
+    const firstAccountSession = createSharedSession();
+
     const extensions = createSharedExtensions(
       [await createExtensionDir("one")],
-      await createSharedInstance(),
+      await createSharedInstance(workerSession.session),
     );
 
-    let workerLostCount = 0;
+    // Set up before the worker's, the order that used to decide the role
+    await extensions.setupSession(firstAccountSession.session);
 
-    extensions.onSharedInstanceWorkerLost(() => {
-      workerLostCount += 1;
+    await extensions.setupSession(workerSession.session);
+
+    const lateAccountSession = createSharedSession();
+
+    await extensions.setupSession(lateAccountSession.session);
+
+    const [workerManifest, firstAccountManifest, lateAccountManifest] = await Promise.all(
+      [workerSession, firstAccountSession, lateAccountSession].map(async ({ loadedDerivedDirs }) =>
+        readDerivedManifest(loadedDerivedDirs[0] as string),
+      ),
+    );
+
+    expect(workerManifest?.background).toEqual({
+      service_worker: "chrome-facade-service-worker.js",
+      type: "module",
     });
 
-    const { session: workerSession } = createSharedSession();
+    expect(firstAccountManifest?.background).toBeUndefined();
 
-    const { session: shimSession } = createSharedSession();
-
-    await extensions.setupSession(workerSession);
-
-    await extensions.setupSession(shimSession);
-
-    extensions.teardownSession(workerSession);
-
-    expect(workerLostCount).toBe(1);
+    expect(lateAccountManifest?.background).toBeUndefined();
   });
 
-  test("staying silent when a content-script-only session goes", async () => {
+  /*
+   * The worker session is the embedder's own rather than an account's, so it
+   * is worth pinning that the loader treats it as an ordinary session: one
+   * bridge listener, no second one, and nothing extra because of the role.
+   */
+  test("the bridge attaches to the worker session exactly once, as to any other", async () => {
+    const workerSession = createSharedSession();
+
+    const accountSession = createSharedSession();
+
     const extensions = createSharedExtensions(
-      [await createExtensionDir("one")],
-      await createSharedInstance(),
+      [await createExtensionDir("one"), await createExtensionDir("two")],
+      await createSharedInstance(workerSession.session),
     );
 
-    let workerLostCount = 0;
+    await extensions.setupSession(workerSession.session);
 
-    extensions.onSharedInstanceWorkerLost(() => {
-      workerLostCount += 1;
-    });
+    await extensions.setupSession(accountSession.session);
 
-    const { session: workerSession } = createSharedSession();
+    // One filtered listener for the session, whatever it loaded into it, and
+    // the same one the accounts get
+    const bridgeFilter = [{ urls: [`${EXTENSION_BRIDGE_SCHEME}://*/*`] }];
 
-    const { session: shimSession } = createSharedSession();
+    expect(workerSession.beforeSendHeadersFilters).toEqual(bridgeFilter);
+
+    expect(accountSession.beforeSendHeadersFilters).toEqual(bridgeFilter);
+
+    expect(workerSession.handledSchemes).toEqual([EXTENSION_BRIDGE_SCHEME]);
+
+    expect(accountSession.handledSchemes).toEqual([EXTENSION_BRIDGE_SCHEME]);
+  });
+
+  /*
+   * Both roles derive from the one source, and each role's copy is derived
+   * once however many sessions ask for it: the memo is keyed by role and
+   * source, and the two copies land in directories of their own. What would
+   * otherwise happen is the two roles fighting over one directory, each
+   * rewriting what the other just wrote, on every launch.
+   */
+  test("each role derives one copy, shared by every session that plays it", async () => {
+    const workerSession = createSharedSession();
+
+    const firstAccountSession = createSharedSession();
+
+    const secondAccountSession = createSharedSession();
+
+    const extensions = createSharedExtensions(
+      [await createExtensionDir("one")],
+      await createSharedInstance(workerSession.session),
+    );
+
+    await extensions.setupSession(workerSession.session);
+
+    await extensions.setupSession(firstAccountSession.session);
+
+    await extensions.setupSession(secondAccountSession.session);
+
+    const [workerDir] = workerSession.loadedDerivedDirs;
+
+    const [firstAccountDir] = firstAccountSession.loadedDerivedDirs;
+
+    const [secondAccountDir] = secondAccountSession.loadedDerivedDirs;
+
+    expect(firstAccountDir).toBe(secondAccountDir as string);
+
+    expect(workerDir).not.toBe(firstAccountDir as string);
+  });
+
+  /*
+   * The worker session's storage path is not a partition of its own: Electron's
+   * default session answers `userData` itself, where an account's answers
+   * `userData/Partitions/<accountId>`. So the store lands at a root the app
+   * keeps its own files in, and what has to hold is that clearing it takes the
+   * extension directories and nothing else — which is also why the embedder's
+   * reset must not put a `clearStorageData()` next to this call.
+   */
+  test("clearing the worker session takes the extension data out of a userData root", async () => {
+    const userDataPath = await createPartitionDir([
+      "Local Extension Settings/aaa/000003.log",
+      "Sync Extension Settings/aaa/000003.log",
+      "Managed Extension Settings/aaa/000003.log",
+      "Extension Rules/000003.log",
+      "Extension Scripts/000003.log",
+      "Extension State/000003.log",
+      "IndexedDB/chrome-extension_aaa_0.indexeddb.leveldb/000003.log",
+      // Everything below is the app's own, at the root only the default session
+      // reports, and none of it is any extension's to clear
+      "config.json",
+      "logs/main.log",
+      "extensions/com.1password/8.11.0/manifest.json",
+      "derived-extensions/0123456789abcdef/manifest.json",
+      "Partitions/account-one/Cookies",
+    ]);
+
+    const { session: workerSession } = createSession({ storagePath: userDataPath });
+
+    const extensions = createSharedExtensions(
+      [await createExtensionDir("one")],
+      await createSharedInstance(workerSession),
+    );
 
     await extensions.setupSession(workerSession);
 
-    await extensions.setupSession(shimSession);
+    await extensions.clearSessionData(workerSession);
 
-    extensions.teardownSession(shimSession);
+    expect(await listPartitionDir(userDataPath)).toEqual([
+      "IndexedDB",
+      "Partitions",
+      path.join("Partitions", "account-one"),
+      path.join("Partitions", "account-one", "Cookies"),
+      "config.json",
+      "derived-extensions",
+      path.join("derived-extensions", "0123456789abcdef"),
+      path.join("derived-extensions", "0123456789abcdef", "manifest.json"),
+      "extensions",
+      path.join("extensions", "com.1password"),
+      path.join("extensions", "com.1password", "8.11.0"),
+      path.join("extensions", "com.1password", "8.11.0", "manifest.json"),
+      "logs",
+      path.join("logs", "main.log"),
+    ]);
 
-    expect(workerLostCount).toBe(0);
+    await fs.rm(userDataPath, { recursive: true, force: true });
+  });
+
+  test("tearing down an account session says nothing about the worker", async () => {
+    const loggedErrors: string[] = [];
+
+    const workerSession = createSharedSession();
+
+    const accountSession = createSharedSession();
+
+    const extensions = createSharedExtensions(
+      [await createExtensionDir("one")],
+      await createSharedInstance(workerSession.session),
+      {
+        info: () => undefined,
+        error: (message) => {
+          loggedErrors.push(message);
+        },
+      },
+    );
+
+    await extensions.setupSession(workerSession.session);
+
+    await extensions.setupSession(accountSession.session);
+
+    extensions.teardownSession(accountSession.session);
+
+    expect(loggedErrors).toEqual([]);
+
+    // And the worker is still the worker, so a session set up afterwards is
+    // still content-script-only
+    const lateAccountSession = createSharedSession();
+
+    await extensions.setupSession(lateAccountSession.session);
+
+    expect(
+      (await readDerivedManifest(lateAccountSession.loadedDerivedDirs[0] as string))?.background,
+    ).toBeUndefined();
+  });
+
+  /*
+   * On an embedder naming a session no user can remove this is shutdown, and
+   * the log is the proof: nothing in the app can reach it while the app runs,
+   * and a naming that ever broke would leave this line in the log rather than
+   * leaving the accounts silently unable to reach anything.
+   */
+  test("tearing down the worker session while others hold the extension is logged", async () => {
+    const loggedErrors: string[] = [];
+
+    const workerSession = createSharedSession();
+
+    const accountSession = createSharedSession();
+
+    const extensions = createSharedExtensions(
+      [await createExtensionDir("one")],
+      await createSharedInstance(workerSession.session),
+      {
+        info: () => undefined,
+        error: (message) => {
+          loggedErrors.push(message);
+        },
+      },
+    );
+
+    await extensions.setupSession(workerSession.session);
+
+    await extensions.setupSession(accountSession.session);
+
+    extensions.teardownSession(workerSession.session);
+
+    expect(loggedErrors).toEqual(["Shared extension instance lost its worker session"]);
   });
 
   test("staying silent when the worker session was the last one", async () => {
+    const loggedErrors: string[] = [];
+
+    const workerSession = createSharedSession();
+
     const extensions = createSharedExtensions(
       [await createExtensionDir("one")],
-      await createSharedInstance(),
+      await createSharedInstance(workerSession.session),
+      {
+        info: () => undefined,
+        error: (message) => {
+          loggedErrors.push(message);
+        },
+      },
     );
 
-    let workerLostCount = 0;
+    await extensions.setupSession(workerSession.session);
 
-    extensions.onSharedInstanceWorkerLost(() => {
-      workerLostCount += 1;
-    });
+    extensions.teardownSession(workerSession.session);
 
-    const { session: workerSession } = createSharedSession();
-
-    await extensions.setupSession(workerSession);
-
-    extensions.teardownSession(workerSession);
-
-    expect(workerLostCount).toBe(0);
-  });
-
-  test("an unsubscribed listener hears nothing", async () => {
-    const extensions = createSharedExtensions(
-      [await createExtensionDir("one")],
-      await createSharedInstance(),
-    );
-
-    let workerLostCount = 0;
-
-    const unsubscribe = extensions.onSharedInstanceWorkerLost(() => {
-      workerLostCount += 1;
-    });
-
-    unsubscribe();
-
-    const { session: workerSession } = createSharedSession();
-
-    const { session: shimSession } = createSharedSession();
-
-    await extensions.setupSession(workerSession);
-
-    await extensions.setupSession(shimSession);
-
-    extensions.teardownSession(workerSession);
-
-    expect(workerLostCount).toBe(0);
-  });
-
-  test("nothing fires without a shared instance, where every session runs its own", async () => {
-    const extensions = createExtensions([await createExtensionDir("one")]);
-
-    let workerLostCount = 0;
-
-    extensions.onSharedInstanceWorkerLost(() => {
-      workerLostCount += 1;
-    });
-
-    const { session: firstSession } = createSharedSession();
-
-    const { session: secondSession } = createSharedSession();
-
-    await extensions.setupSession(firstSession);
-
-    await extensions.setupSession(secondSession);
-
-    extensions.teardownSession(firstSession);
-
-    expect(workerLostCount).toBe(0);
+    expect(loggedErrors).toEqual([]);
   });
 });

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -24,6 +24,36 @@ afterEach(async () => {
   await rm(workDir, { recursive: true, force: true });
 });
 
+/**
+ * A `manifest.key`, because the clamp is looked up by the id the key derives —
+ * a keyless copy is never clamped, and is never curated either.
+ */
+const TEST_MANIFEST_KEY = "dGVzdC1rZXk=";
+
+async function createContentScriptExtensionDir(name: string, matches: string[]) {
+  const extensionDir = path.join(workDir, name);
+
+  await mkdir(extensionDir, { recursive: true });
+
+  await writeFile(
+    path.join(extensionDir, "manifest.json"),
+    JSON.stringify({
+      name,
+      version: "1.0.0",
+      manifest_version: 3,
+      key: TEST_MANIFEST_KEY,
+      background: { service_worker: "background.js", type: "module" },
+      content_scripts: [{ matches, js: ["content.js"] }],
+    }),
+  );
+
+  await writeFile(path.join(extensionDir, "background.js"), "// background\n");
+
+  await writeFile(path.join(extensionDir, "content.js"), "// content\n");
+
+  return extensionDir;
+}
+
 async function createExtensionDir(name: string, key?: string) {
   const extensionDir = path.join(workDir, name);
 
@@ -1040,6 +1070,232 @@ describe("the shared instance's worker session", () => {
       "logs",
       path.join("logs", "main.log"),
     ]);
+
+    await fs.rm(userDataPath, { recursive: true, force: true });
+  });
+
+  /*
+   * Uninstalling has to delete a store nothing is writing, so the app unloads
+   * the extension from the worker session before it clears. What the loader
+   * owns is the unload; the app sequences the two, which is the half no test
+   * here reaches.
+   */
+  /*
+   * The warning exists for an unpacked folder a developer loaded themselves,
+   * whose content scripts the catalog clamp says nothing about. It is asked of
+   * the loaded manifest's own patterns against the embedder's pages, so an
+   * extension aimed anywhere else stays silent — which is what keeps it from
+   * being a line in every launch's log rather than a thing that happened.
+   */
+  async function setUpWorkerSessionWith(
+    extensionDir: string,
+    options: {
+      workerSessionPagePatterns?: string[];
+      getContentScriptMatches?: (extensionId: string) => string[] | undefined;
+    } = {},
+  ) {
+    const loggedErrors: { message: string; details?: Record<string, unknown> }[] = [];
+
+    // Chromium hands back the manifest of the copy it loaded, which is the
+    // derived one — the clamp already written into it, which is what makes the
+    // clamped cases below mean anything
+    const workerSession = createSession({
+      loadExtension: async (derivedDir: string) =>
+        createExtension(
+          "aaa",
+          derivedDir,
+          JSON.parse(await readFile(path.join(derivedDir, "manifest.json"), "utf8")),
+        ),
+    });
+
+    const extensions = new Extensions({
+      extensionDirs: [extensionDir],
+      facadeScriptPath,
+      derivedExtensionsDir: path.join(workDir, "derived"),
+      sharedInstance: await createSharedInstance(workerSession.session),
+      workerSessionPagePatterns: ["http://localhost/*"],
+      ...options,
+      logger: {
+        info: () => undefined,
+        error: (message, details) => {
+          loggedErrors.push({ message, details });
+        },
+      },
+    });
+
+    await extensions.setupSession(workerSession.session);
+
+    return loggedErrors;
+  }
+
+  const APP_PAGE_WARNING = "Extension content scripts run in the app's own pages";
+
+  test("an unclamped extension reaching the app's own pages is named in the log", async () => {
+    const loggedErrors = await setUpWorkerSessionWith(
+      await createContentScriptExtensionDir("dev-folder", [
+        "http://localhost/*",
+        "https://x.test/*",
+      ]),
+    );
+
+    expect(loggedErrors).toHaveLength(1);
+
+    expect(loggedErrors[0]?.message).toBe(APP_PAGE_WARNING);
+
+    // Only the patterns that reach them, so the line says which
+    expect(loggedErrors[0]?.details?.matches).toEqual(["http://localhost/*"]);
+  });
+
+  test("`<all_urls>` reaches them too, a packaged `file://` page included", async () => {
+    const loggedErrors = await setUpWorkerSessionWith(
+      await createContentScriptExtensionDir("everywhere", ["<all_urls>"]),
+      { workerSessionPagePatterns: ["file:///*"] },
+    );
+
+    expect(loggedErrors.map(({ message }) => message)).toEqual([APP_PAGE_WARNING]);
+  });
+
+  /*
+   * The checked-in fixture's shape, and the reason this is a pattern check
+   * rather than a check on whether the extension was clamped: it is unclamped
+   * and it loads on every development launch, so a warning that could not tell
+   * its loopback pages from the app's own would be a permanent line in the log.
+   */
+  test("an unclamped extension aimed somewhere else says nothing", async () => {
+    const loggedErrors = await setUpWorkerSessionWith(
+      await createContentScriptExtensionDir("fixture", ["http://127.0.0.1/*"]),
+    );
+
+    expect(loggedErrors).toEqual([]);
+  });
+
+  test("a curated clamp that keeps the app's pages out says nothing", async () => {
+    const loggedErrors = await setUpWorkerSessionWith(
+      await createContentScriptExtensionDir("curated", ["<all_urls>"]),
+      { getContentScriptMatches: () => ["https://accounts.google.com/*"] },
+    );
+
+    expect(loggedErrors).toEqual([]);
+  });
+
+  test("a clamp that drops every entry says nothing", async () => {
+    const loggedErrors = await setUpWorkerSessionWith(
+      await createContentScriptExtensionDir("clamped-away", ["https://x.test/*"]),
+      { getContentScriptMatches: () => [] },
+    );
+
+    expect(loggedErrors).toEqual([]);
+  });
+
+  test("an extension with no content scripts says nothing", async () => {
+    const loggedErrors = await setUpWorkerSessionWith(await createExtensionDir("worker-only"));
+
+    expect(loggedErrors).toEqual([]);
+  });
+
+  test("unloading one extension leaves the session and its other extensions alone", async () => {
+    // The derived directory is a hash of its source, so the copies are told
+    // apart by the order they load in rather than by name
+    const loadedExtensionIds = ["aaa", "bbb"];
+
+    const workerSession = createSession({
+      loadExtension: async (derivedDir: string) =>
+        createExtension(loadedExtensionIds.shift() as string, derivedDir),
+    });
+
+    const extensions = createSharedExtensions(
+      [await createExtensionDir("one"), await createExtensionDir("two")],
+      await createSharedInstance(workerSession.session),
+    );
+
+    await extensions.setupSession(workerSession.session);
+
+    expect(extensions.isExtensionLoaded(workerSession.session, "aaa")).toBe(true);
+    expect(extensions.isExtensionLoaded(workerSession.session, "bbb")).toBe(true);
+
+    extensions.unloadExtension(workerSession.session, "aaa");
+
+    expect(workerSession.removedExtensionIds).toEqual(["aaa"]);
+
+    expect(extensions.isExtensionLoaded(workerSession.session, "aaa")).toBe(false);
+
+    // The other extension keeps running, and the session keeps its bridge
+    expect(extensions.isExtensionLoaded(workerSession.session, "bbb")).toBe(true);
+
+    expect(workerSession.handledSchemes).toEqual([EXTENSION_BRIDGE_SCHEME]);
+  });
+
+  test("unloading drops the extension's toolbar button and says the actions changed", async () => {
+    const workerSession = createSession({
+      loadExtension: (derivedDir: string) => createActionExtension("aaa", derivedDir),
+    });
+
+    const extensions = createSharedExtensions(
+      [await createExtensionDir("one")],
+      await createSharedInstance(workerSession.session),
+    );
+
+    const actionsChanges: number[] = [];
+
+    extensions.onActionsChanged((_session, actions) => {
+      actionsChanges.push(actions.length);
+    });
+
+    await extensions.setupSession(workerSession.session);
+
+    expect(extensions.getSessionActions(workerSession.session)).toHaveLength(1);
+
+    extensions.unloadExtension(workerSession.session, "aaa");
+
+    expect(extensions.getSessionActions(workerSession.session)).toEqual([]);
+
+    expect(actionsChanges.at(-1)).toBe(0);
+  });
+
+  test("unloading an extension the session never loaded does nothing", async () => {
+    const workerSession = createSharedSession();
+
+    const extensions = createSharedExtensions(
+      [await createExtensionDir("one")],
+      await createSharedInstance(workerSession.session),
+    );
+
+    await extensions.setupSession(workerSession.session);
+
+    extensions.unloadExtension(workerSession.session, "never-loaded");
+
+    expect(workerSession.removedExtensionIds).toEqual([]);
+
+    expect(extensions.isExtensionLoaded(workerSession.session, "aaa")).toBe(true);
+  });
+
+  // The uninstall sequence, in the order the app runs it: nothing is left
+  // running over the store by the time the directories go
+  test("unloading and then clearing leaves the extension gone and its store with it", async () => {
+    const userDataPath = await createPartitionDir([
+      "Local Extension Settings/aaa/000003.log",
+      "IndexedDB/chrome-extension_aaa_0.indexeddb.leveldb/000003.log",
+      "config.json",
+    ]);
+
+    const { session: workerSession, removedExtensionIds } = createSession({
+      storagePath: userDataPath,
+    });
+
+    const extensions = createSharedExtensions(
+      [await createExtensionDir("one")],
+      await createSharedInstance(workerSession),
+    );
+
+    await extensions.setupSession(workerSession);
+
+    extensions.unloadExtension(workerSession, "aaa");
+
+    expect(removedExtensionIds).toEqual(["aaa"]);
+
+    await extensions.clearSessionData(workerSession);
+
+    expect(await listPartitionDir(userDataPath)).toEqual(["IndexedDB", "config.json"]);
 
     await fs.rm(userDataPath, { recursive: true, force: true });
   });

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -1300,6 +1300,69 @@ describe("the shared instance's worker session", () => {
     await fs.rm(userDataPath, { recursive: true, force: true });
   });
 
+  /*
+   * The upgrade cleanup, at the loader level: a profile written before the
+   * worker moved keeps one worker store per account partition, and the launch
+   * after the upgrade clears each of them. What the app adds on top is the
+   * config flag and the loop; this is the part with anything to get wrong —
+   * that each partition loses its own extension data and nothing else at the
+   * root loses anything.
+   */
+  test("clearing every account partition takes each one's extension data and no more", async () => {
+    const userDataPath = await createPartitionDir([
+      "Partitions/account-one/Local Extension Settings/aaa/000003.log",
+      "Partitions/account-one/IndexedDB/chrome-extension_aaa_0.indexeddb.leveldb/000003.log",
+      "Partitions/account-one/Cookies",
+      "Partitions/account-two/Local Extension Settings/aaa/000003.log",
+      "Partitions/account-two/IndexedDB/chrome-extension_aaa_0.indexeddb.leveldb/000003.log",
+      "Partitions/account-two/IndexedDB/https_mail.google.com_0.indexeddb.leveldb/000003.log",
+      // The worker's own store, at the root the default session reports, which
+      // this cleanup has no business touching
+      "Local Extension Settings/aaa/000003.log",
+      "config.json",
+    ]);
+
+    const extensions = createSharedExtensions([], undefined);
+
+    await Promise.all(
+      ["account-one", "account-two"].map((accountId) =>
+        extensions.clearSessionData(
+          createSession({ storagePath: path.join(userDataPath, "Partitions", accountId) }).session,
+        ),
+      ),
+    );
+
+    expect(await listPartitionDir(userDataPath)).toEqual([
+      "Local Extension Settings",
+      path.join("Local Extension Settings", "aaa"),
+      path.join("Local Extension Settings", "aaa", "000003.log"),
+      "Partitions",
+      path.join("Partitions", "account-one"),
+      path.join("Partitions", "account-one", "Cookies"),
+      // The container stays where its extension databases were the only ones,
+      // which is what clearing the databases rather than the directory means
+      path.join("Partitions", "account-one", "IndexedDB"),
+      path.join("Partitions", "account-two"),
+      path.join("Partitions", "account-two", "IndexedDB"),
+      path.join(
+        "Partitions",
+        "account-two",
+        "IndexedDB",
+        "https_mail.google.com_0.indexeddb.leveldb",
+      ),
+      path.join(
+        "Partitions",
+        "account-two",
+        "IndexedDB",
+        "https_mail.google.com_0.indexeddb.leveldb",
+        "000003.log",
+      ),
+      "config.json",
+    ]);
+
+    await fs.rm(userDataPath, { recursive: true, force: true });
+  });
+
   test("tearing down an account session says nothing about the worker", async () => {
     const loggedErrors: string[] = [];
 

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -10,6 +10,7 @@ import {
 import { Alarms, type AlarmWakePolicy } from "./alarms/alarms";
 import { ExtensionBridge } from "./bridge/bridge";
 import { deriveExtension, type SharedInstanceDeriveOptions } from "./derive";
+import { reachesClampedSite } from "./derive/match-pattern";
 import type { ExtensionsLogger } from "./logger";
 import {
   NativeMessaging,
@@ -65,9 +66,9 @@ export type SharedExtensionInstance = {
   /**
    * Whether that session was the one holding the worker, which the loader logs
    * as the sessions left behind having nothing to reach. On an embedder that
-   * names a session no user can remove it can only ever answer true at
-   * shutdown — and this staying here is what makes that provable rather than
-   * assumed, since a naming that ever broke would say so.
+   * names a session of its own and never tears it down, this answers false for
+   * the life of the app — and it staying here is what makes that provable
+   * rather than assumed, since a naming that ever broke would say so.
    */
   teardownSession(session: Session): boolean;
 };
@@ -118,6 +119,14 @@ export type ExtensionsOptions = {
    * session runs its own.
    */
   sharedInstance?: SharedExtensionInstance;
+  /**
+   * The embedder's own pages in the worker session, as match patterns. The
+   * worker session is the embedder's rather than a user's browsing, so an
+   * extension whose content scripts reach a page there is running inside the
+   * app's own UI, which is worth saying out loud. Without this nothing is
+   * checked and nothing is said.
+   */
+  workerSessionPagePatterns?: string[];
   logger?: ExtensionsLogger;
 };
 
@@ -144,6 +153,8 @@ export class Extensions {
   private getContentScriptMatches: ExtensionsOptions["getContentScriptMatches"];
 
   private sharedInstance: SharedExtensionInstance | undefined;
+
+  private workerSessionPagePatterns: string[] | undefined;
 
   private logger: ExtensionsLogger | undefined;
 
@@ -179,6 +190,7 @@ export class Extensions {
     isNativeMessagingHostAllowed,
     shouldWakeWorkerForAlarm,
     sharedInstance,
+    workerSessionPagePatterns,
     logger,
   }: ExtensionsOptions) {
     this.extensionDirs = extensionDirs;
@@ -192,6 +204,8 @@ export class Extensions {
     this.getContentScriptMatches = getContentScriptMatches;
 
     this.sharedInstance = sharedInstance;
+
+    this.workerSessionPagePatterns = workerSessionPagePatterns;
 
     this.logger = logger;
 
@@ -362,28 +376,32 @@ export class Extensions {
 
   /**
    * The worker session belongs to the embedder rather than to a user's
-   * browsing: whatever pages it holds are the app's own. A curated extension
-   * cannot reach them, its content scripts being clamped to a host allowlist,
-   * but an extension the clamp says nothing about injects wherever its author
-   * declared — which for a development folder can be the embedder's own UI.
+   * browsing: whatever pages it holds are the app's own. So an extension whose
+   * content scripts reach one of them is running inside the app's own UI,
+   * which is worth saying out loud once — a curated extension cannot, its
+   * content scripts being clamped to a host allowlist, but an extension the
+   * clamp says nothing about injects wherever its author declared.
    *
-   * Meru's is one page and one page only, the main window's renderer: a
-   * `file://` document in a packaged build, unmatchable by any pattern while
-   * the loader grants no file access, but the dev server over
-   * `http://localhost:3000` in development, which is exactly where an unpacked
-   * folder is loaded from. Naming both the extension and the session is the
-   * point — a content script running inside the app's own UI is otherwise
-   * invisible until it breaks something.
+   * Asked of the manifest Chromium loaded, which is the clamped one, so this
+   * needs no separate question about whether the extension was clamped: an
+   * entry that survived a clamp naming other hosts does not reach these pages,
+   * and the clamp dropping every entry leaves nothing to ask about.
+   *
+   * Meru's pages here are the main window's renderer, the bookmarks and
+   * downloads popups and the desktop-sources page, all one origin: a `file://`
+   * document in a packaged build, unmatchable by
+   * any pattern while the loader grants no file access, but the dev server
+   * over `http://localhost:3000` in development, which is exactly where an
+   * unpacked folder is loaded from. Checking the patterns rather than only the
+   * role is what keeps this quiet for a development extension aimed somewhere
+   * else — the checked-in fixture's loopback pages, say — so that the times it
+   * does fire mean something.
    */
   private warnAboutUnclampedWorkerContentScripts(
     extension: ContentScriptExtension,
     sharedInstanceDerive: SharedInstanceDeriveOptions | undefined,
   ) {
-    if (sharedInstanceDerive?.role !== "worker") {
-      return;
-    }
-
-    if (this.getContentScriptMatches?.(extension.id)) {
+    if (sharedInstanceDerive?.role !== "worker" || !this.workerSessionPagePatterns?.length) {
       return;
     }
 
@@ -391,14 +409,20 @@ export class Extensions {
       (contentScript) => contentScript.matches ?? [],
     );
 
-    if (!contentScriptMatches?.length) {
+    const reachingMatches = contentScriptMatches?.filter((contentScriptMatch) =>
+      this.workerSessionPagePatterns?.some((pagePattern) =>
+        reachesClampedSite(contentScriptMatch, pagePattern),
+      ),
+    );
+
+    if (!reachingMatches?.length) {
       return;
     }
 
-    this.logger?.error("Unclamped extension content scripts run in the worker session", {
+    this.logger?.error("Extension content scripts run in the app's own pages", {
       id: extension.id,
       name: extension.name,
-      matches: contentScriptMatches,
+      matches: reachingMatches,
     });
   }
 
@@ -516,9 +540,9 @@ export class Extensions {
 
     // This session is already out of `loadedExtensionIdsBySession`, so what is
     // left in it is the sessions that keep their content-script-only copies.
-    // An embedder naming a session of its own — one no user can remove — never
-    // reaches this branch outside shutdown, and the log is what would say so if
-    // that ever stopped being true
+    // An embedder naming a session of its own and never tearing it down never
+    // reaches this branch at all, and the log is what would say so if that ever
+    // stopped being true
     const workerRoleWasVacated = this.sharedInstance?.teardownSession(session) === true;
 
     if (workerRoleWasVacated && this.loadedExtensionIdsBySession.size > 0) {
@@ -540,6 +564,36 @@ export class Extensions {
 
       this.logger?.info("Unloaded extension", { id: extensionId });
     }
+
+    this.emitActionsChanged(session);
+  }
+
+  /**
+   * Unloads one extension from one session, leaving the rest of the session's
+   * extensions and the session's own setup alone — what `teardownSession` does
+   * to all of them at once, for one.
+   *
+   * It exists for uninstalling: the extension has to stop running before what
+   * it wrote can be deleted, or a worker still live rewrites part of the store
+   * behind the delete, and on Windows the delete fails outright against the
+   * LevelDB files Chromium still holds open.
+   */
+  unloadExtension(session: Session, extensionId: string) {
+    if (!this.loadedExtensionIdsBySession.get(session)?.delete(extensionId)) {
+      return;
+    }
+
+    session.extensions.removeExtension(extensionId);
+
+    const actions = this.actionsBySession.get(session);
+
+    const actionIndex = actions?.findIndex((action) => action.extensionId === extensionId) ?? -1;
+
+    if (actions && actionIndex !== -1) {
+      actions.splice(actionIndex, 1);
+    }
+
+    this.logger?.info("Unloaded extension", { id: extensionId });
 
     this.emitActionsChanged(session);
   }

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -39,7 +39,12 @@ const CONSOLE_ERROR_LEVEL = 3;
 
 export type ActionsChangedListener = (session: Session, actions: ExtensionAction[]) => void;
 
-export type SharedInstanceWorkerLostListener = () => void;
+/** As much of an Electron `Extension` as the unclamped content script warning reads. */
+type ContentScriptExtension = {
+  id: string;
+  name: string;
+  manifest: { content_scripts?: { matches?: string[] }[] };
+};
 
 export type ExtensionDirs = string[] | (() => Promise<string[]> | string[]);
 
@@ -58,9 +63,11 @@ export type SharedExtensionInstance = {
   /** Called per session before its extensions derive. */
   adoptSession(session: Session): SharedInstanceDeriveOptions;
   /**
-   * Whether that session was the one holding the worker, which is what the
-   * loader needs to tell an embedder that the sessions left behind have
-   * nothing to reach.
+   * Whether that session was the one holding the worker, which the loader logs
+   * as the sessions left behind having nothing to reach. On an embedder that
+   * names a session no user can remove it can only ever answer true at
+   * shutdown — and this staying here is what makes that provable rather than
+   * assumed, since a naming that ever broke would say so.
    */
   teardownSession(session: Session): boolean;
 };
@@ -137,8 +144,6 @@ export class Extensions {
   private getContentScriptMatches: ExtensionsOptions["getContentScriptMatches"];
 
   private sharedInstance: SharedExtensionInstance | undefined;
-
-  private sharedInstanceWorkerLostListeners = new Set<SharedInstanceWorkerLostListener>();
 
   private logger: ExtensionsLogger | undefined;
 
@@ -345,12 +350,56 @@ export class Extensions {
           version: extension.version,
           extensionDir,
         });
+
+        this.warnAboutUnclampedWorkerContentScripts(extension, sharedInstanceDerive);
       } catch (error) {
         this.logger?.error("Failed to load extension", { extensionDir, error });
       }
     }
 
     this.emitActionsChanged(session);
+  }
+
+  /**
+   * The worker session belongs to the embedder rather than to a user's
+   * browsing: whatever pages it holds are the app's own. A curated extension
+   * cannot reach them, its content scripts being clamped to a host allowlist,
+   * but an extension the clamp says nothing about injects wherever its author
+   * declared — which for a development folder can be the embedder's own UI.
+   *
+   * Meru's is one page and one page only, the main window's renderer: a
+   * `file://` document in a packaged build, unmatchable by any pattern while
+   * the loader grants no file access, but the dev server over
+   * `http://localhost:3000` in development, which is exactly where an unpacked
+   * folder is loaded from. Naming both the extension and the session is the
+   * point — a content script running inside the app's own UI is otherwise
+   * invisible until it breaks something.
+   */
+  private warnAboutUnclampedWorkerContentScripts(
+    extension: ContentScriptExtension,
+    sharedInstanceDerive: SharedInstanceDeriveOptions | undefined,
+  ) {
+    if (sharedInstanceDerive?.role !== "worker") {
+      return;
+    }
+
+    if (this.getContentScriptMatches?.(extension.id)) {
+      return;
+    }
+
+    const contentScriptMatches = extension.manifest.content_scripts?.flatMap(
+      (contentScript) => contentScript.matches ?? [],
+    );
+
+    if (!contentScriptMatches?.length) {
+      return;
+    }
+
+    this.logger?.error("Unclamped extension content scripts run in the worker session", {
+      id: extension.id,
+      name: extension.name,
+      matches: contentScriptMatches,
+    });
   }
 
   /**
@@ -466,15 +515,16 @@ export class Extensions {
     this.alarms.teardownSession(session);
 
     // This session is already out of `loadedExtensionIdsBySession`, so what is
-    // left in it is the sessions that keep their content-script-only copies
+    // left in it is the sessions that keep their content-script-only copies.
+    // An embedder naming a session of its own — one no user can remove — never
+    // reaches this branch outside shutdown, and the log is what would say so if
+    // that ever stopped being true
     const workerRoleWasVacated = this.sharedInstance?.teardownSession(session) === true;
 
     if (workerRoleWasVacated && this.loadedExtensionIdsBySession.size > 0) {
-      this.logger?.info("Shared extension instance lost its worker session", {
+      this.logger?.error("Shared extension instance lost its worker session", {
         orphanedSessions: this.loadedExtensionIdsBySession.size,
       });
-
-      this.emitSharedInstanceWorkerLost();
     }
 
     const consoleListener = this.serviceWorkerConsoleListeners.get(session);
@@ -510,30 +560,6 @@ export class Extensions {
     return () => {
       this.actionsChangedListeners.delete(listener);
     };
-  }
-
-  /**
-   * Fires when the session holding the shared instance's worker is torn down
-   * while other sessions still have the extension loaded. Those sessions keep
-   * the content-script-only copies they were derived with, so their extensions
-   * have nothing to reach until the app restarts — or until a session set up
-   * later adopts the vacant role. An embedder that offers a relaunch is what
-   * stands between the user and a password manager that quietly stopped
-   * working. It does not fire when the torn-down session was the last one, as
-   * there is nothing left to be broken.
-   */
-  onSharedInstanceWorkerLost(listener: SharedInstanceWorkerLostListener) {
-    this.sharedInstanceWorkerLostListeners.add(listener);
-
-    return () => {
-      this.sharedInstanceWorkerLostListeners.delete(listener);
-    };
-  }
-
-  private emitSharedInstanceWorkerLost() {
-    for (const listener of this.sharedInstanceWorkerLostListeners) {
-      listener();
-    }
   }
 
   private emitActionsChanged(session: Session) {

--- a/packages/electron-extensions/fixture/fixture.test.ts
+++ b/packages/electron-extensions/fixture/fixture.test.ts
@@ -23,8 +23,14 @@ async function readManifest(): Promise<FixtureManifestFile> {
   return JSON.parse(await readFile(path.join(import.meta.dir, "manifest.json"), "utf8"));
 }
 
-/** The only pages the fixture may touch: a test's own loopback server. */
-const LOOPBACK_MATCHES = ["http://127.0.0.1/*", "http://localhost/*"];
+/**
+ * The only pages the fixture may touch: a test's own loopback server, which
+ * binds `127.0.0.1`. Deliberately not `http://localhost/*` as well — a match
+ * pattern ignores the port, so that one covers the dev server the renderer
+ * itself is served from in development, and the fixture now loads into the
+ * default session where that renderer lives.
+ */
+const LOOPBACK_MATCHES = ["http://127.0.0.1/*"];
 
 describe("the fixture manifest", () => {
   test("derives the pinned extension id from its key", async () => {
@@ -33,7 +39,7 @@ describe("the fixture manifest", () => {
     expect(getExtensionIdFromManifestKey(key)).toBe(FIXTURE_EXTENSION_ID);
   });
 
-  test("aims its content scripts at loopback pages and nowhere else", async () => {
+  test("aims its content scripts at the loopback address and nowhere else", async () => {
     const { content_scripts } = await readManifest();
 
     expect(content_scripts?.map((contentScript) => contentScript.matches)).toEqual([
@@ -41,7 +47,7 @@ describe("the fixture manifest", () => {
     ]);
   });
 
-  test("exposes its frame page to loopback pages and nowhere else", async () => {
+  test("exposes its frame page to the loopback address and nowhere else", async () => {
     const { web_accessible_resources } = await readManifest();
 
     expect(web_accessible_resources?.map((resource) => resource.matches)).toEqual([

--- a/packages/electron-extensions/fixture/manifest.json
+++ b/packages/electron-extensions/fixture/manifest.json
@@ -14,7 +14,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["http://127.0.0.1/*", "http://localhost/*"],
+      "matches": ["http://127.0.0.1/*"],
       "js": ["probe.js"],
       "run_at": "document_idle"
     }
@@ -22,7 +22,7 @@
   "web_accessible_resources": [
     {
       "resources": ["fixture-frame.html"],
-      "matches": ["http://127.0.0.1/*", "http://localhost/*"]
+      "matches": ["http://127.0.0.1/*"]
     }
   ]
 }

--- a/packages/electron-extensions/runtime-proxy/index.test.ts
+++ b/packages/electron-extensions/runtime-proxy/index.test.ts
@@ -2,76 +2,71 @@ import { describe, expect, test } from "bun:test";
 import type { Session } from "electron";
 import { createSharedExtensionInstance } from "./index";
 
+function createSession(label: string) {
+  return { label } as unknown as Session;
+}
+
 /**
  * Role adoption alone, which needs no Electron: `install` is what builds the
  * `RuntimeProxy`, and every method here guards on it, so a shared instance
  * that was never installed hands out roles and nothing else.
  */
-function createRoleAssigner() {
+function createRoleAssigner(workerSession: Session) {
   return createSharedExtensionInstance({
     shimScriptPath: "/shim.js",
     relayScriptPath: "/relay.js",
+    getWorkerSession: () => workerSession,
   });
 }
 
-function createSession(label: string) {
-  return { label } as unknown as Session;
-}
-
 describe("createSharedExtensionInstance role adoption", () => {
-  test("the first session set up keeps the worker and every later one is content-script-only", () => {
-    const sharedInstance = createRoleAssigner();
+  test("the session the embedder names keeps the worker, whenever it is set up", () => {
+    const workerSession = createSession("worker");
 
+    const sharedInstance = createRoleAssigner(workerSession);
+
+    // Set up after another session, which under the rule this replaced would
+    // have been the one keeping it
     expect(sharedInstance.adoptSession(createSession("first"))).toEqual({
+      role: "contentScriptOnly",
+      shimScriptPath: "/shim.js",
+    });
+
+    expect(sharedInstance.adoptSession(workerSession)).toEqual({
       role: "worker",
       relayScriptPath: "/relay.js",
     });
 
-    expect(sharedInstance.adoptSession(createSession("second"))).toEqual({
+    expect(sharedInstance.adoptSession(createSession("third"))).toEqual({
       role: "contentScriptOnly",
       shimScriptPath: "/shim.js",
     });
   });
 
   test("a session asked twice keeps the role it has", () => {
-    const sharedInstance = createRoleAssigner();
-
     const workerSession = createSession("worker");
+
+    const sharedInstance = createRoleAssigner(workerSession);
 
     expect(sharedInstance.adoptSession(workerSession).role).toBe("worker");
     expect(sharedInstance.adoptSession(workerSession).role).toBe("worker");
-  });
-
-  test("tearing down a content-script-only session leaves the worker where it is", () => {
-    const sharedInstance = createRoleAssigner();
-
-    const workerSession = createSession("worker");
-
-    sharedInstance.adoptSession(workerSession);
 
     const shimSession = createSession("shim");
 
-    sharedInstance.adoptSession(shimSession);
-
-    sharedInstance.teardownSession(shimSession);
-
-    expect(sharedInstance.adoptSession(createSession("third")).role).toBe("contentScriptOnly");
+    expect(sharedInstance.adoptSession(shimSession).role).toBe("contentScriptOnly");
+    expect(sharedInstance.adoptSession(shimSession).role).toBe("contentScriptOnly");
   });
 
   /*
-   * The behavior the feature doc records rather than one anybody wants: the
-   * surviving sessions keep the content-script-only copies they were derived
-   * with and have no worker to reach until a session set up later takes the
-   * role — an account added after the removal, or every account after a
-   * restart — because `adoptSession` is reached only from
-   * `Extensions.setupSession` and a session is set up once, when its account
-   * is constructed. What this pins is that the role is genuinely vacant
-   * afterwards, so the next session set up does pick it up.
+   * The point of the whole design: an account session going takes nothing with
+   * it, because it never held the worker in the first place. What the embedder
+   * names — Electron's default session — no account owns, so the one worker and
+   * the one sign-in outlive every removal.
    */
-  test("tearing down the worker session vacates the role for the next session set up", () => {
-    const sharedInstance = createRoleAssigner();
-
+  test("tearing down a content-script-only session leaves the worker where it is", () => {
     const workerSession = createSession("worker");
+
+    const sharedInstance = createRoleAssigner(workerSession);
 
     sharedInstance.adoptSession(workerSession);
 
@@ -79,8 +74,40 @@ describe("createSharedExtensionInstance role adoption", () => {
 
     sharedInstance.adoptSession(shimSession);
 
+    expect(sharedInstance.teardownSession(shimSession)).toBe(false);
+
+    expect(sharedInstance.adoptSession(workerSession).role).toBe("worker");
+  });
+
+  /*
+   * The worker session is the embedder's own, so this is shutdown rather than
+   * anything a user can do — and the answer is what the loader logs to say so
+   * if that ever stops being true.
+   */
+  test("tearing down the worker session answers that the role was vacated", () => {
+    const workerSession = createSession("worker");
+
+    const sharedInstance = createRoleAssigner(workerSession);
+
+    sharedInstance.adoptSession(workerSession);
+
+    expect(sharedInstance.teardownSession(workerSession)).toBe(true);
+
+    // And a session torn down before it ever adopted anything is not the worker
+    expect(sharedInstance.teardownSession(createSession("never-set-up"))).toBe(false);
+  });
+
+  test("a session set up after the worker's teardown does not inherit the role", () => {
+    const workerSession = createSession("worker");
+
+    const sharedInstance = createRoleAssigner(workerSession);
+
+    sharedInstance.adoptSession(workerSession);
+
     sharedInstance.teardownSession(workerSession);
 
-    expect(sharedInstance.adoptSession(createSession("added-later")).role).toBe("worker");
+    expect(sharedInstance.adoptSession(createSession("added-later")).role).toBe(
+      "contentScriptOnly",
+    );
   });
 });

--- a/packages/electron-extensions/runtime-proxy/index.ts
+++ b/packages/electron-extensions/runtime-proxy/index.ts
@@ -15,20 +15,31 @@ export type CreateSharedExtensionInstanceOptions = {
    * copy and imported by its service worker wrapper.
    */
   relayScriptPath: string;
+  /**
+   * The session the one worker runs in. It is the embedder's to name rather
+   * than the first session set up, so that no session can take the role by
+   * being constructed first and none can take it away by going: Meru names
+   * Electron's default session, which no account owns and which outlives every
+   * account removal.
+   *
+   * Asked for lazily, since a `Session` cannot be created before the app is
+   * ready and an embedder builds this at module scope.
+   */
+  getWorkerSession: () => Session;
   /** How a caller frame resolves to its hosting tab for sender reconstruction. */
   getWebContentsFromFrame?: GetWebContentsFromFrame;
 };
 
 /**
  * One shared extension instance serving every session, in place of one full
- * instance per session: the first session set up keeps the whole extension —
- * the one service worker, the one `chrome.storage` — and every later session
- * gets a content-script-only copy whose `chrome.runtime` messaging the
- * `RuntimeProxy` relays to that worker and back — from its content scripts and
- * from its extension pages, which is where a password manager keeps its unlock
- * UI. The prize is one sign-in to a password manager instead of one per
- * account; one worker at any session count instead of one per session comes
- * with it.
+ * instance per session: the session the embedder names as the worker's keeps
+ * the whole extension — the one service worker, the one `chrome.storage` — and
+ * every other session gets a content-script-only copy whose `chrome.runtime`
+ * messaging the `RuntimeProxy` relays to that worker and back — from its
+ * content scripts and from its extension pages, which is where a password
+ * manager keeps its unlock UI. The prize is one sign-in to a password manager
+ * instead of one per account; one worker at any session count instead of one
+ * per session comes with it.
  *
  * The whole feature hangs off the one `sharedInstance` option this creates a
  * value for. An embedder that never passes it runs exactly as before, and
@@ -41,6 +52,7 @@ export type CreateSharedExtensionInstanceOptions = {
 export function createSharedExtensionInstance({
   shimScriptPath,
   relayScriptPath,
+  getWorkerSession,
   getWebContentsFromFrame,
 }: CreateSharedExtensionInstanceOptions): SharedExtensionInstance {
   let proxy: RuntimeProxy | undefined;
@@ -55,25 +67,28 @@ export function createSharedExtensionInstance({
     },
 
     adoptSession(session) {
-      // The first session set up keeps the worker. Which session that is is
-      // deliberately not a setting: any one worker serves every session alike,
-      // and the first one exists whenever any session does.
-      if (!workerSession) {
+      // Which session plays the worker is settled before any of them is set
+      // up, so order decides nothing: a session either is the one the embedder
+      // named or is content-script-only, whether it came first or last.
+      if (session !== getWorkerSession()) {
+        return { role: "contentScriptOnly", shimScriptPath };
+      }
+
+      if (workerSession !== session) {
         workerSession = session;
 
         proxy?.setWorkerSession(session);
       }
 
-      return workerSession === session
-        ? { role: "worker", relayScriptPath }
-        : { role: "contentScriptOnly", shimScriptPath };
+      return { role: "worker", relayScriptPath };
     },
 
     teardownSession(session) {
-      // A torn-down worker session orphans the content-script-only sessions
-      // until the next session adopts the worker role — an account added after
-      // the removal, or a relaunch; the proxy answers them "receiving end does
-      // not exist" in between, which is why the loader passes this answer on
+      // On Meru's own naming this can only answer true at shutdown, the
+      // default session outliving every account: the loader passes the answer
+      // on so that a session tearing the worker out from under the others
+      // stays something an embedder can notice rather than something nothing
+      // reports
       const wasWorkerSession = session === workerSession;
 
       if (wasWorkerSession) {

--- a/packages/electron-extensions/runtime-proxy/index.ts
+++ b/packages/electron-extensions/runtime-proxy/index.ts
@@ -84,11 +84,12 @@ export function createSharedExtensionInstance({
     },
 
     teardownSession(session) {
-      // On Meru's own naming this can only answer true at shutdown, the
-      // default session outliving every account: the loader passes the answer
-      // on so that a session tearing the worker out from under the others
-      // stays something an embedder can notice rather than something nothing
-      // reports
+      // On Meru's own naming nothing ever calls this for the worker session at
+      // all — the default session is torn down by neither an account removal
+      // nor `before-quit` — so it answers false for the life of the app. The
+      // loader passes the answer on regardless, so that a session tearing the
+      // worker out from under the others stays something an embedder can
+      // notice rather than something nothing reports
       const wasWorkerSession = session === workerSession;
 
       if (wasWorkerSession) {

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
@@ -951,16 +951,43 @@ describe("RuntimeProxy", () => {
    * that should never open cost a wait rather than a wrong answer — a job that
    * arrives first waits for the adoption instead of being told the receiving
    * end does not exist.
+   *
+   * The waits are what make this reach the path it names. The enqueue has to
+   * land before the adoption, which the log line is the only signal for: a
+   * bridge request is answered across several awaits, so calling
+   * `adoptWorkerSession()` on the next line would set the session first and
+   * test the ordinary path instead. And the adoption has to be what drives the
+   * queue, which `startWorkerForScope` on the adopted session is the only
+   * observable for: a stream parked afterwards flushes the queue by itself, so
+   * every assertion below would pass with the driving removed.
    */
-  test("a job enqueued before the worker session is adopted waits for it", async () => {
-    const harness = createHarness({}, { adoptWorkerSession: false });
+  test("a job enqueued before the worker session is adopted is driven by the adoption", async () => {
+    const logs: string[] = [];
+
+    const harness = createHarness(
+      { logger: { info: (message) => logs.push(message), error: () => undefined } },
+      { adoptWorkerSession: false },
+    );
 
     const shimResponse = harness.sendShimMessage("early");
 
-    // Nothing to wake yet, and nothing failed either
+    await waitFor(
+      () => logs.some((message) => message.startsWith("No extension worker session yet")),
+      "the job to be queued with no worker session",
+    );
+
+    // Nothing was woken, and nothing was refused either
     expect(harness.workerSession.workerStarts).toEqual([]);
 
     harness.adoptWorkerSession();
+
+    // The adoption drives the queue: this is the wake the job was waiting for
+    await waitFor(
+      () => harness.workerSession.workerStarts.length === 1,
+      "the adopted session's wake",
+    );
+
+    expect(harness.workerSession.workerStarts).toEqual([EXTENSION_SCOPE]);
 
     const workerStream = await harness.openWorkerStream();
 
@@ -982,14 +1009,17 @@ describe("RuntimeProxy", () => {
     });
   });
 
-  // And the wait is bounded by the same timeout as every other: a session that
-  // never arrives answers what Chrome answers, one timeout later
-  test("a job enqueued before an adoption that never comes fails as a missing receiving end", async () => {
+  test("a job enqueued before an adoption that never comes fails one timeout later", async () => {
     const harness = createHarness({ wakeTimeoutMs: 20 }, { adoptWorkerSession: false });
+
+    const startedAt = Date.now();
 
     const shimResponse = await harness.sendShimMessage("nobody home");
 
     expect(await shimResponse.json()).toEqual({ status: "noListener" });
+
+    // The bounded wait, not the instant refusal this replaced
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(15);
   });
 
   test("a session adopted after the worker session went away is woken", async () => {

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
@@ -201,7 +201,15 @@ function createPage(shimSession: Session, contentsId = 7, url = PAGE_URL) {
   return { frame, contents };
 }
 
-function createHarness(proxyOptions: RuntimeProxyOptions = {}) {
+/**
+ * `adoptWorkerSession: false` builds the proxy without one, the way a launch
+ * looks between the routes being registered and the worker session being set
+ * up; `adoptWorkerSession()` on the harness is that setup.
+ */
+function createHarness(
+  proxyOptions: RuntimeProxyOptions = {},
+  { adoptWorkerSession = true }: { adoptWorkerSession?: boolean } = {},
+) {
   const workerSession = createFakeSession();
 
   const shimSession = createFakeSession();
@@ -232,7 +240,9 @@ function createHarness(proxyOptions: RuntimeProxyOptions = {}) {
 
   proxy.registerRoutes(bridge);
 
-  proxy.setWorkerSession(workerSession.session);
+  if (adoptWorkerSession) {
+    proxy.setWorkerSession(workerSession.session);
+  }
 
   /** Parks a worker job stream the way the relay client does, collecting jobs. */
   const openWorkerStream = async () => {
@@ -349,6 +359,9 @@ function createHarness(proxyOptions: RuntimeProxyOptions = {}) {
     replyToJob,
     sendShimMessage,
     connectShimPort,
+    adoptWorkerSession: () => {
+      proxy.setWorkerSession(workerSession.session);
+    },
   };
 }
 
@@ -928,6 +941,53 @@ describe("RuntimeProxy", () => {
     harness.proxy.teardownSession(harness.workerSession.session);
 
     const shimResponse = await harness.sendShimMessage("anyone?");
+
+    expect(await shimResponse.json()).toEqual({ status: "noListener" });
+  });
+
+  /*
+   * The launch window the embedder's ordering closes: the worker session is set
+   * up before any session that could message it. This is what makes a window
+   * that should never open cost a wait rather than a wrong answer — a job that
+   * arrives first waits for the adoption instead of being told the receiving
+   * end does not exist.
+   */
+  test("a job enqueued before the worker session is adopted waits for it", async () => {
+    const harness = createHarness({}, { adoptWorkerSession: false });
+
+    const shimResponse = harness.sendShimMessage("early");
+
+    // Nothing to wake yet, and nothing failed either
+    expect(harness.workerSession.workerStarts).toEqual([]);
+
+    harness.adoptWorkerSession();
+
+    const workerStream = await harness.openWorkerStream();
+
+    const [job] = await workerStream.waitForJobs(1);
+
+    if (job?.type !== "sendMessage") {
+      throw new Error("Expected a sendMessage job");
+    }
+
+    expect(job.message).toBe("early");
+
+    await harness.ackJob(job.jobId);
+
+    await harness.replyToJob(job.jobId, { status: "replied", reply: "late but here" });
+
+    expect(await (await shimResponse).json()).toEqual({
+      status: "replied",
+      reply: "late but here",
+    });
+  });
+
+  // And the wait is bounded by the same timeout as every other: a session that
+  // never arrives answers what Chrome answers, one timeout later
+  test("a job enqueued before an adoption that never comes fails as a missing receiving end", async () => {
+    const harness = createHarness({ wakeTimeoutMs: 20 }, { adoptWorkerSession: false });
+
+    const shimResponse = await harness.sendShimMessage("nobody home");
 
     expect(await shimResponse.json()).toEqual({ status: "noListener" });
   });

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
@@ -206,6 +206,14 @@ export class RuntimeProxy {
 
   private workerSession: Session | undefined;
 
+  /**
+   * Whether a worker session has ever been adopted, which is what tells the two
+   * ways of having none apart. Before the first adoption a job waits, because
+   * the session is coming; after a teardown it fails at once, because the
+   * worker genuinely went away and that is what Chrome would say.
+   */
+  private hasAdoptedWorkerSession = false;
+
   private removeWorkerSessionListener: (() => void) | undefined;
 
   /**
@@ -526,11 +534,20 @@ export class RuntimeProxy {
   /**
    * The session that keeps the workers. Its `running-status-changed` events are
    * what invalidate parked job streams, since nothing else says a worker died.
+   *
+   * Anything queued before this arrives is driven again here, which is the
+   * other half of `wakeWorker` waiting rather than refusing when it has no
+   * session: a wake armed without one has no `startWorkerForScope` behind it,
+   * so it is cleared before the queue is driven, or the real wake would return
+   * early against it and the jobs would wait out a timeout for a worker nobody
+   * asked to start.
    */
   setWorkerSession(session: Session) {
     this.removeWorkerSessionListener?.();
 
     this.workerSession = session;
+
+    this.hasAdoptedWorkerSession = true;
 
     const statusListener = (details: { versionId: number; runningStatus: string }) => {
       this.handleRunningStatusChanged(details.versionId, details.runningStatus);
@@ -543,6 +560,16 @@ export class RuntimeProxy {
 
       this.removeWorkerSessionListener = undefined;
     };
+
+    for (const extensionId of this.wakes.keys()) {
+      this.clearWake(extensionId);
+    }
+
+    for (const [extensionId, queue] of this.queuedJobs) {
+      if (queue.length > 0) {
+        this.ensureDelivery(extensionId);
+      }
+    }
   }
 
   teardownSession(session: Session) {
@@ -1018,12 +1045,6 @@ export class RuntimeProxy {
   }
 
   private enqueueJob(job: RelayJob) {
-    if (!this.workerSession) {
-      this.failJob(job, "noListener");
-
-      return;
-    }
-
     this.queue(job.extensionId).push(job);
 
     this.ensureDelivery(job.extensionId);
@@ -1101,6 +1122,16 @@ export class RuntimeProxy {
    * reconnected yet. Either way the queued jobs wait for a stream, bounded by
    * the wake timeout. The API is experimental on Electron 43, which is why the
    * tests pin its presence.
+   *
+   * With no worker session yet there is nothing to call it on, and the jobs
+   * wait out the same bounded timeout instead. That window is the launch one
+   * the embedder's ordering already closes — the worker session is set up
+   * before any session that could message it — so what this buys is that a
+   * window which should never open costs a wait rather than a wrong answer.
+   * `setWorkerSession` flushes the queue the way a parked stream does, and only
+   * the timer expiring answers "receiving end does not exist", which is the
+   * same shape the cold-launch race settled on for a registration that has not
+   * been stored yet.
    */
   private wakeWorker(extensionId: string) {
     if (this.wakes.has(extensionId)) {
@@ -1109,15 +1140,30 @@ export class RuntimeProxy {
 
     const workerSession = this.workerSession;
 
-    if (!workerSession) {
-      this.failQueuedJobs(extensionId, "noListener");
-
-      return;
-    }
-
     const wake: Wake = { timer: undefined };
 
     this.wakes.set(extensionId, wake);
+
+    if (!workerSession) {
+      // A worker session that went away is Chrome's missing receiving end and
+      // is answered as one; one that has not arrived yet is a window the
+      // embedder's ordering already closes, and the jobs wait it out
+      if (this.hasAdoptedWorkerSession) {
+        this.clearWake(extensionId);
+
+        this.failQueuedJobs(extensionId, "noListener");
+
+        return;
+      }
+
+      this.logger?.info("No extension worker session yet; waiting for one to be adopted", {
+        extensionId,
+      });
+
+      this.armWakeTimeout(extensionId, wake);
+
+      return;
+    }
 
     Promise.resolve()
       .then(() =>
@@ -1130,11 +1176,7 @@ export class RuntimeProxy {
           return;
         }
 
-        wake.timer = setTimeout(() => {
-          this.wakes.delete(extensionId);
-
-          this.failQueuedJobs(extensionId, "noListener");
-        }, this.wakeTimeoutMs);
+        this.armWakeTimeout(extensionId, wake);
       })
       .catch((error: unknown) => {
         if (this.wakes.get(extensionId) !== wake) {
@@ -1163,12 +1205,21 @@ export class RuntimeProxy {
           },
         );
 
-        wake.timer = setTimeout(() => {
-          this.wakes.delete(extensionId);
-
-          this.failQueuedJobs(extensionId, "noListener");
-        }, this.wakeTimeoutMs);
+        this.armWakeTimeout(extensionId, wake);
       });
+  }
+
+  /**
+   * How long a queued job waits for the stream a worker parks once it is
+   * running. Expiring is the one path that answers "receiving end does not
+   * exist" for a job that was queued rather than refused outright.
+   */
+  private armWakeTimeout(extensionId: string, wake: Wake) {
+    wake.timer = setTimeout(() => {
+      this.wakes.delete(extensionId);
+
+      this.failQueuedJobs(extensionId, "noListener");
+    }, this.wakeTimeoutMs);
   }
 
   private clearWake(extensionId: string) {

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
@@ -1124,14 +1124,22 @@ export class RuntimeProxy {
    * tests pin its presence.
    *
    * With no worker session yet there is nothing to call it on, and the jobs
-   * wait out the same bounded timeout instead. That window is the launch one
-   * the embedder's ordering already closes — the worker session is set up
-   * before any session that could message it — so what this buys is that a
-   * window which should never open costs a wait rather than a wrong answer.
-   * `setWorkerSession` flushes the queue the way a parked stream does, and only
-   * the timer expiring answers "receiving end does not exist", which is the
-   * same shape the cold-launch race settled on for a registration that has not
-   * been stored yet.
+   * wait out a bounded timeout instead. That window is the launch one the
+   * embedder's ordering already closes — the worker session is set up before
+   * any session that could message it — so what this buys is that a window
+   * which should never open costs a wait rather than a wrong answer.
+   * `setWorkerSession` drives the queue the way a parked stream does, and only
+   * a timer expiring answers "receiving end does not exist", which is the same
+   * shape the cold-launch race settled on for a registration that has not been
+   * stored yet. The worst case is two of these timeouts rather than one: this
+   * timer, and then the one armed after the adoption's own
+   * `startWorkerForScope`.
+   *
+   * Jobs only. A page stream parked in the same window is refused, since
+   * `isShimmedSession` is false for every session while there is no worker
+   * session to hold one against, and the context re-parks on its own backoff.
+   * The window is the same unreachable one, and closing that half would be a
+   * change to how streams are parked rather than to how jobs are queued.
    */
   private wakeWorker(extensionId: string) {
     if (this.wakes.has(extensionId)) {

--- a/packages/renderer/lib/ipc.ts
+++ b/packages/renderer/lib/ipc.ts
@@ -1,7 +1,6 @@
 import { ipc } from "@meru/shared/renderer/ipc";
 import { navigate } from "wouter/use-hash-location";
 import { playNotificationSound } from "./notifications";
-import { restartRequiredToast } from "./toast";
 
 ipc.renderer.on("navigate", (_event, to) => {
   navigate(to);
@@ -47,17 +46,4 @@ ipc.renderer.on("taskbar.setOverlayIcon", (_event, unreadCount) => {
 
 ipc.renderer.on("notifications.playSound", (_event, { sound, volume }) => {
   playNotificationSound({ sound, volume });
-});
-
-/*
- * The account that was just removed held the one extension instance every
- * account shared, so the accounts left behind have extensions that can no
- * longer reach it. A restart gives the instance to one of them. The message
- * names no extension because main knows the sessions rather than what the user
- * installed into them.
- */
-ipc.renderer.on("extensions.workerSessionLost", () => {
-  restartRequiredToast(
-    "Extensions stopped working in your other accounts. Restart Meru to load them again.",
-  );
 });

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -143,5 +143,6 @@ export function createDefaultConfig({
     "extensions.enabled": true,
     "extensions.installed": [],
     "extensions.showTitlebarButton": false,
+    "extensions.clearStaleAccountData": false,
   };
 }

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -307,7 +307,6 @@ export type IpcRendererEvent = {
   "tabs.changed": [accountsTabs: AccountTabsState[]];
   "bookmarks.changed": [bookmarks: BookmarkState[]];
   "extensions.actionsChanged": [actions: ExtensionActionState[]];
-  "extensions.workerSessionLost": [];
   "findInPage.activate": [];
   "findInPage.result": [result: { activeMatch: number; totalMatches: number }];
   "trial.daysLeftChanged": [daysLeft: number];

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -199,6 +199,13 @@ export type Config = {
   "extensions.enabled": boolean;
   "extensions.installed": string[];
   "extensions.showTitlebarButton": boolean;
+  /**
+   * A one-time cleanup the 3.60.0 migration schedules and the next launch
+   * performs: the extension stores the accounts' own partitions hold from
+   * before the one worker moved to the default session. A migration cannot do
+   * it itself, running before the app is ready and synchronously.
+   */
+  "extensions.clearStaleAccountData": boolean;
 };
 
 export type IpcMainEvents =

--- a/tests/extension-proxy.e2e.ts
+++ b/tests/extension-proxy.e2e.ts
@@ -304,19 +304,26 @@ test("only the default session holds the worker, and every account is content-sc
 });
 
 /*
- * The default session is the app's own, and the only page Meru puts in it is
- * the main window's renderer. A curated extension cannot reach that page, its
- * content scripts being clamped to a host allowlist, and in a packaged build
- * the renderer is a `file://` document no pattern matches without file access
- * the loader never grants. What this pins is the packaged shape: the fixture
- * is unclamped, so if the renderer were reachable at all it would be reachable
- * by this one.
+ * The default session is the app's own, and what Meru puts in it is the main
+ * window's renderer and the popups beside it, all one origin. A curated
+ * extension cannot reach that origin, its content scripts being clamped to a
+ * host allowlist; the fixture is unclamped, so it is the one that would if
+ * anything did.
+ *
+ * What makes it unreachable in a packaged build is the scheme: `loadRenderer`
+ * uses `loadFile` outside development, and the loader never asks for file
+ * access, so no pattern matches. That is what this asserts. Reading the probe
+ * attribute back as `null` would not say it — a context that injected and is
+ * still running its probes has not written the attribute yet either — so the
+ * absence is held to the scheme rather than to the absence of a result.
  */
-test("the main window's renderer runs no content script of the worker session's", async () => {
+test("the main window's renderer is a file:// page no content script can match", async () => {
   await waitForFixture(WORKER_SESSION);
 
-  // The attribute every probe context writes its results into, which is the
-  // only trace the fixture's content script leaves on a page
+  expect(meru.renderer.url()).toMatch(/^file:/);
+
+  // And nothing has written probe results into it, which is consistent with
+  // the above rather than proof of it
   expect(await meru.renderer.locator("html").getAttribute("data-meru-fixture-results")).toBeNull();
 });
 

--- a/tests/extension-proxy.e2e.ts
+++ b/tests/extension-proxy.e2e.ts
@@ -5,13 +5,13 @@
  * the desktop app and a display.
  *
  * The launch carries one extension flag: `MERU_EXTENSIONS_FIXTURE` puts the
- * bundled fixture into every account session of this packaged build. The
- * shared instance needs no flag, because it is how Meru runs extensions — the
- * first account's session keeps the fixture's service worker while the second
- * account's session gets the content-script-only copy whose `chrome.runtime`
- * messaging the proxy relays. Two accounts need Pro, which is why this file
- * launches through `useProApp` — and a file is entirely one entitlement or
- * the other, because `useApp` registers its hooks once at module scope.
+ * bundled fixture into every session of this packaged build. The shared
+ * instance needs no flag, because it is how Meru runs extensions — the default
+ * session keeps the fixture's service worker while every account session gets
+ * the content-script-only copy whose `chrome.runtime` messaging the proxy
+ * relays. Two accounts need Pro, which is why this file launches through
+ * `useProApp` — and a file is entirely one entitlement or the other, because
+ * `useApp` registers its hooks once at module scope.
  *
  * Every probe context — a popup, a content script, an embedded extension
  * frame — runs the same suite (`fixture/probes.ts`) and writes its results
@@ -48,18 +48,24 @@ function account(id: string, label: string, selected: boolean) {
 }
 
 /*
- * The first account's session is the one the shared instance hands the worker
- * role, because sessions adopt roles in the order they are set up and accounts
- * are constructed in config order. The tests do not take that on faith: the
- * copy each session got is asserted from its own manifest.
+ * The one worker runs in Electron's default session, which no account owns, so
+ * both accounts are content-script-only however they are ordered — and the
+ * second is the one that has to keep working after the first is removed, which
+ * is the whole point of the worker living where it does. `null` is how a probe
+ * asks for the default session, there being no partition name for it.
  */
-const WORKER_PARTITION = "persist:worker-account";
+const WORKER_SESSION = null;
 
-const SHIM_PARTITION = "persist:shim-account";
+const REMOVED_PARTITION = "persist:removed-account";
+
+const SURVIVING_PARTITION = "persist:surviving-account";
 
 const meru = useProApp(
   {
-    accounts: [account("worker-account", "Worker", true), account("shim-account", "Shim", false)],
+    accounts: [
+      account("removed-account", "Removed", true),
+      account("surviving-account", "Surviving", false),
+    ],
   },
   { env: { MERU_EXTENSIONS_FIXTURE: "1" } },
 );
@@ -116,35 +122,44 @@ test.afterAll(async () => {
 });
 
 /**
- * Waits until the app has loaded the fixture into the session, which happens
- * while the accounts come up. `fromPartition` returns the session the app
- * uses for that account, creating an empty one only until the app gets there
- * — either way the poll only reads.
+ * The fixture as one session loaded it, or `null` where it is not loaded at
+ * all. `fromPartition` returns the session the app uses for that account,
+ * creating an empty one only until the app gets there, and `null` names the
+ * default session, where the one worker lives — either way this only reads.
  */
-async function waitForFixture(partition: string) {
-  await expect
-    .poll(() =>
-      meru.app.evaluate(
-        ({ session }, { partition: partitionName, extensionId }) =>
-          session
-            .fromPartition(partitionName)
-            .extensions.getAllExtensions()
-            .some((extension) => extension.id === extensionId),
-        { partition, extensionId: FIXTURE_EXTENSION_ID },
-      ),
-    )
-    .toBe(true);
+async function readLoadedFixture(partition: string | null) {
+  return meru.app.evaluate(
+    ({ session }, { partition: partitionName, extensionId }) =>
+      (partitionName === null
+        ? session.defaultSession
+        : session.fromPartition(partitionName)
+      ).extensions
+        .getAllExtensions()
+        .find((extension) => extension.id === extensionId) ?? null,
+    { partition, extensionId: FIXTURE_EXTENSION_ID },
+  );
+}
+
+/**
+ * Waits until the app has loaded the fixture into the session, which happens
+ * as the app comes up: the default session before the accounts, and each
+ * account's while its `Account` is constructed.
+ */
+async function waitForFixture(partition: string | null) {
+  await expect.poll(async () => (await readLoadedFixture(partition)) !== null).toBe(true);
 }
 
 /** Opens a hidden window in the session and resolves to its WebContents id. */
-async function openProbeWindow(partition: string, url: string) {
+async function openProbeWindow(partition: string | null, url: string) {
   await waitForFixture(partition);
 
   return meru.app.evaluate(
     async ({ BrowserWindow }, { partition: partitionName, url: probeUrl }) => {
       const probeWindow = new BrowserWindow({
         show: false,
-        webPreferences: { partition: partitionName },
+        // Named partitions are the accounts'; without one the window runs in
+        // the default session, which is where the one worker is
+        webPreferences: partitionName === null ? {} : { partition: partitionName },
       });
 
       await probeWindow.loadURL(probeUrl);
@@ -257,20 +272,68 @@ function echoReply(
   };
 }
 
-test("both sessions' popups reach the one worker the first session keeps", async () => {
-  const workerPopupId = await openProbeWindow(WORKER_PARTITION, popupUrl("worker-popup"));
+/*
+ * The invariant the whole design rests on, read off the copies Chromium
+ * actually loaded rather than off anything the extension reports about itself:
+ * only the default session carries a `background` key, so no account holds the
+ * worker and removing one can never take it away. It comes first in the file
+ * because every test below is about a session that has to be shimmed.
+ */
+test("only the default session holds the worker, and every account is content-script-only", async () => {
+  await waitForFixture(WORKER_SESSION);
 
-  const shimPopupId = await openProbeWindow(SHIM_PARTITION, popupUrl("shim-popup"));
+  await waitForFixture(REMOVED_PARTITION);
+
+  await waitForFixture(SURVIVING_PARTITION);
+
+  const workerFixture = await readLoadedFixture(WORKER_SESSION);
+
+  expect(workerFixture?.manifest.background).toEqual({
+    service_worker: "chrome-facade-service-worker.js",
+  });
+
+  for (const partition of [REMOVED_PARTITION, SURVIVING_PARTITION]) {
+    const accountFixture = await readLoadedFixture(partition);
+
+    expect(accountFixture?.manifest.background).toBeUndefined();
+
+    // The same extension either way, which is what makes the relay able to
+    // match the two copies at all
+    expect(accountFixture?.id).toBe(FIXTURE_EXTENSION_ID);
+  }
+});
+
+/*
+ * The default session is the app's own, and the only page Meru puts in it is
+ * the main window's renderer. A curated extension cannot reach that page, its
+ * content scripts being clamped to a host allowlist, and in a packaged build
+ * the renderer is a `file://` document no pattern matches without file access
+ * the loader never grants. What this pins is the packaged shape: the fixture
+ * is unclamped, so if the renderer were reachable at all it would be reachable
+ * by this one.
+ */
+test("the main window's renderer runs no content script of the worker session's", async () => {
+  await waitForFixture(WORKER_SESSION);
+
+  // The attribute every probe context writes its results into, which is the
+  // only trace the fixture's content script leaves on a page
+  expect(await meru.renderer.locator("html").getAttribute("data-meru-fixture-results")).toBeNull();
+});
+
+test("both accounts' popups reach the one worker the default session keeps", async () => {
+  const workerPopupId = await openProbeWindow(WORKER_SESSION, popupUrl("worker-popup"));
+
+  const shimPopupId = await openProbeWindow(SURVIVING_PARTITION, popupUrl("shim-popup"));
 
   const workerPopup = await readProbeResults(workerPopupId);
 
   const shimPopup = await readProbeResults(shimPopupId);
 
-  // The two sessions load different copies — the worker session the whole
-  // extension, every other session one derived with no `background` at all —
+  // The two sessions load different copies — the default session the whole
+  // extension, every account session one derived with no `background` at all —
   // and `getManifest` is where that would otherwise show. The worker session's
-  // answer is native and therefore the ground truth; the shim session's is the
-  // shim's, and the two agreeing is the claim
+  // answer is native and therefore the ground truth; the account session's is
+  // the shim's, and the two agreeing is the claim
   expect(workerPopup.manifest).toMatchObject({
     background: { service_worker: "chrome-facade-service-worker.js" },
     // Chromium localized the manifest as it loaded the copy, which the derive
@@ -302,8 +365,8 @@ test("both sessions' popups reach the one worker the first session keeps", async
   expect(workerReply.workerInstanceId).toEqual(expect.any(String));
 
   /*
-   * The shim session's popup has no worker in its own session to answer — its
-   * copy carries none — so a reply at all is cross-session relay, and the
+   * The account session's popup has no worker in its own session to answer —
+   * its copy carries none — so a reply at all is cross-session relay, and the
    * matching `workerInstanceId` pins it to the same worker instance the
    * worker session's popup reached. The sender is the proxy's whole contract
    * for an extension page: URL and origin, and deliberately no tab.
@@ -325,11 +388,11 @@ test("content scripts inject into the shim session and round-trip, a strict page
 
   const cspPageUrl = `${serverOrigin}/csp`;
 
-  const plainPageId = await openProbeWindow(SHIM_PARTITION, plainPageUrl);
+  const plainPageId = await openProbeWindow(SURVIVING_PARTITION, plainPageUrl);
 
-  const cspPageId = await openProbeWindow(SHIM_PARTITION, cspPageUrl);
+  const cspPageId = await openProbeWindow(SURVIVING_PARTITION, cspPageUrl);
 
-  const workerPageId = await openProbeWindow(WORKER_PARTITION, plainPageUrl);
+  const workerPageId = await openProbeWindow(WORKER_SESSION, plainPageUrl);
 
   // The results existing at all is the injection claim: the only thing that
   // writes them into a loopback page is the fixture's content script, and the
@@ -372,7 +435,7 @@ test("content scripts inject into the shim session and round-trip, a strict page
 test("ports relay both ways and both ends observe a disconnect", async () => {
   const pageUrl = `${serverOrigin}/plain`;
 
-  const pageId = await openProbeWindow(SHIM_PARTITION, pageUrl);
+  const pageId = await openProbeWindow(SURVIVING_PARTITION, pageUrl);
 
   const page = await readProbeResults(pageId);
 
@@ -417,9 +480,9 @@ test("a page navigating away disconnects the port it left open", async () => {
    * an unload-time request on this scheme is dropped with the frame, measured
    * with this same case and the cancel handler compiled out.
    */
-  const observerPopupId = await openProbeWindow(WORKER_PARTITION, popupUrl("navigation-observer"));
+  const observerPopupId = await openProbeWindow(WORKER_SESSION, popupUrl("navigation-observer"));
 
-  const pageId = await openProbeWindow(SHIM_PARTITION, `${serverOrigin}/plain`);
+  const pageId = await openProbeWindow(SURVIVING_PARTITION, `${serverOrigin}/plain`);
 
   const page = await readProbeResults(pageId);
 
@@ -445,9 +508,9 @@ test("a message is attributed to the frame that sent it, an embedded extension f
    * must carry its own tab's id, not the other's. The WebContents ids the
    * windows were created with are what the proxy's tab ids are defined to be.
    */
-  const firstSameId = await openProbeWindow(SHIM_PARTITION, samePageUrl);
+  const firstSameId = await openProbeWindow(SURVIVING_PARTITION, samePageUrl);
 
-  const secondSameId = await openProbeWindow(SHIM_PARTITION, samePageUrl);
+  const secondSameId = await openProbeWindow(SURVIVING_PARTITION, samePageUrl);
 
   const firstSame = await readProbeResults(firstSameId);
 
@@ -482,7 +545,7 @@ test("a message is attributed to the frame that sent it, an embedded extension f
    */
   const frameHostUrl = `${serverOrigin}/frame`;
 
-  const frameHostId = await openProbeWindow(SHIM_PARTITION, frameHostUrl);
+  const frameHostId = await openProbeWindow(SURVIVING_PARTITION, frameHostUrl);
 
   const embeddedFrameUrl = `chrome-extension://${FIXTURE_EXTENSION_ID}/fixture-frame.html`;
 
@@ -510,7 +573,7 @@ test("a message is attributed to the frame that sent it, an embedded extension f
 test("the worker reaches a shimmed content script it never heard from first", async () => {
   const pageUrl = `${serverOrigin}/plain`;
 
-  const pageId = await openProbeWindow(SHIM_PARTITION, pageUrl);
+  const pageId = await openProbeWindow(SURVIVING_PARTITION, pageUrl);
 
   const page = await readProbeResults(pageId);
 
@@ -559,7 +622,7 @@ test("the worker reaches a shimmed content script it never heard from first", as
 });
 
 test("an action popup is no tab, and the worker says so rather than guessing", async () => {
-  const shimPopupId = await openProbeWindow(SHIM_PARTITION, popupUrl("shim-popup-no-tab"));
+  const shimPopupId = await openProbeWindow(SURVIVING_PARTITION, popupUrl("shim-popup-no-tab"));
 
   const shimPopup = await readProbeResults(shimPopupId);
 
@@ -575,11 +638,11 @@ test("an action popup is no tab, and the worker says so rather than guessing", a
 });
 
 test("storage is one store: the shim session's contexts read and write the worker's", async () => {
-  const workerPopupId = await openProbeWindow(WORKER_PARTITION, popupUrl("worker-storage"));
+  const workerPopupId = await openProbeWindow(WORKER_SESSION, popupUrl("worker-storage"));
 
-  const shimPopupId = await openProbeWindow(SHIM_PARTITION, popupUrl("shim-storage"));
+  const shimPopupId = await openProbeWindow(SURVIVING_PARTITION, popupUrl("shim-storage"));
 
-  const pageId = await openProbeWindow(SHIM_PARTITION, `${serverOrigin}/same`);
+  const pageId = await openProbeWindow(SURVIVING_PARTITION, `${serverOrigin}/same`);
 
   const workerPopup = await readProbeResults(workerPopupId);
 
@@ -618,11 +681,11 @@ test("storage is one store: the shim session's contexts read and write the worke
 });
 
 test("session storage keeps Chrome's access level across the proxy", async () => {
-  const shimPopupId = await openProbeWindow(SHIM_PARTITION, popupUrl("shim-session-storage"));
+  const shimPopupId = await openProbeWindow(SURVIVING_PARTITION, popupUrl("shim-session-storage"));
 
-  const workerPageId = await openProbeWindow(WORKER_PARTITION, `${serverOrigin}/plain`);
+  const workerPageId = await openProbeWindow(WORKER_SESSION, `${serverOrigin}/plain`);
 
-  const shimPageId = await openProbeWindow(SHIM_PARTITION, `${serverOrigin}/csp`);
+  const shimPageId = await openProbeWindow(SURVIVING_PARTITION, `${serverOrigin}/csp`);
 
   const shimPopup = await readProbeResults(shimPopupId);
 
@@ -674,17 +737,17 @@ test.skip("storage.onChanged fires in the shim session, for the worker's writes 
    * a source that cannot fire — see `probes.ts`.
    */
   const workerPopupId = await openProbeWindow(
-    WORKER_PARTITION,
+    WORKER_SESSION,
     popupUrl("worker-changes", { probeStorageChanges: true }),
   );
 
   const shimPopupId = await openProbeWindow(
-    SHIM_PARTITION,
+    SURVIVING_PARTITION,
     popupUrl("shim-changes", { probeStorageChanges: true }),
   );
 
   const pageId = await openProbeWindow(
-    SHIM_PARTITION,
+    SURVIVING_PARTITION,
     `${serverOrigin}/same?meruProbeStorageChanges=1`,
   );
 
@@ -750,30 +813,51 @@ test.skip("storage.onChanged fires in the shim session, for the worker's writes 
 });
 
 /*
- * Removing the account whose session holds the worker leaves the accounts left
- * behind with content-script-only copies and nothing to reach, until the app
- * restarts or an account added later adopts the vacant role. The app cannot
- * hand the role to a surviving session yet — see "The worker session's removal"
- * in the feature doc for why that is a design change — so what it owes the user
- * is the offer of a restart, and this is the whole chain that produces it: the
- * loader noticing, the main process telling the renderer, and the toast.
+ * What the worker living in the default session buys, and the reason for the
+ * whole change: removing an account is a non-event for every other account.
+ * Nothing about the removed session was load-bearing — it held a
+ * content-script-only copy like all the others — so the worker keeps running,
+ * the one 1Password sign-in it stands in for survives, and the accounts left
+ * behind go on reaching it.
+ *
+ * Last in the file, because it removes an account the tests above open windows
+ * in.
  */
-test("removing the worker account offers a restart to the accounts left behind", async () => {
-  await waitForFixture(WORKER_PARTITION);
+test("removing an account leaves the one worker, and its store, where it was", async () => {
+  await waitForFixture(WORKER_SESSION);
 
-  await waitForFixture(SHIM_PARTITION);
+  await waitForFixture(REMOVED_PARTITION);
+
+  await waitForFixture(SURVIVING_PARTITION);
+
+  /*
+   * The worker instance the surviving account reaches before the removal. The
+   * id is what tells a surviving worker from a new one: a worker that restarted
+   * would answer with an id of its own, and a session that adopted the role
+   * afterwards would have started signed out.
+   */
+  const beforePopupId = await openProbeWindow(SURVIVING_PARTITION, popupUrl("before-removal"));
+
+  const beforePopup = await readProbeResults(beforePopupId);
+
+  expect(beforePopup.echo.status).toBe("replied");
+
+  const { workerInstanceId } = (beforePopup.echo as { reply: { workerInstanceId: string } }).reply;
+
+  expect(workerInstanceId).toEqual(expect.any(String));
+
+  expect(beforePopup.workerStampInLocal.status).toBe("read");
+
+  const workerStamp = (beforePopup.workerStampInLocal as { value: unknown }).value;
+
+  expect(workerStamp).toEqual(expect.any(String));
 
   const navigation = await meru.openSettings();
 
   await openSettingsPage(meru, navigation, "Accounts");
 
-  /*
-   * The first row is the worker account, for the same reason the partition
-   * constants above say so: accounts are constructed in config order and roles
-   * are adopted in the order sessions are set up. Picking the wrong row fails
-   * this test rather than passing it quietly, because removing a shimmed
-   * session raises no toast at all.
-   */
+  // The first row is the account the partition constants name as the removed
+  // one: accounts are listed in config order
   await meru.renderer.getByRole("button", { name: "Remove account" }).first().click();
 
   await meru.renderer
@@ -781,7 +865,44 @@ test("removing the worker account offers a restart to the accounts left behind",
     .getByRole("button", { name: "Remove account" })
     .click();
 
-  await expect(
-    meru.renderer.getByText("Extensions stopped working in your other accounts."),
-  ).toBeVisible();
+  await expect.poll(async () => (await readLoadedFixture(REMOVED_PARTITION)) === null).toBe(true);
+
+  /*
+   * A context opened after the removal, rather than the one from before: what
+   * has to work is the whole path from a new document through the relay to the
+   * worker, which is what a password manager needs the next time a page asks
+   * it to fill something.
+   */
+  const afterPopupId = await openProbeWindow(SURVIVING_PARTITION, popupUrl("after-removal"));
+
+  const afterPopup = await readProbeResults(afterPopupId);
+
+  // The same worker instance, so nothing restarted and nothing was adopted
+  expect(afterPopup.echo).toEqual(
+    echoReply(afterPopup, workerInstanceId, {
+      url: popupUrl("after-removal"),
+      origin: `chrome-extension://${FIXTURE_EXTENSION_ID}`,
+      frameId: null,
+      hasTab: false,
+      tabId: null,
+      tabUrl: null,
+    }),
+  );
+
+  // And the one store is the one it was, which is what the sign-in lives in
+  expect(afterPopup.workerStampInLocal).toEqual({ status: "read", value: workerStamp });
+
+  expect(afterPopup.writeSeenByWorker).toEqual({
+    status: "read",
+    value: afterPopup.contextId,
+  });
+
+  // A content script of the surviving account too, the other side of the shim
+  const pageId = await openProbeWindow(SURVIVING_PARTITION, `${serverOrigin}/plain`);
+
+  const page = await readProbeResults(pageId);
+
+  expect(page.echo.status).toBe("replied");
+
+  expect(page.workerStampInLocal).toEqual({ status: "read", value: workerStamp });
 });


### PR DESCRIPTION
## Summary
Moves the shared extension instance's one worker off the first account's session and onto Electron's default session, which no account owns. Every account session is content-script-only from its first load, so removing an account is a non-event and the one 1Password sign-in survives it. The relaunch prompt from #1030 becomes unreachable and is deleted whole. One upgrade cost: a profile from before this signs 1Password out once, because the sign-in lived in the first account's partition.

## Problem
The shared instance handed the worker role to the first session set up, which is always an account's. Removing that account tore the worker out from under every other account: the survivors kept the content-script-only copies they were derived with and read "Could not establish connection. Receiving end does not exist." until a restart, and the one sign-in went with the removed account either way, restart or no restart. #1030 answered that with the offer of a restart, which was the honest behavior rather than the wanted one.

The full analysis is in the feature doc's [The worker session's removal](https://github.com/zoidsh/docs/blob/main/meru/features/chrome-extensions.md#the-worker-sessions-removal), and the design this builds is the section under it.

## Solution
- **Which session plays the worker is the embedder's to name.** `createSharedExtensionInstance` takes a `getWorkerSession`, and `adoptSession` answers `worker` for that session and `contentScriptOnly` for every other, whenever each is set up. The first-session-wins rule is gone, so order decides nothing — which is what an account added while the app runs needs. The getter is lazy because a `Session` cannot exist before the app is ready and the app builds the shared instance at module scope.
- **`setupExtensionsWorkerSession` runs after the launch-time prunes and before `accounts.init()`**, unawaited. Awaiting it would put a derive and an extension load in front of the window appearing, and buys nothing now that role adoption does not turn on order. Nothing an account session does waits on the worker's load, and the ordering guarantee is exactly the one that already held: `adoptSession` for the worker session — which is what arms the relay — is issued one await into a call made before `accounts.init()`, where the earliest a relayed call can arrive is after an account's own extension load has finished *and* one of its views has loaded a page a content script matches.
- **A relayed job that arrives before the worker session is set waits for it** (second commit). The ordering above is what keeps that window from opening, but it was the only thing standing between it and a wrong answer: `enqueueJob` failed a job outright with no worker session set, and the bounded wake never covered that case, being armed by `startWorkerForScope` rejecting — which needs a session to call it on. The job is now queued and waits out the same `wakeTimeoutMs`, `setWorkerSession` drives the queue the way a parked stream does, and only the timer expiring answers `noListener`, which is the shape the cold-launch wake race settled on. A worker session that went away stays distinct from one that has not arrived: after a teardown the worker genuinely is gone, so Chrome's missing receiving end is answered at once rather than a timeout later.
- **`resetApp` gains one `extensions.clearSessionData(session.defaultSession)`.** The default session's storage path is `userData` itself, so the worker's `chrome.storage` and IndexedDB land where `clearSessionData` already looks. Deliberately no `clearStorageData()` beside it, which at that root would reach far past the extensions.
- **The relaunch prompt is deleted** — `onSharedInstanceWorkerLost`, the `extensions.workerSessionLost` message, the renderer handler — rather than left as a path nothing can take. The loader's own answer from `teardownSession` stays, now behind a logged error, which is what makes the deletion provably safe: a naming that ever broke leaves that line in the log.
- **The derive is untouched.** The memo is already keyed by role and source, the two roles already land in different directories with stamps of their own, so both copies are byte-identical to what they were and `DERIVE_VERSION` does not move.

**The unclamped-development-extension question, decided as warn.** The brief flagged that an unclamped folder could match the renderer's `file://` page where a curated one cannot. That is right for a packaged build and unmatchable there — the loader grants no file access — but `loadRenderer` puts the window on the dev server over `http://localhost:3000` in development, and match patterns ignore the port. So the reachable pages are the renderer over the dev server and the popups beside it, in development, which is exactly where the dev folder loads. The checked-in fixture matched `http://localhost/*` and would have run its probe inside the renderer under `bun run dev`; it is narrowed to `http://127.0.0.1/*`, the address the end-to-end server binds. What is left is a developer's own unpacked folder in their own build, and the loader warns, naming the extension and the patterns that reach.

**The warning is a pattern check, not a check on whether the extension was clamped** (fourth commit, after review — the first version asked only about the clamp and never looked at the page it guarded, so it fired on every development launch and every e2e launch, at error level, for the fixture this PR had just made harmless, right after `262a2e3` cut three sources of noise from that log). The embedder passes `workerSessionPagePatterns` — `file:///*` packaged, the dev server's origin in development — and each entry of the extension's *loaded* manifest is tested against them with the derive's own `reachesClampedSite`. Asking the loaded manifest means the clamp needs no separate question: an entry that survived a clamp naming other hosts does not reach these pages, and a clamp that drops every entry leaves nothing to ask about. Six tests cover it: fires and names only the reaching patterns, `<all_urls>` against a packaged `file://` page, silent for the fixture's loopback shape, silent under a curated clamp, silent under a clamp that drops every entry, silent with no content scripts.

Two alternatives were rejected. Refusing to load an unclamped folder into the worker session leaves it with no worker anywhere, every account being shimmed now — that kills the fixture and with it the whole proxy e2e suite. Clamping the worker copy's content scripts away breaks the shim's `getManifest` overlay, which lays the *worker* role's `background` and `content_scripts` over each shimmed context's native answer (#1020), so every account would report an extension with no content scripts.

**The accounts' stale worker stores are cleared on the first launch after the upgrade** (fifth commit). A profile written before this keeps one worker store per account partition. The sign-in among them is gone either way, but the leftovers are not merely untidy: only `chrome.storage` is proxied, so the stale IndexedDB is not behind the shim, and an extension page opened in the account that used to hold the worker would read it directly where every other account reads an empty one. The 3.60.0 config migration schedules the clear and `init` performs it, over each configured account's partition and before `accounts.init()` constructs those sessions. The migration cannot do it itself — conf runs one synchronously at the store's construction, before `app.whenReady()`, so there is no session to clear and nothing to await — so it sets `extensions.clearStaleAccountData` and `clearStaleAccountExtensionData` acts on it, which is the shape `resetApp` already has. The flag goes back before the work: a clear that throws costs one directory, where a flag left set would clear every account's extension storage on every launch from then on. Unit-tested over a `userData`-shaped root with two partitions — each loses its own extension data, the worker's store at the root and the accounts' own browsing data untouched.

**Uninstalling clears the worker's store** (third commit, reversed from the first version of this PR after review). Removing an account clears that account's extension data, so before the worker moved, uninstalling and then removing every account left nothing behind; with one store in a session no removal touches, nothing short of a full app reset reached it and a reinstall came back signed in. That makes it a regression in what uninstall reaches rather than a leftover that was always there, and Chrome deletes an extension's storage on uninstall with nothing further asked, so the confirmation this looked like it needed is not a question the user is owed.

**The extension is unloaded from the worker session first** (fourth commit, after review). Without it the delete lands on a store the extension is still writing: the copy stays loaded until the restart the settings page asks for, and a running worker writes part of its store back into the very directory a reinstall under the same id reads, so the reinstall comes back signed in — the one outcome the clear exists to prevent. On Windows `fs.rm` retries five times and then logs against LevelDB files Chromium still holds open. `Extensions.unloadExtension` is a new loader method for it, the loader having had only the whole-session teardown. Deferring the clear to the next launch beside the prunes was the alternative and needs a marker that survives the restart while still racing a reinstall made before it. The accounts' content-script-only copies are left loaded: they hold no store.

**It clears every extension's store in the session rather than the uninstalled one's**, recorded rather than fixed, because `clearSessionData` deletes whole directories rather than the per-id subdirectories inside them. Exact while the catalog holds one entry, and the reason **a second curated extension wants a per-id clear before it lands**: otherwise uninstalling 1Password signs Bitwarden out. It is written into the feature doc's Bitwarden slice as a precondition of curating a second extension. The per-id half is straightforward for the three settings directories and IndexedDB, which are keyed by id; `Extension Rules`, `Extension Scripts` and `Extension State` are shared LevelDBs no directory split separates.

**One consequence.** Turning `extensions.enabled` on mid-session and installing an extension leaves no worker until a restart, where before an account added afterwards would have taken the role. The install path already raises the restart toast, so this matches what the app promises.

## Try it
No preview deployment for a desktop app. `MERU_SKIP_BUILD=1 xvfb-run -a bun run test:e2e tests/extension-proxy.e2e.ts` after a build is the way to see it: the last case removes an account through the settings UI and then completes a `sendMessage` round trip and a storage read from a context opened afterwards in the surviving account, with the worker's per-instance id and its storage stamp both unchanged.

## Not verified
- Three single-line calls in `packages/app`, which has no Electron-level test harness: `resetApp`'s, `uninstallCuratedExtension`'s, and the upgrade clear's — `resetApp` relaunches the app, which the e2e harness cannot follow, and uninstall runs only for a curated extension, which the e2e's fixture is not. Nothing tested either path before this change; the account-partition calls in `resetApp` are unverified the same way. What is tested is the logic under both: `clearSessionData` takes the extension directories out of a `userData`-shaped root and leaves `config.json`, `logs/`, `extensions/`, `derived-extensions/` and `Partitions/` alone.
- Against real 1Password, on any platform. This is [section 5 of the manual pass](https://github.com/zoidsh/docs/blob/main/meru/extensions-manual-pass.md#5-runtime-proxy), updated here for what ships, and it remains a release gate.
- The upgrade path off a profile from before this change, which should sign 1Password out once and stay signed in afterwards. Reasoned from the storage paths, not run.
- The development warning was reasoned from `loadRenderer` and Chromium's match-pattern semantics, not observed in a `bun run dev` session with an unclamped folder. Its matching is unit-tested against both page shapes.
- The upgrade clear runs once on the first launch after the upgrade and is reasoned from the storage paths, not run against a real pre-upgrade profile. Its mechanism is unit-tested over two partitions.

Two behavior changes worth listing, neither with an effect today: the worker's own network traffic now runs outside the blocker and with Electron's stock user agent, both being attached per account session, and the default session has no permission handler, so Electron's defaults apply there. Nothing in production opens an extension page in the default session — an action popup runs in the account's session — so nothing reaches either.

Three residuals the review turned up on the uninstall path, recorded in the feature doc and not fixed: an uninstall reaching settings inside the launch window skips the unload, the id reaching the loaded set only once `loadExtension` resolves; how much of the Windows open-handle failure the unload fixes is reasoned rather than measured, `removeExtension` terminating the worker asynchronously; and an unloaded extension's alarms keep their timers until restart, `Alarms` tearing down per session, firing into nothing since Meru passes no wake policy.

Everything else ran here on Linux: `bun test packages/electron-extensions packages/app packages/shared` (717 pass, 1 skip), `bun run types`, `bun run lint`, `bun run fmt:check`, and the full e2e suite under `xvfb-run` (39 passed, 4 skipped), including all 12 cases of `tests/extension-proxy.e2e.ts` against a fresh build.




