### PR TITLE
Drop the stale account extension data migration

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -360,20 +360,6 @@ export const config = new Store<Config>({
         // @ts-expect-error
         store.delete("verificationCodes.confidence");
       }
-
-      /*
-       * The one extension worker moved to the default session in 3.60.0, so
-       * every account partition of a profile written before it holds a worker
-       * store nothing reads any more — a stale `chrome.storage` and, since only
-       * `chrome.storage` is proxied, a stale IndexedDB that a popup opened in
-       * that account would read directly.
-       *
-       * Scheduled rather than done here: a migration runs synchronously, at the
-       * store's construction, which is before `app.whenReady()` — there is no
-       * session to clear yet and no way to await one. `init` performs it and
-       * puts the flag back.
-       */
-      store.set("extensions.clearStaleAccountData", true);
     },
   },
 });

--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -254,43 +254,6 @@ export function setupExtensionsWorkerSession() {
 }
 
 /**
- * Clears what the accounts' own partitions still hold from before the one
- * worker moved to the default session, once, on the first launch after the
- * upgrade. Each partition of such a profile keeps that account's own worker
- * store — a `chrome.storage` nothing reads any more, and an IndexedDB that is
- * worse than unread: only `chrome.storage` is proxied, so an extension page
- * opened in that account reads its stale database directly where every other
- * account reads an empty one.
- *
- * The 3.60.0 migration schedules this rather than doing it, running
- * synchronously and before the app is ready. Runs before `accounts.init()`
- * constructs any of these sessions, so nothing has the files open;
- * `fromPartition` makes an empty session where the account has never run,
- * which has nothing to clear and costs a directory that is not there.
- *
- * The flag goes back before the work rather than after it: a clear that throws
- * is one directory the user can live with, where a flag left set would clear
- * every account's extension storage on every launch from here on.
- */
-export async function clearStaleAccountExtensionData() {
-  if (!config.get("extensions.clearStaleAccountData")) {
-    return;
-  }
-
-  config.set("extensions.clearStaleAccountData", false);
-
-  await Promise.all(
-    config
-      .get("accounts")
-      .map((account) =>
-        extensions.clearSessionData(session.fromPartition(`persist:${account.id}`)),
-      ),
-  );
-
-  log.info("Cleared stale account extension data");
-}
-
-/**
  * What is on disk, which config alone can't tell: an install carries a version,
  * and an opt-in that never finished installing carries nothing.
  */

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -8,7 +8,6 @@ import { config } from "@/config";
 import { downloads } from "@/downloads";
 import { extensionActions } from "@/extension-actions";
 import {
-  clearStaleAccountExtensionData,
   extensions,
   extensionUpdater,
   pruneDerivedExtensionCopies,
@@ -132,9 +131,6 @@ async function init() {
   await pruneInstalledExtensionVersions();
 
   await pruneDerivedExtensionCopies();
-
-  // Before the accounts too, so no session of theirs holds the files open
-  await clearStaleAccountExtensionData();
 
   // Before the accounts, so the one worker is loading while their
   // content-script-only copies come up rather than after them

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -1300,69 +1300,6 @@ describe("the shared instance's worker session", () => {
     await fs.rm(userDataPath, { recursive: true, force: true });
   });
 
-  /*
-   * The upgrade cleanup, at the loader level: a profile written before the
-   * worker moved keeps one worker store per account partition, and the launch
-   * after the upgrade clears each of them. What the app adds on top is the
-   * config flag and the loop; this is the part with anything to get wrong —
-   * that each partition loses its own extension data and nothing else at the
-   * root loses anything.
-   */
-  test("clearing every account partition takes each one's extension data and no more", async () => {
-    const userDataPath = await createPartitionDir([
-      "Partitions/account-one/Local Extension Settings/aaa/000003.log",
-      "Partitions/account-one/IndexedDB/chrome-extension_aaa_0.indexeddb.leveldb/000003.log",
-      "Partitions/account-one/Cookies",
-      "Partitions/account-two/Local Extension Settings/aaa/000003.log",
-      "Partitions/account-two/IndexedDB/chrome-extension_aaa_0.indexeddb.leveldb/000003.log",
-      "Partitions/account-two/IndexedDB/https_mail.google.com_0.indexeddb.leveldb/000003.log",
-      // The worker's own store, at the root the default session reports, which
-      // this cleanup has no business touching
-      "Local Extension Settings/aaa/000003.log",
-      "config.json",
-    ]);
-
-    const extensions = createSharedExtensions([], undefined);
-
-    await Promise.all(
-      ["account-one", "account-two"].map((accountId) =>
-        extensions.clearSessionData(
-          createSession({ storagePath: path.join(userDataPath, "Partitions", accountId) }).session,
-        ),
-      ),
-    );
-
-    expect(await listPartitionDir(userDataPath)).toEqual([
-      "Local Extension Settings",
-      path.join("Local Extension Settings", "aaa"),
-      path.join("Local Extension Settings", "aaa", "000003.log"),
-      "Partitions",
-      path.join("Partitions", "account-one"),
-      path.join("Partitions", "account-one", "Cookies"),
-      // The container stays where its extension databases were the only ones,
-      // which is what clearing the databases rather than the directory means
-      path.join("Partitions", "account-one", "IndexedDB"),
-      path.join("Partitions", "account-two"),
-      path.join("Partitions", "account-two", "IndexedDB"),
-      path.join(
-        "Partitions",
-        "account-two",
-        "IndexedDB",
-        "https_mail.google.com_0.indexeddb.leveldb",
-      ),
-      path.join(
-        "Partitions",
-        "account-two",
-        "IndexedDB",
-        "https_mail.google.com_0.indexeddb.leveldb",
-        "000003.log",
-      ),
-      "config.json",
-    ]);
-
-    await fs.rm(userDataPath, { recursive: true, force: true });
-  });
-
   test("tearing down an account session says nothing about the worker", async () => {
     const loggedErrors: string[] = [];
 

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -143,6 +143,5 @@ export function createDefaultConfig({
     "extensions.enabled": true,
     "extensions.installed": [],
     "extensions.showTitlebarButton": false,
-    "extensions.clearStaleAccountData": false,
   };
 }

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -199,13 +199,6 @@ export type Config = {
   "extensions.enabled": boolean;
   "extensions.installed": string[];
   "extensions.showTitlebarButton": boolean;
-  /**
-   * A one-time cleanup the 3.60.0 migration schedules and the next launch
-   * performs: the extension stores the accounts' own partitions hold from
-   * before the one worker moved to the default session. A migration cannot do
-   * it itself, running before the app is ready and synchronously.
-   */
-  "extensions.clearStaleAccountData": boolean;
 };
 
 export type IpcMainEvents =


### PR DESCRIPTION
## Summary
Removes the one-time "clear stale account extension data" migration [#1032](https://github.com/zoidsh/meru/pull/1032) added, along with its config flag and the loader test written for it. Extensions have not shipped, so the upgrade path the migration serves has nobody on it. Nothing else from #1032 moves — `clearSessionData`, the `resetApp` call on the default session and the uninstall-path clear all stay.

## Problem
[#1032](https://github.com/zoidsh/meru/pull/1032) moved the one extension worker to the default session, which leaves a profile written before it with a per-account worker store nothing reads any more — a stale `chrome.storage`, and a stale IndexedDB that an extension page opened in that account would read directly, only `chrome.storage` being proxied. The 3.60.0 migration set `extensions.clearStaleAccountData` and the next launch cleared each account partition.

No such profile exists. Extensions have not been released, and 3.60.0 is the first version shipping them, so no user has ever run a build that wrote a per-account worker store. The migration guards a transition nobody makes, and the first release sets everything up cleanly on the default session with nothing to clean up behind it.

## Solution
- Drops the `store.set("extensions.clearStaleAccountData", true)` from the `>=3.60.0` migration, keeping the `verificationCodes.confidence` delete beside it
- Deletes `clearStaleAccountExtensionData` from `packages/app/extensions.ts` and the awaited call from the launch, between the derived-copy prune and `setupExtensionsWorkerSession()`
- Drops the `extensions.clearStaleAccountData` default and its type
- Removes the loader-level test that cleared two account partitions

Removed whole rather than left dormant: a flag that is never set and a function that returns immediately are a path no one can take, and the code reads as if the upgrade were real.

The test went with it rather than being reframed as a plain multi-partition `clearSessionData` case. `clearSessionData` is scoped entirely to `session.getStoragePath()` — every path it removes is a `path.join(storagePath, …)` — so running it over two sibling partitions asserts nothing the single-partition test above it (`clears extension storage and leaves the rest of the partition alone`) does not already prove, and that one covers more storage kinds while checking the account's own Gmail IndexedDB survives.

Docs updated in the same pass: the migration paragraph in `features/chrome-extensions.md`, the upgrade sentence in `decisions.md`, and the two release-gate bullets in `extensions-manual-pass.md` for a profile upgraded from before 3 September. The sign-in-cost note went with them — a fresh install has nothing to sign out of, and #1032's "one upgrade cost" was written against internal profiles only.

## Not verified
- The manual pass in the docs is unchanged apart from the two removed bullets; nothing here was exercised in a running app, the change being deletions of a launch-time path with no Electron-level test harness.