### PR TITLE
Let the worker's frame queries reach the sessions it shims

### DIFF
--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -64,6 +64,15 @@ export type SharedExtensionInstance = {
   /** Called per session before its extensions derive. */
   adoptSession(session: Session): SharedInstanceDeriveOptions;
   /**
+   * Whether a frame query from one session may resolve a tab of another, asked
+   * only when the two differ. True for the one worker asking about a session
+   * it shims and false for everything else: the worker runs in a session of
+   * its own, so every tab it has business with is another session's, while a
+   * shimmed session asking about another's tabs is one account reading
+   * another's pages.
+   */
+  canResolveTabAcrossSessions(askingSession: Session, tabSession: Session): boolean;
+  /**
    * Whether that session was the one holding the worker, which the loader logs
    * as the sessions left behind having nothing to reach. On an embedder that
    * names a session of its own and never tears it down, this answers false for
@@ -218,7 +227,10 @@ export class Extensions {
 
     this.nativeMessaging.registerRoutes(this.bridge);
 
-    this.webNavigation = new WebNavigation();
+    this.webNavigation = new WebNavigation({
+      canResolveTabAcrossSessions: (askingSession, tabSession) =>
+        this.sharedInstance?.canResolveTabAcrossSessions(askingSession, tabSession) === true,
+    });
 
     this.webNavigation.registerRoutes(this.bridge);
 

--- a/packages/electron-extensions/fixture/background.ts
+++ b/packages/electron-extensions/fixture/background.ts
@@ -28,6 +28,7 @@ import {
   getChromeRuntime,
   getChromeStorage,
   getChromeTabs,
+  getChromeWebNavigation,
 } from "./chrome";
 
 const workerGlobals = globalThis as unknown as { crypto: { randomUUID: () => string } };
@@ -83,6 +84,8 @@ const runtime = getChromeRuntime();
 
 const tabs = getChromeTabs();
 
+const webNavigation = getChromeWebNavigation();
+
 /**
  * Sends back into the tab the message came from, which is the whole
  * worker-to-page direction: in a shimmed session that tab is in another
@@ -109,6 +112,34 @@ function sendToSender(
       lastError
         ? { status: "error", message: lastError.message ?? "unknown" }
         : { status: "replied", reply },
+    );
+  });
+}
+
+/**
+ * The frame a message came from, as the worker's own
+ * `chrome.webNavigation.getFrame` answers for it. This is the step 1Password's
+ * fill hangs on — it relays an inline-menu click to the frame owning the form
+ * only once `getFrame` has named that frame's parent — and every tab it asks
+ * about is in another session, the worker session holding none of its own.
+ */
+function describeSenderFrame(
+  sender: FixtureMessageSender | undefined,
+  answer: (outcome: WorkerCallOutcome) => void,
+) {
+  const tabId = sender?.tab?.id;
+
+  if (tabId === undefined) {
+    answer({ status: "error", message: "The sender carried no tab" });
+
+    return;
+  }
+
+  webNavigation.getFrame({ tabId, frameId: sender?.frameId ?? 0 }, (frame) => {
+    answer(
+      frame
+        ? { status: "replied", reply: frame }
+        : { status: "error", message: "getFrame answered null" },
     );
   });
 }
@@ -140,6 +171,16 @@ runtime.onMessage.addListener((message, sender, sendResponse) => {
         sendResponse({ type: "send-back-reply", outcome });
       },
     );
+
+    return true;
+  }
+
+  // The worker asking which frame of which tab it is hearing from, which
+  // crosses a session every time. Answers late, so it holds the channel open
+  if (probeMessage?.type === "frame-of-sender") {
+    describeSenderFrame(sender, (outcome) => {
+      sendResponse({ type: "frame-of-sender-reply", outcome });
+    });
 
     return true;
   }

--- a/packages/electron-extensions/fixture/chrome.ts
+++ b/packages/electron-extensions/fixture/chrome.ts
@@ -48,6 +48,21 @@ export type FixtureTabs = {
   connect: (tabId: number, connectInfo: { name: string; frameId?: number }) => FixturePort;
 };
 
+/** One frame as `chrome.webNavigation` describes it, in the slice the fixture reads. */
+export type FixtureFrameDetails = {
+  frameId: number;
+  parentFrameId: number;
+  url: string;
+};
+
+/** The slice of `chrome.webNavigation` the fixture's worker asks. */
+export type FixtureWebNavigation = {
+  getFrame: (
+    query: { tabId: number; frameId: number },
+    callback: (frame: FixtureFrameDetails | null) => void,
+  ) => void;
+};
+
 /** One key's entry in an `onChanged`, in Chrome's own shape. */
 export type FixtureStorageChange = {
   oldValue?: unknown;
@@ -121,6 +136,20 @@ export function getChromeTabs(): FixtureTabs {
   const workerGlobals = globalThis as unknown as { chrome: { tabs: FixtureTabs } };
 
   return workerGlobals.chrome.tabs;
+}
+
+/**
+ * The worker's `chrome.webNavigation`, which is the facade's throughout —
+ * Electron implements none of the namespace. A frame query names a tab of
+ * another session here, the worker session holding no account's tabs, which
+ * is what the loader has to be willing to answer.
+ */
+export function getChromeWebNavigation(): FixtureWebNavigation {
+  const workerGlobals = globalThis as unknown as {
+    chrome: { webNavigation: FixtureWebNavigation };
+  };
+
+  return workerGlobals.chrome.webNavigation;
 }
 
 /**

--- a/packages/electron-extensions/fixture/probes.ts
+++ b/packages/electron-extensions/fixture/probes.ts
@@ -158,6 +158,15 @@ export type ProbeResults = {
    * the worker hearing it disconnect means the context itself went away.
    */
   openPortName: string | null;
+  /**
+   * The frame this context sent from, as the worker's own
+   * `chrome.webNavigation.getFrame` answered for it — a query about a tab of
+   * another session every time, the worker session holding none of its own.
+   * It is the step a fill hangs on: 1Password relays an inline-menu click to
+   * the frame owning the form only once `getFrame` has named that frame's
+   * parent.
+   */
+  senderFrameSeenByWorker: EchoOutcome;
   /** The worker messaging this context's own tab with `tabs.sendMessage`. */
   workerSentBack: WorkerInitiatedOutcome;
   /** The worker opening a port to this context's own tab with `tabs.connect`. */
@@ -347,6 +356,22 @@ async function probeOpenPort(runtime: FixtureRuntime, contextId: string): Promis
   const port = runtime.connect({ name: portName });
 
   return (await portRoundTrip(port, contextId)) ? portName : null;
+}
+
+/** What the worker's frame query answered, unwrapped from its reply. */
+async function probeSenderFrame(runtime: FixtureRuntime): Promise<EchoOutcome> {
+  const askOutcome = await sendMessage(runtime, { type: "frame-of-sender" });
+
+  if (askOutcome.status !== "replied") {
+    return askOutcome;
+  }
+
+  return (
+    (askOutcome.reply as { outcome?: EchoOutcome } | undefined)?.outcome ?? {
+      status: "error",
+      message: "The worker answered without an outcome",
+    }
+  );
 }
 
 /**
@@ -696,6 +721,8 @@ export async function runProbes(): Promise<ProbeResults> {
 
   const openPortName = await probeOpenPort(runtime, contextId);
 
+  const senderFrameSeenByWorker = await probeSenderFrame(runtime);
+
   const workerSentBack = await probeWorkerInitiated(runtime, contextId, "send-back", arrivals);
 
   const workerConnectedBack = await probeWorkerInitiated(
@@ -721,6 +748,7 @@ export async function runProbes(): Promise<ProbeResults> {
     workerClosedPort,
     selfCloseSeenByWorker,
     openPortName,
+    senderFrameSeenByWorker,
     workerSentBack,
     workerConnectedBack,
     portReplySeenByWorker:

--- a/packages/electron-extensions/runtime-proxy/index.test.ts
+++ b/packages/electron-extensions/runtime-proxy/index.test.ts
@@ -111,3 +111,92 @@ describe("createSharedExtensionInstance role adoption", () => {
     );
   });
 });
+
+/*
+ * What the loader asks before it answers a `chrome.webNavigation` frame query
+ * for a tab of a session other than the asking one. The worker has to cross —
+ * it runs in a session holding no account's tabs, and 1Password finds the
+ * frame owning a form with `getFrame` before it relays an inline-menu click to
+ * it — and nothing else may.
+ */
+describe("createSharedExtensionInstance tab resolution across sessions", () => {
+  test("the worker resolves a tab of any session it shims", () => {
+    const workerSession = createSession("worker");
+
+    const sharedInstance = createRoleAssigner(workerSession);
+
+    sharedInstance.adoptSession(workerSession);
+
+    const firstAccountSession = createSession("first-account");
+
+    const secondAccountSession = createSession("second-account");
+
+    sharedInstance.adoptSession(firstAccountSession);
+    sharedInstance.adoptSession(secondAccountSession);
+
+    expect(sharedInstance.canResolveTabAcrossSessions(workerSession, firstAccountSession)).toBe(
+      true,
+    );
+    expect(sharedInstance.canResolveTabAcrossSessions(workerSession, secondAccountSession)).toBe(
+      true,
+    );
+  });
+
+  test("a shimmed session resolves no other session's tab", () => {
+    const workerSession = createSession("worker");
+
+    const sharedInstance = createRoleAssigner(workerSession);
+
+    sharedInstance.adoptSession(workerSession);
+
+    const firstAccountSession = createSession("first-account");
+
+    const secondAccountSession = createSession("second-account");
+
+    sharedInstance.adoptSession(firstAccountSession);
+    sharedInstance.adoptSession(secondAccountSession);
+
+    expect(
+      sharedInstance.canResolveTabAcrossSessions(firstAccountSession, secondAccountSession),
+    ).toBe(false);
+
+    // Not the worker's own tabs either, which is the account reaching into the
+    // app's own session
+    expect(sharedInstance.canResolveTabAcrossSessions(firstAccountSession, workerSession)).toBe(
+      false,
+    );
+  });
+
+  test("the worker resolves no tab of a session this never adopted", () => {
+    const workerSession = createSession("worker");
+
+    const sharedInstance = createRoleAssigner(workerSession);
+
+    sharedInstance.adoptSession(workerSession);
+
+    expect(
+      sharedInstance.canResolveTabAcrossSessions(workerSession, createSession("never-set-up")),
+    ).toBe(false);
+
+    // And a session that went takes its tabs with it
+    const accountSession = createSession("account");
+
+    sharedInstance.adoptSession(accountSession);
+
+    sharedInstance.teardownSession(accountSession);
+
+    expect(sharedInstance.canResolveTabAcrossSessions(workerSession, accountSession)).toBe(false);
+  });
+
+  test("nothing crosses before the worker session is adopted", () => {
+    const workerSession = createSession("worker");
+
+    const sharedInstance = createRoleAssigner(workerSession);
+
+    const accountSession = createSession("account");
+
+    sharedInstance.adoptSession(accountSession);
+
+    expect(sharedInstance.canResolveTabAcrossSessions(workerSession, accountSession)).toBe(false);
+  });
+});

--- a/packages/electron-extensions/runtime-proxy/index.ts
+++ b/packages/electron-extensions/runtime-proxy/index.ts
@@ -59,6 +59,8 @@ export function createSharedExtensionInstance({
 
   let workerSession: Session | undefined;
 
+  const shimmedSessions = new Set<Session>();
+
   return {
     install({ bridge, logger }) {
       proxy = new RuntimeProxy({ logger, getWebContentsFromFrame });
@@ -71,8 +73,12 @@ export function createSharedExtensionInstance({
       // up, so order decides nothing: a session either is the one the embedder
       // named or is content-script-only, whether it came first or last.
       if (session !== getWorkerSession()) {
+        shimmedSessions.add(session);
+
         return { role: "contentScriptOnly", shimScriptPath };
       }
+
+      shimmedSessions.delete(session);
 
       if (workerSession !== session) {
         workerSession = session;
@@ -81,6 +87,21 @@ export function createSharedExtensionInstance({
       }
 
       return { role: "worker", relayScriptPath };
+    },
+
+    /*
+     * `chrome.webNavigation.getFrame` from the one worker, which is how
+     * 1Password finds the frame owning a form before it relays an inline-menu
+     * click to it. The worker session holds no account's tabs, so scoping the
+     * frame queries to the asking session — the loader's own default, and the
+     * right answer for an instance per session — leaves every such query
+     * answering null and the relay dropped silently. Only the worker crosses,
+     * and only into a session it shims: a shimmed session asking about
+     * another's tabs stays refused, and so does any session this never
+     * adopted.
+     */
+    canResolveTabAcrossSessions(askingSession, tabSession) {
+      return askingSession === workerSession && shimmedSessions.has(tabSession);
     },
 
     teardownSession(session) {
@@ -95,6 +116,8 @@ export function createSharedExtensionInstance({
       if (wasWorkerSession) {
         workerSession = undefined;
       }
+
+      shimmedSessions.delete(session);
 
       proxy?.teardownSession(session);
 

--- a/packages/electron-extensions/web-navigation/web-navigation.test.ts
+++ b/packages/electron-extensions/web-navigation/web-navigation.test.ts
@@ -141,9 +141,15 @@ describe("WebNavigation", () => {
   test("answers another session's tab where the embedder allows the crossing", () => {
     const { contents } = createTab();
 
+    const askedAbout: [Session, Session][] = [];
+
     const webNavigation = new WebNavigation({
       getWebContentsById: (tabId) => (tabId === TAB_ID ? contents : undefined),
-      canResolveTabAcrossSessions: (askingSession) => askingSession === WORKER_SESSION,
+      canResolveTabAcrossSessions: (askingSession, tabSession) => {
+        askedAbout.push([askingSession, tabSession]);
+
+        return askingSession === WORKER_SESSION;
+      },
     });
 
     expect(webNavigation.getFrame(WORKER_SESSION, { tabId: TAB_ID, frameId: 42 })).toMatchObject({
@@ -160,6 +166,15 @@ describe("WebNavigation", () => {
     // another's reach
     expect(webNavigation.getFrame(OTHER_SESSION, { tabId: TAB_ID, frameId: 42 })).toBeNull();
     expect(webNavigation.getAllFrames(OTHER_SESSION, { tabId: TAB_ID })).toBeNull();
+
+    // The question asked is who wants what, in that order: the asking session
+    // and the session the tab is really in
+    expect(askedAbout).toEqual([
+      [WORKER_SESSION, SESSION],
+      [WORKER_SESSION, SESSION],
+      [OTHER_SESSION, SESSION],
+      [OTHER_SESSION, SESSION],
+    ]);
   });
 
   test("answers nothing for a destroyed tab", () => {
@@ -170,9 +185,17 @@ describe("WebNavigation", () => {
     ).toBeNull();
 
     // Including where the crossing is allowed, the tab being gone before its
-    // session is ever read — a disposed WebContents throws from that accessor
+    // session is ever read — a disposed WebContents throws from that accessor,
+    // which is what this one does
+    const disposedContents = {
+      isDestroyed: () => true,
+      get session(): Session {
+        throw new Error("Object has been destroyed");
+      },
+    } as unknown as WebContents;
+
     const crossingWebNavigation = new WebNavigation({
-      getWebContentsById: (tabId) => (tabId === TAB_ID ? contents : undefined),
+      getWebContentsById: (tabId) => (tabId === TAB_ID ? disposedContents : undefined),
       canResolveTabAcrossSessions: () => true,
     });
 

--- a/packages/electron-extensions/web-navigation/web-navigation.test.ts
+++ b/packages/electron-extensions/web-navigation/web-navigation.test.ts
@@ -9,6 +9,8 @@ const SESSION = { partition: "persist:one" } as unknown as Session;
 
 const OTHER_SESSION = { partition: "persist:two" } as unknown as Session;
 
+const WORKER_SESSION = { partition: "worker" } as unknown as Session;
+
 const TAB_ID = 12;
 
 type FakeFrame = {
@@ -130,11 +132,52 @@ describe("WebNavigation", () => {
     expect(webNavigation.getAllFrames(OTHER_SESSION, { tabId: TAB_ID })).toBeNull();
   });
 
+  /*
+   * What a shared instance's one worker needs: it runs in a session holding no
+   * account's tabs, so a frame query scoped to the asking session answers null
+   * for every tab there is, and 1Password drops the inline-menu click it was
+   * about to relay to the frame owning the form.
+   */
+  test("answers another session's tab where the embedder allows the crossing", () => {
+    const { contents } = createTab();
+
+    const webNavigation = new WebNavigation({
+      getWebContentsById: (tabId) => (tabId === TAB_ID ? contents : undefined),
+      canResolveTabAcrossSessions: (askingSession) => askingSession === WORKER_SESSION,
+    });
+
+    expect(webNavigation.getFrame(WORKER_SESSION, { tabId: TAB_ID, frameId: 42 })).toMatchObject({
+      frameId: 42,
+      parentFrameId: 0,
+    });
+
+    expect(
+      webNavigation.getAllFrames(WORKER_SESSION, { tabId: TAB_ID })?.map(({ frameId }) => frameId),
+    ).toEqual([0, 42, 77]);
+
+    // And every session the embedder does not allow the crossing for stays
+    // scoped to its own tabs, which is one account's pages staying out of
+    // another's reach
+    expect(webNavigation.getFrame(OTHER_SESSION, { tabId: TAB_ID, frameId: 42 })).toBeNull();
+    expect(webNavigation.getAllFrames(OTHER_SESSION, { tabId: TAB_ID })).toBeNull();
+  });
+
   test("answers nothing for a destroyed tab", () => {
     const { contents } = createTab({ isDestroyed: true });
 
     expect(
       createWebNavigation(contents).getFrame(SESSION, { tabId: TAB_ID, frameId: 0 }),
+    ).toBeNull();
+
+    // Including where the crossing is allowed, the tab being gone before its
+    // session is ever read — a disposed WebContents throws from that accessor
+    const crossingWebNavigation = new WebNavigation({
+      getWebContentsById: (tabId) => (tabId === TAB_ID ? contents : undefined),
+      canResolveTabAcrossSessions: () => true,
+    });
+
+    expect(
+      crossingWebNavigation.getFrame(WORKER_SESSION, { tabId: TAB_ID, frameId: 0 }),
     ).toBeNull();
   });
 

--- a/packages/electron-extensions/web-navigation/web-navigation.ts
+++ b/packages/electron-extensions/web-navigation/web-navigation.ts
@@ -33,6 +33,12 @@ function createFrameDetails(frame: WebFrameMain): WebNavigationFrameDetails {
 export type WebNavigationOptions = {
   /** How a tab id resolves to the WebContents behind it, Electron's mapping by default. */
   getWebContentsById?: (tabId: number) => WebContents | undefined;
+  /**
+   * Whether the session asking may resolve a tab of another session, asked
+   * only when the two differ. Without it nothing crosses a session, which is
+   * what an embedder running one extension instance per session wants.
+   */
+  canResolveTabAcrossSessions?: (askingSession: Session, tabSession: Session) => boolean;
 };
 
 /**
@@ -60,8 +66,12 @@ function getElectronWebContentsById(tabId: number) {
 export class WebNavigation {
   private getWebContentsById: (tabId: number) => WebContents | undefined;
 
-  constructor({ getWebContentsById }: WebNavigationOptions = {}) {
+  private canResolveTabAcrossSessions: (askingSession: Session, tabSession: Session) => boolean;
+
+  constructor({ getWebContentsById, canResolveTabAcrossSessions }: WebNavigationOptions = {}) {
     this.getWebContentsById = getWebContentsById ?? getElectronWebContentsById;
+
+    this.canResolveTabAcrossSessions = canResolveTabAcrossSessions ?? (() => false);
   }
 
   registerRoutes(bridge: ExtensionBridge) {
@@ -122,9 +132,12 @@ export class WebNavigation {
   }
 
   /**
-   * A tab id resolves only within the session that asked: every session runs
-   * its own extension instances, and an id from any other session is another
-   * account's page.
+   * A tab id resolves within the session that asked, and beyond it only where
+   * the embedder says so: every session runs its own extension instances by
+   * default, so an id from any other session is another account's page. One
+   * shared instance is the exception — its one worker runs in a session of its
+   * own and every tab it fills into is another's, which is what
+   * `canResolveTabAcrossSessions` is asked about.
    */
   private getTabContents(session: Session, tabId: unknown) {
     if (typeof tabId !== "number") {
@@ -133,7 +146,16 @@ export class WebNavigation {
 
     const contents = this.getWebContentsById(tabId);
 
-    if (!contents || contents.isDestroyed() || contents.session !== session) {
+    // Destroyed before the session is read, a disposed WebContents throwing
+    // from every other accessor
+    if (!contents || contents.isDestroyed()) {
+      return undefined;
+    }
+
+    if (
+      contents.session !== session &&
+      !this.canResolveTabAcrossSessions(session, contents.session)
+    ) {
       return undefined;
     }
 

--- a/tests/extension-proxy.e2e.ts
+++ b/tests/extension-proxy.e2e.ts
@@ -575,6 +575,31 @@ test("a message is attributed to the frame that sent it, an embedded extension f
   // A subframe is never frame 0; 0 would mean the proxy attributed the
   // message to the host document rather than the extension frame
   expect(embeddedFrameSender.frameId).toBeGreaterThan(0);
+
+  /*
+   * And the worker's own `chrome.webNavigation.getFrame` for that frame, which
+   * is the shape a fill runs in: an extension iframe inside a web page, in a
+   * session the worker's own holds no tab of. 1Password relays the inline-menu
+   * click to the frame owning the form only once this has named that frame's
+   * parent, so a `null` here is a click that does nothing.
+   */
+  expect(embeddedFrame.senderFrameSeenByWorker).toEqual({
+    status: "replied",
+    reply: expect.objectContaining({
+      frameId: embeddedFrameSender.frameId,
+      parentFrameId: 0,
+      url: embeddedFrameUrl,
+    }),
+  });
+
+  // The host document's own frame query, answered for the same cross-session
+  // tab: the main frame, which is frame 0 and has no parent
+  const frameHost = await readProbeResults(frameHostId);
+
+  expect(frameHost.senderFrameSeenByWorker).toEqual({
+    status: "replied",
+    reply: expect.objectContaining({ frameId: 0, parentFrameId: -1, url: frameHostUrl }),
+  });
 });
 
 test("the worker reaches a shimmed content script it never heard from first", async () => {
@@ -639,6 +664,12 @@ test("an action popup is no tab, and the worker says so rather than guessing", a
   expect(shimPopup.workerSentBack.heard).toBeNull();
 
   expect(shimPopup.workerSentBack.outcome).toEqual({
+    status: "error",
+    message: "The sender carried no tab",
+  });
+
+  // And no tab to ask a frame query about either
+  expect(shimPopup.senderFrameSeenByWorker).toEqual({
     status: "error",
     message: "The sender carried no tab",
   });


### PR DESCRIPTION
## Summary
`chrome.webNavigation.getFrame` and `getAllFrames` resolved a tab only within the session that asked, which under the shared extension instance is never the session the tab is in — so both answered `null` for every tab and 1Password's password fill did nothing. The loader now asks the shared instance whether a frame query may cross a session, and only the one worker crosses, into a session it shims. The fix itself is not verified against 1Password, which needs a real Mac.

## Problem
The one extension worker runs in Electron's default session and every account session is content-script-only ([#1041](https://github.com/zoidsh/meru/pull/1032)). 1Password relays an inline-menu click to the frame owning the form only after `chrome.webNavigation.getFrame` has named that frame's parent, and `WebNavigation.getTabContents` resolved a tab id only when the tab's `WebContents` sat in the asking session. The asking session is now the worker's and every tab is an account's, so the query answered `null`, the relay was dropped silently, and clicking an item in the inline menu did nothing — measured against the real extension on Tim's Mac on 3 September 2026, with passkey sign-in, passkey creation and the popup unlock all passing. The worker's own console says as much: every inline-menu item click logs `[Messaging] Exception while handling request <autofill-item>` — eight in four seconds of clicking — and the same worker throws on `<get-nested-frame-configuration>` and `<remove-inline-button>` throughout the session. All three are relays the worker addresses to a frame, so the null frame query is behind each of them. It is the symptom from before [#845](https://github.com/zoidsh/meru/pull/845) with a new cause: the proxy's own `resolveTabTarget` was taught to cross sessions for `tabs.sendMessage`, and the frame queries never were.

## Solution
- `WebNavigation` takes a `canResolveTabAcrossSessions` predicate, asked only when the tab's session differs from the asking one, and refuses by default — so an embedder running one extension instance per session keeps exactly the scoping it has.
- `Extensions` wires that to the shared instance, which is the only thing that knows the worker session and which sessions it shims; `createSharedExtensionInstance` answers true only for the worker asking about a session that adopted a content-script-only role. A shimmed session asking about another's tabs stays refused, as does any session the instance never adopted or has torn down.
- Asked of the shared instance rather than decided inside `WebNavigation` from a worker session handed to it: which sessions are shimmed is the proxy's own bookkeeping, `adoptSession` is where it is already kept, and a second copy of it in the loader would be free to drift. `SharedExtensionInstance` gains one method for the question.
- Sender reconstruction (`runtime-proxy/sender.ts`) was checked for the same problem and has none: its session check holds a caller's frame to the caller's own session, which is the page's, never the worker's.
- The fixture's worker gained a `getFrame` for the frame each probe messaged from, and the end-to-end suite asserts on it. This is why the bug reached a real machine — the suite exercised the relay thoroughly and the frame queries not at all.

## Try it
No preview deployment; this is the desktop app. `xvfb-run -a bun run test:e2e extension-proxy` covers it — the embedded extension frame in "a message is attributed to the frame that sent it" is the fill's own shape, an extension iframe inside a web page of an account session, and the worker's `getFrame` for it now answers with `parentFrameId: 0` instead of `null`. Against a build with the loader's wiring removed, that assertion fails with `getFrame answered null`, which is the production symptom.

On a real Mac after merge, the three worker exceptions above are what to watch: `<autofill-item>`, `<get-nested-frame-configuration>` and `<remove-inline-button>` should all stop throwing. `[Fill] Failed to get active tab when checking for an open and fill tab` after each unlock is the `tabs.query` noop, which is known, separate and not touched here.

## Not verified
- The fix against 1Password itself. The inline-menu fill needs a real Mac, a Google account and the installed extension; Tim will re-run it after merge.
- `getAllFrames` across sessions is covered by unit tests alone. Nothing curated calls it, so no end-to-end path exercises it.

