### PR TITLE
Keep extension worker chatter out of the shipped log

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -217,6 +217,9 @@ export const extensions = new Extensions({
     getWorkerSession: () => session.defaultSession,
   }),
   logger: {
+    debug: (message, details) => {
+      log.debug(message, details);
+    },
     info: (message, details) => {
       log.info(message, details);
     },

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -1,4 +1,4 @@
-import { platform } from "@electron-toolkit/utils";
+import { is, platform } from "@electron-toolkit/utils";
 import { APP_ID } from "@meru/shared/constants";
 import { app, session } from "electron";
 import { accounts } from "@/accounts";
@@ -16,6 +16,7 @@ import {
 } from "@/extensions";
 import { ipc } from "@/ipc";
 import { initLinuxWindowControls } from "@/lib/linux";
+import { log } from "@/lib/log";
 import { licenseKey } from "@/license-key";
 import { main } from "@/main";
 import { appMenu } from "@/menu";
@@ -69,6 +70,20 @@ async function resetApp() {
 }
 
 async function init() {
+  // electron-log writes every level to the file by default, `silly` up, and the
+  // extension worker's console is forwarded at debug, so a shipped build would
+  // otherwise write 1Password's own chatter to disk for as long as it ran: a
+  // lock poll pair every fifteen seconds, sync and cache lines, feature-flag
+  // dumps of several kilobytes. Info keeps Meru's own lines and every worker
+  // error. Development keeps everything, since the worker has no DevTools
+  // surface in Meru and its console is where 1Password says why it declined to
+  // fill; the console transport is left at its default for the same reason.
+  // Set here rather than in `lib/log.ts`, which unit tests import through
+  // `load-url.ts` and which therefore can't touch `app` at module load.
+  if (!is.dev) {
+    log.transports.file.level = "info";
+  }
+
   if (platform.isLinux) {
     app.commandLine.appendSwitch("gtk-version", "3");
     app.commandLine.appendSwitch("enable-features", "GlobalShortcutsPortal");

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -325,6 +325,7 @@ describe("Extensions", () => {
     // Chromium loads both copies under the one id, where the second load's
     // storage clear drops the service worker the first just registered
     await createExtensions([firstExtensionDir, secondExtensionDir], {
+      debug: () => {},
       info: (message, details) => {
         loggedInfo.push({ message, details });
       },
@@ -404,6 +405,9 @@ describe("Extensions", () => {
     const { session, emitServiceWorkerConsole, serviceWorkerConsoleListeners } = createSession();
 
     const extensions = createExtensions([await createExtensionDir("one")], {
+      debug: (message, details) => {
+        logs.push({ level: "debug", message, details });
+      },
       info: (message, details) => {
         logs.push({ level: "info", message, details });
       },
@@ -439,7 +443,7 @@ describe("Extensions", () => {
 
     expect(consoleLogs).toEqual([
       {
-        level: "info",
+        level: "debug",
         message: "Extension service worker log",
         details: {
           sourceUrl: "chrome-extension://aaa/background.js",
@@ -494,6 +498,7 @@ describe("Extensions", () => {
     const { session } = createSession();
 
     const extensions = createExtensions([brokenExtensionDir, await createExtensionDir("one")], {
+      debug: () => {},
       info: () => {},
       error: (_message, details) => {
         loggedErrors.push(details);
@@ -515,6 +520,7 @@ describe("Extensions", () => {
     await mkdir(extensionDir);
 
     const extensions = createExtensions([extensionDir], {
+      debug: () => {},
       info: () => {},
       error: () => {},
     });
@@ -648,6 +654,7 @@ describe("Extensions", () => {
     const { session } = createSession();
 
     const extensions = createExtensions([await createExtensionDir("one")], {
+      debug: () => {},
       info: () => {},
       error: (_message, details) => {
         loggedErrors.push(details);
@@ -704,6 +711,7 @@ describe("Extensions", () => {
     });
 
     const extensions = createExtensions([await createExtensionDir("one")], {
+      debug: () => {},
       info: () => {},
       error: (_message, details) => {
         loggedErrors.push(details);
@@ -763,6 +771,7 @@ describe("Extensions", () => {
     const secondSession = createSession({ loadExtension });
 
     const extensions = createExtensions([await createExtensionDir("one")], {
+      debug: () => {},
       info: () => {},
       error: () => {},
     });
@@ -1116,6 +1125,7 @@ describe("the shared instance's worker session", () => {
       workerSessionPagePatterns: ["http://localhost/*"],
       ...options,
       logger: {
+        debug: () => undefined,
         info: () => undefined,
         error: (message, details) => {
           loggedErrors.push({ message, details });
@@ -1311,6 +1321,7 @@ describe("the shared instance's worker session", () => {
       [await createExtensionDir("one")],
       await createSharedInstance(workerSession.session),
       {
+        debug: () => undefined,
         info: () => undefined,
         error: (message) => {
           loggedErrors.push(message);
@@ -1354,6 +1365,7 @@ describe("the shared instance's worker session", () => {
       [await createExtensionDir("one")],
       await createSharedInstance(workerSession.session),
       {
+        debug: () => undefined,
         info: () => undefined,
         error: (message) => {
           loggedErrors.push(message);
@@ -1379,6 +1391,7 @@ describe("the shared instance's worker session", () => {
       [await createExtensionDir("one")],
       await createSharedInstance(workerSession.session),
       {
+        debug: () => undefined,
         info: () => undefined,
         error: (message) => {
           loggedErrors.push(message);

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -457,6 +457,13 @@ export class Extensions {
    * declined to fill, say — surfaces nowhere unless it is forwarded to the
    * logger. Every worker on a `chrome-extension://` origin is one this loader
    * put there, since nothing else loads extensions into the session.
+   *
+   * Everything below an error goes out at debug: it is the extension's own
+   * chatter, a lock poll every fifteen seconds and feature-flag dumps of
+   * several kilobytes in 1Password's case, which an embedder wants in
+   * development and not on the disk of every shipped install. Errors stay at
+   * error, since a worker's own report of a failure is the diagnostic the
+   * forwarding exists for.
    */
   private pipeServiceWorkerConsole(session: Session) {
     const listener = (_event: ElectronEvent, { message, level, sourceUrl }: MessageDetails) => {
@@ -467,7 +474,7 @@ export class Extensions {
       if (level >= CONSOLE_ERROR_LEVEL) {
         this.logger?.error("Extension service worker error", { sourceUrl, message });
       } else {
-        this.logger?.info("Extension service worker log", { sourceUrl, message });
+        this.logger?.debug("Extension service worker log", { sourceUrl, message });
       }
     };
 

--- a/packages/electron-extensions/logger.ts
+++ b/packages/electron-extensions/logger.ts
@@ -1,5 +1,12 @@
-/** Where the package reports what it did, since an embedder logs its own way. */
+/**
+ * Where the package reports what it did, since an embedder logs its own way.
+ *
+ * `debug` carries what a third party wrote, meaning an extension's own console
+ * output, so an embedder can keep it out of a shipped log while `info` and
+ * `error` stay the package's own account of what it did.
+ */
 export type ExtensionsLogger = {
+  debug: (message: string, details: Record<string, unknown>) => void;
   info: (message: string, details: Record<string, unknown>) => void;
   error: (message: string, details: Record<string, unknown>) => void;
 };

--- a/packages/electron-extensions/native-messaging/native-messaging.test.ts
+++ b/packages/electron-extensions/native-messaging/native-messaging.test.ts
@@ -257,6 +257,7 @@ describe("NativeMessaging", () => {
 
     const { teardown } = createNativeMessaging({
       logger: {
+        debug: () => undefined,
         info: (message, details) => {
           logs.push({ message, details });
         },
@@ -290,6 +291,7 @@ describe("NativeMessaging", () => {
 
     const { teardown } = createNativeMessaging({
       logger: {
+        debug: () => undefined,
         info: (message, details) => {
           logs.push({ message, details });
         },

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
@@ -965,7 +965,13 @@ describe("RuntimeProxy", () => {
     const logs: string[] = [];
 
     const harness = createHarness(
-      { logger: { info: (message) => logs.push(message), error: () => undefined } },
+      {
+        logger: {
+          debug: () => undefined,
+          info: (message) => logs.push(message),
+          error: () => undefined,
+        },
+      },
       { adoptWorkerSession: false },
     );
 


### PR DESCRIPTION
## Summary
Forwarded extension service worker console lines go out at debug instead of info, and the packaged app's file transport writes at info, so a shipped log keeps Meru's own lines and every worker error and no longer fills with 1Password's polling, sync and feature-flag chatter. Development output is unchanged. Covered by the existing forwarding test; the packaged file level is reasoned rather than measured, since the sandbox can't run a packaged build.

## Problem
The 1Password service worker's console is forwarded line for line into the app log, because the worker has no DevTools surface in Meru and its console is where 1Password says why it declines to fill. It went out at info, and electron-log's file transport writes every level by default, so a production log from Tim's Mac showed a shipped build writing 1Password's own chatter to disk constantly: a lock poll pair every fifteen seconds, sync and cache lines, and feature-flag dumps of several kilobytes.

## Solution
- Adds `debug` to `ExtensionsLogger`, and the worker console forwarding in `Extensions.pipeServiceWorkerConsole` uses it for every line below `CONSOLE_ERROR_LEVEL`. Errors still go to `error`. Nothing else in the package changes level: `Loaded extension`, native messaging host stderr and the rest stay at info.
- Maps `debug` onto electron-log in the app's logger wiring.
- Sets `log.transports.file.level = "info"` when `is.dev` is false, in `init()` in `packages/app/index.ts`. Both electron-log transports default to `silly`, so development keeps everything, and the console transport is untouched.
- Set in the app entry rather than in `lib/log.ts`, the obvious place: `@electron-toolkit/utils` reads `electron.app` at import time, and `lib/log.ts` is imported by `load-url.ts`, whose unit tests run under bun where the `electron` module has no `app` export. Putting the flag there broke `load-url.test.ts`.
- Individual 1Password messages such as `[LogManager] Failed to send log metrics` are not filtered or rewritten. They are 1Password's, they are at error level, and the level change is the whole item.

## Try it
Run `bun run dev` with 1Password installed and open the log file from the Help menu. Worker lines still appear, now tagged `[debug]` rather than `[info]`, and worker errors stay `[error]`. In a packaged build the `[debug]` lines are absent from the file.

## Not verified
- The packaged file level is reasoned from electron-log 5.4.2's defaults and `is.dev`, not measured: the sandbox can't run a packaged build.
- Development output was checked by reading the transport defaults, not by running the app.