### PR TITLE
Say what 1Password does and doesn't do in Meru

### DIFF
--- a/packages/shared/extensions.ts
+++ b/packages/shared/extensions.ts
@@ -27,11 +27,14 @@ export const curatedExtensions: CuratedExtension[] = [
   {
     id: ONEPASSWORD_EXTENSION_ID,
     name: "1Password",
-    // Meru only supports what its Google sign-in flows need, so the copy
-    // promises that and nothing else: filling a saved password or passkey to
-    // sign in, and generating a new one on the account pages.
+    // Meru builds for the Google sign-in flows and nothing else, so the copy
+    // names them and then says what the user won't find, rather than leaving
+    // the absences to be discovered: content scripts stop at the two hosts
+    // below, `commands`, `contextMenus` and `notifications` are facade noops,
+    // and a popup link opens in the default browser because Meru has no tab to
+    // give it.
     description:
-      "Signs you in to your Google Account with a saved password or passkey, and generates new ones when you change your password or add a passkey.",
+      "Signs you in to your Google Account with a saved password or passkey, and generates new ones when you change your password or add a passkey. Nothing else is supported: no in-page filling outside those pages, no card or address autofill, no keyboard shortcuts, right-click fill or notifications, and popup links such as 1Password's settings open in your default browser.",
     category: "passwordManager",
     // Sign-in runs on accounts.google.com, and account settings — creating a
     // passkey, changing a password — on myaccount.google.com. Both hosts, not

--- a/packages/shared/extensions.ts
+++ b/packages/shared/extensions.ts
@@ -31,10 +31,11 @@ export const curatedExtensions: CuratedExtension[] = [
     // names them and then says what the user won't find, rather than leaving
     // the absences to be discovered: content scripts stop at the two hosts
     // below, `commands`, `contextMenus` and `notifications` are facade noops,
-    // and a popup link opens in the default browser because Meru has no tab to
-    // give it.
+    // and `tabs.create` is unimplemented, so a popup entry that opens one of
+    // the extension's own pages — its settings, its full item view — does
+    // nothing at all.
     description:
-      "Signs you in to your Google Account with a saved password or passkey, and generates new ones when you change your password or add a passkey. Nothing else is supported: no in-page filling outside those pages, no card or address autofill, no keyboard shortcuts, right-click fill or notifications, and popup links such as 1Password's settings open in your default browser.",
+      "Signs you in to your Google Account with a saved password or passkey, and generates new ones when you change your password or add a passkey. Nothing else is supported: no in-page filling outside those pages, no card or address autofill, no keyboard shortcuts, right-click fill or notifications, and no way to reach 1Password's own pages, such as its settings.",
     category: "passwordManager",
     // Sign-in runs on accounts.google.com, and account settings — creating a
     // passkey, changing a password — on myaccount.google.com. Both hosts, not

--- a/packages/shared/extensions.ts
+++ b/packages/shared/extensions.ts
@@ -27,8 +27,11 @@ export const curatedExtensions: CuratedExtension[] = [
   {
     id: ONEPASSWORD_EXTENSION_ID,
     name: "1Password",
+    // Meru only supports what its Google sign-in flows need, so the copy
+    // promises that and nothing else: filling a saved password or passkey to
+    // sign in, and generating a new one on the account pages.
     description:
-      "Password manager that fills logins and signs you in with passkeys stored in your vault.",
+      "Signs you in to your Google Account with a saved password or passkey, and generates new ones when you change your password or add a passkey.",
     category: "passwordManager",
     // Sign-in runs on accounts.google.com, and account settings — creating a
     // passkey, changing a password — on myaccount.google.com. Both hosts, not


### PR DESCRIPTION
## Summary
Rewrites the curated 1Password description so it promises only what Meru's extension support actually does — signing in to a Google Account with a saved password or passkey, and generating a new one when changing the password or adding a passkey — and then names the features that aren't there, so their absence doesn't read as breakage. Copy-only change to `curatedExtensions`; no behavior moves.

## Problem
The settings page described 1Password as a "Password manager that fills logins and signs you in with passkeys stored in your vault", which reads as the full browser-extension experience across every site. It isn't. Content scripts are clamped to `accounts.google.com` and `myaccount.google.com`, `commands`, `contextMenus` and `notifications` are facade noops by decision, and `chrome.tabs.create` is unimplemented, so a popup entry that opens one of the extension's own pages — Settings, the full item view — does nothing at all. Everything outside the Google sign-in flows is out of scope on purpose, to keep the shipped surface and its CPU and memory cost small.

Overselling it costs twice: users go looking for fills that were never going to happen, and each absence they hit — no inline menu on a Workspace app, `Cmd+Shift+X` doing nothing, Settings not opening — reads as a bug worth reporting.

## Solution
- Replaces the description with one naming the two supported flows, followed by an explicit "Nothing else is supported" clause listing the absences users are most likely to hit.
- Adds a comment tying each half of the copy to the decision or gap behind it, so the next edit doesn't quietly widen the promise back out.

Listed the absences in the description rather than as a separate note or dialog: they are what a user decides against while reading the row, and a second surface is one they'd only find after hitting the thing it explains. It costs about two lines in the settings item.

Named the flows rather than the hosts — "your Google Account" instead of `accounts.google.com` — because the host clamp already sits in `contentScriptMatches` a few lines below, and a user reading a settings row wants to know what they can do, not which origins the content scripts match.

Says the extension's own pages don't open, rather than that they open in the default browser. `setWindowOpenHandler` on the popup does send web links out to the browser, so the second reading is tempting, but it only catches `window.open` and `target="_blank"`; Settings goes through `chrome.tabs.create`, which the facade doesn't implement, and nothing happens. Naming the browser would send the user to check a window that was never going to open.

## Try it
Settings → Extensions, the 1Password row: the description under the title is the new text. No build or fixture needed.

## Not verified
- Not seen in the running app; checked as source only, so the two-line description hasn't been eyeballed in the settings row. `bun run types`, `bun run lint` and `bun run fmt:check` pass.
- The unsupported list is drawn from the extension decisions and the clamp in code, not from re-testing each absence in a build. The exception is the popup's Settings entry, which Tim confirmed does nothing in the running app.