### PR TITLE
Return quietly when Gmail's inbox type is not there yet

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -564,9 +564,16 @@ export class Gmail {
         return;
       }
 
-      const inboxType = inboxTypeSchema.parse(
-        await this.view.webContents.executeJavaScript("window.GM_INBOX_TYPE"),
-      );
+      const inboxTypeValue = await this.view.webContents.executeJavaScript("window.GM_INBOX_TYPE");
+
+      // The URL is already Gmail's while the page is still loading, such as
+      // during sign-in, so the global is missing rather than wrong. Treat that
+      // as "not loaded yet" and return, the way the URL check above does.
+      if (inboxTypeValue === undefined) {
+        return;
+      }
+
+      const inboxType = inboxTypeSchema.parse(inboxTypeValue);
 
       const body = await this.session
         .fetch(


### PR DESCRIPTION
## Summary
Stops `fetchInboxFeed` logging a `ZodError` at error level while Gmail is still loading, by treating a missing `window.GM_INBOX_TYPE` the same way the existing URL check treats a non-Gmail URL — return quietly. A defined but unexpected value, a failed feed request and a malformed feed all still fail and log as before. No test: `packages/app/gmail/index.ts` imports Electron and there is no harness that can reach it.

## Problem
Tim's Mac log showed this twice on 3 September 2026, while an account went through a passkey sign-in and Gmail loaded afterwards:

```
[error] Failed to fetch inbox feed {
  error: 'ZodError: [ { "code": "invalid_type", "expected": "string", "received": "undefined", "path": [], "message": "Required" } ]
    at ZodString.parse ...
    at Gmail.fetchInboxFeed (app.js:240:7121)'
}
```

`fetchInboxFeed` returns early when the view's URL is not Gmail's, then reads `window.GM_INBOX_TYPE` out of the page and parses it with a root-level `z.string()`. During sign-in the URL is already on `mail.google.com` before Gmail's page globals exist, so the global is `undefined`, the parse throws, and the catch at the bottom of the function logs it at error level. Nothing is actually wrong — Gmail is not loaded yet.

## Solution
- Reads `window.GM_INBOX_TYPE` into a variable and returns before parsing when it is `undefined`, extending the "not loaded yet" check the URL guard already makes.
- Kept the parse and the surrounding `try`/`catch` rather than making the schema optional: a *defined* but unexpected inbox type is a real fault and should still throw and log, as should the feed request itself and a malformed feed. Widening the schema would have swallowed all three.

## Try it
No preview environment for a desktop app. Reproduce by signing in to an account with `MERU_*` logging on and watching for `Failed to fetch inbox feed` during the sign-in redirect: on `main` the `ZodError` appears once or twice while the page loads; on this branch it does not, and the feed fetch resumes normally once Gmail is up.

## Not verified
- Not exercised at runtime — no Gmail sign-in was performed against a build of this branch; the fix was reasoned from the code and the log.
- No unit test. `packages/app/gmail/index.ts` imports `electron` at module scope and `packages/app` has no Electron-level test harness (its existing tests all cover `lib/` modules with no Electron imports), so `fetchInboxFeed` cannot be imported in `bun test` without building one — out of proportion to a five-line change.