### PR TITLE
Block 1Password's telemetry from the extension worker

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -211,6 +211,15 @@ export const extensions = new Extensions({
   // account session is never the one holding it — see
   // `setupExtensionsWorkerSession` below.
   workerSessionPagePatterns: getWorkerSessionPagePatterns(),
+  // The worker's own requests never reach `blocker`, which attaches per account
+  // session, so the worker session is the only place a privacy block on them
+  // can go. Unconditional rather than behind `blocker.enabled` or the license:
+  // none of this traffic is anything the user asked for, extensions are Pro
+  // already, and a curated extension that names no telemetry hosts contributes
+  // nothing here.
+  workerSessionBlockedUrls: curatedExtensions.flatMap(
+    (curatedExtension) => curatedExtension.telemetryUrls ?? [],
+  ),
   sharedInstance: createSharedExtensionInstance({
     shimScriptPath: path.join(__dirname, "extensions-runtime-proxy-shim.js"),
     relayScriptPath: path.join(__dirname, "extensions-runtime-proxy-relay.js"),

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -124,6 +124,12 @@ function createSession({
 
   const beforeSendHeadersFilters: unknown[] = [];
 
+  const beforeRequestFilters: unknown[] = [];
+
+  let beforeRequestListener:
+    | ((details: unknown, callback: (response: unknown) => void) => void)
+    | undefined;
+
   let requestHandler: ((request: GlobalRequest) => Promise<Response>) | undefined;
 
   const serviceWorkerConsoleListeners = new Set<
@@ -159,6 +165,14 @@ function createSession({
       onBeforeSendHeaders: (filterOrListener: unknown) => {
         beforeSendHeadersFilters.push(filterOrListener);
       },
+      onBeforeRequest: (
+        filterOrListener: unknown,
+        listener?: (details: unknown, callback: (response: unknown) => void) => void,
+      ) => {
+        beforeRequestFilters.push(filterOrListener);
+
+        beforeRequestListener = listener;
+      },
     },
     serviceWorkers: {
       on: (
@@ -182,6 +196,17 @@ function createSession({
     handledSchemes,
     sessionEvents,
     beforeSendHeadersFilters,
+    beforeRequestFilters,
+    /** What the session's `onBeforeRequest` listener answers for a request. */
+    callBeforeRequest: (details: Record<string, unknown>) => {
+      let response: unknown;
+
+      beforeRequestListener?.(details, (listenerResponse) => {
+        response = listenerResponse;
+      });
+
+      return response;
+    },
     serviceWorkerConsoleListeners,
     emitServiceWorkerConsole: (messageDetails: Record<string, unknown>) => {
       for (const listener of serviceWorkerConsoleListeners) {
@@ -881,6 +906,9 @@ describe("the shared instance's worker session", () => {
     extensionDirs: ConstructorParameters<typeof Extensions>[0]["extensionDirs"],
     sharedInstance: ConstructorParameters<typeof Extensions>[0]["sharedInstance"],
     logger?: ConstructorParameters<typeof Extensions>[0]["logger"],
+    workerSessionBlockedUrls?: ConstructorParameters<
+      typeof Extensions
+    >[0]["workerSessionBlockedUrls"],
   ) {
     return new Extensions({
       extensionDirs,
@@ -888,6 +916,7 @@ describe("the shared instance's worker session", () => {
       derivedExtensionsDir: path.join(workDir, "derived"),
       sharedInstance,
       logger,
+      workerSessionBlockedUrls,
     });
   }
 
@@ -988,6 +1017,80 @@ describe("the shared instance's worker session", () => {
     expect(workerSession.handledSchemes).toEqual([EXTENSION_BRIDGE_SCHEME]);
 
     expect(accountSession.handledSchemes).toEqual([EXTENSION_BRIDGE_SCHEME]);
+  });
+
+  /*
+   * The worker's own traffic never passes the embedder's per-account blocker,
+   * so a block on it can only live in the worker session — and it has to be
+   * the worker session alone, since an account session's one
+   * `onBeforeRequest` belongs to the embedder.
+   */
+  test("blocked URLs are canceled in the worker session and nowhere else", async () => {
+    const workerSession = createSharedSession();
+
+    const accountSession = createSharedSession();
+
+    const blockedUrls = ["https://client-log-forwarder.1password.com/*"];
+
+    const extensions = createSharedExtensions(
+      [await createExtensionDir("one"), await createExtensionDir("two")],
+      await createSharedInstance(workerSession.session),
+      undefined,
+      blockedUrls,
+    );
+
+    await extensions.setupSession(workerSession.session);
+
+    await extensions.setupSession(accountSession.session);
+
+    // One filtered listener however many extensions the session loaded, and
+    // the filter is the embedder's list verbatim: the listener itself matches
+    // nothing
+    expect(workerSession.beforeRequestFilters).toEqual([{ urls: blockedUrls }]);
+
+    expect(accountSession.beforeRequestFilters).toEqual([]);
+
+    expect(
+      workerSession.callBeforeRequest({
+        url: "https://client-log-forwarder.1password.com/twirp",
+      }),
+    ).toEqual({ cancel: true });
+
+    extensions.teardownSession(workerSession.session);
+
+    // Cleared rather than left behind, the way the bridge's listener is
+    expect(workerSession.beforeRequestFilters).toEqual([{ urls: blockedUrls }, null]);
+  });
+
+  /*
+   * An embedder that names nothing to block gets no listener at all, so the
+   * worker session's one `onBeforeRequest` is still there to be taken.
+   */
+  test("no blocked URLs attaches no listener to any session", async () => {
+    const workerSession = createSharedSession();
+
+    const accountSession = createSharedSession();
+
+    const extensions = createSharedExtensions(
+      [await createExtensionDir("one")],
+      await createSharedInstance(workerSession.session),
+      undefined,
+      [],
+    );
+
+    await extensions.setupSession(workerSession.session);
+
+    await extensions.setupSession(accountSession.session);
+
+    expect(workerSession.beforeRequestFilters).toEqual([]);
+
+    expect(accountSession.beforeRequestFilters).toEqual([]);
+
+    extensions.teardownSession(workerSession.session);
+
+    // Nothing was attached, so nothing is cleared — a `null` here would be the
+    // loader clearing a listener it never put on
+    expect(workerSession.beforeRequestFilters).toEqual([]);
   });
 
   /*

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -136,6 +136,19 @@ export type ExtensionsOptions = {
    * checked and nothing is said.
    */
   workerSessionPagePatterns?: string[];
+  /**
+   * Match patterns whose requests are canceled in the worker session, before
+   * they leave the machine. An extension's service worker runs there rather
+   * than in an account session, so whatever the embedder blocks per account
+   * never sees a single request the worker makes, and this is the only place a
+   * block on the worker's own traffic can go.
+   *
+   * The account sessions are deliberately left alone: a session takes exactly
+   * one `onBeforeRequest` listener, and in an account session that one is the
+   * embedder's. Nothing is attached without a shared instance — there being no
+   * worker session to speak of — or with an empty list.
+   */
+  workerSessionBlockedUrls?: string[];
   logger?: ExtensionsLogger;
 };
 
@@ -165,6 +178,8 @@ export class Extensions {
 
   private workerSessionPagePatterns: string[] | undefined;
 
+  private workerSessionBlockedUrls: string[] | undefined;
+
   private logger: ExtensionsLogger | undefined;
 
   private loadedExtensionIdsBySession = new Map<Session, Set<string>>();
@@ -190,6 +205,9 @@ export class Extensions {
     (event: ElectronEvent, messageDetails: MessageDetails) => void
   >();
 
+  /** The sessions carrying the cancel listener, to clear it from again. */
+  private blockedUrlSessions = new Set<Session>();
+
   constructor({
     extensionDirs,
     facadeScriptPath,
@@ -200,6 +218,7 @@ export class Extensions {
     shouldWakeWorkerForAlarm,
     sharedInstance,
     workerSessionPagePatterns,
+    workerSessionBlockedUrls,
     logger,
   }: ExtensionsOptions) {
     this.extensionDirs = extensionDirs;
@@ -215,6 +234,8 @@ export class Extensions {
     this.sharedInstance = sharedInstance;
 
     this.workerSessionPagePatterns = workerSessionPagePatterns;
+
+    this.workerSessionBlockedUrls = workerSessionBlockedUrls;
 
     this.logger = logger;
 
@@ -346,6 +367,8 @@ export class Extensions {
 
     const sharedInstanceDerive = this.sharedInstance?.adoptSession(session);
 
+    this.blockWorkerSessionUrls(session, sharedInstanceDerive);
+
     for (const extensionDir of extensionDirs) {
       try {
         const { derivedDir, bridgeToken, extensionId } = await this.deriveExtension(
@@ -384,6 +407,55 @@ export class Extensions {
     }
 
     this.emitActionsChanged(session);
+  }
+
+  /**
+   * Cancels the requests the embedder named, in the worker session and nowhere
+   * else. An extension's service worker runs there rather than in an account
+   * session, so it sits outside whatever the embedder blocks per account, and
+   * this listener is the only thing standing between the worker and the
+   * network.
+   *
+   * `onBeforeRequest` rather than the `onBeforeSendHeaders` the bridge takes:
+   * a session holds exactly one listener per event, and the worker session is
+   * the embedder's own, where nothing else wants this one. The account
+   * sessions are left alone by the same arithmetic — there the one
+   * `onBeforeRequest` is the embedder's own blocker.
+   *
+   * A cancel and nothing more: the request fails in about a millisecond with
+   * `net::ERR_BLOCKED_BY_CLIENT`, before DNS, TCP or TLS, and the worker sees
+   * the `TypeError` its own fetch would have seen from any other failure.
+   * Answering it instead is not on offer — a `data:` redirect from here aborts
+   * the request rather than resolving it — and would buy nothing anyway, since
+   * an extension retrying on a timer retries whatever it is told.
+   *
+   * The filter does every bit of the matching, so the listener itself parses
+   * no URL: a pattern the embedder got wrong is a pattern that matches
+   * nothing, not a listener that decides.
+   */
+  private blockWorkerSessionUrls(
+    session: Session,
+    sharedInstanceDerive: SharedInstanceDeriveOptions | undefined,
+  ) {
+    if (sharedInstanceDerive?.role !== "worker" || !this.workerSessionBlockedUrls?.length) {
+      return;
+    }
+
+    this.blockedUrlSessions.add(session);
+
+    session.webRequest.onBeforeRequest(
+      { urls: this.workerSessionBlockedUrls },
+      (_details, callback) => {
+        callback({ cancel: true });
+      },
+    );
+
+    // Once, and with the patterns, so that the log says why those requests
+    // fail rather than leaving the extension's own error line to be read as a
+    // network fault
+    this.logger?.info("Blocking extension telemetry in the worker session", {
+      urls: this.workerSessionBlockedUrls,
+    });
   }
 
   /**
@@ -552,6 +624,10 @@ export class Extensions {
     this.actionsBySession.delete(session);
 
     this.bridge.teardownSession(session);
+
+    if (this.blockedUrlSessions.delete(session)) {
+      session.webRequest.onBeforeRequest(null);
+    }
 
     this.nativeMessaging.teardownSession(session);
 

--- a/packages/electron-extensions/fixture/background.ts
+++ b/packages/electron-extensions/fixture/background.ts
@@ -31,7 +31,10 @@ import {
   getChromeWebNavigation,
 } from "./chrome";
 
-const workerGlobals = globalThis as unknown as { crypto: { randomUUID: () => string } };
+const workerGlobals = globalThis as unknown as {
+  crypto: { randomUUID: () => string };
+  fetch: (url: string, init: { method: string; mode: string; body: string }) => Promise<unknown>;
+};
 
 const workerInstanceId = workerGlobals.crypto.randomUUID();
 
@@ -63,6 +66,7 @@ type ProbeMessage = {
   nonce?: string;
   key?: string;
   value?: unknown;
+  url?: string;
 };
 
 /**
@@ -212,6 +216,26 @@ runtime.onMessage.addListener((message, sender, sendResponse) => {
     storage.local.set({ [key]: value }, () => {
       sendResponse({ type: "write-storage-reply", key });
     });
+
+    return true;
+  }
+
+  /*
+   * The worker reaching the network itself, which is the one thing only it can
+   * do: its requests are made in the session it runs in, where the embedder's
+   * per-account blocking never applies. `no-cors` because the fixture asks for
+   * no host permissions — the response is opaque either way, and what is being
+   * probed is whether the request went out at all. This listener answers late.
+   */
+  if (probeMessage?.type === "fetch-url" && typeof probeMessage.url === "string") {
+    workerGlobals.fetch(probeMessage.url, { method: "POST", mode: "no-cors", body: "{}" }).then(
+      () => {
+        sendResponse({ type: "fetch-url-reply", status: "ok" });
+      },
+      (error: unknown) => {
+        sendResponse({ type: "fetch-url-reply", status: "error", message: String(error) });
+      },
+    );
 
     return true;
   }

--- a/packages/shared/extensions.test.ts
+++ b/packages/shared/extensions.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { curatedExtensions } from "./extensions";
+
+/**
+ * Hosts the extensions have to keep reaching, one per shape the catalog could
+ * plausibly swallow: the product API, the certificate revocation endpoint that
+ * shares a second-level domain with two telemetry hosts, and the sign-in host
+ * the content script clamp is written around.
+ */
+const PRODUCT_URLS = [
+  "https://my.1password.com/api/v2/account",
+  "https://crl.1passwordservices.com/1password.crl",
+  "https://accounts.google.com/signin",
+];
+
+/**
+ * The catalog's patterns as the loader's filter reads them: scheme, host, and
+ * a path that matches everything under it.
+ */
+function parseTelemetryUrl(telemetryUrl: string) {
+  const [, host] = telemetryUrl.match(/^https:\/\/([^/*]+)\/\*$/) ?? [];
+
+  return host;
+}
+
+const telemetryUrls = curatedExtensions.flatMap(
+  (curatedExtension) => curatedExtension.telemetryUrls ?? [],
+);
+
+describe("curated extension telemetry URLs", () => {
+  /*
+   * The invariant the whole list rests on: every pattern names one host
+   * outright. A wildcard anywhere in the host would reach past the endpoint it
+   * was written for — `*.1passwordservices.com` covers the certificate
+   * revocation endpoint, and blocking that breaks the password manager rather
+   * than quieting it.
+   */
+  test("every pattern is a host-exact https pattern", () => {
+    expect(telemetryUrls.length).toBeGreaterThan(0);
+
+    for (const telemetryUrl of telemetryUrls) {
+      const host = parseTelemetryUrl(telemetryUrl);
+
+      expect(host).toBeDefined();
+
+      expect(host).not.toContain("*");
+    }
+  });
+
+  /*
+   * And that no pattern reaches a host the product needs. A cancel is
+   * indistinguishable from the network being down, so a mistake here is a
+   * password manager that quietly stops working.
+   */
+  test("no pattern covers a host the extensions need", () => {
+    for (const productUrl of PRODUCT_URLS) {
+      const productHost = new URL(productUrl).host;
+
+      for (const telemetryUrl of telemetryUrls) {
+        expect(parseTelemetryUrl(telemetryUrl)).not.toBe(productHost);
+      }
+    }
+  });
+});

--- a/packages/shared/extensions.ts
+++ b/packages/shared/extensions.ts
@@ -13,6 +13,22 @@ export type CuratedExtension = {
    * for. Absent leaves the manifest's own patterns in place.
    */
   contentScriptMatches?: string[];
+  /**
+   * The extension's telemetry, crash-reporting and log-collection endpoints, as
+   * match patterns. Requests to them are canceled in the session the
+   * extension's service worker runs in, which is where an extension of this
+   * size does its reporting from.
+   *
+   * Only what the product does not need: an endpoint the extension depends on
+   * belongs nowhere near this list, since a cancel here is indistinguishable
+   * from the network being down.
+   *
+   * Host-exact, never a wildcard over a domain. 1Password serves certificate
+   * revocation from `crl.1passwordservices.com`, the same second-level domain
+   * as two of the hosts below, so a pattern that widened to the domain would
+   * take a working password manager with it.
+   */
+  telemetryUrls?: string[];
 };
 
 /** The 1Password Chrome Web Store id, which app and settings both single out. */
@@ -42,6 +58,19 @@ export const curatedExtensions: CuratedExtension[] = [
     // the settings paths alone: Google reshuffles those and redirects between
     // them, and a path that falls outside the clamp offers nothing, silently
     contentScriptMatches: ["https://accounts.google.com/*", "https://myaccount.google.com/*"],
+    telemetryUrls: [
+      // Observability: every console line the worker writes, forwarded as a
+      // metric over Connect, and log entries carrying account uuids beside them
+      "https://client-log-forwarder.1password.com/*",
+      "https://client-log-forwarder.1password.ca/*",
+      "https://client-log-forwarder.1password.eu/*",
+      // Snowplow product telemetry, and the Snowplow Mini collector the
+      // extension's own policy also allows it to reach
+      "https://telemetry.1passwordservices.com/*",
+      "https://com-1password-prod1.mini.snplow.net/*",
+      // Sentry error reporting, initialized as the worker starts
+      "https://b5x-sentry.1passwordservices.com/*",
+    ],
   },
 ];
 

--- a/tests/extension-telemetry.e2e.ts
+++ b/tests/extension-telemetry.e2e.ts
@@ -1,0 +1,231 @@
+/*
+ * The block on the extension worker's telemetry, exercised through the
+ * checked-in fixture extension (`packages/electron-extensions/fixture`) rather
+ * than through 1Password, which needs a real account, the desktop app and a
+ * display. What is under test is the loader's listener and not the catalog:
+ * the listener is attached to the session, so whichever extension the worker
+ * session happens to hold is the one whose requests it cancels — and the
+ * fixture is the one that can be asked to make a request on demand.
+ *
+ * The launch carries `MERU_EXTENSIONS_FIXTURE`, which puts the bundled fixture
+ * into every session of this packaged build, and goes through `useProApp`
+ * because a file is entirely one entitlement or the other — `useApp` registers
+ * its hooks once at module scope. One account is enough here: the worker runs
+ * in the default session, which no account owns, so nothing about this changes
+ * with a second.
+ *
+ * Every assertion is on `net::ERR_BLOCKED_BY_CLIENT` rather than on the fetch
+ * having failed. A fetch to a host this machine cannot resolve fails too, so a
+ * test that only asked whether the request failed would pass on a sandbox with
+ * no network and mean nothing; the error code is what separates Meru
+ * canceling the request from the network never carrying it.
+ */
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { FIXTURE_EXTENSION_ID } from "@meru/electron-extensions/fixture/id";
+import { curatedExtensions } from "@meru/shared/extensions";
+import { expect, test } from "@playwright/test";
+import { useProApp } from "./lib/app";
+
+/** The account the app comes up with, in the shape `pro.e2e.ts` seeds. */
+function account(id: string, label: string) {
+  return {
+    id,
+    label,
+    color: null,
+    selected: true,
+    notifications: true,
+    gmail: { unreadBadge: true, delegatedAccountId: null, unifiedInbox: true },
+    workspaceApps: { savedTabs: [], bookmarks: [] },
+  };
+}
+
+/** `null` is how a probe asks for the default session, where the worker runs. */
+const WORKER_SESSION = null;
+
+const meru = useProApp(
+  { accounts: [account("only-account", "Only")] },
+  { env: { MERU_EXTENSIONS_FIXTURE: "1" } },
+);
+
+/**
+ * A URL under the first telemetry pattern the catalog carries, read from the
+ * catalog rather than written out again: what the app blocks is exactly this
+ * list, so a pattern that were dropped from it would fail this test rather
+ * than leave it asserting against a host nothing blocks any more.
+ */
+function firstTelemetryUrl() {
+  const [telemetryPattern] = curatedExtensions.flatMap(
+    (curatedExtension) => curatedExtension.telemetryUrls ?? [],
+  );
+
+  if (!telemetryPattern) {
+    throw new Error("No curated extension names a telemetry URL to block");
+  }
+
+  return telemetryPattern.replace(/\*$/, "probe");
+}
+
+type RequestError = { url: string; error: string };
+
+/** The loopback server the control request is aimed at. */
+let server: http.Server;
+
+let serverOrigin: string;
+
+test.beforeAll(async () => {
+  server = http.createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "text/plain" }).end("ok");
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  serverOrigin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+test.afterAll(async () => {
+  await new Promise((resolve) => {
+    server.close(resolve);
+  });
+});
+
+/**
+ * Waits until the app has loaded the fixture into the session, which is also
+ * when the loader has attached the block: both happen in `setupSession`.
+ */
+async function waitForFixture(partition: string | null) {
+  await expect
+    .poll(async () =>
+      meru.app.evaluate(
+        ({ session }, { partition: partitionName, extensionId }) =>
+          (partitionName === null
+            ? session.defaultSession
+            : session.fromPartition(partitionName)
+          ).extensions
+            .getAllExtensions()
+            .some((extension) => extension.id === extensionId),
+        { partition, extensionId: FIXTURE_EXTENSION_ID },
+      ),
+    )
+    .toBe(true);
+}
+
+/**
+ * Starts recording how the worker session's failed requests failed, which is
+ * the only place the error code is legible: the worker itself sees the same
+ * `TypeError` for every failure, by design of `fetch`.
+ */
+async function recordRequestErrors() {
+  await meru.app.evaluate(({ session }) => {
+    const mainGlobals = globalThis as unknown as { meruRequestErrors?: RequestError[] };
+
+    mainGlobals.meruRequestErrors = [];
+
+    session.defaultSession.webRequest.onErrorOccurred({ urls: ["<all_urls>"] }, (details) => {
+      mainGlobals.meruRequestErrors?.push({ url: details.url, error: details.error });
+    });
+  });
+}
+
+async function readRequestErrors() {
+  return meru.app.evaluate(() => {
+    const mainGlobals = globalThis as unknown as { meruRequestErrors?: RequestError[] };
+
+    return mainGlobals.meruRequestErrors ?? [];
+  });
+}
+
+/** Opens the fixture's popup in the worker session, and hands back its id. */
+async function openWorkerPopup() {
+  await waitForFixture(WORKER_SESSION);
+
+  return meru.app.evaluate(
+    async ({ BrowserWindow }, { extensionId }) => {
+      // No partition, so the window runs in the default session, which is where
+      // the one worker is
+      const popupWindow = new BrowserWindow({ show: false });
+
+      await popupWindow.loadURL(`chrome-extension://${extensionId}/popup.html?context=telemetry`);
+
+      return popupWindow.webContents.id;
+    },
+    { extensionId: FIXTURE_EXTENSION_ID },
+  );
+}
+
+/**
+ * Asks the worker to fetch a URL, through an extension page of the worker's
+ * own session — natively, with no proxy in the path. The request is the
+ * worker's own, made in the session the block is attached to, which is the
+ * whole point: a page's fetch would be made by the page.
+ */
+async function fetchFromWorker(webContentsId: number, url: string) {
+  return meru.app.evaluate(
+    ({ webContents }, { webContentsId: contentsId, url: fetchUrl }) => {
+      const contents = webContents.fromId(contentsId);
+
+      if (!contents) {
+        return null;
+      }
+
+      return contents.mainFrame.executeJavaScript(
+        `new Promise((resolve) => {
+          chrome.runtime.sendMessage(
+            { type: "fetch-url", url: ${JSON.stringify(fetchUrl)} },
+            (reply) => {
+              resolve(reply ?? null);
+            },
+          );
+        })`,
+      ) as Promise<{ status?: string; message?: string } | null>;
+    },
+    { webContentsId, url },
+  );
+}
+
+test("the worker's telemetry request is canceled before it leaves the machine", async () => {
+  const telemetryUrl = firstTelemetryUrl();
+
+  await recordRequestErrors();
+
+  const popupId = await openWorkerPopup();
+
+  const reply = await fetchFromWorker(popupId, telemetryUrl);
+
+  expect(reply?.status).toBe("error");
+
+  /*
+   * Polled, because `onErrorOccurred` is the last thing the network stack
+   * reports and the worker's `fetch` can reject a moment before it. The code
+   * is what makes this a block rather than a failed lookup.
+   */
+  await expect
+    .poll(async () =>
+      (await readRequestErrors()).find((requestError) => requestError.url === telemetryUrl),
+    )
+    .toEqual({ url: telemetryUrl, error: "net::ERR_BLOCKED_BY_CLIENT" });
+});
+
+test("the worker's other requests go out untouched", async () => {
+  const controlUrl = `${serverOrigin}/probe`;
+
+  await recordRequestErrors();
+
+  const popupId = await openWorkerPopup();
+
+  const reply = await fetchFromWorker(popupId, controlUrl);
+
+  // The filter is what does the matching, so a request outside it never
+  // reaches the listener at all — and this one is answered by a server in this
+  // test process, which is what makes "it resolved" mean the request went out
+  expect(reply?.status).toBe("ok");
+
+  // For this URL rather than for none at all: the app makes requests of its
+  // own in this session, and an update check that fails says nothing about the
+  // block
+  expect(
+    (await readRequestErrors()).filter((requestError) => requestError.url === controlUrl),
+  ).toEqual([]);
+});


### PR DESCRIPTION
## Summary
Cancels 1Password's telemetry, crash-reporting and log-collection requests in the session the extension worker runs in, on purpose, instead of leaving them to fail by accident. Six host-exact endpoints are listed on the catalog entry, the loader attaches one filtered `onBeforeRequest` cancel on the worker session, and nothing the product needs is touched. The thirty-second `Failed to send log metrics` line stays, because 1Password's flush timer re-arms whatever the outcome; it is now Meru's own doing and the log says so at setup.

## Problem
Meru is privacy focused, and the 1Password worker phones home on three channels, read from the 8.12.34.34 bundle: an observability forwarder at `client-log-forwarder.1password.{com,ca,eu}` that ships every console line as a metric and log entries carrying account uuids, Snowplow at `telemetry.1passwordservices.com` (and its Snowplow Mini collector) carrying account, user, device and flag data, and Sentry at `b5x-sentry.1passwordservices.com`. On Tim's Mac the forwarder call fails and the worker logs `[LogManager] Failed to send log metrics: <redacted>` at error level every thirty seconds for the life of the app. There is no opt-out to reach: the metrics gate answers to a server-set pre-registration flag alone, the Firefox-only collection settings are compiled out, and managed storage carries no telemetry policy.

Why the request fails today was not established, but the host permission clamp is ruled out: measured in bare Electron 43.2.0, a worker fetch with `<all_urls>` goes out with no preflight, the derive leaves `host_permissions` alone and keeps `https://*.1password.com` in `connect-src`, and a request shaped like the worker's gets HTTP 200 from the forwarder from the sandbox. The error text is 1Password's own redaction. Whatever it is on that machine, it stops mattering once the request fails locally by design. Full write-up in the feature doc under "1Password's telemetry is blocked in the worker session".

## Solution
- `CuratedExtension.telemetryUrls` on the catalog entry lists the six endpoints as match patterns, with a comment per channel
- `Extensions` gains `workerSessionBlockedUrls`, answered with one filtered `onBeforeRequest` cancel on the worker session and cleared on teardown; the account sessions are left alone because a session takes one listener per event and there it is the blocker's
- `packages/app/extensions.ts` passes the union of the catalog's lists, unconditionally: not behind `blocker.enabled` or the license, since it is a product decision and extensions are Pro already
- Host-exact patterns rather than a wildcard over either domain: `crl.1passwordservices.com` is certificate revocation and `client-log-forwarder` sits under the product domain
- A cancel rather than a sinkhole: measured, the fetch fails in about a millisecond with `net::ERR_BLOCKED_BY_CLIENT` before DNS, and a `data:` redirect from `onBeforeRequest` aborts the fetch anyway, so answering the request would need a custom scheme handler built to deceive a client that keeps its timer regardless
- The fixture worker gains a `fetch-url` probe, and a new end-to-end file reads the default session's `onErrorOccurred` so the assertion tells a block from a DNS failure

## Try it
Run a development build with 1Password installed and watch the app log: one `Blocking extension telemetry in the worker session` line at setup naming the six patterns, and the worker's `[LogManager]` error line continuing every thirty seconds with nothing reaching the network for those hosts.

## Not verified
- The effect on the thirty-second error line against 1Password on a real machine; the evidence is the fixture worker's fetch being canceled and the bare-Electron measurement. Tim re-tests on his Mac after merge.
- The end-to-end suite passed in full on Linux before the rebase onto the two main commits that landed meanwhile (a catalog description string and a Gmail guard), which touch nothing this branch does; types, lint, format and unit tests were rerun after it. No macOS or Windows run.
- That the six hosts are the complete set rests on the bundle read; the `.ca` and `.eu` forwarders, Snowplow and Sentry patterns are covered by shape assertions only, the end-to-end case exercising the first.