### PR TITLE
Let the extension worker's tabs.query and tabs.get see the sessions it shims

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -249,8 +249,9 @@ export const extensions = new Extensions({
  * close a cycle. It holds because nothing here is dereferenced while the
  * modules evaluate: this is a hoisted function declaration, and the first call
  * to it is a query from the worker, which is many awaits past the last module
- * body. The guard is for the other end of the same window — an app whose
- * accounts have not been constructed yet has no front view to name.
+ * body. The guards are for the other end of the same window — an app whose
+ * accounts have not been constructed yet has no front view to name — and for
+ * the moments an account is half removed.
  */
 function isActiveTab(contents: WebContents) {
   const workspaceApp = WorkspaceApp.tryFromViewWebContents(contents);
@@ -259,16 +260,26 @@ function isActiveTab(contents: WebContents) {
     return true;
   }
 
-  const selectedAccount = accounts.instances.size > 0 ? accounts.getSelectedAccount() : undefined;
-
-  if (!selectedAccount) {
+  if (accounts.instances.size === 0) {
     return false;
   }
 
-  const activeView =
-    selectedAccount.instance.tabs.activeTab.view ?? selectedAccount.instance.gmail.view;
+  // Resolving the front view throws while an account is being removed: its
+  // tabs are closed and its Gmail view destroyed several awaits before the
+  // config stops naming it as selected. A page with no front view to name is
+  // not active, and saying so keeps the rest of the answer standing — a throw
+  // here would fail the whole query, and a lock broadcast landing in that
+  // window would reach nobody
+  try {
+    const selectedAccount = accounts.getSelectedAccount();
 
-  return activeView.webContents === contents;
+    const activeView =
+      selectedAccount.instance.tabs.activeTab.view ?? selectedAccount.instance.gmail.view;
+
+    return activeView.webContents === contents;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -15,12 +15,14 @@ import {
 import { curatedExtensions, isCuratedExtensionId } from "@meru/shared/extensions";
 import { ms } from "@meru/shared/ms";
 import type { ExtensionUpdateResult, InstalledExtensionState } from "@meru/shared/types";
-import { app, session } from "electron";
+import { app, session, type WebContents } from "electron";
 import { serializeError } from "serialize-error";
+import { accounts } from "@/accounts";
 import { config } from "@/config";
 import { log } from "@/lib/log";
 import { serializeErrorDetails } from "@/lib/log-details";
 import { licenseKey } from "@/license-key";
+import { WorkspaceApp } from "@/workspace-app";
 
 /** Where the curated extensions are installed, `<installDir>/<id>/<version>`. */
 const INSTALL_DIR = path.join(app.getPath("userData"), "extensions");
@@ -215,6 +217,7 @@ export const extensions = new Extensions({
     shimScriptPath: path.join(__dirname, "extensions-runtime-proxy-shim.js"),
     relayScriptPath: path.join(__dirname, "extensions-runtime-proxy-relay.js"),
     getWorkerSession: () => session.defaultSession,
+    isActiveTab,
   }),
   logger: {
     debug: (message, details) => {
@@ -228,6 +231,45 @@ export const extensions = new Extensions({
     },
   },
 });
+
+/**
+ * Which page Meru is showing, which is what Chrome's `tabs.Tab.active` means
+ * and what the one worker's `chrome.tabs.query({active: true})` asks for. The
+ * selected account's front view is the answer in the main window — the same
+ * derivation the menu's `getActiveViewWebContents` uses — and a workspace app
+ * living in a window of its own is the page that window shows.
+ *
+ * Focus is deliberately not the question, though it is what Electron's own
+ * `tabs` answers: 1Password unlocks behind a Touch ID prompt raised by its
+ * desktop app, so at the moment its worker asks for the active tab none of
+ * Meru's views is focused at all, and a focus-based answer would send the
+ * unlock to nobody.
+ *
+ * `accounts` and `WorkspaceApp` both import this module, so the imports back
+ * close a cycle. It holds because nothing here is dereferenced while the
+ * modules evaluate: this is a hoisted function declaration, and the first call
+ * to it is a query from the worker, which is many awaits past the last module
+ * body. The guard is for the other end of the same window — an app whose
+ * accounts have not been constructed yet has no front view to name.
+ */
+function isActiveTab(contents: WebContents) {
+  const workspaceApp = WorkspaceApp.tryFromViewWebContents(contents);
+
+  if (workspaceApp?.isWindowed) {
+    return true;
+  }
+
+  const selectedAccount = accounts.instances.size > 0 ? accounts.getSelectedAccount() : undefined;
+
+  if (!selectedAccount) {
+    return false;
+  }
+
+  const activeView =
+    selectedAccount.instance.tabs.activeTab.view ?? selectedAccount.instance.gmail.view;
+
+  return activeView.webContents === contents;
+}
 
 /**
  * Loads the extensions into the session the one worker runs in, which is

--- a/packages/electron-extensions/derive/match-pattern.test.ts
+++ b/packages/electron-extensions/derive/match-pattern.test.ts
@@ -99,6 +99,12 @@ describe("matchesUrl", () => {
     expect(matchesUrl("file:///etc/*", "file:///home/tim/notes.html")).toBe(false);
   });
 
+  // Chrome lowercases a pattern's scheme and host as it parses one
+  test("reads the scheme and the host of a pattern case-insensitively, and the path as written", () => {
+    expect(matchesUrl("HTTPS://Accounts.Google.com/*", PAGE_URL)).toBe(true);
+    expect(matchesUrl("https://accounts.google.com/SIGNIN/*", PAGE_URL)).toBe(false);
+  });
+
   test("a pattern that cannot be read, and a URL that is none, reach nothing", () => {
     expect(matchesUrl("accounts.google.com", PAGE_URL)).toBe(false);
     expect(matchesUrl("<all_urls>", "not a url")).toBe(false);

--- a/packages/electron-extensions/derive/match-pattern.test.ts
+++ b/packages/electron-extensions/derive/match-pattern.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { reachesClampedSite } from "./match-pattern";
+import { matchesUrl, reachesClampedSite } from "./match-pattern";
 
 const CLAMPED_SITE = "https://accounts.google.com/*";
 
@@ -53,5 +53,55 @@ describe("reachesClampedSite", () => {
 
   test("reaches nothing from a pattern that cannot be read", () => {
     expect(reachesClampedSite("accounts.google.com", CLAMPED_SITE)).toBe(false);
+  });
+});
+
+/*
+ * The other question a match pattern answers: whether it reaches a page that is
+ * actually open, which is what `chrome.tabs.query({url})` filters on.
+ */
+describe("matchesUrl", () => {
+  const PAGE_URL = "https://accounts.google.com/signin/v2?flow=gmail";
+
+  test("matches the host and the path a pattern names", () => {
+    expect(matchesUrl("https://accounts.google.com/*", PAGE_URL)).toBe(true);
+    expect(matchesUrl("https://accounts.google.com/signin/*", PAGE_URL)).toBe(true);
+    expect(matchesUrl("*://accounts.google.com/*", PAGE_URL)).toBe(true);
+    expect(matchesUrl("https://*.google.com/*", PAGE_URL)).toBe(true);
+    expect(matchesUrl("https://*/*", PAGE_URL)).toBe(true);
+  });
+
+  test("holds a pattern to its scheme, its host and its path alike", () => {
+    expect(matchesUrl("http://accounts.google.com/*", PAGE_URL)).toBe(false);
+    expect(matchesUrl("https://mail.google.com/*", PAGE_URL)).toBe(false);
+    expect(matchesUrl("https://*.notgoogle.com/*", PAGE_URL)).toBe(false);
+    expect(matchesUrl("https://accounts.google.com/settings/*", PAGE_URL)).toBe(false);
+  });
+
+  // Chrome matches a pattern's path against the URL's path and query together
+  test("matches the query string as part of the path", () => {
+    expect(matchesUrl("https://accounts.google.com/signin/v2", PAGE_URL)).toBe(false);
+    expect(matchesUrl("https://accounts.google.com/signin/v2?flow=gmail", PAGE_URL)).toBe(true);
+  });
+
+  test("every URL means Chrome's own list of schemes, not the wildcard's two", () => {
+    expect(matchesUrl("<all_urls>", PAGE_URL)).toBe(true);
+    expect(matchesUrl("<all_urls>", "file:///home/tim/notes.html")).toBe(true);
+    expect(matchesUrl("*://*/*", "file:///home/tim/notes.html")).toBe(false);
+    expect(matchesUrl("<all_urls>", "chrome-extension://aeblfdkhhhdcdjpifhhbdiojplfjncoa/x")).toBe(
+      false,
+    );
+  });
+
+  test("a file URL matches on its path, there being no host to match", () => {
+    expect(matchesUrl("file:///*", "file:///home/tim/notes.html")).toBe(true);
+    expect(matchesUrl("file:///home/*", "file:///home/tim/notes.html")).toBe(true);
+    expect(matchesUrl("file:///etc/*", "file:///home/tim/notes.html")).toBe(false);
+  });
+
+  test("a pattern that cannot be read, and a URL that is none, reach nothing", () => {
+    expect(matchesUrl("accounts.google.com", PAGE_URL)).toBe(false);
+    expect(matchesUrl("<all_urls>", "not a url")).toBe(false);
+    expect(matchesUrl("https://accounts.google.com/*", "")).toBe(false);
   });
 });

--- a/packages/electron-extensions/derive/match-pattern.ts
+++ b/packages/electron-extensions/derive/match-pattern.ts
@@ -152,9 +152,11 @@ export function matchesUrl(pattern: string, url: string) {
     return false;
   }
 
+  // Chrome lowercases a pattern's scheme and host as it parses one, as `URL`
+  // does a URL's; the path stays case-sensitive on both sides
   return (
-    schemeCovers(parsedPattern.scheme, scheme) &&
-    hostCovers(parsedPattern.host, parsedUrl.hostname) &&
+    schemeCovers(parsedPattern.scheme.toLowerCase(), scheme) &&
+    hostCovers(parsedPattern.host.toLowerCase(), parsedUrl.hostname) &&
     pathCovers(parsedPattern.path, `${parsedUrl.pathname}${parsedUrl.search}`)
   );
 }

--- a/packages/electron-extensions/derive/match-pattern.ts
+++ b/packages/electron-extensions/derive/match-pattern.ts
@@ -1,12 +1,18 @@
 /**
- * The sites a clamp names, and whether a content script could ever have run on
- * one of them.
+ * Chrome match patterns: the sites a clamp names and whether a content script
+ * could ever have run on one of them, and whether a pattern reaches a concrete
+ * URL.
  *
  * The clamp is a host allowlist: the catalog names the sites an extension is
  * offered for, and the derive writes them over every content script's own
- * patterns. So the question asked here is about scheme and host, never path — a
- * content script restricted to a path within an allowed host keeps running on
- * that host, which is what the clamp already does to every entry it rewrites.
+ * patterns. So the question `reachesClampedSite` asks is about scheme and host,
+ * never path — a content script restricted to a path within an allowed host
+ * keeps running on that host, which is what the clamp already does to every
+ * entry it rewrites.
+ *
+ * `matchesUrl` is the other question, pattern against a URL, which is what
+ * `chrome.tabs.query({url})` filters on (`runtime-proxy/worker-tabs.ts`); there
+ * the path is part of the answer, since an extension may well ask for one.
  */
 
 const ALL_URLS = "<all_urls>";
@@ -14,6 +20,8 @@ const ALL_URLS = "<all_urls>";
 type MatchPattern = {
   scheme: string;
   host: string;
+  /** Everything from the host's trailing slash on, `"/"` where there is none. */
+  path: string;
 };
 
 /**
@@ -39,6 +47,7 @@ function parseMatchPattern(pattern: string): MatchPattern | undefined {
   return {
     scheme,
     host: pathIndex === -1 ? afterScheme : afterScheme.slice(0, pathIndex),
+    path: pathIndex === -1 ? "/" : afterScheme.slice(pathIndex),
   };
 }
 
@@ -89,5 +98,63 @@ export function reachesClampedSite(contentScriptPattern: string, clampPattern: s
   return (
     schemeCovers(contentScriptSites.scheme, clampedSite.scheme) &&
     hostCovers(contentScriptSites.host, clampedSite.host)
+  );
+}
+
+/**
+ * The schemes `<all_urls>` stands for, which is Chrome's own list rather than
+ * the two a bare `*` covers.
+ */
+const ALL_URLS_SCHEMES = new Set(["http", "https", "file", "ftp"]);
+
+/**
+ * Whether a match pattern's path reaches a URL's. Chrome's path grammar has one
+ * wildcard, `*`, standing for any run of characters, and the pattern is matched
+ * against the URL's path *and* query — `https://example.com/a?b=c` is reached by
+ * `https://example.com/a*` and not by `https://example.com/a`.
+ */
+function pathCovers(patternPath: string, urlPath: string) {
+  const expression = patternPath
+    .split("*")
+    .map((literal) => literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join(".*");
+
+  return new RegExp(`^${expression}$`).test(urlPath);
+}
+
+/**
+ * Whether a match pattern reaches a concrete URL — scheme, host and path, the
+ * whole grammar rather than the clamp's scheme-and-host question.
+ *
+ * A URL `URL` cannot parse reaches nothing: an extension's pattern is a claim
+ * about a page, and a string that names no page is not one. `<all_urls>` is
+ * Chrome's own shorthand for every permitted scheme, which is where it differs
+ * from a wildcard scheme, covering `http` and `https` alone.
+ */
+export function matchesUrl(pattern: string, url: string) {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return false;
+  }
+
+  const scheme = parsedUrl.protocol.slice(0, -":".length);
+
+  if (pattern === ALL_URLS) {
+    return ALL_URLS_SCHEMES.has(scheme);
+  }
+
+  const parsedPattern = parseMatchPattern(pattern);
+
+  if (!parsedPattern) {
+    return false;
+  }
+
+  return (
+    schemeCovers(parsedPattern.scheme, scheme) &&
+    hostCovers(parsedPattern.host, parsedUrl.hostname) &&
+    pathCovers(parsedPattern.path, `${parsedUrl.pathname}${parsedUrl.search}`)
   );
 }

--- a/packages/electron-extensions/fixture/background.ts
+++ b/packages/electron-extensions/fixture/background.ts
@@ -73,6 +73,13 @@ type WorkerCallOutcome =
   | { status: "replied"; reply: unknown }
   | { status: "error"; message: string };
 
+/** One tab of the worker's `tabs.query`, flattened to what a test compares on. */
+type SeenTab = {
+  id: number | null;
+  url: string | null;
+  active: boolean | null;
+};
+
 const storage = getChromeStorage();
 
 /** The stamps, written once at boot, that the probes read back. */
@@ -113,6 +120,109 @@ function sendToSender(
         ? { status: "error", message: lastError.message ?? "unknown" }
         : { status: "replied", reply },
     );
+  });
+}
+
+/**
+ * Every tab the worker can see, and the one the message came from asked for by
+ * id — the two calls a lock broadcast starts with. Natively both are scoped to
+ * the worker's own session, which holds no account's tabs, so in a shimmed
+ * session an unrelayed `query` lists nothing and an unrelayed `get` answers
+ * with `lastError`.
+ */
+function describeTabs(
+  sender: FixtureMessageSender | undefined,
+  answer: (tabs: SeenTab[], activeTabIds: (number | null)[], self: WorkerCallOutcome) => void,
+) {
+  tabs.query({}, (queried) => {
+    const seen = queried.map((tab) => ({
+      id: tab.id ?? null,
+      url: tab.url ?? null,
+      active: tab.active ?? null,
+    }));
+
+    // The filter a fill starts with, asked separately so that what the embedder
+    // calls the front view is visible next to the whole list
+    tabs.query({ active: true }, (activeTabs) => {
+      const activeTabIds = activeTabs.map((tab) => tab.id ?? null);
+
+      const tabId = sender?.tab?.id;
+
+      if (tabId === undefined) {
+        answer(seen, activeTabIds, { status: "error", message: "The sender carried no tab" });
+
+        return;
+      }
+
+      tabs.get(tabId, (tab) => {
+        const lastError = runtime.lastError;
+
+        answer(
+          seen,
+          activeTabIds,
+          lastError
+            ? { status: "error", message: lastError.message ?? "unknown" }
+            : { status: "replied", reply: { id: tab?.id ?? null, url: tab?.url ?? null } },
+        );
+      });
+    });
+  });
+}
+
+/**
+ * The lock broadcast's own shape: `tabs.query` for every tab, then one
+ * `tabs.sendMessage` into each of them. What the asking context gets back is
+ * how the send into *its* tab went, which is the outcome that says whether the
+ * query listed it at all.
+ */
+function notifyAllTabs(
+  sender: FixtureMessageSender | undefined,
+  message: unknown,
+  answer: (outcome: WorkerCallOutcome) => void,
+) {
+  const senderTabId = sender?.tab?.id;
+
+  tabs.query({}, (queried) => {
+    const targets = queried.filter((tab) => typeof tab.id === "number");
+
+    let outcome: WorkerCallOutcome = {
+      status: "error",
+      message: "The worker's tabs.query did not list the sender's tab",
+    };
+
+    let remaining = targets.length;
+
+    const finish = () => {
+      remaining -= 1;
+
+      if (remaining <= 0) {
+        answer(outcome);
+      }
+    };
+
+    if (targets.length === 0) {
+      answer(outcome);
+
+      return;
+    }
+
+    for (const target of targets) {
+      const targetId = target.id as number;
+
+      tabs.sendMessage(targetId, message, {}, (reply) => {
+        const lastError = runtime.lastError;
+
+        // Every tab is messaged, as a lock broadcast messages every tab; only
+        // the asking context's own outcome is reported back to it
+        if (targetId === senderTabId) {
+          outcome = lastError
+            ? { status: "error", message: lastError.message ?? "unknown" }
+            : { status: "replied", reply };
+        }
+
+        finish();
+      });
+    }
   });
 }
 
@@ -169,6 +279,30 @@ runtime.onMessage.addListener((message, sender, sendResponse) => {
       { type: "ping-from-worker", nonce: probeMessage.nonce, workerInstanceId },
       (outcome) => {
         sendResponse({ type: "send-back-reply", outcome });
+      },
+    );
+
+    return true;
+  }
+
+  // What the worker's own `tabs.query` and `tabs.get` can see, which is every
+  // account's tabs only because main answers both. Answers late
+  if (probeMessage?.type === "query-tabs") {
+    describeTabs(sender, (seen, activeTabIds, self) => {
+      sendResponse({ type: "query-tabs-reply", tabs: seen, activeTabIds, self });
+    });
+
+    return true;
+  }
+
+  // And the lock broadcast's shape, which is the query and a send into every
+  // tab it listed. Late as well
+  if (probeMessage?.type === "notify-all-tabs") {
+    notifyAllTabs(
+      sender,
+      { type: "ping-from-worker", nonce: probeMessage.nonce, workerInstanceId },
+      (outcome) => {
+        sendResponse({ type: "notify-all-tabs-reply", outcome });
       },
     );
 

--- a/packages/electron-extensions/fixture/chrome.ts
+++ b/packages/electron-extensions/fixture/chrome.ts
@@ -9,6 +9,7 @@
 export type FixtureTab = {
   id?: number;
   url?: string;
+  active?: boolean;
 };
 
 export type FixtureMessageSender = {
@@ -46,6 +47,13 @@ export type FixtureTabs = {
     callback: (reply: unknown) => void,
   ) => void;
   connect: (tabId: number, connectInfo: { name: string; frameId?: number }) => FixturePort;
+  /**
+   * The two the worker sees only its own session's tabs through natively, which
+   * is none of an account's — the callback form, since `lastError` is what a
+   * `get` for a tab that is not there reports itself with.
+   */
+  query: (queryInfo: Record<string, unknown>, callback: (tabs: FixtureTab[]) => void) => void;
+  get: (tabId: number, callback: (tab: FixtureTab | undefined) => void) => void;
 };
 
 /** One frame as `chrome.webNavigation` describes it, in the slice the fixture reads. */
@@ -127,10 +135,10 @@ export function getChromeRuntime(): FixtureRuntime {
 }
 
 /**
- * The worker's `chrome.tabs`, whose `sendMessage` and `connect` the relay
- * client has shadowed by the time the fixture's background script runs — the
- * worker-to-page direction, which natively would reach the worker session's
- * own tabs alone.
+ * The worker's `chrome.tabs`, whose `sendMessage`, `connect`, `query` and
+ * `get` the relay client has shadowed by the time the fixture's background
+ * script runs — the worker-to-page direction, all four of which natively see
+ * the worker session's own tabs alone.
  */
 export function getChromeTabs(): FixtureTabs {
   const workerGlobals = globalThis as unknown as { chrome: { tabs: FixtureTabs } };

--- a/packages/electron-extensions/fixture/probes.ts
+++ b/packages/electron-extensions/fixture/probes.ts
@@ -70,6 +70,28 @@ export type WorkerInitiatedOutcome = {
   outcome: EchoOutcome;
 };
 
+/** One tab of the worker's own `tabs.query`, as the worker reported it. */
+export type SeenTab = {
+  id: number | null;
+  url: string | null;
+  active: boolean | null;
+};
+
+/**
+ * What the worker's own `chrome.tabs` can see: every tab it listed, and this
+ * context's own tab asked for by id. Both are scoped natively to the worker's
+ * session, which holds no account's tabs at all.
+ */
+export type WorkerTabsOutcome = {
+  tabs: SeenTab[];
+  /**
+   * The ids `tabs.query({active: true})` came back with, which is the filter a
+   * fill starts with and the one only the embedder can answer.
+   */
+  activeTabIds: (number | null)[];
+  self: EchoOutcome;
+};
+
 export type StorageOutcome =
   | { status: "read"; value: unknown }
   | { status: "error"; message: string };
@@ -167,10 +189,24 @@ export type ProbeResults = {
    * parent.
    */
   senderFrameSeenByWorker: EchoOutcome;
+  /**
+   * What the worker's `tabs.query` and `tabs.get` answered. In a
+   * content-script-only session Chromium lists none of these tabs — they belong
+   * to a session the worker is not loaded into — so a context finding itself
+   * here is reading main's answer.
+   */
+  tabsSeenByWorker: WorkerTabsOutcome;
   /** The worker messaging this context's own tab with `tabs.sendMessage`. */
   workerSentBack: WorkerInitiatedOutcome;
   /** The worker opening a port to this context's own tab with `tabs.connect`. */
   workerConnectedBack: WorkerInitiatedOutcome;
+  /**
+   * A lock broadcast's own shape, run by the worker: `tabs.query` for every tab
+   * and then one `tabs.sendMessage` into each. `heard` is what arrived here,
+   * and the outcome is the worker's report for this context's own tab — which
+   * reads as an error naming the query when the query never listed it.
+   */
+  workerNotifiedAllTabs: WorkerInitiatedOutcome;
   /**
    * Whether the worker's event log recorded this context answering on the port
    * the worker opened — the page-to-worker half of a worker-opened port, which
@@ -385,7 +421,7 @@ async function probeSenderFrame(runtime: FixtureRuntime): Promise<EchoOutcome> {
 function probeWorkerInitiated(
   runtime: FixtureRuntime,
   contextId: string,
-  requestType: "send-back" | "connect-back",
+  requestType: "send-back" | "connect-back" | "notify-all-tabs",
   arrivals: Map<string, { message: unknown; sender: SeenSender }>,
 ): Promise<WorkerInitiatedOutcome> {
   const nonce = `${requestType}:${contextId}`;
@@ -419,6 +455,28 @@ function probeWorkerInitiated(
       });
     });
   });
+}
+
+/**
+ * What the worker's own `chrome.tabs.query` and `chrome.tabs.get` see, asked
+ * of the worker because only it can make those calls.
+ */
+async function probeTabsSeenByWorker(runtime: FixtureRuntime): Promise<WorkerTabsOutcome> {
+  const askOutcome = await sendMessage(runtime, { type: "query-tabs" });
+
+  if (askOutcome.status !== "replied") {
+    return { tabs: [], activeTabIds: [], self: askOutcome };
+  }
+
+  const reply = askOutcome.reply as
+    | { tabs?: SeenTab[]; activeTabIds?: (number | null)[]; self?: EchoOutcome }
+    | undefined;
+
+  return {
+    tabs: reply?.tabs ?? [],
+    activeTabIds: reply?.activeTabIds ?? [],
+    self: reply?.self ?? { status: "error", message: "The worker answered without an outcome" },
+  };
 }
 
 /**
@@ -723,12 +781,21 @@ export async function runProbes(): Promise<ProbeResults> {
 
   const senderFrameSeenByWorker = await probeSenderFrame(runtime);
 
+  const tabsSeenByWorker = await probeTabsSeenByWorker(runtime);
+
   const workerSentBack = await probeWorkerInitiated(runtime, contextId, "send-back", arrivals);
 
   const workerConnectedBack = await probeWorkerInitiated(
     runtime,
     contextId,
     "connect-back",
+    arrivals,
+  );
+
+  const workerNotifiedAllTabs = await probeWorkerInitiated(
+    runtime,
+    contextId,
+    "notify-all-tabs",
     arrivals,
   );
 
@@ -749,8 +816,10 @@ export async function runProbes(): Promise<ProbeResults> {
     selfCloseSeenByWorker,
     openPortName,
     senderFrameSeenByWorker,
+    tabsSeenByWorker,
     workerSentBack,
     workerConnectedBack,
+    workerNotifiedAllTabs,
     portReplySeenByWorker:
       workerConnectedBack.heard !== null && (await probePortReplySeenByWorker(runtime, contextId)),
   };

--- a/packages/electron-extensions/runtime-proxy/bridge-protocol.ts
+++ b/packages/electron-extensions/runtime-proxy/bridge-protocol.ts
@@ -71,6 +71,8 @@ export const RUNTIME_PROXY_PATHS = {
   workerSendToTab: "/runtime-proxy/worker-send-to-tab",
   workerConnectToTab: "/runtime-proxy/worker-connect-to-tab",
   workerBroadcast: "/runtime-proxy/worker-broadcast",
+  workerQueryTabs: "/runtime-proxy/worker-query-tabs",
+  workerGetTab: "/runtime-proxy/worker-get-tab",
 } as const;
 
 /**
@@ -231,6 +233,12 @@ export type RuntimeProxyTab = {
   groupId: number;
   selected: boolean;
   audible: boolean;
+  /**
+   * Chrome's own shape, minus the `reason` it fills when something other than
+   * the user did the muting: Electron reports whether a page is muted and never
+   * says who asked.
+   */
+  mutedInfo: { muted: boolean };
   discarded: boolean;
   autoDiscardable: boolean;
 };
@@ -402,4 +410,44 @@ export type RuntimeProxyWorkerSendToTabResult =
 export type RuntimeProxyWorkerConnectToTabResult =
   | RuntimeProxyConnectResult
   | { status: "ownSession" }
+  | { status: "noTarget"; error: string };
+
+/**
+ * What a worker's `chrome.tabs.query` filters on, which is what Electron's own
+ * query honors and no more: `windowId`, `currentWindow`, `lastFocusedWindow`,
+ * `index`, `pinned`, `status`, `groupId` and the rest are ignored there, and
+ * ignoring them here keeps one answer rather than two. The facade shows one
+ * window anyway (`windows` answers a single fake window, id 1), so a window
+ * filter has nothing to narrow.
+ *
+ * `url` is one or more Chrome match patterns and `title` a glob, as Chrome
+ * documents them; both are matched against what the page is showing now.
+ */
+export type RuntimeProxyTabQueryInfo = {
+  active?: boolean;
+  audible?: boolean;
+  muted?: boolean;
+  url?: string | string[];
+  title?: string;
+};
+
+export type RuntimeProxyWorkerQueryTabsRequest = {
+  queryInfo?: RuntimeProxyTabQueryInfo;
+};
+
+export type RuntimeProxyWorkerQueryTabsResult = {
+  tabs: RuntimeProxyTab[];
+};
+
+export type RuntimeProxyWorkerGetTabRequest = {
+  tabId: unknown;
+};
+
+/**
+ * A tab the worker asked for by id, or Chrome's own error for one this app is
+ * not showing — which is what an id of a session the worker neither keeps nor
+ * shims reads as, the same line `tabs.sendMessage` draws.
+ */
+export type RuntimeProxyWorkerGetTabResult =
+  | { status: "tab"; tab: RuntimeProxyTab }
   | { status: "noTarget"; error: string };

--- a/packages/electron-extensions/runtime-proxy/index.test.ts
+++ b/packages/electron-extensions/runtime-proxy/index.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, test } from "bun:test";
-import type { Session } from "electron";
+import { describe, expect, mock, test } from "bun:test";
+import type { Session, WebContents } from "electron";
+import type { ExtensionBridge, ExtensionBridgeHandler } from "../bridge/bridge";
+import { type RuntimeProxyWorkerQueryTabsResult, RUNTIME_PROXY_PATHS } from "./bridge-protocol";
 import { createSharedExtensionInstance } from "./index";
 
+const EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
+
 function createSession(label: string) {
-  return { label } as unknown as Session;
+  return {
+    label,
+    // What `setWorkerSession` attaches its worker-liveness listener to
+    serviceWorkers: { on: () => undefined, removeListener: () => undefined },
+  } as unknown as Session;
 }
 
 /**
@@ -198,5 +206,88 @@ describe("createSharedExtensionInstance tab resolution across sessions", () => {
     sharedInstance.adoptSession(accountSession);
 
     expect(sharedInstance.canResolveTabAcrossSessions(workerSession, accountSession)).toBe(false);
+  });
+});
+
+/*
+ * The worker's own `tabs.query` and `tabs.get` are answered from main for the
+ * worker's session and the sessions it shims, and the shared instance is what
+ * says which those are. It is the same bookkeeping
+ * `canResolveTabAcrossSessions` answers from, so what is worth holding here is
+ * that the predicate handed to the proxy is that bookkeeping rather than a copy
+ * of it: a session adopted after the proxy was built is listed, and a session
+ * torn down stops being.
+ */
+describe("createSharedExtensionInstance tab listing across sessions", () => {
+  function createContents(contentsId: number, session: Session, url: string) {
+    return {
+      id: contentsId,
+      session,
+      getURL: () => url,
+      getTitle: () => "A page",
+      isDestroyed: () => false,
+      isLoading: () => false,
+      isFocused: () => false,
+      isCurrentlyAudible: () => false,
+      isAudioMuted: () => false,
+    } as unknown as WebContents;
+  }
+
+  test("lists a session from the moment it is adopted until it is torn down", async () => {
+    const workerSession = createSession("worker");
+
+    const accountSession = createSession("account");
+
+    const allContents = [
+      createContents(9, workerSession, "https://127.0.0.1/worker-page"),
+      createContents(7, accountSession, "https://mail.google.com/mail/u/0/"),
+    ];
+
+    // `WorkerTabs` resolves Electron's own list at call time, which is what
+    // lets a test hand it one
+    mock.module("electron", () => ({
+      webContents: {
+        getAllWebContents: () => allContents,
+        fromId: (contentsId: number) => allContents.find((contents) => contents.id === contentsId),
+      },
+    }));
+
+    const routes = new Map<string, ExtensionBridgeHandler>();
+
+    const bridge = {
+      handle: (pathName: string, handler: ExtensionBridgeHandler) => {
+        routes.set(pathName, handler);
+      },
+    } as unknown as ExtensionBridge;
+
+    const sharedInstance = createRoleAssigner(workerSession);
+
+    sharedInstance.install({ bridge });
+
+    sharedInstance.adoptSession(workerSession);
+
+    const queryTabs = async () => {
+      const response = await routes.get(RUNTIME_PROXY_PATHS.workerQueryTabs)?.({
+        session: workerSession,
+        extensionId: EXTENSION_ID,
+        senderFrame: undefined,
+        body: {},
+        headers: {},
+      });
+
+      const result = (await response?.json()) as RuntimeProxyWorkerQueryTabsResult;
+
+      return result.tabs.map((tab) => tab.id);
+    };
+
+    expect(await queryTabs()).toEqual([9]);
+
+    sharedInstance.adoptSession(accountSession);
+
+    expect(await queryTabs()).toEqual([9, 7]);
+
+    sharedInstance.teardownSession(accountSession);
+
+    expect(await queryTabs()).toEqual([9]);
   });
 });

--- a/packages/electron-extensions/runtime-proxy/index.ts
+++ b/packages/electron-extensions/runtime-proxy/index.ts
@@ -1,4 +1,4 @@
-import type { Session } from "electron";
+import type { Session, WebContents } from "electron";
 import type { SharedExtensionInstance } from "../extensions";
 import { RuntimeProxy } from "./runtime-proxy";
 import type { GetWebContentsFromFrame } from "./sender";
@@ -28,6 +28,19 @@ export type CreateSharedExtensionInstanceOptions = {
   getWorkerSession: () => Session;
   /** How a caller frame resolves to its hosting tab for sender reconstruction. */
   getWebContentsFromFrame?: GetWebContentsFromFrame;
+  /**
+   * Whether a page is the one its window is showing, which is what Chrome's
+   * `tabs.Tab.active` means and what `tabs.query({active: true})` filters on.
+   * Only the embedder knows: it owns the surface a page is drawn in, and
+   * Electron's own answer is `isFocused`, which is a different question —
+   * 1Password unlocks behind a Touch ID prompt raised by its desktop app, so
+   * at the moment its worker asks for the active tab none of Meru's views is
+   * focused and a focus-based answer would send the unlock to nobody.
+   *
+   * Without it the worker hears Electron's answer, which is honest and narrow
+   * rather than wrong.
+   */
+  isActiveTab?: (contents: WebContents) => boolean;
 };
 
 /**
@@ -54,6 +67,7 @@ export function createSharedExtensionInstance({
   relayScriptPath,
   getWorkerSession,
   getWebContentsFromFrame,
+  isActiveTab,
 }: CreateSharedExtensionInstanceOptions): SharedExtensionInstance {
   let proxy: RuntimeProxy | undefined;
 
@@ -63,7 +77,15 @@ export function createSharedExtensionInstance({
 
   return {
     install({ bridge, logger }) {
-      proxy = new RuntimeProxy({ logger, getWebContentsFromFrame });
+      proxy = new RuntimeProxy({
+        logger,
+        getWebContentsFromFrame,
+        // The same bookkeeping `canResolveTabAcrossSessions` answers from, for
+        // the same reason: which sessions are shimmed is what `adoptSession`
+        // already keeps, and a second copy of it would be free to drift
+        isShimmedSession: (session) => shimmedSessions.has(session),
+        isActiveTab,
+      });
 
       proxy.registerRoutes(bridge);
     },

--- a/packages/electron-extensions/runtime-proxy/relay-client.test.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.test.ts
@@ -935,6 +935,10 @@ function createWorkerChromeWithTabs() {
 
   const nativeConnectCalls: unknown[][] = [];
 
+  const nativeQueryCalls: unknown[][] = [];
+
+  const nativeGetCalls: unknown[][] = [];
+
   chrome.tabs = {
     sendMessage: (...callArguments: unknown[]) => {
       answerNatively(callArguments, nativeTabsReply, nativeTabsError, nativeTabsCalls);
@@ -944,6 +948,14 @@ function createWorkerChromeWithTabs() {
 
       return nativePort;
     },
+    // Recorded rather than answered: the client is not supposed to reach these
+    // at all, main answering for the worker's own session as well
+    query: (...callArguments: unknown[]) => {
+      nativeQueryCalls.push(callArguments);
+    },
+    get: (...callArguments: unknown[]) => {
+      nativeGetCalls.push(callArguments);
+    },
   };
 
   return {
@@ -952,6 +964,8 @@ function createWorkerChromeWithTabs() {
     nativeOnConnect,
     nativeTabsCalls,
     nativeConnectCalls,
+    nativeQueryCalls,
+    nativeGetCalls,
     nativeRuntimeSendMessageCalls,
     nativePort,
     setNativeTabsReply: (reply: unknown) => {
@@ -969,12 +983,14 @@ function createWorkerChromeWithTabs() {
   };
 }
 
-function startClientWithTabs(chrome: ChromeNamespace) {
+function startClientWithTabs(...chromeObjects: ChromeNamespace[]) {
   const client = createRelayClient({ retryDelayMs: 5 });
 
-  client.wrapRuntime(chrome);
+  for (const chrome of chromeObjects) {
+    client.wrapRuntime(chrome);
 
-  client.wrapTabs(chrome);
+    client.wrapTabs(chrome);
+  }
 
   client.start();
 
@@ -1258,5 +1274,154 @@ describe("what the worker sends", () => {
     await waitFor(() => errors.length === 1, "the disconnect");
 
     expect(errors).toEqual([RECEIVING_END_ERROR]);
+  });
+});
+
+type TabsQuery = (queryInfo?: Record<string, unknown>) => Promise<{ id: number; url: string }[]>;
+
+type TabsGet = (tabId: number) => Promise<{ id: number; url: string }>;
+
+/**
+ * The tab shape main builds, as much of it as these tests read. The relay
+ * client passes it through whole, so what it carries is `worker-tabs.ts`'s
+ * business rather than this side's.
+ */
+const RELAYED_TAB = { id: 7, url: "https://mail.google.com/mail/u/0/" };
+
+describe("what the worker asks about tabs", () => {
+  test("tabs.query is relayed, and never asked of the native namespace", async () => {
+    const stub = stubBridge();
+
+    stub.answerWith(RUNTIME_PROXY_PATHS.workerQueryTabs, { tabs: [RELAYED_TAB] });
+
+    const { chrome, nativeQueryCalls } = createWorkerChromeWithTabs();
+
+    startClientWithTabs(chrome);
+
+    const tabs = chrome.tabs as ChromeNamespace;
+
+    expect(await (tabs.query as TabsQuery)({ active: true })).toEqual([RELAYED_TAB]);
+
+    expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerQueryTabs)[0]?.body).toEqual({
+      queryInfo: { active: true },
+    });
+
+    /*
+     * Where `tabs.sendMessage` falls through to Chromium for a tab of the
+     * worker's own session, a query does not: main lists that session too, so
+     * a native call beside it would answer the same tabs twice, with a
+     * different `active` on the second copy.
+     */
+    expect(nativeQueryCalls).toEqual([]);
+  });
+
+  test("a callback hears the tabs the relay listed", async () => {
+    const stub = stubBridge();
+
+    stub.answerWith(RUNTIME_PROXY_PATHS.workerQueryTabs, { tabs: [RELAYED_TAB] });
+
+    const { chrome } = createWorkerChromeWithTabs();
+
+    startClientWithTabs(chrome);
+
+    const tabs = chrome.tabs as ChromeNamespace;
+
+    const listed: unknown[] = [];
+
+    (tabs.query as (...callArguments: unknown[]) => void)({}, (queried: unknown) => {
+      listed.push(queried);
+    });
+
+    await waitFor(() => listed.length === 1, "the callback");
+
+    expect(listed).toEqual([[RELAYED_TAB]]);
+  });
+
+  test("chrome and browser are both shadowed, as Electron builds two objects", async () => {
+    const stub = stubBridge();
+
+    stub.answerWith(RUNTIME_PROXY_PATHS.workerQueryTabs, { tabs: [RELAYED_TAB] });
+
+    const { chrome } = createWorkerChromeWithTabs();
+
+    const { chrome: browser } = createWorkerChromeWithTabs();
+
+    startClientWithTabs(chrome, browser);
+
+    expect(await ((browser.tabs as ChromeNamespace).query as TabsQuery)({})).toEqual([RELAYED_TAB]);
+  });
+
+  /*
+   * Chrome has no `lastError` for "no tabs matched", so a bridge that refused
+   * or went away answers the way a browser showing nothing does. Failing the
+   * call instead would turn a query an extension makes on every lock into an
+   * unhandled rejection in its worker.
+   */
+  test("a refused bridge answers no tabs rather than an error", async () => {
+    const stub = stubBridge();
+
+    stub.refuse(RUNTIME_PROXY_PATHS.workerQueryTabs, 403);
+
+    const { chrome } = createWorkerChromeWithTabs();
+
+    startClientWithTabs(chrome);
+
+    expect(await ((chrome.tabs as ChromeNamespace).query as TabsQuery)({})).toEqual([]);
+  });
+
+  test("tabs.get answers the tab main named, natively asking nothing", async () => {
+    const stub = stubBridge();
+
+    stub.answerWith(RUNTIME_PROXY_PATHS.workerGetTab, { status: "tab", tab: RELAYED_TAB });
+
+    const { chrome, nativeGetCalls } = createWorkerChromeWithTabs();
+
+    startClientWithTabs(chrome);
+
+    expect(await ((chrome.tabs as ChromeNamespace).get as TabsGet)(7)).toEqual(RELAYED_TAB);
+
+    expect(stub.postsTo(RUNTIME_PROXY_PATHS.workerGetTab)[0]?.body).toEqual({ tabId: 7 });
+
+    expect(nativeGetCalls).toEqual([]);
+  });
+
+  test("a tab main will not name sets lastError the way Chrome does", async () => {
+    const stub = stubBridge();
+
+    stub.answerWith(RUNTIME_PROXY_PATHS.workerGetTab, {
+      status: "noTarget",
+      error: "No tab with id: 404.",
+    });
+
+    const { chrome } = createWorkerChromeWithTabs();
+
+    startClientWithTabs(chrome);
+
+    const runtime = chrome.runtime as ChromeNamespace;
+
+    const errors: (string | undefined)[] = [];
+
+    ((chrome.tabs as ChromeNamespace).get as (...callArguments: unknown[]) => void)(404, () => {
+      errors.push((runtime.lastError as { message?: string } | undefined)?.message);
+    });
+
+    await waitFor(() => errors.length === 1, "the callback");
+
+    expect(errors).toEqual(["No tab with id: 404."]);
+    expect(runtime.lastError).toBeUndefined();
+  });
+
+  test("an unreachable bridge reads as a tab this app is not showing", async () => {
+    const stub = stubBridge();
+
+    stub.refuse(RUNTIME_PROXY_PATHS.workerGetTab, 403);
+
+    const { chrome } = createWorkerChromeWithTabs();
+
+    startClientWithTabs(chrome);
+
+    await expect(((chrome.tabs as ChromeNamespace).get as TabsGet)(7)).rejects.toThrow(
+      "No tab with id: 7.",
+    );
   });
 });

--- a/packages/electron-extensions/runtime-proxy/relay-client.ts
+++ b/packages/electron-extensions/runtime-proxy/relay-client.ts
@@ -4,6 +4,7 @@ import { getLastErrorMessage, withLastError } from "../facade/lib/last-error";
 import { NativeMessageDecoder } from "../native-messaging/framing";
 import {
   MAX_RUNTIME_PROXY_FRAME_BYTES,
+  noTabError,
   PORT_CLOSED_ERROR,
   RECEIVING_END_ERROR,
   RUNTIME_PROXY_PATHS,
@@ -11,7 +12,11 @@ import {
   type RuntimeProxyJob,
   type RuntimeProxySender,
   type RuntimeProxySendMessageResult,
+  type RuntimeProxyTab,
+  type RuntimeProxyTabQueryInfo,
   type RuntimeProxyWorkerConnectToTabResult,
+  type RuntimeProxyWorkerGetTabResult,
+  type RuntimeProxyWorkerQueryTabsResult,
   type RuntimeProxyWorkerSendToTabResult,
 } from "./bridge-protocol";
 import { createCleanEndBackoff, DEFAULT_CLEAN_END_WINDOW_MS } from "./clean-end-backoff";
@@ -441,6 +446,35 @@ export function createRelayClient({
   };
 
   /**
+   * The same, for a call whose answer is a value rather than one of the three
+   * message statuses: a callback gets the value, with `lastError` set around it
+   * when the call failed the way Chrome sets one, and a call without a callback
+   * gets the promise Chrome's promise form returns.
+   */
+  const answerValue = <Value>(
+    runtime: ChromeNamespace,
+    result: Promise<Value>,
+    callback: ((value: Value | undefined) => void) | undefined,
+  ) => {
+    if (!callback) {
+      return result;
+    }
+
+    result.then(
+      (value) => {
+        callback(value);
+      },
+      (error: Error) => {
+        withLastError(runtime, error.message, () => {
+          callback(undefined);
+        });
+      },
+    );
+
+    return undefined;
+  };
+
+  /**
    * `chrome.runtime.sendMessage` with no target extension: Chrome delivers it
    * to every frame of the extension except the sender, which here is both the
    * worker's own session — natively, where Chromium still does it — and the
@@ -533,6 +567,81 @@ export function createRelayClient({
       };
 
       return answer(runtime, deliver(), callback);
+    };
+
+  /**
+   * `chrome.tabs.query`, which natively lists the tabs of the worker's own
+   * session and no others: Chromium filters its WebContents list by the browser
+   * context the extension is loaded into, and the session the one worker runs
+   * in holds no account's tabs. 1Password's lock and unlock reach content
+   * scripts by querying the tabs and messaging each of them, so an empty answer
+   * leaves every account page believing the vault is still unlocked.
+   *
+   * The native call is not made at all, where `tabs.sendMessage` falls through
+   * to it for the worker's own session. Delivery there is Chromium's and must
+   * stay Chromium's; a list is not, and answering the worker's own session from
+   * main too is what keeps one `active` semantic — the embedder's, rather than
+   * Chromium's `IsFocused` for some tabs and the embedder's for the rest — and
+   * one ordering across the whole answer.
+   */
+  const createProxiedTabsQuery =
+    (runtime: ChromeNamespace) =>
+    (...callArguments: unknown[]) => {
+      const callback =
+        typeof callArguments.at(-1) === "function"
+          ? (callArguments.pop() as (tabs: RuntimeProxyTab[] | undefined) => void)
+          : undefined;
+
+      const [queryInfo] = callArguments as [RuntimeProxyTabQueryInfo | undefined];
+
+      const query = postForResult<RuntimeProxyWorkerQueryTabsResult>(
+        RUNTIME_PROXY_PATHS.workerQueryTabs,
+        { queryInfo },
+      )
+        .then((result) => result.tabs ?? [])
+        // A query has no `lastError` for "no tabs" in Chrome, so a bridge that
+        // refused or went away answers the way a browser showing nothing does
+        .catch(() => []);
+
+      return answerValue(runtime, query, callback);
+    };
+
+  /**
+   * `chrome.tabs.get`, scoped natively the same way and answered from main for
+   * the same reason. An id of a session main neither keeps nor shims comes back
+   * as Chrome's own "no tab with id", which is also what an unreachable bridge
+   * reads as.
+   */
+  const createProxiedTabsGet =
+    (runtime: ChromeNamespace) =>
+    (...callArguments: unknown[]) => {
+      const callback =
+        typeof callArguments.at(-1) === "function"
+          ? (callArguments.pop() as (tab: RuntimeProxyTab | undefined) => void)
+          : undefined;
+
+      const [tabId] = callArguments as [number];
+
+      const get = async () => {
+        let result: RuntimeProxyWorkerGetTabResult;
+
+        try {
+          result = await postForResult<RuntimeProxyWorkerGetTabResult>(
+            RUNTIME_PROXY_PATHS.workerGetTab,
+            { tabId },
+          );
+        } catch {
+          throw new Error(noTabError(tabId));
+        }
+
+        if (result.status !== "tab") {
+          throw new Error(result.error);
+        }
+
+        return result.tab;
+      };
+
+      return answerValue(runtime, get(), callback);
     };
 
   /**
@@ -644,9 +753,10 @@ export function createRelayClient({
     },
 
     /**
-     * Shadows `tabs.sendMessage` and `tabs.connect` of one extension API
-     * object, which natively reach only the tabs of the worker's own session.
-     * Everything else on `chrome.tabs` stays as Electron made it.
+     * Shadows `tabs.sendMessage`, `tabs.connect`, `tabs.query` and `tabs.get`
+     * of one extension API object, all four of which natively see only the tabs
+     * of the worker's own session. Everything else on `chrome.tabs` stays as
+     * Electron made it.
      */
     wrapTabs(extensionApi: ChromeNamespace) {
       const tabs = extensionApi.tabs as ChromeNamespace | undefined;
@@ -667,6 +777,12 @@ export function createRelayClient({
       );
 
       tabs.connect = createProxiedTabsConnect(getNativeMethod(tabs, "connect"));
+
+      // No native method is captured for these two: main answers for the
+      // worker's own session as well, so there is nothing to fall through to
+      tabs.query = createProxiedTabsQuery(runtime);
+
+      tabs.get = createProxiedTabsGet(runtime);
     },
 
     /** Parks the job stream at the bridge, and keeps it parked. */

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.test.ts
@@ -194,6 +194,7 @@ function createPage(shimSession: Session, contentsId = 7, url = PAGE_URL) {
     isDestroyed: () => false,
     isLoading: () => false,
     isCurrentlyAudible: () => false,
+    isAudioMuted: () => false,
     getURL: () => url,
     getTitle: () => "Sign in",
   } as unknown as WebContents;

--- a/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
+++ b/packages/electron-extensions/runtime-proxy/runtime-proxy.ts
@@ -42,6 +42,7 @@ import {
   parseStorageChangedReport,
   StorageAccessLevels,
 } from "./storage-proxy";
+import { WorkerTabs } from "./worker-tabs";
 import { createWorkerSender, WorkerToPage } from "./worker-to-page";
 
 type RelayJobBase = {
@@ -155,6 +156,19 @@ export type RuntimeProxyOptions = {
   waitForContextMs?: number;
   /** How a tab id resolves to the page behind it, for the worker's own calls. */
   getWebContentsById?: (tabId: number) => WebContents | undefined;
+  /**
+   * Whether a session took the content-script-only role, which is who the
+   * worker's own `tabs.query` and `tabs.get` answer for besides its own
+   * session. Without it the worker sees its own session alone, which is what
+   * Chromium already gives it.
+   */
+  isShimmedSession?: (session: Session) => boolean;
+  /**
+   * Whether a page is the one its window is showing, which is Chrome's `active`
+   * and only the embedder knows; `worker-tabs.ts` says why Electron's
+   * focus-based answer is the wrong default for it.
+   */
+  isActiveTab?: (contents: WebContents) => boolean;
 };
 
 const DEFAULT_WAKE_TIMEOUT_MS = 10_000;
@@ -191,7 +205,10 @@ const DEFAULT_IN_FLIGHT_TIMEOUT_MS = 5 * 60_000;
  * `runtime.sendMessage` broadcast the worker starts itself — reaches a shimmed
  * context over the receive stream it parks at the bridge; `page-stream.ts`
  * keeps those and `worker-to-page.ts` carries the messages, while the ports
- * stay here with the ones a page opened.
+ * stay here with the ones a page opened. The worker's own `tabs.query` and
+ * `tabs.get` are answered from main too, by `worker-tabs.ts`, for the same
+ * reason: Chromium scopes both to the worker's session, where no account tab
+ * lives.
  */
 export class RuntimeProxy {
   private logger: ExtensionsLogger | undefined;
@@ -240,6 +257,9 @@ export class RuntimeProxy {
 
   private workerToPage: WorkerToPage;
 
+  /** The worker's own `tabs.query` and `tabs.get`, answered from here. */
+  private workerTabs: WorkerTabs;
+
   /** What each extension's worker last said about who may reach an area. */
   private storageAccessLevels = new StorageAccessLevels();
 
@@ -251,6 +271,8 @@ export class RuntimeProxy {
     maxDeliveryAttempts = DEFAULT_MAX_DELIVERY_ATTEMPTS,
     inFlightTimeoutMs = DEFAULT_IN_FLIGHT_TIMEOUT_MS,
     waitForContextMs,
+    isShimmedSession = () => false,
+    isActiveTab,
   }: RuntimeProxyOptions = {}) {
     this.logger = logger;
 
@@ -270,6 +292,13 @@ export class RuntimeProxy {
       getWebContentsById,
       logger,
       deliveryTimeoutMs: inFlightTimeoutMs,
+    });
+
+    this.workerTabs = new WorkerTabs({
+      getWorkerSession: () => this.workerSession,
+      isShimmedSession,
+      isActiveTab,
+      getWebContentsById,
     });
 
     // A bound context going away takes its share of a worker-opened port with
@@ -430,6 +459,8 @@ export class RuntimeProxy {
 
     // The rest of what the worker starts, and the streams it reaches pages on
     this.workerToPage.registerRoutes(bridge);
+
+    this.workerTabs.registerRoutes(bridge);
 
     this.pageStreams.registerRoutes(
       bridge,

--- a/packages/electron-extensions/runtime-proxy/sender.test.ts
+++ b/packages/electron-extensions/runtime-proxy/sender.test.ts
@@ -35,6 +35,7 @@ function createContents(
     isDestroyed: () => false,
     isLoading: () => isLoading,
     isCurrentlyAudible: () => isCurrentlyAudible,
+    isAudioMuted: () => false,
     getURL: () => url,
     getTitle: () => title,
   } as unknown as WebContents;
@@ -95,6 +96,7 @@ describe("reconstructSender", () => {
         status: "complete",
         groupId: -1,
         audible: false,
+        mutedInfo: { muted: false },
         discarded: false,
         autoDiscardable: true,
       },

--- a/packages/electron-extensions/runtime-proxy/sender.ts
+++ b/packages/electron-extensions/runtime-proxy/sender.ts
@@ -44,8 +44,15 @@ export function parseSenderReport(reported: unknown): RuntimeProxySenderReport |
  * tabs would collide the moment one worker serves both. It is also the mapping
  * the bridge's webNavigation frame queries already answer in, so a sender's
  * `tab.id` means the same thing everywhere the bridge speaks.
+ *
+ * Exported because the worker's own `tabs.query` and `tabs.get` are answered
+ * from main as well (`worker-tabs.ts`), and a tab an extension is handed has
+ * one shape whether it arrived on a sender or as a query's answer.
  */
-function createTabDetails(contents: WebContents): RuntimeProxyTab {
+export function createTabDetails(
+  contents: WebContents,
+  { active }: { active: boolean },
+): RuntimeProxyTab {
   return {
     id: contents.id,
     url: contents.getURL(),
@@ -54,16 +61,21 @@ function createTabDetails(contents: WebContents): RuntimeProxyTab {
     // these carry Chrome's own "no such thing" values rather than a guess
     windowId: -1,
     index: -1,
-    // The page is speaking, which is the closest this layer has to "in front"
-    active: true,
-    highlighted: true,
-    selected: true,
+    // Whether the page is the one its window is showing, which only the
+    // embedder can say — a sender says `true`, the page being the one
+    // speaking, and a listed tab is asked about (`worker-tabs.ts`). The three
+    // move together the way Chrome's do for a window showing one tab
+    active,
+    highlighted: active,
+    selected: active,
     pinned: false,
     incognito: false,
     status: contents.isLoading() ? "loading" : "complete",
     // What Chromium derives Chrome's own `audible` from; Gmail's notification
     // sounds and Meet's audio make this a real value rather than a constant
     audible: contents.isCurrentlyAudible(),
+    // The other real value here, and what `tabs.query({muted})` filters on
+    mutedInfo: { muted: contents.isAudioMuted() },
     // Tab groups are Chrome UI the embedder has none of, which is what
     // Chrome's own `TAB_GROUP_ID_NONE` says
     groupId: -1,
@@ -176,7 +188,12 @@ export function reconstructSender({
 
   return isExtensionPage
     ? sender
-    : { ...sender, frameId: getExtensionFrameId(senderFrame), tab: createTabDetails(contents) };
+    : {
+        ...sender,
+        frameId: getExtensionFrameId(senderFrame),
+        // The page is speaking, which is the closest a sender has to "in front"
+        tab: createTabDetails(contents, { active: true }),
+      };
 }
 
 function getOrigin(url: string) {

--- a/packages/electron-extensions/runtime-proxy/worker-tabs.test.ts
+++ b/packages/electron-extensions/runtime-proxy/worker-tabs.test.ts
@@ -1,0 +1,407 @@
+import { describe, expect, test } from "bun:test";
+import type { OnBeforeSendHeadersListenerDetails, Session, WebContents } from "electron";
+import { ExtensionBridge } from "../bridge/bridge";
+import { getExtensionBridgeUrl } from "../bridge/protocol";
+import {
+  noTabError,
+  type RuntimeProxyTab,
+  type RuntimeProxyWorkerGetTabResult,
+  type RuntimeProxyWorkerQueryTabsResult,
+  RUNTIME_PROXY_PATHS,
+} from "./bridge-protocol";
+import { WorkerTabs } from "./worker-tabs";
+
+const EXTENSION_ID = "aeblfdkhhhdcdjpifhhbdiojplfjncoa";
+
+const WORKER_TOKEN = "worker-token";
+
+const SHIM_TOKEN = "shim-token";
+
+type BeforeSendHeadersListener = (
+  details: OnBeforeSendHeadersListenerDetails,
+  callback: (response: { requestHeaders?: Record<string, string> }) => void,
+) => void;
+
+/**
+ * A session the bridge can be set up on, which is all these routes need: they
+ * carry no sender report, so nothing here depends on a caller frame.
+ */
+function createFakeSession() {
+  let requestHandler: ((request: GlobalRequest) => Promise<Response>) | undefined;
+
+  let beforeSendHeadersListener: BeforeSendHeadersListener | null = null;
+
+  const session = {
+    protocol: {
+      handle: (_scheme: string, handler: (request: GlobalRequest) => Promise<Response>) => {
+        requestHandler = handler;
+      },
+      unhandle: () => {
+        requestHandler = undefined;
+      },
+    },
+    webRequest: {
+      onBeforeSendHeaders: (
+        filterOrListener: unknown,
+        maybeListener?: BeforeSendHeadersListener | null,
+      ) => {
+        beforeSendHeadersListener =
+          maybeListener === undefined
+            ? (filterOrListener as BeforeSendHeadersListener | null)
+            : maybeListener;
+      },
+    },
+  } as unknown as Session;
+
+  return {
+    session,
+    request: (pathName: string, bridgeToken: string, body: Record<string, unknown>) => {
+      const url = getExtensionBridgeUrl(pathName, bridgeToken);
+
+      let requestHeaders: Record<string, string> = {};
+
+      beforeSendHeadersListener?.(
+        { url, frame: null, requestHeaders } as OnBeforeSendHeadersListenerDetails,
+        ({ requestHeaders: stampedHeaders }) => {
+          if (stampedHeaders) {
+            requestHeaders = stampedHeaders;
+          }
+        },
+      );
+
+      return requestHandler?.(
+        new Request(url, {
+          method: "POST",
+          headers: requestHeaders,
+          body: JSON.stringify(body),
+        }) as GlobalRequest,
+      ) as Promise<Response>;
+    },
+  };
+}
+
+type FakeContentsOptions = {
+  title?: string;
+  isDestroyed?: boolean;
+  isFocused?: boolean;
+  isCurrentlyAudible?: boolean;
+  isAudioMuted?: boolean;
+};
+
+function createContents(
+  contentsId: number,
+  session: Session,
+  url: string,
+  {
+    title = "A page",
+    isDestroyed = false,
+    isFocused = false,
+    isCurrentlyAudible = false,
+    isAudioMuted = false,
+  }: FakeContentsOptions = {},
+) {
+  return {
+    id: contentsId,
+    session,
+    getURL: () => url,
+    getTitle: () => title,
+    isDestroyed: () => isDestroyed,
+    isLoading: () => false,
+    isFocused: () => isFocused,
+    isCurrentlyAudible: () => isCurrentlyAudible,
+    isAudioMuted: () => isAudioMuted,
+  } as unknown as WebContents;
+}
+
+const PAGE_URL = "https://accounts.google.com/signin";
+
+const SECOND_PAGE_URL = "https://mail.google.com/mail/u/0/";
+
+const WORKER_PAGE_URL = "https://127.0.0.1/worker-page";
+
+type Harness = {
+  isActiveTab?: (contents: WebContents) => boolean;
+  /** Whether the shimmed session ever adopted the content-script-only role. */
+  isShimmed?: boolean;
+};
+
+function createHarness({ isActiveTab, isShimmed = true }: Harness = {}) {
+  const workerSession = createFakeSession();
+
+  const shimSession = createFakeSession();
+
+  /** A session the shared instance never adopted, whose tabs stay invisible. */
+  const strangerSession = createFakeSession();
+
+  const bridge = new ExtensionBridge();
+
+  bridge.setupSession(workerSession.session, {
+    getExtensionId: (bridgeToken) => (bridgeToken === WORKER_TOKEN ? EXTENSION_ID : undefined),
+  });
+
+  bridge.setupSession(shimSession.session, {
+    getExtensionId: (bridgeToken) => (bridgeToken === SHIM_TOKEN ? EXTENSION_ID : undefined),
+  });
+
+  const shimTab = createContents(7, shimSession.session, PAGE_URL);
+
+  const secondShimTab = createContents(8, shimSession.session, SECOND_PAGE_URL, {
+    title: "Inbox",
+    isCurrentlyAudible: true,
+    isAudioMuted: true,
+  });
+
+  const workerTab = createContents(9, workerSession.session, WORKER_PAGE_URL, {
+    isFocused: true,
+  });
+
+  const strangerTab = createContents(10, strangerSession.session, PAGE_URL);
+
+  const destroyedTab = createContents(11, shimSession.session, PAGE_URL, { isDestroyed: true });
+
+  const allContents = [shimTab, secondShimTab, workerTab, strangerTab, destroyedTab];
+
+  const workerTabs = new WorkerTabs({
+    getWorkerSession: () => workerSession.session,
+    isShimmedSession: (session) => isShimmed && session === shimSession.session,
+    isActiveTab,
+    getAllWebContents: () => allContents,
+    getWebContentsById: (tabId) => allContents.find((contents) => contents.id === tabId),
+  });
+
+  workerTabs.registerRoutes(bridge);
+
+  const query = async (queryInfo?: Record<string, unknown>) => {
+    const response = await workerSession.request(
+      RUNTIME_PROXY_PATHS.workerQueryTabs,
+      WORKER_TOKEN,
+      { queryInfo },
+    );
+
+    expect(response.status).toBe(200);
+
+    return ((await response.json()) as RuntimeProxyWorkerQueryTabsResult).tabs;
+  };
+
+  const getTab = async (tabId: unknown) => {
+    const response = await workerSession.request(RUNTIME_PROXY_PATHS.workerGetTab, WORKER_TOKEN, {
+      tabId,
+    });
+
+    expect(response.status).toBe(200);
+
+    return (await response.json()) as RuntimeProxyWorkerGetTabResult;
+  };
+
+  return {
+    workerTabs,
+    workerSession,
+    shimSession,
+    shimTab,
+    secondShimTab,
+    workerTab,
+    strangerTab,
+    query,
+    getTab,
+  };
+}
+
+const tabIds = (tabs: RuntimeProxyTab[]) => tabs.map((tab) => tab.id);
+
+describe("tabs.query from the worker", () => {
+  test("is refused from any session but the worker's", async () => {
+    const { shimSession } = createHarness();
+
+    const queryResponse = await shimSession.request(
+      RUNTIME_PROXY_PATHS.workerQueryTabs,
+      SHIM_TOKEN,
+      {},
+    );
+
+    expect(queryResponse.status).toBe(403);
+
+    const getResponse = await shimSession.request(RUNTIME_PROXY_PATHS.workerGetTab, SHIM_TOKEN, {
+      tabId: 7,
+    });
+
+    expect(getResponse.status).toBe(403);
+  });
+
+  /*
+   * The whole point: Chromium lists the worker session's own pages and nothing
+   * else, which is nothing an account is looking at. What main adds is the
+   * sessions the one worker shims — and only those, so an account session this
+   * never adopted stays as invisible as it is to every other account.
+   */
+  test("lists the worker's own session and every session it shims, and no other", async () => {
+    const { query, strangerTab } = createHarness();
+
+    expect(tabIds(await query())).toEqual([7, 8, 9]);
+
+    expect(strangerTab.id).toBe(10);
+  });
+
+  test("lists nothing of another session while no session is shimmed", async () => {
+    const { query } = createHarness({ isShimmed: false });
+
+    expect(tabIds(await query())).toEqual([9]);
+  });
+
+  test("a page that is gone is no tab, whatever the list still holds", async () => {
+    const { query } = createHarness();
+
+    expect(tabIds(await query())).not.toContain(11);
+  });
+
+  test("carries the whole tab shape, ids being WebContents ids throughout", async () => {
+    const { query } = createHarness();
+
+    const [tab] = await query({ url: PAGE_URL });
+
+    expect(tab).toEqual({
+      id: 7,
+      url: PAGE_URL,
+      title: "A page",
+      windowId: -1,
+      index: -1,
+      active: false,
+      highlighted: false,
+      selected: false,
+      pinned: false,
+      incognito: false,
+      status: "complete",
+      groupId: -1,
+      audible: false,
+      mutedInfo: { muted: false },
+      discarded: false,
+      autoDiscardable: true,
+    });
+  });
+
+  /*
+   * Chrome's `active` is "the tab its window is showing", which the embedder
+   * owns; Electron's own answer is focus, and a window can show a page while
+   * something else has the focus — a password manager's own unlock prompt, for
+   * one, which is exactly when the worker asks.
+   */
+  test("takes `active` from the embedder's hook", async () => {
+    const { query } = createHarness({ isActiveTab: (contents) => contents.id === 8 });
+
+    expect(tabIds(await query({ active: true }))).toEqual([8]);
+
+    expect(tabIds(await query({ active: false }))).toEqual([7, 9]);
+  });
+
+  test("falls back to Electron's own focus when the embedder says nothing", async () => {
+    const { query } = createHarness();
+
+    expect(tabIds(await query({ active: true }))).toEqual([9]);
+  });
+
+  test("filters on a match pattern, on several, and on every URL", async () => {
+    const { query } = createHarness();
+
+    expect(tabIds(await query({ url: "https://mail.google.com/*" }))).toEqual([8]);
+
+    expect(
+      tabIds(await query({ url: ["https://mail.google.com/*", "https://accounts.google.com/*"] })),
+    ).toEqual([7, 8]);
+
+    expect(tabIds(await query({ url: "<all_urls>" }))).toEqual([7, 8, 9]);
+
+    expect(tabIds(await query({ url: "https://example.com/*" }))).toEqual([]);
+  });
+
+  test("filters on audio, both what is playing and what is muted", async () => {
+    const { query } = createHarness();
+
+    expect(tabIds(await query({ audible: true }))).toEqual([8]);
+
+    expect(tabIds(await query({ muted: true }))).toEqual([8]);
+
+    expect(tabIds(await query({ muted: false }))).toEqual([7, 9]);
+  });
+
+  test("filters on a title glob, the way Chrome's own filter reads one", async () => {
+    const { query } = createHarness();
+
+    expect(tabIds(await query({ title: "Inbox" }))).toEqual([8]);
+
+    expect(tabIds(await query({ title: "A p*" }))).toEqual([7, 9]);
+  });
+
+  /*
+   * Everything Electron's own query ignores is ignored here too, so an
+   * extension gets one answer whichever session it asks from. There is one
+   * window in the facade's model anyway — `windows` answers a single fake
+   * window — so a window filter has nothing to narrow.
+   */
+  test("ignores the keys Electron ignores rather than answering nothing", async () => {
+    const { query } = createHarness();
+
+    expect(
+      tabIds(
+        await query({
+          windowId: 42,
+          currentWindow: true,
+          lastFocusedWindow: true,
+          index: 3,
+          pinned: true,
+          status: "loading",
+          groupId: 7,
+        }),
+      ),
+    ).toEqual([7, 8, 9]);
+  });
+
+  test("a queryInfo that is no object at all filters nothing", async () => {
+    const { query } = createHarness();
+
+    expect(tabIds(await query())).toEqual([7, 8, 9]);
+
+    expect(tabIds(await query("everything" as unknown as Record<string, unknown>))).toEqual([
+      7, 8, 9,
+    ]);
+  });
+});
+
+describe("tabs.get from the worker", () => {
+  test("answers a tab of a session the worker shims", async () => {
+    const { getTab } = createHarness();
+
+    expect(await getTab(7)).toEqual({
+      status: "tab",
+      tab: expect.objectContaining({ id: 7, url: PAGE_URL }),
+    });
+  });
+
+  test("answers a tab of the worker's own session too", async () => {
+    const { getTab } = createHarness();
+
+    expect(await getTab(9)).toEqual({
+      status: "tab",
+      tab: expect.objectContaining({ id: 9, url: WORKER_PAGE_URL }),
+    });
+  });
+
+  /*
+   * A tab of a session this never adopted is answered the way a tab that does
+   * not exist is: the worker has no business reading it, and saying so with
+   * Chrome's own error is the same line `tabs.sendMessage` draws.
+   */
+  test("a tab of an un-adopted session is no tab, and says so Chrome's way", async () => {
+    const { getTab } = createHarness();
+
+    expect(await getTab(10)).toEqual({ status: "noTarget", error: noTabError(10) });
+  });
+
+  test("a destroyed tab, an unknown id and a garbage id are all no tab", async () => {
+    const { getTab } = createHarness();
+
+    expect(await getTab(11)).toEqual({ status: "noTarget", error: noTabError(11) });
+
+    expect(await getTab(404)).toEqual({ status: "noTarget", error: noTabError(404) });
+
+    expect(await getTab("7")).toEqual({ status: "noTarget", error: noTabError("7") });
+  });
+});

--- a/packages/electron-extensions/runtime-proxy/worker-tabs.ts
+++ b/packages/electron-extensions/runtime-proxy/worker-tabs.ts
@@ -1,0 +1,258 @@
+import type { Session, WebContents } from "electron";
+import type { ExtensionBridge } from "../bridge/bridge";
+import { matchesUrl } from "../derive/match-pattern";
+import {
+  noTabError,
+  type RuntimeProxyTab,
+  type RuntimeProxyTabQueryInfo,
+  type RuntimeProxyWorkerGetTabRequest,
+  type RuntimeProxyWorkerGetTabResult,
+  type RuntimeProxyWorkerQueryTabsRequest,
+  type RuntimeProxyWorkerQueryTabsResult,
+  RUNTIME_PROXY_PATHS,
+} from "./bridge-protocol";
+import { createTabDetails } from "./sender";
+
+/**
+ * Resolved at call time: a value import of "electron" cannot even be loaded
+ * outside Electron, which is where this module's tests run.
+ */
+function getElectronWebContents() {
+  const { webContents } = require("electron") as typeof import("electron");
+
+  return webContents.getAllWebContents();
+}
+
+function getElectronWebContentsById(tabId: number) {
+  const { webContents } = require("electron") as typeof import("electron");
+
+  return webContents.fromId(tabId);
+}
+
+export type WorkerTabsOptions = {
+  /** The session keeping the worker, the only one allowed to ask. */
+  getWorkerSession: () => Session | undefined;
+  /** Whether a session took the content-script-only role, and is therefore listed. */
+  isShimmedSession: (session: Session) => boolean;
+  /**
+   * Whether a page is the one its window is showing, which is Chrome's `active`
+   * and only the embedder can say. Electron's own answer — `isFocused` — is the
+   * default, and is the wrong one wherever a window can be unfocused while
+   * still showing the page.
+   */
+  isActiveTab?: (contents: WebContents) => boolean;
+  /** Every page the app has, Electron's own list by default. */
+  getAllWebContents?: () => WebContents[];
+  /** How a tab id resolves to the page behind it, Electron's own mapping by default. */
+  getWebContentsById?: (tabId: number) => WebContents | undefined;
+};
+
+/**
+ * The worker's own `chrome.tabs.query` and `chrome.tabs.get`, answered from
+ * main.
+ *
+ * Chromium answers both natively, scoped to the browser context the asking
+ * extension is loaded into — `TabsQueryFunction` filters the WebContents list
+ * by `GetBrowserContext()`, and `tabs.get` resolves an id within it — so in the
+ * session the one worker runs in, which holds no account's tabs, a query lists
+ * nothing and every account tab is invisible. That is not a cosmetic gap:
+ * 1Password tells content scripts the vault locked by asking `tabs.query` for
+ * the tabs and then `tabs.sendMessage`-ing each of them, so an empty answer
+ * means every account page keeps showing an unlocked inline menu until it is
+ * reloaded.
+ *
+ * Main answers for the worker's own session *and* every session it shims,
+ * rather than merging a relayed answer into Chromium's. A merge would carry two
+ * `active` semantics — Chromium's `IsFocused` for the worker session's pages
+ * and the embedder's for the rest — and two orderings, and the extension would
+ * have no way to tell which it was reading. This is where it differs from
+ * `tabs.sendMessage`, which must fall through to Chromium for the worker's own
+ * session because delivery there is Chromium's; a query depends on nothing but
+ * the list.
+ *
+ * Only the worker session may ask (403 otherwise, as `workerSendToTab` does),
+ * and only the worker session and sessions that adopted the content-script-only
+ * role are listed — the same line `canResolveTabAcrossSessions` draws for frame
+ * queries, so one session's tabs never surface in another's answer. Nothing
+ * changes for a shimmed session's own extension pages: their native
+ * `chrome.tabs` stays scoped to their session.
+ */
+export class WorkerTabs {
+  private getWorkerSession: () => Session | undefined;
+
+  private isShimmedSession: (session: Session) => boolean;
+
+  private isActiveTab: (contents: WebContents) => boolean;
+
+  private getAllWebContents: () => WebContents[];
+
+  private getWebContentsById: (tabId: number) => WebContents | undefined;
+
+  constructor({
+    getWorkerSession,
+    isShimmedSession,
+    isActiveTab = (contents) => contents.isFocused(),
+    getAllWebContents = getElectronWebContents,
+    getWebContentsById = getElectronWebContentsById,
+  }: WorkerTabsOptions) {
+    this.getWorkerSession = getWorkerSession;
+
+    this.isShimmedSession = isShimmedSession;
+
+    this.isActiveTab = isActiveTab;
+
+    this.getAllWebContents = getAllWebContents;
+
+    this.getWebContentsById = getWebContentsById;
+  }
+
+  registerRoutes(bridge: ExtensionBridge) {
+    bridge.handle(RUNTIME_PROXY_PATHS.workerQueryTabs, ({ session, body, headers }) => {
+      if (session !== this.getWorkerSession()) {
+        return new Response(null, { status: 403, headers });
+      }
+
+      const { queryInfo } = body as unknown as RuntimeProxyWorkerQueryTabsRequest;
+
+      return Response.json(
+        { tabs: this.queryTabs(queryInfo) } satisfies RuntimeProxyWorkerQueryTabsResult,
+        { headers },
+      );
+    });
+
+    bridge.handle(RUNTIME_PROXY_PATHS.workerGetTab, ({ session, body, headers }) => {
+      if (session !== this.getWorkerSession()) {
+        return new Response(null, { status: 403, headers });
+      }
+
+      const { tabId } = body as unknown as RuntimeProxyWorkerGetTabRequest;
+
+      return Response.json(this.getTab(tabId) satisfies RuntimeProxyWorkerGetTabResult, {
+        headers,
+      });
+    });
+  }
+
+  /**
+   * Every page of the worker's session and of the sessions it shims, in the
+   * order Electron lists them, which is creation order and stable.
+   *
+   * Every `WebContents` of those sessions counts, the embedder's own renderer
+   * and its popups included, because that is exactly what Chromium's own answer
+   * counts for a browser context — `GetWebContentsList()` is not a tab strip.
+   * Filtering to what Meru would call a tab would be a second, narrower notion
+   * of a tab than the one the rest of the proxy addresses by `WebContents` id,
+   * and a message sent to an id a query never listed is worse than a list with
+   * a page an extension does not care about in it.
+   */
+  listTabs(): RuntimeProxyTab[] {
+    const tabs: RuntimeProxyTab[] = [];
+
+    for (const contents of this.getAllWebContents()) {
+      if (contents.isDestroyed() || !this.isListedSession(contents.session)) {
+        continue;
+      }
+
+      tabs.push(createTabDetails(contents, { active: this.isActiveTab(contents) }));
+    }
+
+    return tabs;
+  }
+
+  /**
+   * The listed tabs a `queryInfo` keeps. Electron honors `active`, `audible`,
+   * `muted`, `url` and `title` and ignores the rest of Chrome's keys; this
+   * honors the same five, so an extension gets one answer whichever session it
+   * asks from. A `queryInfo` that is not an object at all — or one carrying
+   * nothing but ignored keys — filters nothing, which is what `query({})`
+   * means.
+   */
+  queryTabs(queryInfo: RuntimeProxyTabQueryInfo | undefined): RuntimeProxyTab[] {
+    if (typeof queryInfo !== "object" || queryInfo === null) {
+      return this.listTabs();
+    }
+
+    const { active, audible, muted, url, title } = queryInfo;
+
+    return this.listTabs().filter((tab) => {
+      if (typeof active === "boolean" && tab.active !== active) {
+        return false;
+      }
+
+      if (typeof audible === "boolean" && tab.audible !== audible) {
+        return false;
+      }
+
+      if (typeof muted === "boolean" && tab.mutedInfo.muted !== muted) {
+        return false;
+      }
+
+      if (url !== undefined && !matchesAnyPattern(url, tab.url)) {
+        return false;
+      }
+
+      if (typeof title === "string" && !matchesGlob(title, tab.title)) {
+        return false;
+      }
+
+      return true;
+    });
+  }
+
+  /**
+   * One tab by id. An id naming a page of a session this neither keeps nor
+   * shims answers the way a page that is gone does: Chrome's own "no tab with
+   * id", rather than a tab from a session the worker has no business reading.
+   */
+  getTab(tabId: unknown): RuntimeProxyWorkerGetTabResult {
+    if (typeof tabId !== "number") {
+      return { status: "noTarget", error: noTabError(tabId) };
+    }
+
+    const contents = this.getWebContentsById(tabId);
+
+    if (!contents || contents.isDestroyed() || !this.isListedSession(contents.session)) {
+      return { status: "noTarget", error: noTabError(tabId) };
+    }
+
+    return {
+      status: "tab",
+      tab: createTabDetails(contents, { active: this.isActiveTab(contents) }),
+    };
+  }
+
+  private isListedSession(session: Session) {
+    return session === this.getWorkerSession() || this.isShimmedSession(session);
+  }
+}
+
+/**
+ * Chrome's `url` filter, which takes one match pattern or several and keeps a
+ * tab any of them reaches.
+ */
+function matchesAnyPattern(patterns: string | string[], url: string) {
+  if (typeof patterns === "string") {
+    return matchesUrl(patterns, url);
+  }
+
+  if (!Array.isArray(patterns)) {
+    return true;
+  }
+
+  return patterns.some((pattern) => typeof pattern === "string" && matchesUrl(pattern, url));
+}
+
+/**
+ * Chrome's `title` filter, which is a glob rather than a match pattern: `*`
+ * stands for any run of characters and `?` for exactly one, as Chromium's own
+ * `base::MatchPattern` reads it. Escaping is not honored, there being no `\`
+ * escape in the shape an extension writes a title filter in.
+ */
+function matchesGlob(pattern: string, title: string) {
+  const expression = pattern
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    .replaceAll("\\*", ".*")
+    .replaceAll("\\?", ".");
+
+  return new RegExp(`^${expression}$`).test(title);
+}

--- a/packages/electron-extensions/runtime-proxy/worker-tabs.ts
+++ b/packages/electron-extensions/runtime-proxy/worker-tabs.ts
@@ -135,7 +135,7 @@ export class WorkerTabs {
 
   /**
    * Every page of the worker's session and of the sessions it shims, in the
-   * order Electron lists them, which is creation order and stable.
+   * order Electron's own list has them.
    *
    * Every `WebContents` of those sessions counts, the embedder's own renderer
    * and its popups included, because that is exactly what Chromium's own answer

--- a/packages/electron-extensions/runtime-proxy/worker-to-page.test.ts
+++ b/packages/electron-extensions/runtime-proxy/worker-to-page.test.ts
@@ -156,6 +156,7 @@ function createTab(session: Session, contentsId: number, url: string) {
     getTitle: () => "Sign in",
     isLoading: () => false,
     isCurrentlyAudible: () => false,
+    isAudioMuted: () => false,
     mainFrame: {
       ...mainFrame,
       framesInSubtree: [mainFrame, subFrame, inlineMenuFrame],
@@ -194,6 +195,7 @@ function createHarness(proxyOptions: RuntimeProxyOptions = {}) {
     getTitle: () => "1Password",
     isLoading: () => false,
     isCurrentlyAudible: () => false,
+    isAudioMuted: () => false,
     mainFrame: { ...popupFrame, framesInSubtree: [popupFrame] },
   } as unknown as WebContents;
 

--- a/tests/bundle-budget.json
+++ b/tests/bundle-budget.json
@@ -1,9 +1,9 @@
 {
   "app.js": 1302528,
   "extensions-chrome-facade.js": 9216,
-  "extensions-runtime-proxy-relay.js": 12288,
+  "extensions-runtime-proxy-relay.js": 13312,
   "extensions-runtime-proxy-shim.js": 12288,
-  "fixture-extension/background.js": 4096,
+  "fixture-extension/background.js": 5120,
   "fixture-extension/probe.js": 8192,
   "preload-gmail.js": 59392,
   "preload-renderer.js": 3072,

--- a/tests/extension-proxy.e2e.ts
+++ b/tests/extension-proxy.e2e.ts
@@ -249,6 +249,27 @@ async function readWorkerPortEvents(webContentsId: number) {
   );
 }
 
+/**
+ * The `WebContents` ids of the views Meru is showing, which is what the
+ * embedder answers `tabs.Tab.active` from. Read off the windows rather than
+ * from the app's own modules, which a packaged build exposes nothing of.
+ */
+async function readVisibleViewIds() {
+  return meru.app.evaluate(({ BrowserWindow, WebContentsView }) => {
+    const viewIds: number[] = [];
+
+    for (const window of BrowserWindow.getAllWindows()) {
+      for (const child of window.contentView.children) {
+        if (child instanceof WebContentsView && child.getVisible()) {
+          viewIds.push(child.webContents.id);
+        }
+      }
+    }
+
+    return viewIds;
+  });
+}
+
 function popupUrl(context: string, { probeStorageChanges = false } = {}) {
   const flag = probeStorageChanges ? "&meruProbeStorageChanges=1" : "";
 
@@ -651,6 +672,73 @@ test("the worker reaches a shimmed content script it never heard from first", as
   // And the port carries the page's answer back, which only the worker can
   // see: the answering side has nothing of its own left to observe
   expect(page.portReplySeenByWorker).toBe(true);
+});
+
+/*
+ * What the lock-state broadcast rests on. 1Password tells content scripts the
+ * vault locked by asking `tabs.query` for the tabs and then messaging each of
+ * them, and natively the worker's query lists the tabs of its own session
+ * alone — none of which is an account's.
+ */
+test("the worker's tabs.query lists a tab of a session it shims, and tabs.get answers it", async () => {
+  const pageUrl = `${serverOrigin}/plain`;
+
+  const pageId = await openProbeWindow(SURVIVING_PARTITION, pageUrl);
+
+  const page = await readProbeResults(pageId);
+
+  expect(page.tabsSeenByWorker.tabs).toContainEqual({
+    id: pageId,
+    url: pageUrl,
+    active: expect.any(Boolean),
+  });
+
+  // And by id, which is what a worker holding a tab id from a sender does next
+  expect(page.tabsSeenByWorker.self).toEqual({
+    status: "replied",
+    reply: { id: pageId, url: pageUrl },
+  });
+
+  /*
+   * `active` is the embedder's answer rather than Electron's focus: a hidden
+   * window is never the tab a window is showing, and the view Meru has in
+   * front is, whether or not anything is focused — which matters because
+   * 1Password unlocks behind a Touch ID prompt that takes the focus away.
+   */
+  expect(page.tabsSeenByWorker.activeTabIds).not.toContain(pageId);
+
+  const [activeTabId, ...alsoActive] = page.tabsSeenByWorker.activeTabIds;
+
+  // One tab is in front, and it is one of the views the window is showing.
+  // Which of them is the selected account's is Meru's own business, and not
+  // something a packaged build exposes to read back here
+  expect(alsoActive).toEqual([]);
+
+  expect(await readVisibleViewIds()).toContain(activeTabId);
+});
+
+test("a lock-state-shaped broadcast reaches a shimmed content script", async () => {
+  const pageId = await openProbeWindow(SURVIVING_PARTITION, `${serverOrigin}/plain`);
+
+  const page = await readProbeResults(pageId);
+
+  // The whole shape, run by the worker: `tabs.query` for every tab, then one
+  // `tabs.sendMessage` into each. A query that listed nothing reports itself
+  // here as the worker never finding this context's tab to send to
+  expect(page.workerNotifiedAllTabs.heard).toEqual({
+    type: "ping-from-worker",
+    nonce: `notify-all-tabs:${page.contextId}`,
+    workerInstanceId: expect.any(String),
+  });
+
+  expect(page.workerNotifiedAllTabs.outcome).toEqual({
+    status: "replied",
+    reply: {
+      type: "pong",
+      nonce: `notify-all-tabs:${page.contextId}`,
+      contextId: page.contextId,
+    },
+  });
 });
 
 test("an action popup is no tab, and the worker says so rather than guessing", async () => {


### PR DESCRIPTION
## Summary
The one extension worker runs in Electron's default session, where Chromium's `chrome.tabs.query` lists that session's own pages and nothing else — so 1Password's lock and unlock, which query the tabs and then message each of them, reached no account page at all. This shadows `tabs.query` and `tabs.get` in the worker's relay client and answers both from the main process, for the worker's own session and every session it shims. Not run against 1Password itself; the fixture's end-to-end suite runs the broadcast's exact shape instead.

## Problem
Read out of the 1Password 8.12.32.33 bundle, the lock-state path to content scripts is `chrome.tabs.query({})` followed by one `chrome.tabs.sendMessage` per tab carrying `lock-state-changed`; unlock is the same call with `{active: true}`, and refresh-items, can-request-unlock-changed, frozen accounts and settings all go through a generic broadcaster of the same shape. The content script stores `locked` from that message, and the flag is what decides between "Unlock 1Password" and "no items" in the inline menu.

Chromium's `TabsQueryFunction` filters the WebContents list by the asking extension's browser context, and `tabs.get` resolves an id inside it. Since [PR #1034](https://github.com/zoidsh/meru/pull/1034)'s predecessor moved the worker to the default session, that context holds no account's tabs: the query listed nothing, nobody was told the vault locked, and every account page kept an unlocked-looking inline menu until it was reloaded. `[Fill] Failed to get active tab when checking for an open and fill tab`, in the log after each unlock, is the same call.

Two things that look related and are not. The `[PortManager] … broadcasting across all active=[]` line is the extension-iframe port channel — those ports exist only while one of the four supported iframes is open, so an empty list with the inline menu closed is correct. And `<get-nested-frame-configuration>` / `<remove-inline-button>` are a family of their own: both relay into the sender's own tab across every frame, and `autofill-item` takes the same relay and has worked since #1034, so what is left there is per message rather than the tab lookup. Both are left alone here.

## Solution
- `runtime-proxy/worker-tabs.ts` answers both calls in main, over two new bridge routes. Only the worker session may call them (403 otherwise, as `workerSendToTab` does), and only the worker session and the sessions that adopted the content-script-only role are listed — the same bookkeeping `canResolveTabAcrossSessions` answers from, so one account's tabs never surface in another's answer. A shimmed session's own extension pages keep Chromium's native, scoped `chrome.tabs`.
- The relay client shadows both and makes no native call, where `tabs.sendMessage` falls through to Chromium for a tab of the worker's own session. Delivery there has to stay Chromium's; a list does not, and answering the worker's own session from main too is what keeps one `active` semantic and one ordering across the whole answer. Merging a relayed list into Chromium's would carry Chromium's `IsFocused` for some tabs and the embedder's `active` for the rest, with nothing in the result to say which.
- The filters are the five Electron's own query honors — `active`, `audible`, `muted`, `url`, `title` — and everything else is ignored exactly as Electron ignores it, so an extension gets the same answer whichever session it asks from. `windowId`/`currentWindow` would filter nothing anyway: the facade shows one window.
- **`active` comes from an embedder hook rather than Electron's `isFocused`.** Chrome's `active` means "the tab its window is showing". 1Password unlocks behind a Touch ID prompt raised by its desktop app, so at the moment its worker asks for the active tab, none of Meru's views is focused — a focus-based answer would send the unlock to nobody. Meru answers with the selected account's front view (the derivation `getActiveViewWebContents` already uses) plus a workspace app in a window of its own.
- A refused or unreachable bridge answers a query with no tabs rather than an error, since Chrome sets no `lastError` for a query that matched nothing; `tabs.get` has an error to report, so it reads there as Chrome's own `No tab with id: N.`, which is also what main answers for an id of a session it neither keeps nor shims.
- `packages/app/extensions.ts` imports `accounts` and `WorkspaceApp` back, closing an import cycle. It holds because the predicate is a hoisted function declaration that dereferences neither at module-evaluation time — the first call is a query from the worker — and the bundled output was checked for it.

## Try it
There is no preview deployment for a desktop app. Locally, with 1Password in `extensions/1password` and two accounts signed in: `bun run dev`, lock the vault from the desktop app, and the inline menu on a sign-in page in *either* account now offers "Unlock 1Password" instead of behaving as though the vault were open.

Without 1Password, the fixture covers the same shape: `xvfb-run -a bun run test:e2e tests/extension-proxy.e2e.ts -g "tabs.query lists a tab|lock-state-shaped"`.

## Not verified
- **Not run against 1Password itself** — that needs Tim's Mac, a real Google account and the desktop app. He re-tests there after merge. Everything below the 1Password reading is exercised against the checked-in fixture extension instead.
- The two surviving exceptions (`<get-nested-frame-configuration>`, `<remove-inline-button>`) are untouched and still throw `NoRelayedListener`; this change is not expected to move them.
- macOS and Windows are unmeasured: the suite ran on Linux under `xvfb`.
- The end-to-end `active` assertion stops at "the active tab is one of the views the window is showing" — which of them is the selected account's is not something a packaged build lets a test read back — so the hook picking the *right* view of several is covered by unit tests and by the code path menu.ts shares, not end to end.
- `title` is matched as a glob (`*` and `?`) to follow Chromium's `base::MatchPattern`; no extension in the catalog was observed using it.