### PR TITLE
Hibernate unpinned tabs by default, with a per-tab override

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -336,7 +336,7 @@ export const config = new Store<Config>({
                 url: savedTab.url,
                 title: savedTab.title,
                 loadOnLaunch: savedTab.loadOnLaunch,
-                hibernatesWhenIdle: false,
+                hibernatesWhenIdle: null,
                 windowed: savedTab.windowed,
                 opensLinksForApp: null,
               })),

--- a/packages/app/ipc.ts
+++ b/packages/app/ipc.ts
@@ -49,6 +49,7 @@ import {
   uninstallCuratedExtension,
 } from "./extensions";
 import { GMAIL_USER_STYLES_PATH } from "./gmail";
+import { hibernatesTabWhenIdle } from "./lib/hibernation";
 import { log } from "./lib/log";
 import {
   areWorkspaceAppNotificationsAllowed,
@@ -479,11 +480,11 @@ class Ipc {
             openExternalUrl(tab.url, { skipTrustedHostCheck: true });
           },
         },
+        {
+          type: "separator" as const,
+        },
         ...(tabApp
           ? [
-              {
-                type: "separator" as const,
-              },
               {
                 label: tab.pinned ? "Unpin" : "Pin",
                 click: () => {
@@ -514,34 +515,30 @@ class Ipc {
                     },
                   ]
                 : []),
-              // While the setting is on Selected Tabs, only the tabs marked
-              // here hibernate.
-              ...(config.get("workspaceApps.hibernation") === "selected"
-                ? [
-                    {
-                      label: "Hibernate When Idle",
-                      type: "checkbox" as const,
-                      checked: tab.hibernatesWhenIdle,
-                      click: () => {
-                        tab.hibernatesWhenIdle = !tab.hibernatesWhenIdle;
-
-                        // An unpinned tab is not saved, so the mark lasts as
-                        // long as the tab itself does.
-                        if (tab.pinned) {
-                          accounts.saveTabs();
-                        }
-                      },
-                    },
-                  ]
-                : []),
             ]
           : []),
+        // The checkbox shows what the tab does today, under the setting and any
+        // mark it already carries, so ticking it always says hibernate this one
+        // and clearing it always says leave it alone.
+        {
+          label: "Hibernate When Idle",
+          type: "checkbox" as const,
+          checked: hibernatesTabWhenIdle(tab, config.get("workspaceApps.hibernation")),
+          click: () => {
+            tab.hibernatesWhenIdle = !hibernatesTabWhenIdle(
+              tab,
+              config.get("workspaceApps.hibernation"),
+            );
+
+            // An unpinned tab is not saved, so the mark lasts as long as the
+            // tab itself does.
+            if (tab.pinned) {
+              accounts.saveTabs();
+            }
+          },
+        },
         ...(appLinksApp && !workspaceApps[appLinksApp].singleInstance
           ? [
-              // A tab that browsed off Google has no app and so no menu group of
-              // its own, but it can still be holding a designation from before —
-              // which then needs a separator to sit under.
-              ...(tabApp ? [] : [{ type: "separator" as const }]),
               {
                 label: `Open ${workspaceApps[appLinksApp].label} Links in This ${
                   isTabWindowed ? "Window" : "Tab"

--- a/packages/app/lib/hibernation.test.ts
+++ b/packages/app/lib/hibernation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { ms } from "@meru/shared/ms";
-import { canHibernateTab } from "./hibernation";
+import { canHibernateTab, hibernatesTabWhenIdle } from "./hibernation";
 
 const now = new Date("2026-08-18T12:00:00Z").getTime();
 
@@ -11,7 +11,7 @@ const idleTab = {
   isAudible: false,
   url: "https://calendar.google.com/",
   pinned: false,
-  hibernatesWhenIdle: false,
+  hibernatesWhenIdle: null,
   lastActiveAt: now - ms("2h"),
 };
 
@@ -64,9 +64,35 @@ describe("canHibernateTab", () => {
     expect(canHibernateTab({ ...idleTab, hibernatesWhenIdle: true }, sweepSelectedTabs)).toBe(true);
   });
 
-  test("unloads a marked pinned tab while the sweep is on selected tabs", () => {
-    expect(
-      canHibernateTab({ ...idleTab, pinned: true, hibernatesWhenIdle: true }, sweepSelectedTabs),
-    ).toBe(true);
+  test("unloads a tab marked in, whichever tabs the sweep is on", () => {
+    const markedInTab = { ...idleTab, pinned: true, hibernatesWhenIdle: true };
+
+    expect(canHibernateTab(markedInTab, sweepUnpinnedTabs)).toBe(true);
+    expect(canHibernateTab(markedInTab, sweepSelectedTabs)).toBe(true);
+  });
+
+  test("keeps a tab marked out, whichever tabs the sweep is on", () => {
+    const markedOutTab = { ...idleTab, hibernatesWhenIdle: false };
+
+    expect(canHibernateTab(markedOutTab, sweepEveryTab)).toBe(false);
+    expect(canHibernateTab(markedOutTab, sweepUnpinnedTabs)).toBe(false);
+  });
+});
+
+describe("hibernatesTabWhenIdle", () => {
+  const unmarkedTab = { pinned: false, hibernatesWhenIdle: null };
+
+  test("follows the setting while the tab carries no mark", () => {
+    expect(hibernatesTabWhenIdle(unmarkedTab, "all")).toBe(true);
+    expect(hibernatesTabWhenIdle(unmarkedTab, "unpinned")).toBe(true);
+    expect(hibernatesTabWhenIdle({ ...unmarkedTab, pinned: true }, "unpinned")).toBe(false);
+    expect(hibernatesTabWhenIdle(unmarkedTab, "selected")).toBe(false);
+  });
+
+  test("takes the mark over the setting either way", () => {
+    expect(hibernatesTabWhenIdle({ pinned: true, hibernatesWhenIdle: true }, "unpinned")).toBe(
+      true,
+    );
+    expect(hibernatesTabWhenIdle({ pinned: false, hibernatesWhenIdle: false }, "all")).toBe(false);
   });
 });

--- a/packages/app/lib/hibernation.test.ts
+++ b/packages/app/lib/hibernation.test.ts
@@ -10,13 +10,16 @@ const idleTab = {
   isWindowed: false,
   isAudible: false,
   url: "https://calendar.google.com/",
+  pinned: false,
   hibernatesWhenIdle: false,
   lastActiveAt: now - ms("2h"),
 };
 
-const sweepEveryTab = { hibernatesEveryTab: true, idleTimeout, now };
+const sweepEveryTab = { hibernation: "all", idleTimeout, now } as const;
 
-const sweepSelectedTabs = { hibernatesEveryTab: false, idleTimeout, now };
+const sweepUnpinnedTabs = { hibernation: "unpinned", idleTimeout, now } as const;
+
+const sweepSelectedTabs = { hibernation: "selected", idleTimeout, now } as const;
 
 describe("canHibernateTab", () => {
   test("unloads a tab idle past the timeout", () => {
@@ -47,8 +50,23 @@ describe("canHibernateTab", () => {
     expect(canHibernateTab({ ...idleTab, url: "" }, sweepEveryTab)).toBe(false);
   });
 
+  test("unloads a pinned tab while the sweep is on every tab", () => {
+    expect(canHibernateTab({ ...idleTab, pinned: true }, sweepEveryTab)).toBe(true);
+  });
+
+  test("keeps a pinned tab while the sweep is on unpinned tabs", () => {
+    expect(canHibernateTab(idleTab, sweepUnpinnedTabs)).toBe(true);
+    expect(canHibernateTab({ ...idleTab, pinned: true }, sweepUnpinnedTabs)).toBe(false);
+  });
+
   test("unloads only marked tabs while the sweep is on selected tabs", () => {
     expect(canHibernateTab(idleTab, sweepSelectedTabs)).toBe(false);
     expect(canHibernateTab({ ...idleTab, hibernatesWhenIdle: true }, sweepSelectedTabs)).toBe(true);
+  });
+
+  test("unloads a marked pinned tab while the sweep is on selected tabs", () => {
+    expect(
+      canHibernateTab({ ...idleTab, pinned: true, hibernatesWhenIdle: true }, sweepSelectedTabs),
+    ).toBe(true);
   });
 });

--- a/packages/app/lib/hibernation.ts
+++ b/packages/app/lib/hibernation.ts
@@ -1,3 +1,5 @@
+import type { WorkspaceAppsHibernation } from "@meru/shared/workspace-apps";
+
 /**
  * What the idle sweep reads off a tab to determine whether it can unload it. A
  * `WorkspaceApp` satisfies it; nothing else is needed to make the call.
@@ -6,6 +8,7 @@ type HibernatableTab = {
   isWindowed: boolean;
   isAudible: boolean;
   url: string;
+  pinned: boolean;
   hibernatesWhenIdle: boolean;
   lastActiveAt: number;
 };
@@ -18,10 +21,10 @@ type HibernatableTab = {
 export function canHibernateTab(
   tab: HibernatableTab,
   {
-    hibernatesEveryTab,
+    hibernation,
     idleTimeout,
     now,
-  }: { hibernatesEveryTab: boolean; idleTimeout: number; now: number },
+  }: { hibernation: WorkspaceAppsHibernation; idleTimeout: number; now: number },
 ) {
   // A tab in its own window is a window the user left open, and one playing
   // audio stops mid-track if its renderer goes away.
@@ -29,7 +32,12 @@ export function canHibernateTab(
     return false;
   }
 
-  if (!hibernatesEveryTab && !tab.hibernatesWhenIdle) {
+  // `all` narrows nothing down, so it has no clause of its own.
+  if (hibernation === "unpinned" && tab.pinned) {
+    return false;
+  }
+
+  if (hibernation === "selected" && !tab.hibernatesWhenIdle) {
     return false;
   }
 

--- a/packages/app/lib/hibernation.ts
+++ b/packages/app/lib/hibernation.ts
@@ -9,9 +9,33 @@ type HibernatableTab = {
   isAudible: boolean;
   url: string;
   pinned: boolean;
-  hibernatesWhenIdle: boolean;
+  hibernatesWhenIdle: boolean | null;
   lastActiveAt: number;
 };
+
+/**
+ * Whether the sweep takes this tab, before anything about how long it has been
+ * idle. The per-tab mark is the user's own answer and wins either way, so it
+ * both pulls a pinned tab into the unpinned sweep and holds a tab out of the
+ * sweep over every tab. Only a tab that carries no mark follows the setting.
+ */
+export function hibernatesTabWhenIdle(
+  tab: Pick<HibernatableTab, "pinned" | "hibernatesWhenIdle">,
+  hibernation: WorkspaceAppsHibernation,
+) {
+  if (tab.hibernatesWhenIdle !== null) {
+    return tab.hibernatesWhenIdle;
+  }
+
+  switch (hibernation) {
+    case "all":
+      return true;
+    case "unpinned":
+      return !tab.pinned;
+    case "selected":
+      return false;
+  }
+}
 
 /**
  * Whether a tab has gone idle long enough to be unloaded. The caller has
@@ -32,12 +56,7 @@ export function canHibernateTab(
     return false;
   }
 
-  // `all` narrows nothing down, so it has no clause of its own.
-  if (hibernation === "unpinned" && tab.pinned) {
-    return false;
-  }
-
-  if (hibernation === "selected" && !tab.hibernatesWhenIdle) {
+  if (!hibernatesTabWhenIdle(tab, hibernation)) {
     return false;
   }
 

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -489,7 +489,7 @@ export class Tabs {
       activeTab.lastActiveAt = now;
     }
 
-    const hibernatesEveryTab = config.get("workspaceApps.hibernation") === "all";
+    const hibernation = config.get("workspaceApps.hibernation");
 
     const idleTimeout = ms(config.get("workspaceApps.hibernationTimeout"));
 
@@ -498,7 +498,7 @@ export class Tabs {
         continue;
       }
 
-      if (canHibernateTab(tab, { hibernatesEveryTab, idleTimeout, now })) {
+      if (canHibernateTab(tab, { hibernation, idleTimeout, now })) {
         this.hibernateTab(tab);
       }
     }

--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -106,7 +106,7 @@ export class DormantTab {
 
   loadOnLaunch: boolean;
 
-  hibernatesWhenIdle: boolean;
+  hibernatesWhenIdle: boolean | null;
 
   opensLinksForApp: SupportedWorkspaceApp | null;
 
@@ -124,7 +124,7 @@ export class DormantTab {
     this.title = dormantTab.title;
     this.pinned = dormantTab.pinned;
     this.loadOnLaunch = Boolean(dormantTab.loadOnLaunch);
-    this.hibernatesWhenIdle = Boolean(dormantTab.hibernatesWhenIdle);
+    this.hibernatesWhenIdle = dormantTab.hibernatesWhenIdle ?? null;
     this.opensLinksForApp = dormantTab.opensLinksForApp ?? null;
     this.windowed = Boolean(dormantTab.windowed);
     this.zoomFactor = unloadedViewState?.zoomFactor;

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -92,7 +92,7 @@ type WorkspaceAppOptions = {
   savedAsWindow?: boolean;
   pinned?: boolean;
   loadOnLaunch?: boolean;
-  hibernatesWhenIdle?: boolean;
+  hibernatesWhenIdle?: boolean | null;
   opensLinksForApp?: SupportedWorkspaceApp | null;
   app?: SupportedWorkspaceApp;
   zoomFactor?: number;
@@ -468,7 +468,11 @@ export class WorkspaceApp {
 
   loadOnLaunch = false;
 
-  hibernatesWhenIdle = false;
+  /**
+   * The user's own answer for this tab, which overrides the Hibernate idle tabs
+   * setting either way. `null` leaves the tab following the setting.
+   */
+  hibernatesWhenIdle: boolean | null = null;
 
   /**
    * When this tab was last the account's active one. The sweep keeps it on the
@@ -514,7 +518,7 @@ export class WorkspaceApp {
     this.app = app ?? getWorkspaceAppFromUrl(url);
     this.pinned = Boolean(pinned);
     this.loadOnLaunch = Boolean(loadOnLaunch);
-    this.hibernatesWhenIdle = Boolean(hibernatesWhenIdle);
+    this.hibernatesWhenIdle = hibernatesWhenIdle ?? null;
     this.opensLinksForApp = opensLinksForApp ?? null;
     this.opensAsWindow =
       savedAsWindow ?? (Boolean(asWindow) && config.get("workspaceApps.mode") !== "windows");

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -297,7 +297,7 @@ export function WorkspaceAppsSettings() {
           <FieldSeparator />
           <ConfigSelectField
             label="Hibernate idle tabs"
-            description="Unload tabs that have been sitting unused, giving back the memory they hold. A hibernated tab keeps its place in the sidebar and loads again when you click it, on the page you left. Selected tabs only hibernates the tabs you mark with Hibernate When Idle in the tab's context menu."
+            description="Unload tabs that have been sitting unused, giving back the memory they hold. A hibernated tab keeps its place in the sidebar and loads again when you click it, on the page you left. Unpinned tabs leaves your pinned tabs loaded, and Selected tabs hibernates only the tabs you mark with Hibernate When Idle in the tab's context menu."
             configKey="workspaceApps.hibernation"
             licenseKeyRequired
             items={Object.entries(workspaceAppsHibernations).map(([value, label]) => ({

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -297,7 +297,7 @@ export function WorkspaceAppsSettings() {
           <FieldSeparator />
           <ConfigSelectField
             label="Hibernate idle tabs"
-            description="Unload tabs that have been sitting unused, giving back the memory they hold. A hibernated tab keeps its place in the sidebar and loads again when you click it, on the page you left. Unpinned tabs leaves your pinned tabs loaded, and Selected tabs hibernates only the tabs you mark with Hibernate When Idle in the tab's context menu."
+            description="Unload tabs that have been sitting unused, giving back the memory they hold. A hibernated tab keeps its place in the sidebar and loads again when you click it, on the page you left. Unpinned tabs leaves your pinned tabs loaded, and Selected tabs hibernates nothing until you mark a tab. Whichever you pick, a single tab can opt in or out with Hibernate When Idle in its context menu."
             configKey="workspaceApps.hibernation"
             licenseKeyRequired
             items={Object.entries(workspaceAppsHibernations).map(([value, label]) => ({

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -122,7 +122,7 @@ export function createDefaultConfig({
     "workspaceApps.persistZoom": true,
     "workspaceApps.zoomFactors": {},
     "workspaceApps.hidePasskeyDialog": false,
-    "workspaceApps.hibernation": "selected",
+    "workspaceApps.hibernation": "unpinned",
     "workspaceApps.hibernationTimeout": "1h",
     "verificationCodes.autoCopy": false,
     "verificationCodes.copyMode": "immediately",

--- a/packages/shared/schemas.ts
+++ b/packages/shared/schemas.ts
@@ -35,7 +35,8 @@ export const savedTabSchema = z.object({
   url: z.string(),
   title: z.string(),
   loadOnLaunch: z.boolean(),
-  hibernatesWhenIdle: z.boolean(),
+  /** `null` leaves the tab following the Hibernate idle tabs setting. */
+  hibernatesWhenIdle: z.boolean().nullable(),
   windowed: z.boolean(),
   opensLinksForApp: workspaceAppSchema.nullable(),
 });

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -90,6 +90,7 @@ export type WorkspaceAppsMode = keyof typeof workspaceAppsModes;
  * with no tab marked hibernates nothing.
  */
 export const workspaceAppsHibernations = {
+  unpinned: "Unpinned tabs",
   selected: "Selected tabs",
   all: "All tabs",
 } as const;

--- a/tests/lib/accounts.ts
+++ b/tests/lib/accounts.ts
@@ -32,7 +32,7 @@ export function seedSavedTab({
     url,
     title,
     loadOnLaunch,
-    hibernatesWhenIdle: false,
+    hibernatesWhenIdle: null,
     windowed: false,
     opensLinksForApp: null,
   };


### PR DESCRIPTION
## Summary
Adds an Unpinned tabs option to Hibernate idle tabs and makes it the default, so the idle sweep actually runs for a user who never opens the setting. The per-tab Hibernate When Idle mark becomes a two-way override that works under every setting, so a pinned app can be swept and a tab that has to stay live can be held back. No config migration is needed because hibernation has not shipped in a release yet.

## Problem
`workspaceApps.hibernation` shipped with two values, Selected tabs and All tabs, defaulting to Selected tabs. Selected tabs hibernates nothing until the user marks tabs one at a time in the tab context menu, so the feature is off by default for everyone — the memory it gives back only arrives for the people who go looking for the setting. All tabs is the only alternative, and it unloads pinned tabs, which are the ones the user deliberately kept.

The per-tab mark had the same shape of problem. It only counted under Selected tabs, so there was no way to pull one heavy pinned app into a sweep, and no way to hold one tab out of All tabs. Getting a single exception meant switching to Selected tabs and then marking every other tab by hand.

## Solution
- Adds `unpinned` to `workspaceAppsHibernations`, labeled Unpinned tabs, listed first per the repository's `ConfigSelectField` default-first convention, and makes it the default value of `workspaceApps.hibernation`.
- Makes `SavedTab.hibernatesWhenIdle` a three-state `boolean | null`: `null` follows the setting, `true` hibernates the tab whatever the setting says, `false` holds it out. Keeping it a boolean and reading it as opt-in under one setting and opt-out under another would silently invert every existing mark the moment the setting changed.
- `hibernatesTabWhenIdle` resolves the mark against the setting, and `canHibernateTab` calls it in place of its own mode clauses. `canHibernateTab` now takes the `WorkspaceAppsHibernation` value instead of a `hibernatesEveryTab` boolean, since the choice stopped being binary.
- Shows Hibernate When Idle in the tab context menu under every setting, checked to what the tab does today, so ticking it always means hibernate this one and clearing it always means leave it alone. It moves out of the menu group that needs an app, because a tab that browsed off Google hibernates too and needs the same escape hatch; that group's separator moves out with it.
- No config migration. Hibernation merged on 18 August 2026, after 3.59.0 shipped on 12 August, so no released build ever wrote `"selected"` into a config or a mark into a saved tab; it lands in 3.60.0 with the new default. A migration flipping `"selected"` to `"unpinned"` also could not tell a stored default from a deliberate choice. The one place that wrote `hibernatesWhenIdle: false` for real users, the legacy saved-tab migration, now writes `null` so a converted tab follows the setting rather than reading as a deliberate opt-out.

## Try it
Settings → Workspace apps → Hibernate idle tabs, on a fresh config: it now reads Unpinned tabs. Open a couple of unpinned tabs beside a pinned one, set Hibernate after to 30 minutes, and the unpinned ones drop their views while the pinned one stays loaded. Right-click the pinned tab and tick Hibernate When Idle and it joins them; right-click an unpinned one and clear the tick and it stays loaded.

## Not verified
- Nothing is verified in the running app: the sandbox has no display server. `canHibernateTab` and `hibernatesTabWhenIdle` carry unit tests, and `Tabs` has no test harness, so the sweep and the rebuilt context menu — including the separator that moved out of the app group — are reasoned from code only.