### PR TITLE
Demote 1Password's blocked-telemetry error line to debug

### DIFF
--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -222,6 +222,16 @@ export const extensions = new Extensions({
   workerSessionBlockedUrls: curatedExtensions.flatMap(
     (curatedExtension) => curatedExtension.telemetryUrls ?? [],
   ),
+  // What the block above leaves behind: 1Password re-arms its log-metrics
+  // flush every thirty seconds however the last one went, and each canceled
+  // flush writes an error line the worker console forwarder would otherwise
+  // put in the shipped log twice a minute. Demoted rather than dropped, so
+  // development still sees the only trace there is of what the worker is
+  // doing, and read off the same catalog entries as the blocked hosts, so the
+  // line and the cancel that causes it stay in one place.
+  benignWorkerConsoleErrors: curatedExtensions.flatMap(
+    (curatedExtension) => curatedExtension.benignWorkerConsoleErrors ?? [],
+  ),
   sharedInstance: createSharedExtensionInstance({
     shimScriptPath: path.join(__dirname, "extensions-runtime-proxy-shim.js"),
     relayScriptPath: path.join(__dirname, "extensions-runtime-proxy-relay.js"),

--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -78,12 +78,16 @@ async function createExtensionDir(name: string, key?: string) {
 function createExtensions(
   extensionDirs: ConstructorParameters<typeof Extensions>[0]["extensionDirs"],
   logger?: ConstructorParameters<typeof Extensions>[0]["logger"],
+  benignWorkerConsoleErrors?: ConstructorParameters<
+    typeof Extensions
+  >[0]["benignWorkerConsoleErrors"],
 ) {
   return new Extensions({
     extensionDirs,
     facadeScriptPath,
     derivedExtensionsDir: path.join(workDir, "derived"),
     logger,
+    benignWorkerConsoleErrors,
   });
 }
 
@@ -429,17 +433,21 @@ describe("Extensions", () => {
 
     const { session, emitServiceWorkerConsole, serviceWorkerConsoleListeners } = createSession();
 
-    const extensions = createExtensions([await createExtensionDir("one")], {
-      debug: (message, details) => {
-        logs.push({ level: "debug", message, details });
+    const extensions = createExtensions(
+      [await createExtensionDir("one")],
+      {
+        debug: (message, details) => {
+          logs.push({ level: "debug", message, details });
+        },
+        info: (message, details) => {
+          logs.push({ level: "info", message, details });
+        },
+        error: (message, details) => {
+          logs.push({ level: "error", message, details });
+        },
       },
-      info: (message, details) => {
-        logs.push({ level: "info", message, details });
-      },
-      error: (message, details) => {
-        logs.push({ level: "error", message, details });
-      },
-    });
+      ["[LogManager] Failed to send log metrics"],
+    );
 
     await extensions.setupSession(session);
 
@@ -451,6 +459,14 @@ describe("Extensions", () => {
 
     emitServiceWorkerConsole({
       message: "unlock failed",
+      level: 3,
+      sourceUrl: "chrome-extension://aaa/background.js",
+    });
+
+    // A named error, matched on its prefix rather than the whole line: the
+    // retry that writes it is the embedder's own cancel coming back
+    emitServiceWorkerConsole({
+      message: "[LogManager] Failed to send log metrics: <redacted>",
       level: 3,
       sourceUrl: "chrome-extension://aaa/background.js",
     });
@@ -481,6 +497,16 @@ describe("Extensions", () => {
         details: {
           sourceUrl: "chrome-extension://aaa/background.js",
           message: "unlock failed",
+        },
+      },
+      // Named, so the line is still the error the worker wrote and only the
+      // level moves — a shipped log stays clean and development keeps it
+      {
+        level: "debug",
+        message: "Extension service worker error",
+        details: {
+          sourceUrl: "chrome-extension://aaa/background.js",
+          message: "[LogManager] Failed to send log metrics: <redacted>",
         },
       },
     ]);

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -149,6 +149,18 @@ export type ExtensionsOptions = {
    * worker session to speak of — or with an empty list.
    */
   workerSessionBlockedUrls?: string[];
+  /**
+   * Service worker console errors to forward at debug rather than error, as
+   * prefixes matched against the start of the message. An extension retrying
+   * on a timer writes the same failure line forever, and one the embedder has
+   * already accounted for — a request the embedder itself cancels, say — is
+   * noise it would carry in every log it keeps.
+   *
+   * Demoted, never dropped: the worker's console is the only trace of what an
+   * extension is doing, so the line has to stay readable in development.
+   * Without this every worker error is forwarded at error.
+   */
+  benignWorkerConsoleErrors?: string[];
   logger?: ExtensionsLogger;
 };
 
@@ -179,6 +191,8 @@ export class Extensions {
   private workerSessionPagePatterns: string[] | undefined;
 
   private workerSessionBlockedUrls: string[] | undefined;
+
+  private benignWorkerConsoleErrors: string[] | undefined;
 
   private logger: ExtensionsLogger | undefined;
 
@@ -219,6 +233,7 @@ export class Extensions {
     sharedInstance,
     workerSessionPagePatterns,
     workerSessionBlockedUrls,
+    benignWorkerConsoleErrors,
     logger,
   }: ExtensionsOptions) {
     this.extensionDirs = extensionDirs;
@@ -236,6 +251,8 @@ export class Extensions {
     this.workerSessionPagePatterns = workerSessionPagePatterns;
 
     this.workerSessionBlockedUrls = workerSessionBlockedUrls;
+
+    this.benignWorkerConsoleErrors = benignWorkerConsoleErrors;
 
     this.logger = logger;
 
@@ -547,7 +564,8 @@ export class Extensions {
    * several kilobytes in 1Password's case, which an embedder wants in
    * development and not on the disk of every shipped install. Errors stay at
    * error, since a worker's own report of a failure is the diagnostic the
-   * forwarding exists for.
+   * forwarding exists for — except the ones the embedder named as benign,
+   * which are the same line one level down.
    */
   private pipeServiceWorkerConsole(session: Session) {
     const listener = (_event: ElectronEvent, { message, level, sourceUrl }: MessageDetails) => {
@@ -555,16 +573,41 @@ export class Extensions {
         return;
       }
 
-      if (level >= CONSOLE_ERROR_LEVEL) {
-        this.logger?.error("Extension service worker error", { sourceUrl, message });
-      } else {
+      if (level < CONSOLE_ERROR_LEVEL) {
         this.logger?.debug("Extension service worker log", { sourceUrl, message });
+
+        return;
       }
+
+      // Still reported as the error the worker called it, so development reads
+      // what the worker actually wrote rather than a line dressed up as
+      // chatter — only the level moves
+      if (this.isBenignWorkerConsoleError(message)) {
+        this.logger?.debug("Extension service worker error", { sourceUrl, message });
+
+        return;
+      }
+
+      this.logger?.error("Extension service worker error", { sourceUrl, message });
     };
 
     this.serviceWorkerConsoleListeners.set(session, listener);
 
     session.serviceWorkers.on("console-message", listener);
+  }
+
+  /**
+   * Whether a worker's error line is one the embedder already accounted for.
+   * A prefix rather than the whole line, because what follows it is the
+   * extension's own detail — a redacted payload, a request id — and differs
+   * line to line.
+   */
+  private isBenignWorkerConsoleError(message: string) {
+    return Boolean(
+      this.benignWorkerConsoleErrors?.some((benignWorkerConsoleError) =>
+        message.startsWith(benignWorkerConsoleError),
+      ),
+    );
   }
 
   /**

--- a/packages/shared/extensions.test.ts
+++ b/packages/shared/extensions.test.ts
@@ -27,6 +27,26 @@ const telemetryUrls = curatedExtensions.flatMap(
   (curatedExtension) => curatedExtension.telemetryUrls ?? [],
 );
 
+const benignWorkerConsoleErrors = curatedExtensions.flatMap(
+  (curatedExtension) => curatedExtension.benignWorkerConsoleErrors ?? [],
+);
+
+describe("curated extension benign worker console errors", () => {
+  /*
+   * A prefix is matched with `startsWith`, where the empty string matches
+   * every message: one blank entry, or one trimmed down to a word, would take
+   * every error an extension's worker reports down to debug — and that console
+   * is the only place a worker's failure surfaces at all.
+   */
+  test("every prefix names one line rather than a class of them", () => {
+    for (const benignWorkerConsoleError of benignWorkerConsoleErrors) {
+      expect(benignWorkerConsoleError.trim()).toBe(benignWorkerConsoleError);
+
+      expect(benignWorkerConsoleError.length).toBeGreaterThan(20);
+    }
+  });
+});
+
 describe("curated extension telemetry URLs", () => {
   /*
    * The invariant the whole list rests on: every pattern names one host

--- a/packages/shared/extensions.ts
+++ b/packages/shared/extensions.ts
@@ -29,6 +29,22 @@ export type CuratedExtension = {
    * take a working password manager with it.
    */
   telemetryUrls?: string[];
+  /**
+   * Error lines the extension's service worker writes that say nothing an
+   * embedder can act on, as prefixes matched against the start of the message.
+   * The worker's console is forwarded to Meru's log, and a line named here
+   * goes out at debug instead of error: still there in development, where the
+   * worker's console is the only trace of what the extension is doing, and off
+   * the disk of every shipped install.
+   *
+   * A prefix rather than the whole line, because the tail is the extension's
+   * own detail — a redacted payload, a request id — and differs line to line.
+   *
+   * Only lines that carry no diagnostic: this is the last place a worker's
+   * failure surfaces, so a prefix wider than the one benign line it was
+   * written for takes real errors down to debug with it.
+   */
+  benignWorkerConsoleErrors?: string[];
 };
 
 /** The 1Password Chrome Web Store id, which app and settings both single out. */
@@ -70,6 +86,14 @@ export const curatedExtensions: CuratedExtension[] = [
       "https://com-1password-prod1.mini.snplow.net/*",
       // Sentry error reporting, initialized as the worker starts
       "https://b5x-sentry.1passwordservices.com/*",
+    ],
+    benignWorkerConsoleErrors: [
+      // 1Password re-arms its log-metrics flush every thirty seconds whatever
+      // happened to the last one, so the forwarder above being canceled costs
+      // two error lines a minute in every shipped log. The line reports Meru's
+      // own decision back to it — nothing to act on, and nothing a user could
+      // do about it — while a worker error that is not this one still matters
+      "[LogManager] Failed to send log metrics",
     ],
   },
 ];


### PR DESCRIPTION
## Summary
The extension worker console forwarder now takes a list of benign error prefixes and sends a matching line to `logger.debug` rather than `logger.error`. One prefix is named, `[LogManager] Failed to send log metrics`, which is what 1Password writes every thirty seconds because [PR #1038](https://github.com/zoidsh/meru/pull/1038) cancels the flush behind it. Nothing else changes level, and the line is demoted rather than dropped.

## Problem
[PR #1038](https://github.com/zoidsh/meru/pull/1038) cancels 1Password's telemetry in the worker session on purpose. 1Password re-arms its log-metrics flush every thirty seconds however the last one went, and every canceled flush writes `[LogManager] Failed to send log metrics: <redacted>` to the worker console at error level, which the forwarder [PR #1035](https://github.com/zoidsh/meru/pull/1035) shipped writes to the main log as "Extension service worker error". Confirmed on Tim's Mac after the block landed: two lines a minute in every shipped log, from a request Meru itself cancels, reporting Meru's own decision back to it. There is nothing to act on and nothing a user could do about it, so it is noise a shipped log carries for the life of the app.

## Solution
- The catalog entry gains `benignWorkerConsoleErrors` beside the `telemetryUrls` whose cancel causes the line, and the app passes the union of those lists to the loader unconditionally, the way it already passes `workerSessionBlockedUrls`
- The loader's `console-message` listener forwards a `chrome-extension://` error at debug when its message starts with one of those prefixes, and at error otherwise
- Demoted rather than dropped, because the worker's console is the only trace there is of what 1Password is doing and development wants it — the extension has no page and no devtools anywhere in Meru
- Forwarded as the error the worker called it: the message stays `Extension service worker error` and only the level moves, so a development log is not reading a failure dressed up as chatter
- A prefix rather than the whole line, because the tail is 1Password's own `redactUnsafe` output and differs line to line
- It lives in the catalog rather than as a constant in the loader so that the block and its leftover are read together, and so that a second curated extension's noisy line is added next to its own blocked hosts
- Not a filter on the message text in the app's logger, which would have kept the level split in one place but hidden the line from development too, and not a wider match on the log-manager prefix: `startsWith` on an over-trimmed prefix takes every worker error down to debug, and that console is the last place a worker failure surfaces

## Try it
No preview deployment for the Electron app, and the line comes from real 1Password rather than the fixture, so this needs a dev run on a machine with the extension installed and signed in: `bun run dev`, then watch the worker console lines. The `[LogManager] Failed to send log metrics` line still appears — the development transports write every level — while a packaged build's log file, which sits at info, no longer carries it.

## Not verified
- The effect on a real shipped log, which needs a packaged build on Tim's Mac. The sandbox cannot run one, and the line comes from 1Password's own timer rather than from anything the fixture does.