### PR TITLE
Keep focus where it was when a verification code is copied from the notification

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -720,13 +720,17 @@ export class Gmail {
                   "delete",
                 );
               }
+            };
 
-              // macOS activates the app whenever a notification is clicked, and
-              // Electron cannot opt out. This notification's only job is to
-              // write the clipboard, so hand activation back to the app the
-              // user was in. `app.hide()` also stops the `did-become-active`
-              // handler in index.ts from showing a hidden window; `app.show()`
-              // then unhides, without activating, a window that was visible.
+            // macOS activates the app whenever a notification is clicked, and
+            // Electron cannot opt out. This notification's only job is to
+            // write the clipboard, so hand activation back to the app the
+            // user was in. `app.hide()` also stops the `did-become-active`
+            // handler in index.ts from showing a hidden window; `app.show()`
+            // then unhides, without activating, a window that was visible.
+            const copyVerificationCodeOnClick = () => {
+              copyVerificationCode();
+
               if (platform.isMacOS && !wasFocused) {
                 app.hide();
 
@@ -751,7 +755,7 @@ export class Gmail {
               body: copiesOnNotificationClick
                 ? `Click to copy verification code ${verificationCode}`
                 : `Copied verification code ${verificationCode}`,
-              click: copiesOnNotificationClick ? copyVerificationCode : undefined,
+              click: copiesOnNotificationClick ? copyVerificationCodeOnClick : undefined,
             });
 
             continue;

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -697,6 +697,9 @@ export class Gmail {
           const verificationCode = extractVerificationCode([newMail.subject, newMail.summary]);
 
           if (verificationCode) {
+            const wasFocused = main.window.isFocused();
+            const wasVisible = main.window.isVisible();
+
             const copyVerificationCode = () => {
               clipboard.writeText(verificationCode);
 
@@ -716,6 +719,20 @@ export class Gmail {
                   newMail.id,
                   "delete",
                 );
+              }
+
+              // macOS activates the app whenever a notification is clicked, and
+              // Electron cannot opt out. This notification's only job is to
+              // write the clipboard, so hand activation back to the app the
+              // user was in. `app.hide()` also stops the `did-become-active`
+              // handler in index.ts from showing a hidden window; `app.show()`
+              // then unhides, without activating, a window that was visible.
+              if (platform.isMacOS && !wasFocused) {
+                app.hide();
+
+                if (wasVisible) {
+                  app.show();
+                }
               }
             };
 


### PR DESCRIPTION
## Summary
Clicking the "Click to copy verification code" notification no longer brings Meru to the front. On macOS the click handler hands activation back to the app the user was in, so the code lands on the clipboard while they stay on the sign-in screen. The macOS behavior is reasoned from Electron's API, not observed.

## Problem
In `notificationClick` mode the notification's whole job is a clipboard write, but macOS activates the app on every notification click and Electron has no opt-out. The `did-become-active` handler in `packages/app/index.ts` then shows the window if it was hidden, so the user lost the window they were typing the code into.

## Solution
- Captures whether the main window was focused and visible when the notification is created
- On click, macOS only, calls `app.hide()` when Meru was not focused, which returns activation to the previous app and stops `did-become-active` from surfacing a hidden window; a window that was visible in the background is restored with `app.show()`, which unhides without activating
- The handoff lives in a click-only wrapper, not in `copyVerificationCode` itself, because that function also runs synchronously on arrival in `immediately` mode, where hiding the app would make a code email vanish Meru from under the user
- The `immediately` notification and the new-mail notification are untouched

## Try it
Set copy mode to "On notification click", switch to another app with Meru hidden or in the background, and trigger a code email. Clicking the notification should copy the code and leave the other app frontmost; Meru should not come forward.

## Not verified
- The macOS activation handoff itself. The sandbox is Linux without a display, so both cases need a check on a Mac: window hidden, and window visible behind another app.