### PR TITLE
Offer a 1 minute hibernation timeout in development

### DIFF
--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -3,6 +3,7 @@ import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
 import { GMAIL_TAB_ID, verticalTabsWidths } from "@meru/shared/tabs";
 import {
+  DEV_WORKSPACE_APPS_HIBERNATION_TIMEOUT,
   launcherAndBookmarksPlacements,
   type LauncherWorkspaceApp,
   launcherWorkspaceApps,
@@ -310,10 +311,15 @@ export function WorkspaceAppsSettings() {
             description="How long a tab has to go unused before it hibernates. The active tab, tabs in their own window, and tabs playing audio are left alone."
             configKey="workspaceApps.hibernationTimeout"
             licenseKeyRequired
-            items={Object.entries(workspaceAppsHibernationTimeouts).map(([value, label]) => ({
-              value,
-              label,
-            }))}
+            items={Object.entries(workspaceAppsHibernationTimeouts)
+              .filter(
+                ([value]) =>
+                  import.meta.env.DEV || value !== DEV_WORKSPACE_APPS_HIBERNATION_TIMEOUT,
+              )
+              .map(([value, label]) => ({
+                value,
+                label,
+              }))}
           />
           <FieldSeparator />
           <FieldSet>

--- a/packages/renderer/types/globals.d.ts
+++ b/packages/renderer/types/globals.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="vite/client" />
+
 declare module "*.wav" {
   const soundUrl: string;
   export default soundUrl;

--- a/packages/shared/workspace-apps.ts
+++ b/packages/shared/workspace-apps.ts
@@ -98,6 +98,7 @@ export type WorkspaceAppsHibernation = keyof typeof workspaceAppsHibernations;
 
 /** Keys double as durations for `ms`. */
 export const workspaceAppsHibernationTimeouts = {
+  "1m": "1 minute",
   "30m": "30 minutes",
   "1h": "1 hour",
   "3h": "3 hours",
@@ -105,6 +106,14 @@ export const workspaceAppsHibernationTimeouts = {
 } as const;
 
 export type WorkspaceAppsHibernationTimeout = keyof typeof workspaceAppsHibernationTimeouts;
+
+/**
+ * A minute is too short to ship — a tab left alone for the length of a phone
+ * call would hibernate — but it's the only way to watch an idle sweep happen
+ * without waiting half an hour, so the settings UI offers it in a development
+ * run and nowhere else.
+ */
+export const DEV_WORKSPACE_APPS_HIBERNATION_TIMEOUT: WorkspaceAppsHibernationTimeout = "1m";
 
 /**
  * How a single Workspace App ends up being opened. Resolved per click from the


### PR DESCRIPTION
## Summary
Adds a "1 minute" option to the Hibernate after select, offered only in a development run. It makes idle-tab hibernation watchable without waiting half an hour, and folds out of the shipped bundle entirely, so nothing changes for users.

## Problem
The shortest hibernation timeout is 30 minutes, so seeing an idle sweep actually hibernate a tab — and seeing what the tab looks like when it wakes — means leaving the app alone for half an hour per attempt. That is long enough that the sweep mostly goes untested by hand.

## Solution
- Adds `"1m": "1 minute"` to `workspaceAppsHibernationTimeouts`, first in the scale, along with `DEV_WORKSPACE_APPS_HIBERNATION_TIMEOUT` naming it
- Filters that one option out of the `ConfigSelectField` in Workspace Apps settings unless `import.meta.env.DEV`
- References `vite/client` from the renderer's `globals.d.ts`, which is what types `import.meta.env`

Vite's `DEV` flag rather than a dev flag plumbed from the main process: it is a constant at build time, so the shipped renderer minifies down to `.filter(([value]) => value !== "1m")` with the option gone, instead of the shipped app carrying a runtime check that could be got wrong. Development also keeps its own config file (`config.dev`), so a minute set while developing can never turn up in the shipped app's settings.

The 1-minute sweep interval means a tab set to 1 minute hibernates within a minute or two of going idle, not on the second.

## Try it
`bun run dev`, then Settings → Workspace Apps → Hibernate after: the list starts at 1 minute. Set it, mark a tab Hibernate When Idle from its context menu, switch away, and it unloads within a couple of minutes. A shipped or `bun run build:*` build shows the list starting at 30 minutes.

## Not verified
- Not run in the app: this sandbox has no display, so the select was not seen rendered and no tab was watched hibernating. What was checked is the built bundle, where the filter collapses to the 1m-excluding form; plus `types`, `lint`, `fmt:check` and `bun test`.