### PR TITLE
Explain the experimental status in extensions settings

### DIFF
--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -292,11 +292,10 @@ function ExperimentalAlert() {
   return (
     <Alert>
       <FlaskConicalIcon />
-      <AlertTitle>Extensions are experimental</AlertTitle>
+      <AlertTitle>Extensions are in testing</AlertTitle>
       <AlertDescription>
-        Meru builds Chrome's extension support itself rather than shipping a whole browser, and that
-        support is still being tested. Extensions can behave in ways they don't in Chrome, and this
-        feature may change or be withdrawn in a later release.
+        Extension support is still being tested and may not work as reliably as the rest of Meru. To
+        help make it stable, report any issues.
       </AlertDescription>
     </Alert>
   );

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -35,7 +35,7 @@ import { Spinner } from "@meru/ui/components/spinner";
 import { Switch } from "@meru/ui/components/switch";
 import { cn } from "@meru/ui/lib/utils";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { ExternalLinkIcon, KeyRoundIcon } from "lucide-react";
+import { ExternalLinkIcon, FlaskConicalIcon, KeyRoundIcon } from "lucide-react";
 import { type ComponentProps, useState } from "react";
 import { toast } from "sonner";
 import { ConfigSwitchField } from "@/components/config-switch-field";
@@ -288,6 +288,20 @@ function ExtensionItem({
   );
 }
 
+function ExperimentalAlert() {
+  return (
+    <Alert>
+      <FlaskConicalIcon />
+      <AlertTitle>Extensions are experimental</AlertTitle>
+      <AlertDescription>
+        Meru builds Chrome's extension support itself rather than shipping a whole browser, and that
+        support is still being tested. Extensions can behave in ways they don't in Chrome, and this
+        feature may change or be withdrawn in a later release.
+      </AlertDescription>
+    </Alert>
+  );
+}
+
 function PasskeysAlert() {
   if (platform.isMacOS) {
     return (
@@ -443,6 +457,7 @@ export function ExtensionsSettings() {
       <SettingsContent>
         <LicenseKeyRequiredBanner />
         <FieldGroup>
+          <ExperimentalAlert />
           <FieldDescription>
             Extensions are loaded into every account and take effect after a restart. Meru installs
             the official extensions from the Chrome Web Store.

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -458,8 +458,10 @@ export function ExtensionsSettings() {
         <FieldGroup>
           <ExperimentalAlert />
           <FieldDescription>
-            Extensions are loaded into every account and take effect after a restart. Meru installs
-            the official extensions from the Chrome Web Store.
+            Extensions add features to Meru, like filling passwords on the Google sign-in page. Turn
+            one on below and Meru installs the official version from the Chrome Web Store.
+            Extensions start after a restart, and every account shares one copy, so you sign in to
+            an extension once.
           </FieldDescription>
           <ConfigSwitchField
             label="Enable extensions"


### PR DESCRIPTION
## Summary
Adds an alert at the top of Extensions settings saying that extension support is still being tested, and rewrites the page description, which claimed one extension is loaded per account — something the shared instance made false. Verified in a packaged build on Linux.

## Problem
The page title carries an `Experimental` badge and nothing else. The badge says a feature is unstable without saying what that costs the user, so someone installing 1Password has no way to know whether "experimental" means a rough edge or a thing that might stop working — and no prompt to send back what they hit. [The badge-label decision](https://github.com/zoidsh/meru/pull/1000) settled the word deliberately, since Beta oversold the layer, but the word alone carries none of that.

The page description was also wrong and thin. It opened "Extensions are loaded into every account and take effect after a restart", which stopped being true when [the shared instance shipped on by default](https://github.com/zoidsh/meru/pull/985): one copy is shared across accounts, with a single worker on the default session and a content-script-only copy everywhere else. That is the user-visible half of the proxy — it is why an extension is signed in to once rather than per account — so the line stated its opposite. And it led with behavior on a page that never said what an extension is.

## Solution
- Adds a local `ExperimentalAlert` in the Extensions settings route, rendered below the Pro banner and above the page description, so the caveat is read before the instructions.
- It is an `Alert` with a `FlaskConicalIcon`, matching `PasskeysAlert` further down the same page, rather than a new shared component. Extensions is the only page-level `Experimental` in the app — `MaturityFieldBadge`'s other caller is a single field on Gmail — so a shared banner would have one call site and a second tier to design for.
- The alert copy states the condition and then the action, in Apple's shape for beta-software notices. An earlier draft led with why the layer is unstable, that Meru builds Chrome's extension support itself rather than shipping a whole browser; that is Meru's architecture, and it isn't what a reader needs to decide whether to install 1Password. The ask names no destination: a draft ended in a link to the issue tracker, derived from the `GITHUB_REPO_URL` the Help menu's **Source Code** item uses, and it was cut.
- The description now says what an extension is and how to use one before it says how it behaves — features added to Meru, filling passwords on the Google sign-in page as the example; turned on below and installed from the Chrome Web Store; started after a restart, with one copy shared by every account. The Chrome Web Store provenance is kept where it was, since every curated extension is official and that is stated once for the page rather than per item.

## Try it
Open Settings → Extensions. This is the page from a packaged Linux build of this branch:

![Extensions settings, with the testing alert under the Pro banner and the rewritten description below it](https://github.com/user-attachments/assets/961965f2-7477-4201-9096-71c84911969f)

## Not verified
- Only Linux was exercised, in a packaged build. Neither string has a platform branch, unlike `PasskeysAlert` beneath them.
- "Every account shares one copy" is read off the shared-instance design rather than demonstrated with two accounts in this branch.