### PR TITLE
Disable extensions by default

### DIFF
--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -140,7 +140,7 @@ export function createDefaultConfig({
     "verticalTabs.showWidthToggle": true,
     "verticalTabs.hideUnreadBadgeWhenActive": false,
     "verticalTabs.showAppLinksBadge": true,
-    "extensions.enabled": true,
+    "extensions.enabled": false,
     "extensions.installed": [],
     "extensions.showTitlebarButton": false,
   };

--- a/tests/extension-proxy.e2e.ts
+++ b/tests/extension-proxy.e2e.ts
@@ -5,7 +5,8 @@
  * the desktop app and a display.
  *
  * The launch carries one extension flag: `MERU_EXTENSIONS_FIXTURE` puts the
- * bundled fixture into every session of this packaged build. The shared
+ * bundled fixture into every session of this packaged build, and the seed
+ * turns the master switch on, extensions being off by default. The shared
  * instance needs no flag, because it is how Meru runs extensions — the default
  * session keeps the fixture's service worker while every account session gets
  * the content-script-only copy whose `chrome.runtime` messaging the proxy
@@ -62,6 +63,7 @@ const SURVIVING_PARTITION = "persist:surviving-account";
 
 const meru = useProApp(
   {
+    "extensions.enabled": true,
     accounts: [
       account("removed-account", "Removed", true),
       account("surviving-account", "Surviving", false),

--- a/tests/extension-telemetry.e2e.ts
+++ b/tests/extension-telemetry.e2e.ts
@@ -8,7 +8,8 @@
  * fixture is the one that can be asked to make a request on demand.
  *
  * The launch carries `MERU_EXTENSIONS_FIXTURE`, which puts the bundled fixture
- * into every session of this packaged build, and goes through `useProApp`
+ * into every session of this packaged build, seeds the master switch on
+ * because extensions are off by default, and goes through `useProApp`
  * because a file is entirely one entitlement or the other — `useApp` registers
  * its hooks once at module scope. One account is enough here: the worker runs
  * in the default session, which no account owns, so nothing about this changes
@@ -44,7 +45,7 @@ function account(id: string, label: string) {
 const WORKER_SESSION = null;
 
 const meru = useProApp(
-  { accounts: [account("only-account", "Only")] },
+  { "extensions.enabled": true, accounts: [account("only-account", "Only")] },
   { env: { MERU_EXTENSIONS_FIXTURE: "1" } },
 );
 

--- a/tests/launch.e2e.ts
+++ b/tests/launch.e2e.ts
@@ -57,7 +57,9 @@ test("a packaged run without the fixture flag loads no extensions", async () => 
    * The checked-in fixture extension ships inside this build, and
    * MERU_EXTENSIONS_FIXTURE is what may load it. This launch does not set the
    * flag, so the account session has to come up with no extensions at all —
-   * the claim that a shipped Meru loads nothing unless told to.
+   * the claim that a shipped Meru loads nothing unless told to. The master
+   * switch is off in a fresh config as well, so what this pins is the shipped
+   * default rather than the flag on its own.
    *
    * The account's id is generated on first launch, so it is read back from
    * the config the app wrote rather than seeded.

--- a/tests/pro.e2e.ts
+++ b/tests/pro.e2e.ts
@@ -54,6 +54,13 @@ const meru = useProApp({
    * license had nothing to do with.
    */
   "verificationCodes.autoCopy": true,
+  /*
+   * The same shape, for the extensions master switch: it is off by default, and
+   * with it off every curated extension's item locks whatever the license says.
+   * Nothing loads from turning it on here, since no extension is installed and
+   * this launch carries no fixture flag.
+   */
+  "extensions.enabled": true,
 });
 
 test("both accounts survive into the app", async () => {


### PR DESCRIPTION
## Summary
`extensions.enabled` now defaults to `false`, so a fresh Meru loads no extension until the master switch is turned on. Extension support is opt-in because the sign-in Meru wants users on is a passkey held by the OS. No migration is needed — extensions ship first in 3.60 and 3.59 is the released version, so no profile has ever had the key set by a build that offered the feature. The only other changes are the three end-to-end suites the flip forces to seed the switch on.

## Problem
The master switch shipped defaulting to `true`, which would hand every new install a third-party extension in every account session before the user asked for one. That is the wrong default for what the feature is. A passkey enrolled into the OS and unlocked with Touch ID or Windows Hello is the sign-in Meru wants people on: it installs nothing and costs none of the per-account extension instance that [the memory numbers](https://github.com/zoidsh/meru/pull/1030) price at 80 to 110 MB per account with the 1Password desktop app connected. The extension is the fallback for the users that route can't serve — an existing 1Password vault they sign in with, an iCloud passkey that doesn't work here, an ordinary password to fill — and a fallback shouldn't be on before it's wanted. On by default also made the native route the thing a user has to find.

## Solution
- Flips `"extensions.enabled"` to `false` in `createDefaultConfig`. Nothing else about the switch moves: it is read where it always was, in `getOptedInExtensionIds` and `getExtensionDirs`, ahead of the license check in both.
- Seeds the switch on in `tests/extension-proxy.e2e.ts` and `tests/extension-telemetry.e2e.ts`. `getExtensionDirs` gates the checked-in fixture on the same switch, so `MERU_EXTENSIONS_FIXTURE` on its own now loads nothing and both suites failed without the seed.
- Seeds it on in `tests/pro.e2e.ts` as well. Its walk asserts every Pro-gated field has a usable control, and with the switch off each curated extension's item locks whatever the license says — the same shape as the `"verificationCodes.autoCopy"` seed already there, and the reason that one exists.
- No settings copy change. The switch is now the gate a first-time visitor meets, with the curated list, the titlebar-button switch and **Set up desktop app** locked below it, and its description still reads "Run the installed extensions" rather than saying it gates installing too. Deliberately left for its own change rather than folded into a default flip.
- `tests/launch.e2e.ts` keeps its assertion and gains a line saying what it now pins: the shipped default, rather than the fixture flag on its own, both being off in a fresh config.

## Try it
There is nothing deployed to open — this is a desktop app. On a local build, launch against a fresh user data directory and go to Settings > Extensions: **Enable extensions** is off, and the whole page below it is disabled rather than hidden. An existing development profile keeps whatever it had, the key being persisted once toggled.

## Not verified
- Nothing about the settings page was seen on a real display. The sandbox has none, so the first-visit reading of a locked page with an off switch at the top is reasoned from the code and from the existing e2e walks, not looked at.
- The manual pass for 3.60 gains a step from this — turn the switch on before installing 1Password — and has not been re-run.