### PR TITLE
Cover a subframe's tabs.sendMessage relay answered by the top frame

### DIFF
--- a/packages/electron-extensions/fixture/background.ts
+++ b/packages/electron-extensions/fixture/background.ts
@@ -128,6 +128,39 @@ function sendToSender(
 }
 
 /**
+ * Sends into the sender's tab without naming a frame, which is the shape
+ * 1Password's `get-nested-frame-configuration` relay has: a nested frame asks
+ * the worker something, the worker messages the whole tab, and the answer is
+ * meant to come from the top frame rather than from the frame that asked. The
+ * sender's own `frameId` is deliberately not passed — with it the message
+ * would go back to the asking frame alone, which is the one frame that has no
+ * answer to give.
+ */
+function askTab(
+  sender: FixtureMessageSender | undefined,
+  message: unknown,
+  answer: (outcome: WorkerCallOutcome) => void,
+) {
+  const tabId = sender?.tab?.id;
+
+  if (tabId === undefined) {
+    answer({ status: "error", message: "The sender carried no tab" });
+
+    return;
+  }
+
+  tabs.sendMessage(tabId, message, {}, (reply) => {
+    const lastError = runtime.lastError;
+
+    answer(
+      lastError
+        ? { status: "error", message: lastError.message ?? "unknown" }
+        : { status: "replied", reply },
+    );
+  });
+}
+
+/**
  * Every tab the worker can see, and the one the message came from asked for by
  * id — the two calls a lock broadcast starts with. Natively both are scoped to
  * the worker's own session, which holds no account's tabs, so in a shimmed
@@ -283,6 +316,20 @@ runtime.onMessage.addListener((message, sender, sendResponse) => {
       { type: "ping-from-worker", nonce: probeMessage.nonce, workerInstanceId },
       (outcome) => {
         sendResponse({ type: "send-back-reply", outcome });
+      },
+    );
+
+    return true;
+  }
+
+  // The same direction with no frame named, so every frame of the tab hears it
+  // and whichever frame answers is the one that replies. Answers late too
+  if (probeMessage?.type === "ask-tab") {
+    askTab(
+      sender,
+      { type: "answer-if-top", nonce: probeMessage.nonce, workerInstanceId },
+      (outcome) => {
+        sendResponse({ type: "ask-tab-reply", outcome });
       },
     );
 

--- a/packages/electron-extensions/fixture/fixture.test.ts
+++ b/packages/electron-extensions/fixture/fixture.test.ts
@@ -15,7 +15,7 @@ type FixtureManifestFile = {
   default_locale?: string;
   background?: { service_worker?: string };
   action?: { default_popup?: string };
-  content_scripts?: { matches?: string[]; js?: string[] }[];
+  content_scripts?: { matches?: string[]; js?: string[]; all_frames?: boolean }[];
   web_accessible_resources?: { resources?: string[]; matches?: string[] }[];
 };
 
@@ -45,6 +45,14 @@ describe("the fixture manifest", () => {
     expect(content_scripts?.map((contentScript) => contentScript.matches)).toEqual([
       LOOPBACK_MATCHES,
     ]);
+  });
+
+  test("injects into subframes, which the nested-frame relay coverage rests on", async () => {
+    const { content_scripts } = await readManifest();
+
+    // A subframe asking the worker to message its tab, and the top frame
+    // answering, is only reachable with a content script in both frames
+    expect(content_scripts?.map((contentScript) => contentScript.all_frames)).toEqual([true]);
   });
 
   test("exposes its frame page to the loopback address and nowhere else", async () => {

--- a/packages/electron-extensions/fixture/manifest.json
+++ b/packages/electron-extensions/fixture/manifest.json
@@ -16,7 +16,8 @@
     {
       "matches": ["http://127.0.0.1/*"],
       "js": ["probe.js"],
-      "run_at": "document_idle"
+      "run_at": "document_idle",
+      "all_frames": true
     }
   ],
   "web_accessible_resources": [

--- a/packages/electron-extensions/fixture/probes.ts
+++ b/packages/electron-extensions/fixture/probes.ts
@@ -208,12 +208,26 @@ export type ProbeResults = {
    */
   workerNotifiedAllTabs: WorkerInitiatedOutcome;
   /**
+   * The worker messaging this context's whole tab, no frame named — the shape
+   * 1Password's `get-nested-frame-configuration` relay has. Every frame hears
+   * it and only the top frame answers, so in a subframe the reply names the
+   * top frame's own `contextId` rather than the asking frame's. A single-frame
+   * page answers itself, which is the same call with nothing to distinguish.
+   */
+  askedTab: WorkerInitiatedOutcome;
+  /**
    * Whether the worker's event log recorded this context answering on the port
    * the worker opened — the page-to-worker half of a worker-opened port, which
    * nothing this side can observe.
    */
   portReplySeenByWorker: boolean;
 };
+
+/**
+ * The one thing a probe needs of `window`: whether this context is the top
+ * frame of its tab, which is how the nested-frame relay decides who answers.
+ */
+type ProbeWindow = { top: ProbeWindow | null };
 
 function seeSender(sender: FixtureMessageSender | undefined): SeenSender {
   return {
@@ -421,7 +435,7 @@ async function probeSenderFrame(runtime: FixtureRuntime): Promise<EchoOutcome> {
 function probeWorkerInitiated(
   runtime: FixtureRuntime,
   contextId: string,
-  requestType: "send-back" | "connect-back" | "notify-all-tabs",
+  requestType: "send-back" | "connect-back" | "notify-all-tabs" | "ask-tab",
   arrivals: Map<string, { message: unknown; sender: SeenSender }>,
 ): Promise<WorkerInitiatedOutcome> {
   const nonce = `${requestType}:${contextId}`;
@@ -676,7 +690,11 @@ export async function runProbes(): Promise<ProbeResults> {
   const contextGlobals = globalThis as unknown as {
     crypto: { randomUUID: () => string };
     location: { href: string };
+    /** Only ever compared with its own `top`, which is what names a subframe. */
+    window: ProbeWindow;
   };
+
+  const isTopFrame = contextGlobals.window === contextGlobals.window.top;
 
   const contextId = contextGlobals.crypto.randomUUID();
 
@@ -698,13 +716,37 @@ export async function runProbes(): Promise<ProbeResults> {
   runtime.onMessage.addListener((message, sender, sendResponse) => {
     const probeMessage = message as { type?: string; nonce?: string } | undefined;
 
-    if (probeMessage?.type !== "ping-from-worker" || typeof probeMessage.nonce !== "string") {
+    if (typeof probeMessage?.nonce !== "string") {
       return undefined;
     }
 
-    arrivals.set(probeMessage.nonce, { message, sender: seeSender(sender) });
+    if (probeMessage.type === "ping-from-worker") {
+      arrivals.set(probeMessage.nonce, { message, sender: seeSender(sender) });
 
-    sendResponse({ type: "pong", nonce: probeMessage.nonce, contextId });
+      sendResponse({ type: "pong", nonce: probeMessage.nonce, contextId });
+
+      return undefined;
+    }
+
+    /*
+     * The nested-frame shape, which the worker fanned out to every frame of
+     * the tab: only the top frame has an answer, and a subframe declines by
+     * returning without calling `sendResponse` — 1Password's own subframes do
+     * exactly this, which is why the tab's port closes when the top frame's
+     * script has not loaded yet. The arrival is recorded either way, so a
+     * frame that heard the message and declined is visible as such.
+     */
+    if (probeMessage.type === "answer-if-top") {
+      arrivals.set(probeMessage.nonce, { message, sender: seeSender(sender) });
+
+      if (!isTopFrame) {
+        return false;
+      }
+
+      sendResponse({ type: "top-answered", nonce: probeMessage.nonce, contextId });
+
+      return undefined;
+    }
 
     return undefined;
   });
@@ -799,6 +841,8 @@ export async function runProbes(): Promise<ProbeResults> {
     arrivals,
   );
 
+  const askedTab = await probeWorkerInitiated(runtime, contextId, "ask-tab", arrivals);
+
   return {
     contextId,
     documentUrl: contextGlobals.location.href,
@@ -820,6 +864,7 @@ export async function runProbes(): Promise<ProbeResults> {
     workerSentBack,
     workerConnectedBack,
     workerNotifiedAllTabs,
+    askedTab,
     portReplySeenByWorker:
       workerConnectedBack.heard !== null && (await probePortReplySeenByWorker(runtime, contextId)),
   };

--- a/tests/extension-proxy.e2e.ts
+++ b/tests/extension-proxy.e2e.ts
@@ -89,6 +89,16 @@ const SERVED_PAGES: Record<string, string> = {
   "/frame": `<!doctype html><html><head><meta charset='utf-8'><title>frame</title></head><body><iframe src="chrome-extension://${FIXTURE_EXTENSION_ID}/fixture-frame.html"></iframe></body></html>`,
   "/same":
     "<!doctype html><html><head><meta charset='utf-8'><title>same</title></head><body>same</body></html>",
+  /*
+   * A web page embedding a web page of the same origin, which is the shape
+   * 1Password's nested-frame handshake runs in: both frames are inside the
+   * content script's match pattern, so both get the script, and only the top
+   * frame answers what the worker fans out to the tab.
+   */
+  "/nested":
+    "<!doctype html><html><head><meta charset='utf-8'><title>nested</title></head><body><iframe src=\"/nested-child\"></iframe></body></html>",
+  "/nested-child":
+    "<!doctype html><html><head><meta charset='utf-8'><title>nested child</title></head><body>nested child</body></html>",
 };
 
 let server: http.Server;
@@ -620,6 +630,57 @@ test("a message is attributed to the frame that sent it, an embedded extension f
   expect(frameHost.senderFrameSeenByWorker).toEqual({
     status: "replied",
     reply: expect.objectContaining({ frameId: 0, parentFrameId: -1, url: frameHostUrl }),
+  });
+});
+
+/*
+ * The relay shape 1Password's `get-nested-frame-configuration` and
+ * `remove-inline-button` requests have, and the one nothing else here covered:
+ * the asking context is a subframe, the worker's `tabs.sendMessage` names no
+ * frame, the asking frame's own listener declines, and the answer has to come
+ * from the top frame. Every other worker-to-tab test either names a `frameId`
+ * or runs on a page with one frame.
+ *
+ * When every frame declines, the tab's message port closes rather than
+ * replying, and 1Password reads that as a missing receiving end — the same
+ * value Chrome gives it. So the assertion worth making is not that the call
+ * came back at all but that what came back is the *top* frame's answer.
+ */
+test("a subframe's relayed message to its own tab is answered by the top frame", async () => {
+  const nestedUrl = `${serverOrigin}/nested`;
+
+  const nestedId = await openProbeWindow(SURVIVING_PARTITION, nestedUrl);
+
+  const subframe = await readProbeResults(nestedId, `${serverOrigin}/nested-child`);
+
+  const top = await readProbeResults(nestedId);
+
+  /*
+   * The reply carries the top frame's own `contextId`, which is the whole
+   * claim: the subframe asked, the worker sent into the tab without naming a
+   * frame, and the frame that answered is not the one that asked.
+   */
+  expect(subframe.askedTab.outcome).toEqual({
+    status: "replied",
+    reply: {
+      type: "top-answered",
+      nonce: `ask-tab:${subframe.contextId}`,
+      contextId: top.contextId,
+    },
+  });
+
+  // And the subframe heard the message it declined, so the fan-out reached
+  // both frames rather than the top frame alone
+  expect(subframe.askedTab.heard).toEqual({
+    type: "answer-if-top",
+    nonce: `ask-tab:${subframe.contextId}`,
+    workerInstanceId: expect.any(String),
+  });
+
+  // The top frame's own turn at the same call, which it answers itself
+  expect(top.askedTab.outcome).toEqual({
+    status: "replied",
+    reply: { type: "top-answered", nonce: `ask-tab:${top.contextId}`, contextId: top.contextId },
   });
 });
 


### PR DESCRIPTION
## Summary
1Password's `<get-nested-frame-configuration>` and `<remove-inline-button>` exceptions in the worker console are not a relay fault. Both are nested-frame-to-top-frame requests, and the end-to-end suite had never exercised their shape — a subframe asks, the worker's `tabs.sendMessage` names no frame, the sender's own listener declines, and the answer must come from the top frame. This adds that assertion, which passes: no runtime code changed. What the inbox reports is the content-script clamp, and what sign-in pages can report is 1Password's own load race.

## Problem
Reading 1Password 8.12.32.33's own bundle (Tim's machine runs 8.12.34.34; `@1password/b5x-messaging` is the same shape in both) settles what both messages are. `get-nested-frame-configuration` is sent by the content script's nested-frame manager the instant `injected.js` finishes loading in a subframe — the manager is constructed only when `window !== window.top` — and only the *top* frame's manager registers a handler for it, answering `{ isRenderer }`. `remove-inline-button` is sent by a subframe's inline-button manager on blur and `pagehide`, and answered by the top frame's drawn-button manager. The worker relays both identically: `tabs.sendMessage(sender.tab.id, …)` with no `frameId`, so every frame of the tab hears it and the answer is meant to come from the top.

On the inbox no frame can answer, and that is the clamp. The top frame is `mail.google.com`, outside `packages/shared/extensions.ts`'s `https://accounts.google.com/*` and `https://myaccount.google.com/*`, so it carries no 1Password content script and no handler; the `accounts.google.com` iframes Gmail embeds — the `ServiceLogin` frame, the cookie-rotation frames — are inside the clamp, load `injected.js`, construct the nested-frame manager and ask. In Chrome the top frame would have had the script and answered. It is deterministic, once per such iframe, and costless: those iframes carry no sign-in form. On sign-in pages, where both frames are `accounts.google.com` and inside the clamp, it is 1Password's own race: the top frame's handler exists only once its dynamic `import()` of `injected.js` lands (`inline/inject-content-scripts.js` retries at 25 ms and 50 ms), and a subframe whose own import landed first asks before there is anything to answer. That race exists in Chrome too, which is why 1Password catches the failure at all — `.catch(() => false)` yields `isRenderer = false`, the same value a rendering top frame answers with.

What had never been checked is that Meru's relay reproduces the fan-out at all. Every worker-to-tab test in the suite either named a `frameId` or ran on a page with one frame, so if the relay had delivered only to the asking frame, sign-in pages would have failed silently for the same reason the inbox does and nothing here would have caught it.

## Solution
- The fixture's content script gets `"all_frames": true`, and the loopback server serves `/nested` (embedding a same-origin `/nested-child`). The existing `/frame` test embeds a `chrome-extension://` iframe, which `http://127.0.0.1/*` never matched, so nothing else changes.
- A new worker request `ask-tab` sends `{ type: "answer-if-top", … }` into the sender's whole tab with no `frameId` — deliberately, since the sender's own frame is the one frame that has no answer — and reports the outcome back inside the reply.
- The content script answers `answer-if-top` only from the top frame and returns `false` elsewhere, recording the arrival either way, so a frame that heard the message and declined is visible as such.
- The assertion is not that the call came back but that the reply carries the *top* frame's `contextId` rather than the asking frame's, plus the subframe's own record of hearing and declining the same message.
- Asserted through the probe results rather than a unit test of `firstReply`, because the claim spans the shim's dispatch, main's fan-out and the aggregation, and each of those already has unit coverage of its own half. A unit test would have passed against a relay that only ever delivered to the sender.
- No runtime code changed: `waitForTabContexts` fans out to every parked frame of the tab and `firstReply` takes the first `replied`, whichever frame it came from. `dispatchMessage` gives a frame whose listeners all decline the status `closed`, and `firstReply` reports `closed` for a fan-out where nothing replied — surfacing as `The message port closed before a response was received.`, the string 1Password maps to `NoListener` alongside `Receiving end does not exist`, exactly as Chrome's closed port does.

The user-visible effect is the clamp's trade, not the relay's, and is left alone here: nothing on Google's own sign-in pages, whose forms are in the top frame, but a sign-in form inside an `accounts.google.com` iframe whose top frame is outside the clamp — a Gmail re-auth iframe, or a workspace app embedding Google sign-in — gets no inline button and no inline menu, because the subframe forwards its UI to a parent with no content script and the worker's `forward-*` handlers relay to `parentFrameId` and find nothing. Keyboard-shortcut and action-popup fill are unaffected. Whether to widen the clamp is a separate decision.

## Try it
`xvfb-run -a bun run test:e2e extension-proxy` — the new test is *a subframe's relayed message to its own tab is answered by the top frame*. To see that it is meaningful, make the content script's `answer-if-top` branch decline in the top frame too (`packages/electron-extensions/fixture/probes.ts`) and rerun: it fails with `The message port closed before a response was received.` in place of the top frame's reply, which is the production shape.

## Not verified
- The effect is not observed against 1Password on a real machine; Tim re-tests on his Mac.
- The bundle read was 1Password 8.12.32.33 rather than the 8.12.34.34 his machine runs. The messaging layer is the same shape in both, but the read was of the older build.