### PR TITLE
Copy the verification code from a notification action button instead of a body click

### DIFF
--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -739,9 +739,11 @@ export class Gmail {
 
             createNotification({
               title: notificationTitle,
-              body: copiesOnNotificationClick
-                ? `${hasCopyButton ? "Copy" : "Click to copy"} verification code ${verificationCode}`
-                : `Copied verification code ${verificationCode}`,
+              body: hasCopyButton
+                ? `Verification code ${verificationCode}`
+                : copiesOnNotificationClick
+                  ? `Click to copy verification code ${verificationCode}`
+                  : `Copied verification code ${verificationCode}`,
               actions: hasCopyButton ? [{ text: "Copy", type: "button" }] : undefined,
               action: hasCopyButton ? copyVerificationCode : undefined,
               click: copiesOnNotificationClick ? copyVerificationCode : undefined,

--- a/packages/app/gmail/index.ts
+++ b/packages/app/gmail/index.ts
@@ -697,9 +697,6 @@ export class Gmail {
           const verificationCode = extractVerificationCode([newMail.subject, newMail.summary]);
 
           if (verificationCode) {
-            const wasFocused = main.window.isFocused();
-            const wasVisible = main.window.isVisible();
-
             const copyVerificationCode = () => {
               clipboard.writeText(verificationCode);
 
@@ -722,24 +719,6 @@ export class Gmail {
               }
             };
 
-            // macOS activates the app whenever a notification is clicked, and
-            // Electron cannot opt out. This notification's only job is to
-            // write the clipboard, so hand activation back to the app the
-            // user was in. `app.hide()` also stops the `did-become-active`
-            // handler in index.ts from showing a hidden window; `app.show()`
-            // then unhides, without activating, a window that was visible.
-            const copyVerificationCodeOnClick = () => {
-              copyVerificationCode();
-
-              if (platform.isMacOS && !wasFocused) {
-                app.hide();
-
-                if (wasVisible) {
-                  app.show();
-                }
-              }
-            };
-
             // Marking as read and deleting ride along with the copy rather than
             // with the detection, so that nothing touches an email the user has
             // not yet acted on.
@@ -750,12 +729,22 @@ export class Gmail {
               copyVerificationCode();
             }
 
+            // Clicking a notification's body always activates the app on
+            // macOS, and Electron cannot opt out. An action button does not:
+            // Electron registers actions without the foreground option, so
+            // macOS delivers the press and leaves the user in the app they
+            // were signing in to. The body click stays as a fallback that
+            // copies too. Linux has no action buttons, so its body says click.
+            const hasCopyButton = copiesOnNotificationClick && !platform.isLinux;
+
             createNotification({
               title: notificationTitle,
               body: copiesOnNotificationClick
-                ? `Click to copy verification code ${verificationCode}`
+                ? `${hasCopyButton ? "Copy" : "Click to copy"} verification code ${verificationCode}`
                 : `Copied verification code ${verificationCode}`,
-              click: copiesOnNotificationClick ? copyVerificationCodeOnClick : undefined,
+              actions: hasCopyButton ? [{ text: "Copy", type: "button" }] : undefined,
+              action: hasCopyButton ? copyVerificationCode : undefined,
+              click: copiesOnNotificationClick ? copyVerificationCode : undefined,
             });
 
             continue;

--- a/packages/renderer/routes/settings/verification-codes.tsx
+++ b/packages/renderer/routes/settings/verification-codes.tsx
@@ -5,6 +5,7 @@ import { ConfigSwitchField } from "@/components/config-switch-field";
 import { LicenseKeyRequiredBanner } from "@/components/license-key-required-banner";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
 import { useConfig } from "@/lib/react-query";
+import { platform } from "@/lib/utils";
 
 export function VerificationCodesSettings() {
   const { config } = useConfig();
@@ -29,7 +30,7 @@ export function VerificationCodesSettings() {
           />
           <ConfigSelectField
             label="When to copy"
-            description="A notification shows the code either way. Copying on click leaves your clipboard untouched until you act."
+            description={`A notification shows the code either way. Copying ${platform.isLinux ? "on click" : "from its Copy button"} leaves your clipboard untouched until you act.`}
             configKey="verificationCodes.copyMode"
             items={Object.entries(verificationCodeCopyModes).map(([value, label]) => ({
               value,

--- a/packages/shared/verification-codes.ts
+++ b/packages/shared/verification-codes.ts
@@ -1,5 +1,5 @@
 export const verificationCodeCopyModes = {
-  notificationClick: "When you click the notification",
+  notificationClick: "From the notification",
   immediately: "As soon as it arrives",
 } as const;
 


### PR DESCRIPTION
## Summary
Replaces the `app.hide()` workaround from d336753 with a "Copy" action button on the click-to-copy verification code notification, because macOS ignored the hide and still brought Meru forward. Action buttons are the one path where macOS keeps focus in the app the user was signing in to. Untested on a Mac.

## Problem
In `notificationClick` mode the notification's only job is to write the clipboard, but clicking its body activates Meru on macOS and pulls the user out of the sign-in screen they were about to paste into. The previous workaround called `app.hide()` in the click handler. It could not hold: since Electron 42 the macOS backend is `UNUserNotificationCenter`, whose response callback, where Electron emits `click`, runs before macOS activates the app. The activation undid the hide, and `did-become-active` showed the window again. Neither Apple nor Electron offer an opt-out for body clicks.

## Solution
- Adds a "Copy" action button in `notificationClick` mode on macOS and Windows, wired to the same copy handler, and drops the hide/show dance
- Electron registers action buttons without `UNNotificationActionOptionForeground`, so macOS delivers the press without activating the app
- The body click stays as a fallback that copies and brings Meru forward, since macOS insists on that for body clicks
- Linux has no action buttons in Electron, so its body keeps saying "Click to copy" and the body click is the only path there
- The settings page follows: the copy mode option reads "From the notification", and its description names the Copy button, or the click on Linux
- A deferred hide on the next `did-become-active` was rejected: timing-dependent, and it would flash the window

## Try it
Turn on verification codes in `notificationClick` mode, switch to a browser, and trigger a sign-in code email. Hover the notification and press "Copy": the code lands on the clipboard and the browser stays in front.

## Not verified
- Not tested on a Mac; the action-button path is inferred from Electron's source
- Electron issue [#51885](https://github.com/electron/electron/issues/51885): on macOS 42+ a banner shown while Meru is frontmost never delivers `click`, and the action press likely shares the gap. Predates this change