### PR TITLE
Demote 1Password's nested-frame messaging errors to debug

### DIFF
--- a/packages/shared/extensions.test.ts
+++ b/packages/shared/extensions.test.ts
@@ -31,6 +31,33 @@ const benignWorkerConsoleErrors = curatedExtensions.flatMap(
   (curatedExtension) => curatedExtension.benignWorkerConsoleErrors ?? [],
 );
 
+/**
+ * Worker error lines a healthy session writes, against whether the catalog
+ * answers for them. `<autofill-item>` is the one that has to stay at error: it
+ * was a real relay fault rather than 1Password's own behavior, and a prefix
+ * that stopped at the request bracket would take it down to debug beside the
+ * two benign siblings it is logged next to.
+ */
+const WORKER_ERROR_LINES: { line: string; isBenign: boolean }[] = [
+  { line: "[LogManager] Failed to send log metrics: <redacted>", isBenign: true },
+  {
+    line: "[Messaging] Exception while handling request <get-nested-frame-configuration>: <redacted>",
+    isBenign: true,
+  },
+  {
+    line: "[Messaging] Exception while handling request <remove-inline-button>: <redacted>",
+    isBenign: true,
+  },
+  {
+    line: "[Messaging] Exception while handling request <autofill-item>: <redacted>",
+    isBenign: false,
+  },
+  {
+    line: "[Fill] Failed to get active tab when checking for an open and fill tab",
+    isBenign: false,
+  },
+];
+
 describe("curated extension benign worker console errors", () => {
   /*
    * A prefix is matched with `startsWith`, where the empty string matches
@@ -43,6 +70,20 @@ describe("curated extension benign worker console errors", () => {
       expect(benignWorkerConsoleError.trim()).toBe(benignWorkerConsoleError);
 
       expect(benignWorkerConsoleError.length).toBeGreaterThan(20);
+    }
+  });
+
+  /*
+   * The list read the way the forwarder reads it, against the lines it was
+   * written for and the ones it was written around.
+   */
+  test("answers for the known-benign lines and no others", () => {
+    for (const { line, isBenign } of WORKER_ERROR_LINES) {
+      expect(
+        benignWorkerConsoleErrors.some((benignWorkerConsoleError) =>
+          line.startsWith(benignWorkerConsoleError),
+        ),
+      ).toBe(isBenign);
     }
   });
 });

--- a/packages/shared/extensions.ts
+++ b/packages/shared/extensions.ts
@@ -94,6 +94,15 @@ export const curatedExtensions: CuratedExtension[] = [
       // own decision back to it — nothing to act on, and nothing a user could
       // do about it — while a worker error that is not this one still matters
       "[LogManager] Failed to send log metrics",
+      // A subframe asking its top frame for configuration, and a subframe
+      // telling it to drop an inline button. On the inbox the top frame is
+      // outside the content-script clamp so nothing can answer, and on sign-in
+      // pages the top frame's handler may not have loaded yet — 1Password's
+      // own race, which it catches. Both are deterministic, cost nothing, and
+      // name the request they are, so a real relay fault under a different
+      // request name — `<autofill-item>`, which once was one — still surfaces
+      "[Messaging] Exception while handling request <get-nested-frame-configuration>",
+      "[Messaging] Exception while handling request <remove-inline-button>",
     ],
   },
 ];


### PR DESCRIPTION
## Summary
The 1Password worker's `[Messaging] Exception while handling request <get-nested-frame-configuration>` and `<remove-inline-button>` lines join the telemetry line in the catalog's known-benign list, so they forward at debug instead of error. [PR #1048](https://github.com/zoidsh/meru/pull/1048) settled both as 1Password's own behavior under Meru rather than a relay fault, and they were the last error-level lines a healthy session wrote. Nothing else changes level — in particular `<autofill-item>`, the same messaging layer but a real fault when it appeared, stays at error.

## Problem
A healthy session writes those two lines at error a few times per launch and per sign-in, and since [PR #1042](https://github.com/zoidsh/meru/pull/1042) demoted `[LogManager] Failed to send log metrics` they are the only error-level lines left in one. That makes the error level useless as a signal: a real worker failure arrives next to lines that have already been investigated and closed.

[PR #1048](https://github.com/zoidsh/meru/pull/1048) is what closed them. Both are nested-frame-to-top-frame requests. On the inbox the top frame is `mail.google.com`, outside the `accounts.google.com` / `myaccount.google.com` content-script clamp, so it carries no 1Password content script and nothing can answer the `accounts.google.com` iframes Gmail embeds; on sign-in pages both frames are inside the clamp and it is a load-order race inside 1Password's own injected script, which is why 1Password catches the failure at all. The subframe's caller treats a missing answer as `isRenderer = false`, the same value a rendering top frame gives. Fill, passkeys and lock state all work with the lines present.

## Solution
- Adds both prefixes to `benignWorkerConsoleErrors` in `packages/shared/extensions.ts`, which the worker console forwarder in `packages/electron-extensions/extensions.ts` already consults.
- Each prefix carries its request name through the closing bracket rather than stopping at `request <`. A prefix that stopped there would cover every request this layer relays, `<autofill-item>` included — the same shape of line, but a genuine relay fault when it appeared, fixed in [PR #1034](https://github.com/zoidsh/meru/pull/1034). One line per request name costs a list entry and keeps that one at error.
- Extends the catalog test beside the telemetry cases with a table of worker error lines read the way the forwarder reads them, asserting `<autofill-item>` and `[Fill] Failed to get active tab …` are *not* covered alongside the three that are. The existing prefix-shape test was the only guard, and it can't see which lines a prefix reaches.

## Try it
`bun test packages/shared/extensions.test.ts`. In the app, run a development build with 1Password installed and open the extension worker's forwarded output: the two lines are still there, at debug.

## Not verified
- Not observed against 1Password itself — that needs Tim's Mac, as [PR #1048](https://github.com/zoidsh/meru/pull/1048)'s own finding was. The prefixes are taken from the exact strings recorded in that pass.
- `bun run test:e2e` and `bun run test:perf` were not run; `bun run types`, `bun run lint`, `bun run fmt:check` and `bun test` pass.