### PR TITLE
Quiet the extension launch log

### DIFF
--- a/packages/electron-extensions/extensions.test.ts
+++ b/packages/electron-extensions/extensions.test.ts
@@ -379,7 +379,66 @@ describe("Extensions", () => {
           id: "aaa",
           name: "Extension aaa",
           version: "1.0.0",
+          sessions: 1,
           extensionDir: firstExtensionDir,
+        },
+      },
+    ]);
+  });
+
+  /*
+   * One extension loads into the worker session and into every account's, and
+   * a launch log wants that said once rather than once per session. The
+   * sessions a launch sets up are all in flight together, so what closes the
+   * line is the last of them finishing; a session set up after that — an
+   * account added while the app runs — is a separate event and says so on its
+   * own line.
+   */
+  test("reports one line per extension for the sessions set up together", async () => {
+    const loggedInfo: { message: string; details: Record<string, unknown> }[] = [];
+
+    const extensionDir = await createExtensionDir("one");
+
+    const extensions = createExtensions([extensionDir], {
+      debug: () => {},
+      info: (message, details) => {
+        loggedInfo.push({ message, details });
+      },
+      error: () => {},
+    });
+
+    // Started in the one tick and awaited afterwards, the way the app starts
+    // the worker session and then every account's
+    await Promise.all(
+      [createSession(), createSession(), createSession()].map(({ session }) =>
+        extensions.setupSession(session),
+      ),
+    );
+
+    expect(loggedInfo).toEqual([
+      {
+        message: "Loaded extension",
+        details: {
+          id: "aaa",
+          name: "Extension aaa",
+          version: "1.0.0",
+          sessions: 3,
+          extensionDir,
+        },
+      },
+    ]);
+
+    await extensions.setupSession(createSession().session);
+
+    expect(loggedInfo.slice(1)).toEqual([
+      {
+        message: "Loaded extension",
+        details: {
+          id: "aaa",
+          name: "Extension aaa",
+          version: "1.0.0",
+          sessions: 1,
+          extensionDir,
         },
       },
     ]);
@@ -1086,6 +1145,52 @@ describe("the shared instance's worker session", () => {
 
     // Cleared rather than left behind, the way the bridge's listener is
     expect(workerSession.beforeRequestFilters).toEqual([{ urls: blockedUrls }, null]);
+  });
+
+  /*
+   * The block never changes once the app ships, so the line saying it is armed
+   * is for whoever is testing: `debug`, which a packaged run's file transport
+   * drops and a development run keeps, and with the patterns, since those are
+   * what the line is worth reading for.
+   */
+  test("the worker session block is reported at debug, with its patterns", async () => {
+    const workerSession = createSharedSession();
+
+    const accountSession = createSharedSession();
+
+    const blockedUrls = ["https://client-log-forwarder.1password.com/*"];
+
+    const loggedDebug: { message: string; details: Record<string, unknown> }[] = [];
+
+    const loggedInfoMessages: string[] = [];
+
+    const extensions = createSharedExtensions(
+      [await createExtensionDir("one")],
+      await createSharedInstance(workerSession.session),
+      {
+        debug: (message, details) => {
+          loggedDebug.push({ message, details });
+        },
+        info: (message) => {
+          loggedInfoMessages.push(message);
+        },
+        error: () => {},
+      },
+      blockedUrls,
+    );
+
+    await extensions.setupSession(workerSession.session);
+
+    await extensions.setupSession(accountSession.session);
+
+    expect(loggedDebug).toEqual([
+      {
+        message: "Blocking extension telemetry in the worker session",
+        details: { urls: blockedUrls },
+      },
+    ]);
+
+    expect(loggedInfoMessages).not.toContain("Blocking extension telemetry in the worker session");
   });
 
   /*

--- a/packages/electron-extensions/extensions.ts
+++ b/packages/electron-extensions/extensions.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { Event as ElectronEvent, MessageDetails, Session } from "electron";
+import type { Event as ElectronEvent, Extension, MessageDetails, Session } from "electron";
 import {
   type ActionExtension,
   createExtensionAction,
@@ -198,6 +198,13 @@ export class Extensions {
 
   private loadedExtensionIdsBySession = new Map<Session, Set<string>>();
 
+  private pendingSessionSetups = 0;
+
+  private loadedExtensionsToReport = new Map<
+    string,
+    { name: string; version: string; extensionDir: string; sessions: number }
+  >();
+
   private actionsBySession = new Map<Session, ExtensionAction[]>();
 
   private actionsChangedListeners = new Set<ActionsChangedListener>();
@@ -357,7 +364,25 @@ export class Extensions {
     });
   }
 
+  /**
+   * Loads into the session, and reports what loaded once the sessions asking
+   * together have all finished — see `recordLoadedExtension`.
+   */
   async setupSession(session: Session) {
+    this.pendingSessionSetups += 1;
+
+    try {
+      await this.loadExtensionsIntoSession(session);
+    } finally {
+      this.pendingSessionSetups -= 1;
+
+      if (this.pendingSessionSetups === 0) {
+        this.reportLoadedExtensions();
+      }
+    }
+  }
+
+  private async loadExtensionsIntoSession(session: Session) {
     const extensionDirs = this.dedupeExtensionDirs(
       typeof this.extensionDirs === "function" ? await this.extensionDirs() : this.extensionDirs,
     );
@@ -410,12 +435,7 @@ export class Extensions {
 
         actions.push(await this.createAction(extension));
 
-        this.logger?.info("Loaded extension", {
-          id: extension.id,
-          name: extension.name,
-          version: extension.version,
-          extensionDir,
-        });
+        this.recordLoadedExtension(extension, extensionDir);
 
         this.warnAboutUnclampedWorkerContentScripts(extension, sharedInstanceDerive);
       } catch (error) {
@@ -424,6 +444,47 @@ export class Extensions {
     }
 
     this.emitActionsChanged(session);
+  }
+
+  /**
+   * Held rather than logged, because the same extension loads into every
+   * session and a line per session says the same thing once per account.
+   *
+   * The count is what a per-session line was worth: it says the extension
+   * reached every session that asked, and a shortfall is visible without
+   * counting repeated lines.
+   */
+  private recordLoadedExtension(extension: Extension, extensionDir: string) {
+    const loadedExtension = this.loadedExtensionsToReport.get(extension.id);
+
+    if (loadedExtension) {
+      loadedExtension.sessions += 1;
+
+      return;
+    }
+
+    this.loadedExtensionsToReport.set(extension.id, {
+      name: extension.name,
+      version: extension.version,
+      extensionDir,
+      sessions: 1,
+    });
+  }
+
+  /**
+   * One line per extension, once every session that was setting up alongside
+   * the others has finished. At launch the embedder starts them all in the one
+   * tick — the worker session and every account's — so they are all in flight
+   * together and the count is the launch's; a session set up afterwards, an
+   * account added while the app runs, is on its own and reports its own line,
+   * that being a separate event rather than a repeat of the launch.
+   */
+  private reportLoadedExtensions() {
+    for (const [id, { name, version, extensionDir, sessions }] of this.loadedExtensionsToReport) {
+      this.logger?.info("Loaded extension", { id, name, version, sessions, extensionDir });
+    }
+
+    this.loadedExtensionsToReport.clear();
   }
 
   /**
@@ -469,8 +530,10 @@ export class Extensions {
 
     // Once, and with the patterns, so that the log says why those requests
     // fail rather than leaving the extension's own error line to be read as a
-    // network fault
-    this.logger?.info("Blocking extension telemetry in the worker session", {
+    // network fault. At `debug`, since a shipped log has nothing to do with a
+    // block that never changes: the line is for whoever is testing that it is
+    // armed, and the file transport keeps it out of a packaged run
+    this.logger?.debug("Blocking extension telemetry in the worker session", {
       urls: this.workerSessionBlockedUrls,
     });
   }


### PR DESCRIPTION
## Summary
Two lines the extension loader prints on every launch that a launch log has no use for: the worker-session telemetry block, which never changes once the app ships, and "Loaded extension", which repeated itself once per session so a two-account launch printed three identical blocks per extension. The first moves to debug, the second is reported once per extension with the number of sessions it loaded into. A load failure is untouched.

## Problem
A launch log from a packaged build is mostly these two lines. "Blocking extension telemetry in the worker session" prints at info with all six blocked URL patterns on every launch, though the block is fixed at build time and there is nothing in the line a shipped log can act on. "Loaded extension" prints at info once per session the extension loads into — the worker session and each account — so the same id, name, version and directory are repeated verbatim as many times as there are sessions.

## Solution
- The telemetry block moves to `debug`. The loader's logger gained a debug level in #1035 and the file transport writes at info when packaged, so a shipped log drops the line and a development log keeps it — which is where someone testing that the block is armed is reading. The URL patterns stay on it, being what the line is worth reading for.
- "Loaded extension" is held rather than logged, and reported once per extension when the sessions setting up together have all finished, carrying `sessions: <count>` in place of the repeats and the `extensionDir` once.

Where "once" lands needs no new API and no count passed in from the app. The loader counts the `setupSession` calls in flight and reports when the last one finishes. At launch `packages/app/index.ts` starts the worker session and then every account in the one synchronous tick, awaiting none of them, so they are all in flight together and the count is the launch's. An account added while the app runs starts alone, so it reports its own line — a separate event rather than a repeat of the launch.

The alternative was the fallback of one debug line per session plus an info summary from wherever the count is known. It was not needed: no single place in `packages/app` knows how many sessions a launch sets up — the worker session comes from `index.ts` and the accounts from `Accounts.init` — so that route meant plumbing a launch-session count into the loader, and the in-flight count already answers the same question from inside it.

## Try it
Run `bun run dev` with an extension installed and two accounts. The log now carries one `Loaded extension` line per extension with `sessions: 3`, and the telemetry block line still appears because development logs debug. A packaged build drops the block line and keeps the single load line.

## Not verified
- Not run against a packaged build, so the file transport dropping the debug line at info is read off the transport's configuration rather than observed.
- The launch ordering the single line depends on — worker session and every account started in the one tick — is covered by a test that starts the sessions together, not by an end-to-end launch.