### PR TITLE
Upgrade Electron to 43.5.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dayjs": "^1.11.13",
-        "electron": "^43.2.0",
+        "electron": "^43.5.1",
         "electron-builder": "26.15.6",
         "electron-context-menu": "^4.1.0",
         "electron-dl": "^4.0.0",
@@ -892,7 +892,7 @@
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
-    "electron": ["electron@43.2.0", "", { "dependencies": { "@electron-internal/extract-zip": "^1.0.1", "@electron/get": "^5.0.0", "@types/node": "^24.9.0" }, "bin": { "electron": "cli.js", "install-electron": "install.js" } }, "sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA=="],
+    "electron": ["electron@43.5.1", "", { "dependencies": { "@electron-internal/extract-zip": "^1.0.1", "@electron/get": "^5.0.0", "@types/node": "^24.9.0" }, "bin": { "electron": "cli.js", "install-electron": "install.js" } }, "sha512-lRHSwzZimdWWeqcTHFRCpicWwxBE6kotKIyGTusums/jvmVVC27rLPFikUz8LsLwV7gVWlYaiEYQAWzitbN6nA=="],
 
     "electron-builder": ["electron-builder@26.15.6", "", { "dependencies": { "app-builder-lib": "26.15.6", "builder-util": "26.15.3", "builder-util-runtime": "9.7.0", "chalk": "^4.1.2", "ci-info": "^4.2.0", "dmg-builder": "26.15.6", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "simple-update-notifier": "2.0.0", "yargs": "^17.6.2" }, "bin": { "electron-builder": "./cli.js", "install-app-deps": "./install-app-deps.js" } }, "sha512-jxlHRjqYrlTgLVo/aoACGpiki3QFYv8s4f2djsqaEbwTBZ9PcTBK03Tj/HMa65kiE0hdZxxbZdmVFo22eou2wA=="],
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.13",
-    "electron": "^43.2.0",
+    "electron": "^43.5.1",
     "electron-builder": "26.15.6",
     "electron-context-menu": "^4.1.0",
     "electron-dl": "^4.0.0",

--- a/packages/electron-extensions/derive/index.ts
+++ b/packages/electron-extensions/derive/index.ts
@@ -33,7 +33,7 @@ const RUNTIME_PROXY_RELAY_FILE_NAME = "chrome-runtime-proxy-relay.js";
 const CONTENT_SCRIPT_ONLY_DIR_SUFFIX = "-content-scripts";
 
 /** Bump whenever what is written into a derived copy changes. */
-const DERIVE_VERSION = 9;
+const DERIVE_VERSION = 10;
 
 /**
  * The copy's part in one shared extension instance serving every session (see

--- a/packages/electron-extensions/derive/manifest.test.ts
+++ b/packages/electron-extensions/derive/manifest.test.ts
@@ -98,37 +98,6 @@ describe("deriveManifest", () => {
     expect(manifest.permissions).toEqual(["storage", "nativeMessaging", "tabs"]);
   });
 
-  test("carries the permissions that arm the WebRequest proxy, and their rulesets", () => {
-    const { manifest } = deriveManifest(
-      {
-        permissions: [
-          "storage",
-          "declarativeNetRequest",
-          "declarativeNetRequestWithHostAccess",
-          "declarativeNetRequestFeedback",
-          "declarativeWebRequest",
-          "tabs",
-        ],
-        declarative_net_request: { rule_resources: [{ id: "ruleset_1", path: "rules_1.json" }] },
-      },
-      fileNames,
-    );
-
-    // These were dropped while a main process `session.fetch` segfaulted with
-    // any of them declared, which electron/electron#53294 fixed in 43.5.0.
-    expect(manifest.permissions).toEqual([
-      "storage",
-      "declarativeNetRequest",
-      "declarativeNetRequestWithHostAccess",
-      "declarativeNetRequestFeedback",
-      "declarativeWebRequest",
-      "tabs",
-    ]);
-    expect(manifest.declarative_net_request).toEqual({
-      rule_resources: [{ id: "ruleset_1", path: "rules_1.json" }],
-    });
-  });
-
   test("leaves a manifest without permissions alone", () => {
     const { manifest } = deriveManifest({ name: "No permissions" }, fileNames);
 

--- a/packages/electron-extensions/derive/manifest.test.ts
+++ b/packages/electron-extensions/derive/manifest.test.ts
@@ -98,7 +98,7 @@ describe("deriveManifest", () => {
     expect(manifest.permissions).toEqual(["storage", "nativeMessaging", "tabs"]);
   });
 
-  test("drops the permissions that arm the WebRequest proxy, and their rulesets", () => {
+  test("carries the permissions that arm the WebRequest proxy, and their rulesets", () => {
     const { manifest } = deriveManifest(
       {
         permissions: [
@@ -114,10 +114,19 @@ describe("deriveManifest", () => {
       fileNames,
     );
 
-    // A main process `session.fetch` segfaults while any of these is declared,
-    // so this is load-bearing rather than tidying.
-    expect(manifest.permissions).toEqual(["storage", "tabs"]);
-    expect(manifest.declarative_net_request).toBeUndefined();
+    // These were dropped while a main process `session.fetch` segfaulted with
+    // any of them declared, which electron/electron#53294 fixed in 43.5.0.
+    expect(manifest.permissions).toEqual([
+      "storage",
+      "declarativeNetRequest",
+      "declarativeNetRequestWithHostAccess",
+      "declarativeNetRequestFeedback",
+      "declarativeWebRequest",
+      "tabs",
+    ]);
+    expect(manifest.declarative_net_request).toEqual({
+      rule_resources: [{ id: "ruleset_1", path: "rules_1.json" }],
+    });
   });
 
   test("leaves a manifest without permissions alone", () => {

--- a/packages/electron-extensions/derive/manifest.ts
+++ b/packages/electron-extensions/derive/manifest.ts
@@ -88,9 +88,12 @@ const DROPPED_PERMISSIONS = new Set(["webRequest", "webRequestAuthProvider"]);
  * alone with no listener and no ruleset content required. Electron then hands
  * it a browser process factory as a navigation with a null `RenderFrameHost`
  * and `MaybeProxyURLLoaderFactory` dereferences it, which is a segfault rather
- * than an exception, so no caller can catch it. electron/electron#45050 carries
- * the one line that fixes it and has sat open and unmerged, so no upgrade
- * avoids this.
+ * than an exception, so no caller can catch it. electron/electron#53294 fixed
+ * this in Electron 43.5.0, backported as #53304: a factory built for the browser
+ * process no longer reaches the extensions WebRequest layer at all, whichever
+ * permission armed the proxy count. The drop stays until restoring these
+ * permissions is verified on its own — it is a behavior change to every
+ * installed extension, 1Password's rules below among them.
  *
  * Dropped so a main process `session.fetch` against an account session stays a
  * usable primitive. An account with no view has no other way to read its unread

--- a/packages/electron-extensions/derive/manifest.ts
+++ b/packages/electron-extensions/derive/manifest.ts
@@ -81,49 +81,8 @@ function createServiceWorkerWrapper(
  */
 const DROPPED_PERMISSIONS = new Set(["webRequest", "webRequestAuthProvider"]);
 
-/**
- * Permissions that put an extension into Chromium's WebRequest proxy count.
- * Chromium proxies every URL loader factory built for the browser context as
- * soon as one loaded extension declares any of them, counted from the manifest
- * alone with no listener and no ruleset content required. Electron then hands
- * it a browser process factory as a navigation with a null `RenderFrameHost`
- * and `MaybeProxyURLLoaderFactory` dereferences it, which is a segfault rather
- * than an exception, so no caller can catch it. electron/electron#53294 fixed
- * this in Electron 43.5.0, backported as #53304: a factory built for the browser
- * process no longer reaches the extensions WebRequest layer at all, whichever
- * permission armed the proxy count. The drop stays until restoring these
- * permissions is verified on its own — it is a behavior change to every
- * installed extension, 1Password's rules below among them.
- *
- * Dropped so a main process `session.fetch` against an account session stays a
- * usable primitive. An account with no view has no other way to read its unread
- * feed, which is what the hibernation and lazy view work is built on.
- *
- * The cost is 1Password's rules, which scrub `user-agent`, `accept-language`
- * and `origin` from its DNS-over-HTTPS lookups and from the
- * `/.well-known/webauthn` request behind related-origin passkeys. Every rule it
- * ships is `modifyHeaders`, so nothing it asks for stops being requested, and
- * its own call site reads the namespace through `?.` and carries on without it.
- */
-const DROPPED_NETWORK_PERMISSIONS = new Set([
-  "declarativeWebRequest",
-  "declarativeNetRequest",
-  "declarativeNetRequestWithHostAccess",
-  "declarativeNetRequestFeedback",
-]);
-
-/**
- * The rulesets those permissions carry. Chromium rejects a manifest declaring
- * `declarative_net_request` without a permission to match, so the key has to go
- * with them rather than be left behind as a load error.
- */
-const DROPPED_MANIFEST_KEYS = ["declarative_net_request"];
-
 function derivePermissions(permissions: ExtensionManifest["permissions"]) {
-  return permissions?.filter(
-    (permission) =>
-      !DROPPED_PERMISSIONS.has(permission) && !DROPPED_NETWORK_PERMISSIONS.has(permission),
-  );
+  return permissions?.filter((permission) => !DROPPED_PERMISSIONS.has(permission));
 }
 
 function parseDirectives(contentSecurityPolicy: string) {
@@ -324,10 +283,6 @@ export function deriveManifest(
         ? prependContentScriptShim(clampedContentScripts, sharedInstance.shimFileName)
         : clampedContentScripts,
   };
-
-  for (const droppedManifestKey of DROPPED_MANIFEST_KEYS) {
-    delete derivedManifest[droppedManifestKey];
-  }
 
   for (const strippedManifestKey of strippedManifestKeys) {
     delete derivedManifest[strippedManifestKey];


### PR DESCRIPTION
## Summary
Moves Electron from 43.2.0 to 43.5.1 for 3.60 — patch-level within the 43 line, Chromium 150.0.7871.250 and Node 24.19.0, no breaking changes. It then removes the workaround the bump makes unnecessary: the derive stops dropping extensions' `declarativeNetRequest` permissions, because the segfault that forced the drop is fixed upstream in 43.5.0. That closes [MER-39](https://linear.app/zoidsh/issue/MER-39/restore-1passwords-declarativenetrequest-rules) and gives 1Password back its header-scrubbing rules. It is a behavior change to every installed extension, so read the second commit on its own.

## Problem
43.2.0 is four patch releases behind on the 43 line, and several of the fixes in between land on paths 3.60 already carries risk on — WebAuthn and Touch ID, the updater's asar handling, `WebContentsView` blanking, and Linux tray icons. The full assessment of 43.2.0 against everything up to 44.1.1, including why 3.60 takes 43.5.1 rather than 44, is in the docs at `meru/electron-44-upgrade.md`. Electron 44 is [MER-38](https://linear.app/zoidsh/issue/MER-38/upgrade-to-electron-44), after this release.

Separately, the derive drops every `declarativeNetRequest*` permission an extension declares, and the `declarative_net_request` ruleset key with them, because a main-process `session.fetch` segfaulted while any of them was declared. The comment justifying it ended by saying electron/electron#45050 "has sat open and unmerged, so no upgrade avoids this." #45050 is indeed still closed-unmerged — but a different PR fixed the same crash, so the workaround has been costing 1Password its only rules for nothing.

## Solution
Two commits, separable:

1. `electron` `^43.2.0` → `^43.5.1`, with the lockfile.
2. Deletes `DROPPED_NETWORK_PERMISSIONS` and `DROPPED_MANIFEST_KEYS`, taking `DERIVE_VERSION` to 10 so every cached derived copy is rebuilt with the permissions back.

The `webRequest`/`webRequestAuthProvider` drop stays. That one is a different fault — bindings Electron declares with no implementation behind them, a NOTREACHED in every extension context — and #53294 does nothing for it. Per-extension `strippedManifestKeys` also stays, so a curated extension's ruleset can still be removed by name if one ever needs to be.

The removal was measured rather than inferred, because #53294's own description names the `webRequest` permission while Meru's crash arrived through the DNR ones. Reading the diff, its guard sits in `ElectronBrowserClient::WillCreateURLLoaderFactory` and short-circuits a `kNavigation` factory with a null `RenderFrameHost` *before* `MaybeProxyURLLoaderFactory` is called at all, so it never inspects which permission armed the proxy count. Confirmed by running it, twice over. A bare Electron loading a DNR-declaring MV3 extension into a session, then calling `session.fetch` and `net.fetch` from main, **segfaults on 43.2.0** — exit 139, before either fetch returns — and **returns both bodies on 43.5.1**; same script, same machine, Linux x64. Then against the real crash site on macOS: the Gmail inbox feed poll, which is the one main-process `session.fetch` Meru has and the fetch that actually brought the app down, no longer reproduces the crash.

The macOS pass also covered what the restored permissions are for: 1Password password autofill and passkey sign-in both work with its `modifyHeaders` rules back in place, and Touch ID passkey works alongside them — the `app.configureWebAuthn()` path that `meru/release-risk-3.60.md` group 1 rates High-risk and never-executed in CI.

The perf suite was run on both sides of the bump to see whether it moved anything. One run each, on Linux x64 under `xvfb`: cold-launch total working set 811.1 MB → 762.1 MB and main-process resident 234.1 MB → 184.4 MB, with the main JS heap flat at 7505 → 7542 KB against its 8000 KB ceiling. Consistent with the `BrowserWindow` creation leak fix in the range, but it is a single sample per side and not a benchmark.

One upstream behavior change in 43.5.1 was checked and needs no code here: `chrome.tabs.query` no longer returns `url`/`title` to extensions lacking the `tabs` permission. Meru's worker path is unaffected — `runtime-proxy/worker-tabs.ts` answers `tabs.query`/`tabs.get` from main, and `runtime-proxy/sender.ts:56-58` fills `url`/`title` from the `WebContents` regardless of declared permissions. Extension pages inside shimmed sessions use native `chrome.tabs` and would see the change.

## Try it
No preview deployment for a desktop app, so locally:

```sh
git fetch origin electron-43-5-1 && git checkout electron-43-5-1
bun install && bun run dev
```

The bump itself has nothing specific to look at — the check is that the app launches, accounts load and Gmail renders on the new Chromium.

The second commit does. With a Pro license and 1Password installed from the Extensions settings page, **with the ad blocker off** (its `onBeforeRequest` masks this whole family of bugs): 3–5 cold launches with no crash and no blank Gmail, then password and passkey sign-in on `accounts.google.com`. The derived copy under the extension's data directory should now show `declarativeNetRequest` in its `manifest.json` and keep its `declarative_net_request` key, where before both were stripped.

## Not verified
- **Windows.** Nothing in this PR has been run on Windows. The automated suites ran under `xvfb` on Linux x64; the manual pass was macOS.
- **Whether the content blocker was off during the macOS pass.** This is the one qualifier on the result above. Electron skips extension proxying entirely when the session already has a `webRequest` listener, and the blocker's `onBeforeRequest` is one — which is why the original segfault only ever surfaced with the blocker off. With it on, the proxy path the removal re-enables is not the path exercised, and a non-reproduction is uninformative.
- **Whether the macOS pass ran on a signed build** or under `bun run dev`.
- **The updater** (asar replaced while running), **Linux tray icons** via StatusNotifierItem, and the `WebContentsView` blanking fixes — all upstream fixes taken on trust, none exercised here.
- **Installer packaging and signing.** The e2e and perf runs build `--dir` and unsigned.
