### PR TITLE
Keep a tab's id when it hibernates and wakes

### DIFF
--- a/packages/app/tabs.ts
+++ b/packages/app/tabs.ts
@@ -82,6 +82,7 @@ type UnloadedViewState = {
 type DormantTabOptions = Omit<SavedTab, "app"> & {
   app: SupportedWorkspaceApp | undefined;
   pinned: boolean;
+  id?: string;
 };
 
 /**
@@ -90,7 +91,15 @@ type DormantTabOptions = Omit<SavedTab, "app"> & {
  * Either way it holds its place in the strip until something materializes it.
  */
 export class DormantTab {
-  id = randomUUID();
+  /**
+   * The id of the tab this one took the place of, when it took the place of
+   * one. Hibernating swaps the object behind a tab without the user's tab going
+   * anywhere, so the id has to survive the swap: anything still holding it — a
+   * notification raised before the tab went idle, above all — is asking for a
+   * tab that is very much still in the strip. Only a tab restored from disk
+   * mints a new id, having succeeded nothing.
+   */
+  id: string;
 
   app: SupportedWorkspaceApp | undefined;
 
@@ -119,6 +128,7 @@ export class DormantTab {
   restorableNavigationHistory: RestoreOptions | undefined;
 
   constructor(dormantTab: DormantTabOptions, unloadedViewState?: UnloadedViewState) {
+    this.id = dormantTab.id ?? randomUUID();
     this.app = dormantTab.app;
     this.url = dormantTab.url;
     this.title = dormantTab.title;
@@ -312,6 +322,7 @@ export class Tabs {
 
   private materializeDormantTab(dormantTab: DormantTab, url?: string) {
     const workspaceApp = new WorkspaceApp({
+      id: dormantTab.id,
       accountId: this.accountId,
       url: url ?? dormantTab.url,
       pinned: dormantTab.pinned,
@@ -446,6 +457,7 @@ export class Tabs {
       1,
       new DormantTab(
         {
+          id: workspaceApp.id,
           app: workspaceApp.app,
           url: workspaceApp.url,
           title: workspaceApp.title,

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -84,6 +84,7 @@ export function resolveWorkspaceAppOpenBehavior(
 }
 
 type WorkspaceAppOptions = {
+  id?: string;
   accountId: AccountConfig["id"];
   url: string;
   window?: BrowserWindowConstructorOptions;
@@ -413,7 +414,12 @@ export class WorkspaceApp {
 
   app: SupportedWorkspaceApp | undefined;
 
-  id = randomUUID();
+  /**
+   * The id of the dormant tab this one woke from, when it woke from one. A tab
+   * that hibernates and wakes keeps the id it started with, so nothing holding
+   * it has to learn the tab was unloaded in between.
+   */
+  id: string;
 
   private _window: BrowserWindow | undefined;
 
@@ -500,6 +506,7 @@ export class WorkspaceApp {
   private htmlFullscreen = false;
 
   constructor({
+    id,
     accountId,
     url,
     window,
@@ -514,6 +521,7 @@ export class WorkspaceApp {
     zoomFactor,
     navigationHistory,
   }: WorkspaceAppOptions) {
+    this.id = id ?? randomUUID();
     this.accountId = accountId;
     this.app = app ?? getWorkspaceAppFromUrl(url);
     this.pinned = Boolean(pinned);

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -663,7 +663,13 @@ export class WorkspaceApp {
       this._window.destroy();
     }
 
-    this.account.instance.tabs.removeTab(this.id);
+    // Only when the strip still holds this instance. Dormantizing splices a
+    // `DormantTab` into this tab's place under the same id before closing the
+    // view, so removing by id alone would take the replacement straight back
+    // out — the tab would vanish from the strip instead of going dormant.
+    if (this.account.instance.tabs.getTab(this.id) === this) {
+      this.account.instance.tabs.removeTab(this.id);
+    }
   }
 
   private teardown() {


### PR DESCRIPTION
## Summary
Hibernating a tab used to change its id, so a notification raised before the tab went idle clicked through to nothing. `DormantTab` and `WorkspaceApp` now take the outgoing tab's id instead of minting a new one, so the id belongs to the tab the user sees rather than to whichever object is currently behind it. That turned out to need a second change — `WorkspaceApp.close()` was quietly relying on the id having changed — so read the second bullet of the solution before reviewing the first. Closes [MER-9](https://linear.app/zoidsh/issue/MER-9). Verified by hand: the hibernate, wake and pinned-close paths in a development build, and the notification click itself on a signed macOS build.

## Problem
`Tabs.dormantizeTab` carried the app, URL, title, pinned, `loadOnLaunch`, `hibernatesWhenIdle`, `opensLinksForApp`, `windowed`, zoom and navigation history across to the new `DormantTab` — but not the id. `DormantTab` minted its own, and `materializeDormantTab` minted another on the way back. Anything still holding an id from before the sweep was then naming nothing, and the `!activatedTab` guard in `activateTab` returned early.

The visible case is a notification. A `requireInteraction` notification gets `timeoutType: "never"` and sits on screen indefinitely, so it easily outlives the idle timeout. Clicking it brought the window forward and selected the account, but left the tab dormant. `b6558df` made hibernation default to unpinned tabs at a 1 hour timeout, which puts this on the default path rather than behind an opt-in.

## Solution
- `DormantTab` and `WorkspaceApp` each take an optional `id` in their constructor options, still defaulting to `randomUUID()`. `dormantizeTab` passes `workspaceApp.id` into the new `DormantTab`, and `materializeDormantTab` passes `dormantTab.id` into the new `WorkspaceApp`. The notification click handler is untouched, and so is `getTab`.
- `WorkspaceApp.close()` needed a guard. It ends with `tabs.removeTab(this.id)`, and that call was relying on the id having changed. Dormantizing splices the replacement into the strip *before* the view is closed, so once the id is reused it matched the fresh `DormantTab` and filtered it straight back out — the tab disappeared from the strip instead of going dormant. It now removes only when `getTab(this.id)` is this instance. Both paths that dormantize and then close were affected: the idle sweep, and closing a pinned tab by hand.

Recording the id a `DormantTab` succeeded, which the issue itself proposed, was rejected. It is the one-hop version and breaks on the second cycle: waking mints a fresh id too, so hibernate, wake and hibernate again gives a chain, which needs a predecessor field on `WorkspaceApp` as well, chain-walking or a retired-id map in `getTab`, and a chain that grows without bound. Reusing the id means no id ever goes stale.

Three things make reuse safe. Both swaps are a single `this.tabs.splice(indexOf(old), 1, replacement)`, so there is never a moment where two tabs share an id. `SavedTab` carries no id, so tab ids are session-only and a reused one cannot collide with anything restored from disk. And `restoreSavedTabs` goes on minting new ids, since the tabs it builds at launch succeed nothing.

Beyond `close()`, nothing else read the old id in the window where it changes. `dormantizeTab` already fixes `activeTabId`, reorders, broadcasts and saves, so the removal was incidental to hibernation either way. `WorkspaceApp.instances` is the only other id-keyed structure, and the outgoing instance deletes its entry in `teardown()` before any replacement claims it; `workspaceApps.zoomFactors` is keyed by app, not by tab.

The `!activatedTab` guard from #993 stays. A tab genuinely removed still leaves a dead id behind, and that early return is what keeps one from wedging the menu refresh, the view refresh and every sweep tick. This change takes hibernation out of the set of things that make dead ids; it does not make dead ids impossible.

Notification lifetime is deliberately left alone. The `timeoutType: "never"` on a `requireInteraction` notification is what lets a click outlive the hibernation timeout, but once the click resolves to the right tab a long-lived notification is harmless, and changing it is a separate behavior change that should not ride along days before a release.

## Try it
Run a development build with `bun run dev`, then Settings → Workspace apps → Hibernate after → 1 minute (a development-only option, from `2dba754`). Leave **Hibernate idle tabs** on the default **Unpinned tabs**. Open Google Calendar as an unpinned tab and let it raise a reminder notification, but do not click it. Switch to Gmail and leave Calendar alone for over a minute so it hibernates, then click the notification. On main the window comes forward and the account is selected but the tab stays dormant; here Calendar wakes and comes forward.

Worth checking the same two paths for the regression the second commit fixes: the hibernated tab should stay visible in the strip as a dormant entry, and closing a pinned tab by hand should leave its entry behind rather than removing it.

## Not verified
- All verified by hand after merge. Hibernating a tab, waking it again and closing a pinned tab by hand were confirmed in a development build; the notification click on a hibernated tab — the defect itself — was then confirmed on a signed macOS build, with `workspaceApps.hibernationTimeout` set to `1m` directly in `config.json`, since the settings UI only offers that option in a development run.
- No test covers the change. `packages/app/tabs.ts` cannot be imported under `bun test`: the `electron` package has no named exports outside an Electron process, and `new WorkspaceApp` constructs a real `WebContentsView`, so a unit test needs a module mock that does not exist yet. Covering the hibernate and wake cycle end to end is [MER-10](https://linear.app/zoidsh/issue/MER-10), and the vanishing-tab regression is the argument for it. `bun run types`, `bun run lint`, `bun run fmt:check` and `bun test` all pass.

