### PR TITLE
Close two traps in the release publish path

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -40,6 +40,7 @@ The channel is named Beta in the app and versioned `beta` on the wire, so the in
 - The version is the next stable version per the triage above with `-beta.N` appended: the first beta release of a cycle is `X.Y.Z-beta.1`. Each further one before that stable ships increments `N`.
 - Everything else follows the stable flow, with two differences: `gh release create` gets `--prerelease`, and the triage range runs from the last release of any kind, not the last stable.
 - Promoting a beta release to stable is the normal stable flow with the suffix dropped, as in `3.60.0-beta.2` → `3.60.0`. Beta users are moved onto the stable build automatically.
+- **Never promote by unticking "pre-release" on the existing GitHub release.** Editing a prerelease into a release makes GitHub send `released`, so `release.yml` rebuilds with `github.event.release.prerelease` false and publishes `latest*.yml` carrying the `-beta.N` version onto the beta tag. `/releases/latest` then moves onto that release and stable users are offered a Beta build. A fresh `vX.Y.Z` tag is the only correct promotion.
 
 ## Confirm the bump
 
@@ -68,3 +69,4 @@ Always confirm before editing `package.json`, even when the bump is obvious.
 
 - Run the `release-notes` skill. It expects `HEAD` to be the version commit and writes onto the `v<version>` release, which now exists.
 - Report the release URL and the release build's run URL (`gh run list --workflow=release.yml -L 1 --json url,status`). Don't wait for the build — it takes many minutes across three platforms.
+- Re-running a single failed platform job is safe, however long after the release it happens. `release.yml` sets `EP_GH_IGNORE_TIME`, which turns off electron-publish's refusal to upload into a release published more than two hours earlier — without it the rebuild uploads nothing for that platform and still reports success.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,11 +42,20 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Uploads into a release published over two hours ago; without it a
+          # re-run skips every asset and still exits zero.
+          EP_GH_IGNORE_TIME: true
       - if: startsWith(matrix.os, 'ubuntu')
         run: bun run build:linux -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=beta' || '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Uploads into a release published over two hours ago; without it a
+          # re-run skips every asset and still exits zero.
+          EP_GH_IGNORE_TIME: true
       - if: startsWith(matrix.os, 'windows')
         run: bun run build:win -- --publish always ${{ github.event.release.prerelease && '--config.publish.channel=beta' || '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Uploads into a release published over two hours ago; without it a
+          # re-run skips every asset and still exits zero.
+          EP_GH_IGNORE_TIME: true


### PR DESCRIPTION
## Summary
Sets `EP_GH_IGNORE_TIME` on all three build steps in `release.yml`, so a re-run of a failed platform job actually uploads its assets instead of skipping every one and still exiting zero, and adds two warnings to the release skill: never promote a beta by unticking "pre-release" on GitHub, and why the env var is there. Wanted before `v3.60.0-beta.1`, the first prerelease Meru has ever published. Nothing here is type-checked or exercisable without a real release.

## Problem
Two process traps sit in the publish path, found in the release-channel audit against the vendored electron-updater 6.6.2, app-builder-lib 26.15.6 and electron-publish 26.15.3. The channel wiring itself is correct and is untouched here.

**The two-hour publish window.** `GitHubPublisher.getOrCreateRelease` (`electron-publish/out/gitHubPublisher.js:88`) refuses to upload into a GitHub release published more than two hours ago. It logs `GitHub release not created` and returns null; `doUpload` then logs `skipped publishing` and returns normally, so electron-builder exits zero and the CI job goes green with no assets uploaded. A fresh cut is safe — recent `release.yml` runs take 7–16 minutes — so the exposure is re-running a failed platform job later: the rebuild succeeds, uploads nothing, reports success. On a prerelease that is worse than on a stable. A prerelease carries only `beta*.yml`, so if that platform's `beta.yml` never lands, its Beta users request it, 404, and the provider's fallback then asks the same prerelease for `latest*.yml`, which a prerelease never has — the check errors rather than degrading quietly.

**Promotion by unticking "pre-release".** `release.yml` fires on `release: [prereleased, released]`, and GitHub also sends `released` when an existing prerelease is edited into a full release. `github.event.release.prerelease` is then false, so the rebuild publishes `latest*.yml` carrying version `3.60.0-beta.1` onto tag `v3.60.0-beta.1`, and `/releases/latest` moves onto it — stable users would be offered a Beta build. The skill already documents the correct promotion path, a fresh `vX.Y.Z` tag with the suffix dropped; it just never said the alternative is forbidden.

## Solution
- Adds `EP_GH_IGNORE_TIME: true` to the `env:` block of the macOS, Ubuntu and Windows build steps, alongside `GH_TOKEN`, with a short comment on each.
- Adds a **Never promote by unticking "pre-release"** bullet to the skill's **Beta releases** section, and a note under **Notes and reporting** saying a single-platform re-run is safe and that `EP_GH_IGNORE_TIME` is what makes it so.

The value is `true` and not a duration because `EP_GH_IGNORE_TIME` is a boolean: `isEnvTrue` (`builder-util/out/util.js:471-476`) accepts only `"true"`, `""` or `"1"`, so a numeric value such as `7200` evaluates false and silently leaves the check on. There is no way to express a narrower window.

The trade-off was weighed and accepted: with the rail off, a build targeting an old tag could overwrite that release's assets. The release skill's flow makes that structurally unlikely — the tag comes from `package.json`'s version and the release is created moments before the workflow fires.

`generateUpdatesFilesForAllChannels` is deliberately still absent. `computeChannelNames` in `app-builder-lib/out/publish/updateInfoBuilder.js` short-circuits on `publishConfig.provider === "github"` before reading the flag, so setting it would imply a mechanism this repo does not use.

## Not verified
- Nothing here is type-checked or covered by a test — the change is one YAML file and one Markdown file. `bun run types`, `bun run lint` and `bun run fmt:check` all pass, but none of them read either change.
- Neither the workflow change nor the two-hour behavior can be exercised without an actual release. The first proof that `EP_GH_IGNORE_TIME` does what it should is a real re-run of a stale platform job.
- The promotion warning is documentation only; nothing enforces it in the workflow.