### PR TITLE
Guard the 3.60.0 config migration against an empty store

### DIFF
--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -380,40 +380,51 @@ export const config = new Store<Config>({
       const renameNotebookApp = <App extends string>(app: App) =>
         (app === "notebooklm" ? "notebook" : app) as App;
 
-      store.set(
-        "workspaceApps.launcherApps",
-        store.get("workspaceApps.launcherApps").map(renameNotebookApp),
-      );
+      // conf runs the migrations before it merges the defaults in, so on a
+      // profile with no config file every one of these reads comes back
+      // `undefined` — and a throw here takes the main process down at module
+      // load, which is a new install that cannot launch at all.
+      const launcherApps = store.get("workspaceApps.launcherApps");
 
-      store.set(
-        "workspaceApps.openInAppExcludedApps",
-        store.get("workspaceApps.openInAppExcludedApps").map(renameNotebookApp),
-      );
+      if (Array.isArray(launcherApps)) {
+        store.set("workspaceApps.launcherApps", launcherApps.map(renameNotebookApp));
+      }
+
+      const openInAppExcludedApps = store.get("workspaceApps.openInAppExcludedApps");
+
+      if (Array.isArray(openInAppExcludedApps)) {
+        store.set(
+          "workspaceApps.openInAppExcludedApps",
+          openInAppExcludedApps.map(renameNotebookApp),
+        );
+      }
 
       const zoomFactors = store.get("workspaceApps.zoomFactors");
 
-      store.set(
-        "workspaceApps.zoomFactors",
-        Object.fromEntries(
-          Object.entries(zoomFactors).map(([app, zoomFactor]) => [
-            renameNotebookApp(app),
-            zoomFactor,
-          ]),
-        ),
-      );
+      if (zoomFactors) {
+        store.set(
+          "workspaceApps.zoomFactors",
+          Object.fromEntries(
+            Object.entries(zoomFactors).map(([app, zoomFactor]) => [
+              renameNotebookApp(app),
+              zoomFactor,
+            ]),
+          ),
+        );
+      }
 
       const accounts = store.get("accounts");
 
       if (Array.isArray(accounts)) {
         for (const account of accounts) {
           account.workspaceApps = {
-            savedTabs: account.workspaceApps.savedTabs.map((savedTab) => ({
+            savedTabs: (account.workspaceApps?.savedTabs ?? []).map((savedTab) => ({
               ...savedTab,
               app: renameNotebookApp(savedTab.app),
               opensLinksForApp:
                 savedTab.opensLinksForApp && renameNotebookApp(savedTab.opensLinksForApp),
             })),
-            bookmarks: account.workspaceApps.bookmarks.map((bookmark) => ({
+            bookmarks: (account.workspaceApps?.bookmarks ?? []).map((bookmark) => ({
               ...bookmark,
               app: renameNotebookApp(bookmark.app),
             })),


### PR DESCRIPTION
## Summary
A new install of 3.60.0-beta.1 cannot launch: conf runs migrations before it merges the defaults in, so on a fresh profile the `">=3.60.0"` migration reads `undefined` and throws, taking `new Store(...)` down at module load in the main process. Four guards, in the style of the rest of the ladder. Upgrades from 3.59.0 were never affected.

Deliberately minimal for an overdue release — one file, no restructuring, no new dependency. The unit coverage and a second conf fault found while writing it are parked for the next version; see **Follow-ups**.

## Problem
conf's constructor reads the config file, computes `defaults + file` in memory, runs the migration ladder, and only then writes the merged result. A migration therefore sees the file as it sits on disk and nothing else, and on a profile with no config file that store is completely empty.

The `">=3.60.0"` migration called `.map` on `workspaceApps.launcherApps`, `workspaceApps.openInAppExcludedApps` and `workspaceApps.zoomFactors`, and read `account.workspaceApps`, without checking any of them:

```
TypeError: undefined is not an object (evaluating 'store.get("workspaceApps.launcherApps").map')
  at _migrate (node_modules/conf/dist/source/index.js:385:27)
  at new Conf (node_modules/conf/dist/source/index.js:102:18)
```

conf catches that, restores its backup and rethrows as "Something went wrong during the migration!", so `config.ts` throws at module load and the app never starts. Upgrades from 3.59.0 are fine — all three keys were 3.59.0 defaults, so an existing profile has them on disk with real values.

`40e433b` is what set this off. It differs from its parent by the version string alone, and `453797d` resolves a prerelease to its base version, so `projectVersion` became `3.60.0` and `">=3.60.0"` matched for the first time ever. That is also why nothing caught it earlier: CI's `e2e` job is the only thing that launches the app on a fresh profile, and it hung on all three platforms in [run 33818291369](https://github.com/zoidsh/meru/actions/runs/33818291369), the release build for the tag. Nothing was published.

## Solution
- Guards the four reads, in the same style as the rest of the ladder, which checks before it reads (`if (Array.isArray(accounts))`, `typeof showDockIcon === "boolean"`).
- The accounts loop follows `">3.58.0"` immediately above it in using `account.workspaceApps?.savedTabs ?? []`, which repairs a missing shape rather than skipping the account — the account schema requires `workspaceApps`, and `">3.57.0"` already backfills exactly that.
- Left alone on purpose: `account.gmail.unreadBadge` in `">=3.31.2"` and `account.gmail.unifiedInbox` in `">3.38.4"` are unguarded and predate this. Both stand on ordering rather than a check — `">=3.11.0"` writes `gmail` on any account that lacks it, and it sits above both — and `?.` on the read in `">3.38.4"` would leave the assignment beside it throwing anyway, so guarding them means rewriting the migrations rather than checking a read. Out of scope for a release fix.

## Try it
Nothing to open — this is a main-process crash on launch. This branch carries the 3.60.0-beta.1 version commit, so its own CI `e2e` job runs the migration for real on a fresh user-data directory on all three platforms; a green `e2e` here is the end-to-end proof, and the hang in [run 33818291369](https://github.com/zoidsh/meru/actions/runs/33818291369) is the before.

## Not verified
- **A second conf fault is unfixed and ships with 3.60.0.** conf 14 snapshots the config file and computes `defaults + snapshot` *before* running the ladder, then writes that stale merge back afterwards — so the first launch after an upgrade that adds a default key throws every migration's writes away, `__internal__.migrations.version` included, and the ladder only sticks on the second launch. Measured against Meru's defaults and a 3.59.0-shaped config: launch 1 leaves `workspaceApps.launcherApps` as `["calendar", "notebooklm"]`, launch 2 gives `["calendar", "notebook"]`. It is long-standing — 3.58.0's `googleApps.*` rename had the same delay — but 3.60.0 is the first release where the stale state is invalid rather than merely old, because `notebooklm` is not a key in `workspaceApps` and `workspaceApps[app].label`, `.url` and `.singleInstance` are read unguarded. A user with a NotebookLM saved tab, launcher entry or bookmark gets one launch of `undefined` app lookups before it corrects itself. Deferred deliberately: the fix is a conf 15 bump, which is not something to take on an overdue release.
- **No unit coverage lands here.** The ladder cannot be imported by a `bun test` today, because `config.ts` calls `app.getVersion()` and `app.getPath("downloads")` at module scope. CI's `e2e` job is the only thing exercising this change, and it exercises the fresh-install path only.
- The guards were verified by running this branch's ladder against conf 14 outside Electron: a fresh profile launches, an upgrade renames `notebooklm` across the launcher, the excluded apps, the zoom factors and each account's saved tabs and bookmarks, and a profile missing those keys launches. Not verified in a packaged app on any platform, and not verified against a real upgrade over a 3.59.0 profile.

## Follow-ups
Both are pushed and ready for the next version, neither is proposed here:

- `config-migrations-coverage` — extracts the ladder to `packages/app/lib/config-migrations.ts` so a `bun test` can run it, and adds 43 tests: two data-driven suites over `Object.keys(configMigrations)` so a rung keyed above the current version is exercised, plus the 3.59.0 rename and promotion cases.
- `config-store-conf-15` (was #1059) — the above plus electron-store 11.0.2 for conf 15.1.0, which fixes the ordering fault above and cost no application code beyond comments.