### PR TITLE
Reword the verification-code copy mode options

### DIFF
--- a/packages/renderer/routes/settings/verification-codes.tsx
+++ b/packages/renderer/routes/settings/verification-codes.tsx
@@ -30,7 +30,7 @@ export function VerificationCodesSettings() {
           />
           <ConfigSelectField
             label="When to copy"
-            description={`A notification shows the code either way. Copying ${platform.isLinux ? "on click" : "from its Copy button"} leaves your clipboard untouched until you act.`}
+            description={`A notification shows the code either way. ${platform.isLinux ? "Click it" : "Press its Copy button"} to copy the code yourself.`}
             configKey="verificationCodes.copyMode"
             items={Object.entries(verificationCodeCopyModes).map(([value, label]) => ({
               value,

--- a/packages/shared/verification-codes.ts
+++ b/packages/shared/verification-codes.ts
@@ -1,5 +1,5 @@
 export const verificationCodeCopyModes = {
-  notificationClick: "From the notification",
+  notificationClick: "Only when you ask",
   immediately: "As soon as it arrives",
 } as const;
 


### PR DESCRIPTION
## Summary
The two options under **When to copy** on the verification codes settings page never said what differs between them, because a notification shows the code in either mode. They become **Only when you ask** and **As soon as it arrives**, and the field description stops arguing the choice and names the gesture instead. Strings only — the config values are untouched, so no migration. `verificationCodes.copyMode` ships for the first time in 3.60.0, so this wants to land before that release is cut.

## Problem
`verificationCodes.copyMode` decides whether Meru writes the clipboard the moment a code arrives, or waits for you to act on the notification. Its options read "From the notification" and "As soon as it arrives", which don't describe that difference: a notification appears in both modes and shows the code either way, so the first option answered *where* while the second answered *when*, and neither said who writes the clipboard. This came out of drafting the 3.60.0 release notes, where the two modes couldn't be described from their own labels.

## Solution
- `notificationClick` → **Only when you ask**, `immediately` → **As soon as it arrives**. `notificationClick` stays listed first as the config default, per the `ConfigSelectField` convention in `CLAUDE.md`.
- The field description drops its second sentence — it argued that one mode "leaves your clipboard untouched until you act", which is now what the option itself says — and names the gesture instead: "A notification shows the code either way. Press its Copy button to copy the code yourself." On Linux that reads "Click it", because Linux notifications have no action buttons and the body click is the only path.

Both options answer the question the label asks, which is what keeps **When to copy** working unchanged. Phrasing them as agency instead — "Copy it myself" / "Copy automatically" — was weighed and rejected: it stutters against a label already carrying the verb, and answers a question the label doesn't ask. Apple's shape for this choice is a bare adverb against a named manual trigger, as in Safari's "Downloads" / "Ask for each download", but "Manually" reads in a code-copying feature as *select the digits yourself*, and "Automatically" drops the timing that "As soon as it arrives" states outright. "Only" is load-bearing on the default — it is the word promising nothing reaches the clipboard unasked.

The three notification bodies in `packages/app/gmail/index.ts` were re-read against the new options and left alone; "Copied verification code X" and "Click to copy verification code X" still track the modes they belong to.

## Try it
No preview deployment for a desktop app. `bun run dev`, then Settings → Verification codes — the **When to copy** select and its description are the change. The field is Pro-gated and disabled unless **Copy codes to clipboard** is on.

## Not verified
- Not run in the app; the change was read against the settings page and the notification call site, not exercised.
- The Linux branch of the description is not visible on this machine.