### PR TITLE
Gate macOS Touch ID passkey enrollment behind Meru Pro

### DIFF
--- a/packages/app/dialogs.ts
+++ b/packages/app/dialogs.ts
@@ -42,6 +42,10 @@ export async function confirmAppLinksTabHandover(
   return response === 0;
 }
 
+export function openProUpgradeUrl() {
+  openExternalUrl(`${WEBSITE_URL}/#pricing`, { skipTrustedHostCheck: true });
+}
+
 export async function showProUpgradeDialog(message: string) {
   const { response } = await dialog.showMessageBox(main.window, {
     type: "warning",
@@ -52,6 +56,6 @@ export async function showProUpgradeDialog(message: string) {
   });
 
   if (response === 0) {
-    openExternalUrl(`${WEBSITE_URL}/#pricing`, { skipTrustedHostCheck: true });
+    openProUpgradeUrl();
   }
 }

--- a/packages/app/index.ts
+++ b/packages/app/index.ts
@@ -93,16 +93,6 @@ async function init() {
     app.setAppUserModelId(APP_ID);
   }
 
-  // The team id is only known to signed builds, and without it the keychain
-  // access group can't match the `keychain-access-groups` entitlement
-  if (platform.isMacOS && process.env.APPLE_TEAM_ID) {
-    app.configureWebAuthn({
-      touchID: {
-        keychainAccessGroup: `${process.env.APPLE_TEAM_ID}.${APP_ID}.webauthn`,
-      },
-    });
-  }
-
   setMeruProtocolClient();
 
   if (!app.requestSingleInstanceLock()) {
@@ -135,6 +125,20 @@ async function init() {
     app.quit();
 
     return;
+  }
+
+  // The team id is only known to signed builds, and without it the keychain
+  // access group can't match the `keychain-access-groups` entitlement. Touch ID
+  // enrollment is Pro, so this sits after the validation that settles
+  // `isValid`. `configureWebAuthn` only sets a static that the WebAuthn
+  // delegate reads per request, so it takes effect whenever it is called, and
+  // here it is still ahead of the first view
+  if (platform.isMacOS && process.env.APPLE_TEAM_ID && licenseKey.isValid) {
+    app.configureWebAuthn({
+      touchID: {
+        keychainAccessGroup: `${process.env.APPLE_TEAM_ID}.${APP_ID}.webauthn`,
+      },
+    });
   }
 
   blocker.init();

--- a/packages/app/workspace-app.ts
+++ b/packages/app/workspace-app.ts
@@ -28,6 +28,7 @@ import {
 import { accounts } from "./accounts";
 import { bookmarks } from "./bookmarks";
 import { config } from "./config";
+import { openProUpgradeUrl } from "./dialogs";
 import { extensions } from "./extensions";
 import { ipc } from "./ipc";
 import { loadUrl, loadUrlOrRestoreNavigationHistory } from "./lib/load-url";
@@ -182,22 +183,44 @@ export class WorkspaceApp {
     }
 
     // The team id is only inlined into signed builds, which are the only ones
-    // where Touch ID passkeys are configured (see `init` in index.ts).
-    const touchIdAvailable = platform.isMacOS && Boolean(process.env.APPLE_TEAM_ID);
+    // where Touch ID passkeys can be configured (see `init` in index.ts).
+    const touchIdSupported = platform.isMacOS && Boolean(process.env.APPLE_TEAM_ID);
 
-    const { checkboxChecked } = await dialog.showMessageBox({
+    const touchIdRequiresUpgrade = touchIdSupported && !licenseKey.isValid;
+
+    let message: string;
+    let detail: string;
+
+    if (!touchIdSupported) {
+      message = "Passkey sign-in isn't supported on this platform yet.";
+      detail =
+        "Sign in with your password or another available second factor. If the account has no password, add one at myaccount.google.com in a browser first, then sign in here.";
+    } else if (touchIdRequiresUpgrade) {
+      message = "Meru Pro is required to sign in with Touch ID.";
+      detail =
+        "Sign in with your password or another second factor. Meru Pro lets you create a passkey for this Mac in your Google account's security settings and sign in with Touch ID. Passkeys from Chrome, iCloud, or your phone don't work in Meru either way.";
+    } else {
+      message = "Only passkeys created in Meru work here.";
+      detail =
+        "Continue with Touch ID if you've created a passkey in Meru. Passkeys from Chrome, iCloud, or your phone don't work here — sign in with your password or another second factor, then create a passkey for Meru in your Google account's security settings.";
+    }
+
+    const { response, checkboxChecked } = await dialog.showMessageBox({
       type: "info",
-      message: touchIdAvailable
-        ? "Only passkeys created in Meru work here."
-        : "Passkey sign-in isn't supported on this platform yet.",
-      detail: touchIdAvailable
-        ? "Continue with Touch ID if you've created a passkey in Meru. Passkeys from Chrome, iCloud, or your phone don't work here — sign in with your password or another second factor, then create a passkey for Meru in your Google account's security settings."
-        : "Sign in with your password or another available second factor. If the account has no password, add one at myaccount.google.com in a browser first, then sign in here.",
+      message,
+      detail,
+      buttons: touchIdRequiresUpgrade ? ["Upgrade to Meru Pro", "Cancel"] : ["OK"],
+      defaultId: 0,
+      cancelId: touchIdRequiresUpgrade ? 1 : 0,
       checkboxLabel: "Don't show again",
     });
 
     if (checkboxChecked) {
       config.set("workspaceApps.hidePasskeyDialog", true);
+    }
+
+    if (touchIdRequiresUpgrade && response === 0) {
+      openProUpgradeUrl();
     }
   }
 

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -302,15 +302,20 @@ function ExperimentalAlert() {
 }
 
 function PasskeysAlert() {
+  const isLicenseKeyValid = useIsLicenseKeyValid();
+
   if (platform.isMacOS) {
     return (
       <Alert>
         <KeyRoundIcon />
         <AlertTitle>Sign in to Google with a passkey and Touch ID</AlertTitle>
         <AlertDescription>
-          Add a passkey to your Google account from its security settings inside Meru, then sign in
-          with Touch ID — no password manager extension to install, so Meru stays fast and light.
-          iCloud passkeys don't work here, and filling passwords still needs a password manager.
+          {isLicenseKeyValid
+            ? "Add a passkey to your Google account"
+            : "Meru Pro lets you add a passkey to your Google account"}{" "}
+          from its security settings inside Meru, then sign in with Touch ID — no password manager
+          extension to install, so Meru stays fast and light. iCloud passkeys don't work here, and
+          filling passwords still needs a password manager.
         </AlertDescription>
       </Alert>
     );


### PR DESCRIPTION
## Summary
Passkey sign-in ships for the first time in 3.60.0 and is currently free for everyone. This gates the macOS Touch ID half behind Meru Pro, and deliberately leaves Windows alone — Meru contributes no code there, and gating it would break a sign-in path that works by default. Nothing here can be exercised outside a signed macOS build, so the whole change is unverified at runtime; see `## Not verified`.

## Problem
`app.configureWebAuthn({ touchID })` is Meru's own code and its own signing infrastructure — an entitlement, a Developer ID provisioning profile, a `beforePack` hook — and it is what makes `isUserVerifyingPlatformAuthenticatorAvailable()` return true so a Mac user can enroll a Google passkey inside Meru. It had no license check anywhere near it, and the Extensions settings page promised it to free users. The release is imminent.

## Solution
- `configureWebAuthn` is gated on `licenseKey.isValid`, and moves from the top of `init` to just after the license and trial validation so it reads a settled value rather than one that is always `false` that early. An active trial counts as Pro, as it does for every other gated feature.
- The macOS passkey intercept dialog gains a third branch for free users, with an "Upgrade to Meru Pro" button alongside the existing "Don't show again" checkbox. `openProUpgradeUrl` is split out of `showProUpgradeDialog` so both surfaces open the same page.
- The `PasskeysAlert` on the Extensions settings page says Meru Pro on its macOS branch when the license isn't valid.

**Why the call moved rather than reading the config.** Keeping `configureWebAuthn` at the top of `init` would have meant presuming the entitlement from `Boolean(config.get("licenseKey")) || !config.get("trial.expired")`. That is exact for every surviving case, but it is a guess where an exact answer is available a few lines later. The move is safe: `App::ConfigureWebAuthn` in `shell/browser/api/electron_api_app.cc` validates its options and then does nothing but call `ElectronWebAuthenticationDelegate::SetTouchIdKeychainAccessGroup`, a static the delegate reads when a WebAuthn request arrives — no readiness check anywhere in it, and the docs state no ordering constraint against `ready` where `configureHostResolver` right beside it does. Electron issue #52302 reads the same way from the other side, objecting to dynamic reconfiguration because it would race concurrent ceremonies rather than because it wouldn't take effect. The new position is still ahead of `accounts.createViews`, which is the property the original placement was chosen for.

**Why Windows is not gated.** Two reasons, either sufficient. `handleNavigate` runs on `did-navigate`, after the navigation has committed, so it is advisory and blocks nothing — gating Windows would mean a new `will-navigate` intercept that cancels Google's challenge page and strands the sign-in mid-flow rather than degrading. And Chromium delegates to `webauthn.dll` below the layer Electron exposes, so Meru contributes nothing there to charge for, and the gate would break a flow that works by default and lock out accounts with no password fallback: passkey-only accounts, Workspace accounts on "skip passwords", and Advanced Protection Program accounts. Electron 43 offers no finer hook — `configureWebAuthn` is darwin-only, and `select-webauthn-account` is a chooser for multiple discoverable credentials rather than an allow-or-deny gate.

**Why one dialog and not `showProUpgradeDialog` on top of it.** At the moment the dialog fires, Google is challenging the user for a passkey they already hold elsewhere — one that Pro would not unlock. A bare upsell there would mislead, so the copy says outright that Chrome, iCloud, and phone passkeys don't work in Meru either way.

## Try it
Nothing to open. `APPLE_TEAM_ID` is inlined at build time and only signed macOS builds have it, so every branch this touches is unreachable in a development build and on every other platform.

## Not verified
- No part of the macOS path was exercised. Touch ID enrollment needs a signed build, so neither the gated nor the ungated side ran, and the free-user branch of the intercept dialog has never been seen.
- That `configureWebAuthn` still takes effect from its new position is argued from the Electron implementation and the docs, not observed.
- `licenseKey.isValid` is settled by the time the moved call runs, which is the same ordering `blocker.init()` and `spellchecker.init()` below it already rely on, but it wasn't asserted by a test — `license-key.ts` imports `electron` and has no unit test harness.
- A macOS user whose trial lapses after enrolling a Meru passkey loses the use of it, since `configureWebAuthn` governs `navigator.credentials.get()` as well as create. Meru never sees the enrollment, so there is no way to grandfather one. Accepted knowingly.
- `bun run types`, `bun run lint`, `bun run fmt:check`, `bun test` (1012 pass) and `bun run test:e2e` (44 pass) all pass on Linux.