### PR TITLE
Say 1Password needs its desktop app, and stop clamping item descriptions

### DIFF
--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -244,10 +244,7 @@ function ExtensionItem({
             {installedVersion && <Badge variant="outline">Version {installedVersion}</Badge>}
             <LicenseKeyRequiredFieldBadge />
           </ItemTitle>
-          {/* `ItemDescription` clamps to two lines, which cuts these mid-word.
-              An extension's description is the only place its limits are
-              written down, so it is shown whole. */}
-          <ItemDescription className="line-clamp-none">{extension.description}</ItemDescription>
+          <ItemDescription>{extension.description}</ItemDescription>
           {isOnePassword && (
             <Button
               variant="outline"

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -244,7 +244,10 @@ function ExtensionItem({
             {installedVersion && <Badge variant="outline">Version {installedVersion}</Badge>}
             <LicenseKeyRequiredFieldBadge />
           </ItemTitle>
-          <ItemDescription>{extension.description}</ItemDescription>
+          {/* `ItemDescription` clamps to two lines, which cuts these mid-word.
+              An extension's description is the only place its limits are
+              written down, so it is shown whole. */}
+          <ItemDescription className="line-clamp-none">{extension.description}</ItemDescription>
           {isOnePassword && (
             <Button
               variant="outline"

--- a/packages/shared/extensions.ts
+++ b/packages/shared/extensions.ts
@@ -66,8 +66,16 @@ export const curatedExtensions: CuratedExtension[] = [
     // and `tabs.create` is unimplemented, so a popup entry that opens one of
     // the extension's own pages — its settings, its full item view — does
     // nothing at all.
+    //
+    // The desktop-app requirement is named before the absences because it is
+    // the one that decides whether any of this works: the extension fills
+    // nothing until it is connected, and a user who installs without it sees
+    // an extension that does nothing rather than one Meru limited. How to
+    // connect the two is the setup dialog's job, and the button that opens it
+    // sits directly under this text, so the copy states the requirement and
+    // stops there.
     description:
-      "Signs you in to your Google Account with a saved password or passkey, and generates new ones when you change your password or add a passkey. Nothing else is supported: no in-page filling outside those pages, no card or address autofill, no keyboard shortcuts, right-click fill or notifications, and no way to reach 1Password's own pages, such as its settings.",
+      "Signs you in to your Google Account with a saved password or passkey, and generates new ones when you change your password or add a passkey. Needs the 1Password desktop app, connected to Meru. Nothing else is supported: no in-page filling outside those pages, no card or address autofill, no keyboard shortcuts, right-click fill or notifications, and no way to reach 1Password's own pages, such as its settings.",
     category: "passwordManager",
     // Sign-in runs on accounts.google.com, and account settings — creating a
     // passkey, changing a password — on myaccount.google.com. Both hosts, not

--- a/packages/ui/components/item.tsx
+++ b/packages/ui/components/item.tsx
@@ -139,7 +139,7 @@ function ItemDescription({ className, ...props }: React.ComponentProps<"p">) {
     <p
       data-slot="item-description"
       className={cn(
-        "line-clamp-2 text-left text-sm leading-normal font-normal text-muted-foreground group-data-[size=xs]/item:text-xs [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        "text-left text-sm leading-normal font-normal text-muted-foreground group-data-[size=xs]/item:text-xs [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
The 1Password entry in Settings > Extensions was cut mid-word at two lines and never said the extension needs the 1Password desktop app. This drops the clamp from `ItemDescription` and adds the requirement as the description's second sentence. Copy and one class — no behavior change, and nothing asserts on the text.

## Problem
`ItemDescription` carries shadcn's `line-clamp-2`, and the 1Password description is long enough to hit it, so the list of what the extension can't do ended in "…and generates new ones when you change your password or add a…". That list is the only place those limits are written down, and the half that was cut is the half naming the absences.

The description also never mentioned that filling needs the 1Password desktop app, installed and trusting Meru. Without it the extension fills nothing, so a user who turns it on and reads only the description sees an extension that appears broken rather than one that has an unmet requirement.

## Solution
- Removes `line-clamp-2` from `ItemDescription` in `packages/ui/components/item.tsx`, rather than overriding it at the one call site. An override leaves the clamp armed for every other description, so the next long one is cut the same way — and the clamp fires nowhere it is wanted: four of the five call sites hold a single line (a filename, a search query, an about-page value, a relative date) and the fifth is the description it was cutting. It also truncates silently, with no tooltip, no `title` and no way to expand, so the text it hides is text nobody can reach.
- `about.tsx` passes `truncate`, which tailwind-merge does not treat as conflicting with `line-clamp-2`, so that call site has been shipping both — `display: -webkit-box` under a `white-space: nowrap` it fights. Removing the clamp leaves it meaning what it says.
- Deviating from shadcn here costs nothing at update time that `packages/ui` is not already paying: #709 stripped the focus rings out of eight of these components by hand.
- Adds "Needs the 1Password desktop app, connected to Meru." as the description's second sentence, before the absences rather than after them: it is the requirement that decides whether any of the rest applies.
- States the requirement and stops. `OnePasswordSetupDialog` already carries the steps and the reason ("because Meru stores no vault data of its own"), and the **Set up desktop app** button that opens it sits directly under this text, so repeating the steps here would duplicate the dialog a click away.
- Extends the comment above the description with why the requirement is ordered where it is, since the comment records the copy's reasoning.

## Try it
Settings > Extensions > Password managers, the 1Password item. The description now runs to three sentences with no ellipsis, and the second names the desktop-app requirement. Needs a running app rather than a URL — Meru is an Electron app with no preview deployment.

## Not verified
- Not seen in a running app: no display in this sandbox, so nothing was rendered at any window width — neither the unclamped description nor the four other `ItemDescription` call sites the shared change also touches (downloads, saved searches, about, version history).