### PR TITLE
Keep the Gmail dark theme out of the editor so it stops leaking into sent mail

### DIFF
--- a/packages/preload-gmail/dark-theme/compose.ts
+++ b/packages/preload-gmail/dark-theme/compose.ts
@@ -2,6 +2,7 @@ import { applyDarkTheme, type DarkThemeController } from "@meru/dark-theme";
 import { GMAIL_PRELOAD_ARGUMENTS } from "@meru/shared/gmail";
 import { $$ } from "select-dom";
 import composeCss from "./compose.css";
+import editorCss from "./editor.css";
 
 const isExtendDarkThemeEnabled = process.argv.includes(GMAIL_PRELOAD_ARGUMENTS.extendDarkTheme);
 
@@ -31,7 +32,11 @@ export function darkThemeCompose() {
       composeElement,
       applyDarkTheme(composeElement, {
         backgroundColor: "rgb(19, 19, 19)",
-        css: composeCss,
+        ignore: [
+          // Gmail's rich-text editor, themed by stylesheet in editor.css instead
+          '[contenteditable="true"]',
+        ],
+        css: `${composeCss}\n${editorCss}`,
       }),
     );
   }

--- a/packages/preload-gmail/dark-theme/editor.css
+++ b/packages/preload-gmail/dark-theme/editor.css
@@ -1,0 +1,29 @@
+/* Gmail's rich-text editor, shared by the compose window and the inline reply.
+   Gmail serializes its innerHTML as the draft and as the sent message, so the
+   inline overrides the engine writes would be baked into the mail — recipients,
+   and the sender in a light-themed client, would see near-white text on white.
+   Both call sites pass it to `ignore` instead, which skips the whole subtree,
+   and it is themed here by stylesheet, which never leaves Meru's page. Keep the
+   selector in sync with those `ignore` entries. */
+
+[data-dark-theme-root] [contenteditable="true"] {
+  background-color: rgb(19, 19, 19) !important;
+  caret-color: rgb(232, 230, 227) !important;
+  color: rgb(232, 230, 227) !important;
+}
+
+/* Content carries its own light-theme colors — a signature set to #000, quoted
+   text, pasted markup — so descendants are flattened onto the editor's colors */
+[data-dark-theme-root] [contenteditable="true"] *:not(a) {
+  background-color: transparent !important;
+  color: inherit !important;
+}
+
+[data-dark-theme-root] [contenteditable="true"] a {
+  color: rgb(138, 180, 248) !important;
+}
+
+/* Quoted text in a reply, which Gmail writes with an inline light border-left */
+[data-dark-theme-root] [contenteditable="true"] blockquote {
+  border-color: rgb(61, 61, 61) !important;
+}

--- a/packages/preload-gmail/dark-theme/editor.css
+++ b/packages/preload-gmail/dark-theme/editor.css
@@ -13,8 +13,9 @@
    own, so nothing here depends on Gmail's markup. */
 
 [data-dark-theme-root] [contenteditable="true"] {
-  /* Inverts to rgb(19, 19, 19), the background both call sites pass to the engine */
-  background-color: rgb(236, 236, 236) !important;
+  /* Transparent survives the filter, so the surface the engine gave the compose
+     window shows through and the editor matches whatever surrounds it */
+  background-color: transparent !important;
   /* The editor inherits the light text color the engine gave its container, which
      the filter would turn dark, so give it Gmail's own dark text to invert */
   caret-color: rgb(34, 34, 34) !important;

--- a/packages/preload-gmail/dark-theme/editor.css
+++ b/packages/preload-gmail/dark-theme/editor.css
@@ -3,27 +3,22 @@
    inline overrides the engine writes would be baked into the mail — recipients,
    and the sender in a light-themed client, would see near-white text on white.
    Both call sites pass it to `ignore` instead, which skips the whole subtree,
-   and it is themed here by stylesheet, which never leaves Meru's page. Keep the
-   selector in sync with those `ignore` entries. */
+   and it is themed here by a CSS filter, which never leaves Meru's page. Keep
+   the selector in sync with those `ignore` entries.
+
+   Inverting flips lightness and the hue rotation restores the hue, so black
+   text and a signature set to #000 read light, a color picked in the toolbar
+   keeps its hue and still shows as picked when sent, and the light blue
+   selection highlight becomes a dark one. Nothing inside gets a rule of its
+   own, so nothing here depends on Gmail's markup. */
 
 [data-dark-theme-root] [contenteditable="true"] {
-  background-color: rgb(19, 19, 19) !important;
-  caret-color: rgb(232, 230, 227) !important;
-  color: rgb(232, 230, 227) !important;
+  /* Inverts to rgb(19, 19, 19), the background both call sites pass to the engine */
+  background-color: rgb(236, 236, 236) !important;
+  filter: invert(1) hue-rotate(180deg) !important;
 }
 
-/* Content carries its own light-theme colors — a signature set to #000, quoted
-   text, pasted markup — so descendants are flattened onto the editor's colors */
-[data-dark-theme-root] [contenteditable="true"] *:not(a) {
-  background-color: transparent !important;
-  color: inherit !important;
-}
-
-[data-dark-theme-root] [contenteditable="true"] a {
-  color: rgb(138, 180, 248) !important;
-}
-
-/* Quoted text in a reply, which Gmail writes with an inline light border-left */
-[data-dark-theme-root] [contenteditable="true"] blockquote {
-  border-color: rgb(61, 61, 61) !important;
+/* The same filter twice is the identity, so images keep their true colors */
+[data-dark-theme-root] [contenteditable="true"] img {
+  filter: invert(1) hue-rotate(180deg) !important;
 }

--- a/packages/preload-gmail/dark-theme/editor.css
+++ b/packages/preload-gmail/dark-theme/editor.css
@@ -15,6 +15,10 @@
 [data-dark-theme-root] [contenteditable="true"] {
   /* Inverts to rgb(19, 19, 19), the background both call sites pass to the engine */
   background-color: rgb(236, 236, 236) !important;
+  /* The editor inherits the light text color the engine gave its container, which
+     the filter would turn dark, so give it Gmail's own dark text to invert */
+  caret-color: rgb(34, 34, 34) !important;
+  color: rgb(34, 34, 34) !important;
   filter: invert(1) hue-rotate(180deg) !important;
 }
 

--- a/packages/preload-gmail/dark-theme/message.ts
+++ b/packages/preload-gmail/dark-theme/message.ts
@@ -1,6 +1,7 @@
 import { applyDarkTheme, type DarkThemeController } from "@meru/dark-theme";
 import { GMAIL_PRELOAD_ARGUMENTS } from "@meru/shared/gmail";
 import { $$ } from "select-dom";
+import editorCss from "./editor.css";
 import messageCss from "./message.css";
 
 const isExtendDarkThemeEnabled = process.argv.includes(GMAIL_PRELOAD_ARGUMENTS.extendDarkTheme);
@@ -32,6 +33,8 @@ export function darkThemeMessage() {
       applyDarkTheme(messageElement, {
         backgroundColor: "rgb(19, 19, 19)",
         ignore: [
+          // Gmail's rich-text editor, themed by stylesheet in editor.css instead
+          '[contenteditable="true"]',
           // Conversation labels inside message
           ".edeTZ",
           // Reply container
@@ -53,7 +56,7 @@ export function darkThemeMessage() {
           "schedule_send_googblue_20dp.png",
           "label_important_fill_googyellow500_20dp.png",
         ],
-        css: messageCss,
+        css: `${messageCss}\n${editorCss}`,
       }),
     );
   }


### PR DESCRIPTION
## Summary
With **Extend dark theme** on, the dark theme engine was writing its inline color overrides into Gmail's compose editor, and Gmail serializes that editor as the draft and the sent message, so every mail went out with near-white text baked in. The editor is now opted out of the engine and themed by an injected CSS filter that never leaves Meru's page. Verified end to end in the running app over a CDP tunnel: the editor carries no engine styles, the mail Gmail sends is byte-for-byte what was typed, and the filtered editor renders plain, colored, black-styled, linked and quoted text readably.

## Problem
A user reported that sent emails, viewed on a white background, have almost unreadable light gray text once the experimental dark theme is on. The engine in `packages/dark-theme` darkens by writing `style="color: … !important"` and a `data-dark-theme` attribute on every element in a themed subtree, and its observer keeps doing so for nodes added later. Both Gmail call sites, the compose dialog in `compose.ts` and the message pane with its inline reply in `message.ts`, include Gmail's rich-text editor (`div[contenteditable="true"]`) in that subtree: the typed lines, the inserted signature, quoted text. Gmail sends and autosaves the editor's innerHTML, so Gmail's default `#222` text became `rgb(232, 230, 227)` in the mail itself, and the signature's `#000` and link colors went the same way. Dark Reader, which the engine derives from, carries the same open bug (darkreader/darkreader#13892).

## Solution
- Both call sites add `'[contenteditable="true"]'` to `ignore`, which the engine matches with `closest`, so nothing inside the editor is ever written inline. Every inline-style and attribute write in the engine is gated by that check, so no engine change was needed.
- A new `editor.css`, appended to both call sites' `css`, themes the editor with `filter: invert(1) hue-rotate(180deg)` scoped to `[data-dark-theme-root]`, with the editor background set to a light gray that inverts to the engine's `rgb(19, 19, 19)`, and images filtered a second time so they keep their true colors. Inverting flips lightness and the hue rotation restores hue, so black text and a black signature read light, a color picked in the toolbar keeps its hue and is still sent as picked, and the selection highlight turns dark.
- A first version flattened every descendant to the editor's text color by stylesheet, which kept a black signature readable but hid the color a user picks in the toolbar while editing, so it was replaced. Stripping the overrides at send time was rejected because drafts autosave the same HTML. Routing the editor's overrides into the injected stylesheet keyed by a per-element attribute would give the engine's own color math but needs an engine feature and leaves a data attribute in the sent HTML: probed in the app, Gmail serializes `data-*`, `id` and `class` attributes into the draft untouched, so there is no DOM key that stays out of the mail. The filter's known limit is accepted instead: the CSS hue rotation is a luminance-preserving approximation, so saturated blue and green text look pale while editing, while black, red and grays render right and the mail carries the picked color.

## Try it
Turn on Settings → Gmail → Extend dark theme with Gmail's theme set to dark, compose a mail with a signature and send it to yourself, then open it in Gmail on the web in the light theme. The text and signature should be the normal dark colors, and the compose editor in Meru should render light on dark with toolbar colors showing as picked.

## Not verified
- Verified in the running app over a CDP tunnel, with Gmail in its dark theme and Extend dark theme on: the editor and everything inside it carry no `data-dark-theme` attribute or inline `!important` style; Gmail's serialized draft body and the raw source of the sent message, read through "Show original", contain only the typed markup, with zero engine attributes or declarations; with the feature off the received message renders in its plain colors; and the filtered editor renders plain text light, a picked red as red, a `color:#000` span light, links light blue and a quoted border dark. A third commit came out of that pass: the editor inherited the engine's light text color, which the filter turned dark, so it now gets Gmail's own dark text to invert.
- Text copied out of a dark-themed message pane carries the engine's inline colors on the clipboard, so pasting it into compose still bakes them into the mail. That path is untouched here.
- `test:e2e` and `test:perf` were not run.

