### PR TITLE
Add a --debug-port option to the dev script

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -19,6 +19,11 @@ const args = parseArgs({
       type: "boolean",
       short: "d",
     },
+    // Opens Chromium's remote debugging port on the development app, so that a
+    // CDP client such as Playwright can drive it: `bun run dev --debug-port 9222`.
+    "debug-port": {
+      type: "string",
+    },
   },
   strict: true,
   allowPositionals: true,
@@ -285,18 +290,28 @@ if (args.values.dev) {
   let isRestartingElectron = false;
 
   const startElectron = () => {
-    electron = spawn(["electron", ".", ...(args.values.devtools ? ["--devtools"] : [])], {
-      env: { ...process.env, MERU_RENDERER_URL: rendererUrl },
-      onExit: async () => {
-        if (isRestartingElectron) {
-          isRestartingElectron = false;
-        } else {
-          await electron.exited;
+    electron = spawn(
+      [
+        "electron",
+        ".",
+        ...(args.values.devtools ? ["--devtools"] : []),
+        ...(args.values["debug-port"]
+          ? [`--remote-debugging-port=${args.values["debug-port"]}`]
+          : []),
+      ],
+      {
+        env: { ...process.env, MERU_RENDERER_URL: rendererUrl },
+        onExit: async () => {
+          if (isRestartingElectron) {
+            isRestartingElectron = false;
+          } else {
+            await electron.exited;
 
-          process.exit(0);
-        }
+            process.exit(0);
+          }
+        },
       },
-    });
+    );
   };
 
   const stopElectron = () => {


### PR DESCRIPTION
## Summary
`bun run dev --debug-port 9222` now starts the development app with Chromium's remote debugging port open, so a CDP client such as Playwright can drive it from another machine over a tunnel. Not run with a real Electron here; only the argument parsing was exercised.

## Problem
The dev script spawns `electron .` itself, so there was no way to pass a Chromium switch through, and the only route to a debugging port was running Electron by hand after a dev build.

## Solution
- Adds a `--debug-port` string option to the script's `parseArgs` and forwards it as `--remote-debugging-port=<port>` in the spawn arguments, next to the existing `--devtools`.

## Try it
```sh
bun run dev --debug-port 9222
curl http://localhost:9222/json/version
```
The second command should print the Chromium and Electron versions.

## Not verified
- Not run against Electron in this sandbox, which has no display. `bun run scripts/build.ts --dev --debug-port` fails as expected with "argument missing", and format and lint pass.