### PR TITLE
Let users add sites to an extension's content-script clamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is the draft of the next release, written one line at a time as work l
 
 ## [Unreleased]
 
+### Added
+
+- Settings → Extensions lets you add sites where 1Password runs, such as your company's single sign-on provider, beside Google's sign-in pages
+
 ### Changed
 
 - The 1Password extension's description in Settings → Extensions now says it needs the 1Password desktop app, and is no longer cut off after two lines

--- a/packages/app/extensions.ts
+++ b/packages/app/extensions.ts
@@ -12,7 +12,11 @@ import {
   registerExtensionBridgeScheme,
   uninstallExtension,
 } from "@meru/electron-extensions";
-import { curatedExtensions, isCuratedExtensionId } from "@meru/shared/extensions";
+import {
+  curatedExtensions,
+  hostnameToMatchPattern,
+  isCuratedExtensionId,
+} from "@meru/shared/extensions";
 import { ms } from "@meru/shared/ms";
 import type { ExtensionUpdateResult, InstalledExtensionState } from "@meru/shared/types";
 import { app, session, type WebContents } from "electron";
@@ -144,13 +148,27 @@ async function getExtensionDirs() {
 }
 
 /**
- * Where a curated extension's content scripts may run, from the catalog entry it
- * is offered under. An extension the catalog says nothing about — a development
- * folder — runs its content scripts as its author declared them.
+ * Where a curated extension's content scripts may run: the catalog entry it is
+ * offered under, plus the sites the user added for it. An extension the catalog
+ * says nothing about — a development folder — runs its content scripts as its
+ * author declared them, and additional sites never start clamping one.
+ *
+ * Read per call rather than through a listener, because the derive reads the
+ * applied list while a session is set up and stamps it into the copy, so a
+ * change lands on the next launch like every other extension change.
  */
 function getContentScriptMatches(extensionId: string) {
-  return curatedExtensions.find((curatedExtension) => curatedExtension.id === extensionId)
-    ?.contentScriptMatches;
+  const contentScriptMatches = curatedExtensions.find(
+    (curatedExtension) => curatedExtension.id === extensionId,
+  )?.contentScriptMatches;
+
+  if (!contentScriptMatches) {
+    return;
+  }
+
+  const additionalSites = config.get("extensions.additionalSites")[extensionId] ?? [];
+
+  return [...contentScriptMatches, ...additionalSites.map(hostnameToMatchPattern)];
 }
 
 /**

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -1,9 +1,11 @@
 import {
   type CuratedExtension,
   curatedExtensions,
+  normalizeExtensionSiteHostname,
   ONEPASSWORD_EXTENSION_ID,
 } from "@meru/shared/extensions";
 import { ipc } from "@meru/shared/renderer/ipc";
+import type { Config } from "@meru/shared/types";
 import { Alert, AlertDescription, AlertTitle } from "@meru/ui/components/alert";
 import { Badge } from "@meru/ui/components/badge";
 import { Button } from "@meru/ui/components/button";
@@ -17,17 +19,22 @@ import {
   DialogTitle,
 } from "@meru/ui/components/dialog";
 import {
+  Field,
   FieldDescription,
+  FieldError,
   FieldGroup,
+  FieldLabel,
   FieldLegend,
   FieldSeparator,
   FieldSet,
 } from "@meru/ui/components/field";
+import { Input } from "@meru/ui/components/input";
 import {
   Item,
   ItemActions,
   ItemContent,
   ItemDescription,
+  ItemFooter,
   ItemGroup,
   ItemTitle,
 } from "@meru/ui/components/item";
@@ -36,7 +43,7 @@ import { Switch } from "@meru/ui/components/switch";
 import { cn } from "@meru/ui/lib/utils";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { ExternalLinkIcon, FlaskConicalIcon, KeyRoundIcon } from "lucide-react";
-import { type ComponentProps, useState } from "react";
+import { type ComponentProps, useId, useState } from "react";
 import { toast } from "sonner";
 import { ConfigSwitchField } from "@/components/config-switch-field";
 import { CopyButton } from "@/components/copy-button";
@@ -45,7 +52,7 @@ import { LicenseKeyRequiredFieldBadge } from "@/components/license-key-required-
 import { MaturityFieldBadge } from "@/components/maturity-field-badge";
 import { Settings, SettingsContent, SettingsHeader, SettingsTitle } from "@/components/settings";
 import { useIsLicenseKeyValid } from "@/lib/hooks";
-import { queryClient, useConfig } from "@/lib/react-query";
+import { queryClient, useConfig, useConfigMutation } from "@/lib/react-query";
 import { restartRequiredToast } from "@/lib/toast";
 import { platform } from "@/lib/utils";
 
@@ -169,16 +176,118 @@ function ExtensionErrorDialog({
   );
 }
 
+/**
+ * The sites the user added on top of the ones the extension is offered for,
+ * which only exist for an extension the catalog clamps to begin with.
+ */
+function ExtensionAdditionalSites({
+  extension,
+  additionalSites,
+}: {
+  extension: CuratedExtension;
+  additionalSites: Config["extensions.additionalSites"];
+}) {
+  const siteInputId = useId();
+
+  const [siteInput, setSiteInput] = useState("");
+
+  const [siteInputError, setSiteInputError] = useState<string | null>(null);
+
+  const configMutation = useConfigMutation({ onSuccess: restartRequiredToast });
+
+  const sites = additionalSites[extension.id] ?? [];
+
+  const saveSites = (updatedSites: string[]) => {
+    configMutation.mutate({
+      "extensions.additionalSites": { ...additionalSites, [extension.id]: updatedSites },
+    });
+  };
+
+  const addSite = () => {
+    const hostname = normalizeExtensionSiteHostname(siteInput);
+
+    if (!hostname) {
+      setSiteInputError("Enter a website address, like sso.example.com.");
+
+      return;
+    }
+
+    setSiteInput("");
+
+    setSiteInputError(null);
+
+    if (sites.includes(hostname)) {
+      return;
+    }
+
+    saveSites([...sites, hostname]);
+  };
+
+  return (
+    <Field>
+      <FieldLabel htmlFor={siteInputId}>Additional sites</FieldLabel>
+      <FieldDescription>
+        {extension.name} runs on Google's sign-in pages only. Add a site to run it there too, such
+        as your company's single sign-on provider. Sites apply after a restart.
+      </FieldDescription>
+      {sites.length > 0 && (
+        <div className="space-y-2">
+          {sites.map((site) => (
+            <div className="flex items-center gap-2 text-sm" key={site}>
+              <div className="flex-1">{site}</div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  saveSites(sites.filter((keptSite) => keptSite !== site));
+                }}
+                aria-label={`Remove ${site}`}
+              >
+                Remove
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+      <form
+        className="flex gap-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+
+          addSite();
+        }}
+      >
+        <Input
+          id={siteInputId}
+          value={siteInput}
+          onChange={(event) => {
+            setSiteInput(event.target.value);
+
+            setSiteInputError(null);
+          }}
+          placeholder="sso.example.com"
+        />
+        <Button type="submit" variant="outline">
+          Add
+        </Button>
+      </form>
+      {siteInputError && <FieldError>{siteInputError}</FieldError>}
+    </Field>
+  );
+}
+
 function ExtensionItem({
   extension,
   extensionsEnabled,
   installed,
   installedVersion,
+  additionalSites,
 }: {
   extension: CuratedExtension;
   extensionsEnabled: boolean;
   installed: boolean;
   installedVersion: string | undefined;
+  additionalSites: Config["extensions.additionalSites"];
 }) {
   const isLicenseKeyValid = useIsLicenseKeyValid();
 
@@ -274,6 +383,13 @@ function ExtensionItem({
             aria-label={`Install ${extension.name}`}
           />
         </ItemActions>
+        {/* Same gate as the setup button: nothing to scope until the extension
+            is installed and loaded, which needs Meru Pro and the master switch */}
+        {extension.contentScriptMatches && extensionsEnabled && isLicenseKeyValid && installed && (
+          <ItemFooter className="mt-1 flex-col items-stretch">
+            <ExtensionAdditionalSites extension={extension} additionalSites={additionalSites} />
+          </ItemFooter>
+        )}
       </Item>
       {isOnePassword && (
         <OnePasswordSetupDialog open={isSetupDialogOpen} onOpenChange={setIsSetupDialogOpen} />
@@ -491,6 +607,7 @@ export function ExtensionsSettings() {
                     installedVersion={
                       installedExtensions?.find(({ id }) => id === extension.id)?.version
                     }
+                    additionalSites={config["extensions.additionalSites"]}
                   />
                 ))}
             </ItemGroup>

--- a/packages/renderer/routes/settings/extensions.tsx
+++ b/packages/renderer/routes/settings/extensions.tsx
@@ -34,7 +34,6 @@ import {
   ItemActions,
   ItemContent,
   ItemDescription,
-  ItemFooter,
   ItemGroup,
   ItemTitle,
 } from "@meru/ui/components/item";
@@ -180,12 +179,16 @@ function ExtensionErrorDialog({
  * The sites the user added on top of the ones the extension is offered for,
  * which only exist for an extension the catalog clamps to begin with.
  */
-function ExtensionAdditionalSites({
+function ExtensionSitesDialog({
   extension,
   additionalSites,
+  open,
+  onOpenChange,
 }: {
   extension: CuratedExtension;
   additionalSites: Config["extensions.additionalSites"];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }) {
   const siteInputId = useId();
 
@@ -224,55 +227,67 @@ function ExtensionAdditionalSites({
   };
 
   return (
-    <Field>
-      <FieldLabel htmlFor={siteInputId}>Additional sites</FieldLabel>
-      <FieldDescription>
-        {extension.name} runs on Google's sign-in pages only. Add a site to run it there too, such
-        as your company's single sign-on provider. Sites apply after a restart.
-      </FieldDescription>
-      {sites.length > 0 && (
-        <div className="space-y-2">
-          {sites.map((site) => (
-            <div className="flex items-center gap-2 text-sm" key={site}>
-              <div className="flex-1">{site}</div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  saveSites(sites.filter((keptSite) => keptSite !== site));
-                }}
-                aria-label={`Remove ${site}`}
-              >
-                Remove
-              </Button>
-            </div>
-          ))}
-        </div>
-      )}
-      <form
-        className="flex gap-2"
-        onSubmit={(event) => {
-          event.preventDefault();
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Sites for {extension.name}</DialogTitle>
+        </DialogHeader>
+        <DialogDescription>
+          {extension.name} runs on Google's sign-in pages only. Add a site to run it there too, such
+          as your company's single sign-on provider. Sites apply after a restart.
+        </DialogDescription>
+        {sites.length > 0 && (
+          <div className="space-y-2">
+            {sites.map((site) => (
+              <div className="flex items-center gap-2 text-sm" key={site}>
+                <div className="flex-1">{site}</div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    saveSites(sites.filter((keptSite) => keptSite !== site));
+                  }}
+                  aria-label={`Remove ${site}`}
+                >
+                  Remove
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+        <Field>
+          <FieldLabel htmlFor={siteInputId} className="sr-only">
+            Site to add
+          </FieldLabel>
+          <form
+            className="flex gap-2"
+            onSubmit={(event) => {
+              event.preventDefault();
 
-          addSite();
-        }}
-      >
-        <Input
-          id={siteInputId}
-          value={siteInput}
-          onChange={(event) => {
-            setSiteInput(event.target.value);
+              addSite();
+            }}
+          >
+            <Input
+              id={siteInputId}
+              value={siteInput}
+              onChange={(event) => {
+                setSiteInput(event.target.value);
 
-            setSiteInputError(null);
-          }}
-          placeholder="sso.example.com"
-        />
-        <Button type="submit" variant="outline">
-          Add
-        </Button>
-      </form>
-      {siteInputError && <FieldError>{siteInputError}</FieldError>}
-    </Field>
+                setSiteInputError(null);
+              }}
+              placeholder="sso.example.com"
+            />
+            <Button type="submit" variant="outline">
+              Add
+            </Button>
+          </form>
+          {siteInputError && <FieldError>{siteInputError}</FieldError>}
+        </Field>
+        <DialogFooter>
+          <DialogClose render={<Button>Done</Button>} />
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -300,6 +315,12 @@ function ExtensionItem({
   const isOnePassword = extension.id === ONEPASSWORD_EXTENSION_ID;
 
   const [isSetupDialogOpen, setIsSetupDialogOpen] = useState(false);
+
+  const [isSitesDialogOpen, setIsSitesDialogOpen] = useState(false);
+
+  // Both dialogs act on an extension that is installed and loaded, which needs
+  // Meru Pro and the master switch
+  const dialogsLocked = !extensionsEnabled || !isLicenseKeyValid || !installed;
 
   const [extensionError, setExtensionError] = useState<ExtensionError | null>(null);
 
@@ -354,22 +375,39 @@ function ExtensionItem({
             <LicenseKeyRequiredFieldBadge />
           </ItemTitle>
           <ItemDescription>{extension.description}</ItemDescription>
-          {isOnePassword && (
-            <Button
-              variant="outline"
-              size="sm"
-              className="mt-1 self-start"
-              // The dialog explains how to pair the extension with 1Password's
-              // desktop app, which there is nothing to pair until it is
-              // installed and loaded. Installing needs Meru Pro and loading
-              // needs the master switch, so this locks with both.
-              disabled={!extensionsEnabled || !isLicenseKeyValid || !installed}
-              onClick={() => {
-                setIsSetupDialogOpen(true);
-              }}
-            >
-              Set up desktop app
-            </Button>
+          {(isOnePassword || extension.contentScriptMatches) && (
+            <div className="mt-1 flex flex-wrap gap-2 self-start">
+              {isOnePassword && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  // The dialog explains how to pair the extension with
+                  // 1Password's desktop app, which there is nothing to pair
+                  // until it is installed and loaded. Installing needs Meru Pro
+                  // and loading needs the master switch, so this locks with both.
+                  disabled={dialogsLocked}
+                  onClick={() => {
+                    setIsSetupDialogOpen(true);
+                  }}
+                >
+                  Set up desktop app
+                </Button>
+              )}
+              {extension.contentScriptMatches && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  // Locked with the setup button: nothing to scope until the
+                  // extension is installed and loaded
+                  disabled={dialogsLocked}
+                  onClick={() => {
+                    setIsSitesDialogOpen(true);
+                  }}
+                >
+                  Add sites
+                </Button>
+              )}
+            </div>
           )}
         </ItemContent>
         <ItemActions>
@@ -383,16 +421,17 @@ function ExtensionItem({
             aria-label={`Install ${extension.name}`}
           />
         </ItemActions>
-        {/* Same gate as the setup button: nothing to scope until the extension
-            is installed and loaded, which needs Meru Pro and the master switch */}
-        {extension.contentScriptMatches && extensionsEnabled && isLicenseKeyValid && installed && (
-          <ItemFooter className="mt-1 flex-col items-stretch">
-            <ExtensionAdditionalSites extension={extension} additionalSites={additionalSites} />
-          </ItemFooter>
-        )}
       </Item>
       {isOnePassword && (
         <OnePasswordSetupDialog open={isSetupDialogOpen} onOpenChange={setIsSetupDialogOpen} />
+      )}
+      {extension.contentScriptMatches && (
+        <ExtensionSitesDialog
+          extension={extension}
+          additionalSites={additionalSites}
+          open={isSitesDialogOpen}
+          onOpenChange={setIsSitesDialogOpen}
+        />
       )}
       <ExtensionErrorDialog
         error={extensionError}

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -142,5 +142,6 @@ export function createDefaultConfig({
     "verticalTabs.showAppLinksBadge": true,
     "extensions.enabled": false,
     "extensions.installed": [],
+    "extensions.additionalSites": {},
   };
 }

--- a/packages/shared/extensions.test.ts
+++ b/packages/shared/extensions.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { curatedExtensions } from "./extensions";
+import {
+  curatedExtensions,
+  hostnameToMatchPattern,
+  normalizeExtensionSiteHostname,
+} from "./extensions";
 
 /**
  * Hosts the extensions have to keep reaching, one per shape the catalog could
@@ -121,5 +125,77 @@ describe("curated extension telemetry URLs", () => {
         expect(parseTelemetryUrl(telemetryUrl)).not.toBe(productHost);
       }
     }
+  });
+});
+
+describe("hostnameToMatchPattern", () => {
+  test("covers every path of the site over HTTPS", () => {
+    expect(hostnameToMatchPattern("sso.okta.com")).toBe("https://sso.okta.com/*");
+  });
+});
+
+describe("normalizeExtensionSiteHostname", () => {
+  test("takes a bare hostname", () => {
+    expect(normalizeExtensionSiteHostname("sso.okta.com")).toBe("sso.okta.com");
+    expect(normalizeExtensionSiteHostname("login.microsoftonline.com")).toBe(
+      "login.microsoftonline.com",
+    );
+    expect(normalizeExtensionSiteHostname("my-company.onelogin.com")).toBe(
+      "my-company.onelogin.com",
+    );
+  });
+
+  test("lowercases and trims what it takes", () => {
+    expect(normalizeExtensionSiteHostname("  SSO.Okta.com ")).toBe("sso.okta.com");
+  });
+
+  /*
+   * The address bar of the sign-in page is what a user has at hand, so a pasted
+   * URL keeps only the host it names.
+   */
+  test("takes the hostname out of a pasted URL", () => {
+    expect(normalizeExtensionSiteHostname("https://sso.okta.com")).toBe("sso.okta.com");
+    expect(normalizeExtensionSiteHostname("https://sso.okta.com/app/x?y=1#z")).toBe("sso.okta.com");
+    expect(normalizeExtensionSiteHostname("sso.okta.com/app/x")).toBe("sso.okta.com");
+  });
+
+  test("refuses an empty entry", () => {
+    expect(normalizeExtensionSiteHostname("")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname("   ")).toBeUndefined();
+  });
+
+  test("refuses a hostname without a dot", () => {
+    expect(normalizeExtensionSiteHostname("localhost")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname("okta")).toBeUndefined();
+  });
+
+  /*
+   * A pattern's host is the whole of what the clamp grants, so anything the
+   * host part cannot carry is refused rather than dropped: a port, credentials
+   * and a scheme the clamp doesn't grant all change what was asked for.
+   */
+  test("refuses what a hostname cannot carry", () => {
+    expect(normalizeExtensionSiteHostname("sso.okta.com:8443")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname("user@sso.okta.com")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname("user:secret@sso.okta.com")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname("http://sso.okta.com")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname("sso okta.com")).toBeUndefined();
+  });
+
+  /*
+   * A user-typed pattern is never written into a manifest: Chromium refuses the
+   * whole manifest over one pattern it can't parse, which would take the
+   * extension down rather than the entry.
+   */
+  test("refuses a match pattern of its own", () => {
+    expect(normalizeExtensionSiteHostname("*.okta.com")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname("https://*.okta.com/*")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname("<all_urls>")).toBeUndefined();
+  });
+
+  test("refuses empty labels", () => {
+    expect(normalizeExtensionSiteHostname("sso..okta.com")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname(".okta.com")).toBeUndefined();
+    expect(normalizeExtensionSiteHostname("okta.com.")).toBeUndefined();
   });
 });

--- a/packages/shared/extensions.ts
+++ b/packages/shared/extensions.ts
@@ -10,7 +10,8 @@ export type CuratedExtension = {
   /**
    * Match patterns the derive writes over every `content_scripts[].matches` of
    * the extension, so its content scripts only reach the sites it is offered
-   * for. Absent leaves the manifest's own patterns in place.
+   * for. Absent leaves the manifest's own patterns in place, and the sites the
+   * user adds in settings never start a clamp — they are appended to this one.
    */
   contentScriptMatches?: string[];
   /**
@@ -78,7 +79,10 @@ export const curatedExtensions: CuratedExtension[] = [
     // Sign-in runs on accounts.google.com, and account settings — creating a
     // passkey, changing a password — on myaccount.google.com. Both hosts, not
     // the settings paths alone: Google reshuffles those and redirects between
-    // them, and a path that falls outside the clamp offers nothing, silently
+    // them, and a path that falls outside the clamp offers nothing, silently.
+    // A Workspace account behind third-party single sign-on redirects off both
+    // hosts mid-sign-in, which is what the sites the user adds in settings are
+    // for; the app appends them here
     contentScriptMatches: ["https://accounts.google.com/*", "https://myaccount.google.com/*"],
     telemetryUrls: [
       // Observability: every console line the worker writes, forwarded as a
@@ -115,4 +119,51 @@ export const curatedExtensions: CuratedExtension[] = [
 
 export function isCuratedExtensionId(extensionId: string) {
   return curatedExtensions.some((curatedExtension) => curatedExtension.id === extensionId);
+}
+
+/** The pattern a site the user added stands for: every path of it over HTTPS. */
+export function hostnameToMatchPattern(hostname: string) {
+  return `https://${hostname}/*`;
+}
+
+const SCHEME = /^[a-z][a-z0-9+.-]*:\/\//;
+
+const HOSTNAME_LABEL = /^[a-z0-9-]+$/;
+
+/**
+ * The hostname a site the user typed holds, lowercased, or `undefined` when what
+ * they typed carries more than a hostname can: a port, credentials, a wildcard,
+ * a scheme other than HTTPS. A whole URL is taken as well as a bare hostname,
+ * since the address of the sign-in page is what a user has at hand.
+ *
+ * The result reaches a manifest inside a match pattern, and Chromium refuses an
+ * entire manifest over one pattern it can't parse, so only a hostname `URL`
+ * itself produced ever gets stored.
+ */
+export function normalizeExtensionSiteHostname(site: string) {
+  const input = site.trim().toLowerCase();
+
+  if (!input) {
+    return;
+  }
+
+  let url: URL;
+
+  try {
+    url = new URL(SCHEME.test(input) ? input : `https://${input}`);
+  } catch {
+    return;
+  }
+
+  if (url.protocol !== "https:" || url.port || url.username || url.password) {
+    return;
+  }
+
+  const labels = url.hostname.split(".");
+
+  if (labels.length < 2 || !labels.every((label) => HOSTNAME_LABEL.test(label))) {
+    return;
+  }
+
+  return url.hostname;
 }

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -183,6 +183,12 @@ export type Config = {
   "verticalTabs.showAppLinksBadge": boolean;
   "extensions.enabled": boolean;
   "extensions.installed": string[];
+  /**
+   * Hostnames the user added to a curated extension's content-script clamp,
+   * keyed by extension id. They survive an uninstall, so a reinstall keeps
+   * them.
+   */
+  "extensions.additionalSites": Record<string, string[]>;
 };
 
 export type IpcMainEvents =


### PR DESCRIPTION
## Summary

- Adds `extensions.additionalSites`, a per-extension list of hostnames the user manages in Settings → Extensions, appended to the catalog's content-script clamp as `https://<host>/*`. This is the escape hatch for a Workspace account behind third-party SSO, where 1Password redirected off `accounts.google.com` mid-sign-in and could not fill.
- Only hostnames are stored: `normalizeExtensionSiteHostname` reduces a pasted URL to its host and refuses a port, credentials, a wildcard or a non-HTTPS scheme, since one unparseable pattern makes Chromium reject the whole manifest. An extension the catalog does not clamp stays unclamped.
- The applied list is part of the derive stamp, so a change lands on the next launch and the UI raises the restart toast. The field shows under the same gate as the 1Password setup button: master switch on, Pro, installed.
- Adapted from the parked PR #852 (commit b4e59cf), which Tim has now decided to ship. Docs in the private repo are updated alongside.

## Test plan

- [x] `bun run fmt:check`, `bun run lint`, `bun run types`, `bun test` (1027 pass)
- [ ] With 1Password installed and Pro: add a site in Settings → Extensions, restart, confirm the derived manifest's `content_scripts[].matches` includes it and 1Password fills on that host
- [ ] Remove the site, restart, confirm it is gone from the derived manifest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Settings → Extensions option to add websites where supported extensions can run.
  - Users can configure sites such as company single sign-on providers alongside Google sign-in pages.
  - Added an “Add sites” dialog with hostname and URL validation.
  - Additional site settings are saved across app restarts and applied to supported extension content scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->