### PR TITLE
Upgrade Electron to 43.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This file is the draft of the next release, written one line at a time as work l
 - The 1Password extension's description in Settings → Extensions now says it needs the 1Password desktop app, and is no longer cut off after two lines
 - The Show extensions button setting and the titlebar button it showed are gone: the 1Password popup that button opened isn't fully supported in Meru, and 1Password is meant to be used on the Google sign-in pages, through its inline menu and the prompts it shows there
 - On macOS 12 and earlier, this is the last version of Meru: it stops checking for updates there and gets no further fixes, security fixes included, so continued use on those Macs is at your own risk
+- Upgraded Electron from 43.5.1 to 43.7.0, picking up the matching Chromium security and performance fixes
 
 ### Fixed
 

--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dayjs": "^1.11.13",
-        "electron": "^43.5.1",
+        "electron": "^43.7.0",
         "electron-builder": "26.15.6",
         "electron-context-menu": "^4.1.0",
         "electron-dl": "^4.0.0",
@@ -892,7 +892,7 @@
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
-    "electron": ["electron@43.5.1", "", { "dependencies": { "@electron-internal/extract-zip": "^1.0.1", "@electron/get": "^5.0.0", "@types/node": "^24.9.0" }, "bin": { "electron": "cli.js", "install-electron": "install.js" } }, "sha512-lRHSwzZimdWWeqcTHFRCpicWwxBE6kotKIyGTusums/jvmVVC27rLPFikUz8LsLwV7gVWlYaiEYQAWzitbN6nA=="],
+    "electron": ["electron@43.7.0", "", { "dependencies": { "@electron-internal/extract-zip": "^1.0.1", "@electron/get": "^5.0.0", "@types/node": "^24.9.0" }, "bin": { "electron": "cli.js", "install-electron": "install.js" } }, "sha512-m98FUehwnoo6q2D9Mr+n602Natb2CRFeKD81GhTdJlKh/Iyud0R1X8hChjpaMBLSsIX9r2ZEFnz0sdIALiO9ZQ=="],
 
     "electron-builder": ["electron-builder@26.15.6", "", { "dependencies": { "app-builder-lib": "26.15.6", "builder-util": "26.15.3", "builder-util-runtime": "9.7.0", "chalk": "^4.1.2", "ci-info": "^4.2.0", "dmg-builder": "26.15.6", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "simple-update-notifier": "2.0.0", "yargs": "^17.6.2" }, "bin": { "electron-builder": "./cli.js", "install-app-deps": "./install-app-deps.js" } }, "sha512-jxlHRjqYrlTgLVo/aoACGpiki3QFYv8s4f2djsqaEbwTBZ9PcTBK03Tj/HMa65kiE0hdZxxbZdmVFo22eou2wA=="],
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.13",
-    "electron": "^43.5.1",
+    "electron": "^43.7.0",
     "electron-builder": "26.15.6",
     "electron-context-menu": "^4.1.0",
     "electron-dl": "^4.0.0",


### PR DESCRIPTION
Moves Electron from 43.5.1 to 43.7.0, across 43.6.0 and 43.7.0. Chromium stays at `150.0.7871.250` with backported ANGLE, Chromium, Skia, V8 and PDFium fixes on top, and Node goes from 24.19.0 to 24.21.0. No breaking changes are declared in either release, so the version bump is the whole diff. Electron 44 is still a change of its own: the macOS 12 gate landed in #1067, but the clipboard migration has not.

## What actually matters

Four fixes land in paths Meru runs and that nothing here could have reached from a test:

- **A crash after a large number of IPC messages from renderers** ([#53420](https://github.com/electron/electron/pull/53420)) — V8 object-template exhaustion. Meru's IPC is per-account and per-view and runs for the life of the app, which is exactly the shape that exhausts a counter that only goes up.
- **A Linux crash when `process.env` is written while another thread reads it, plus a memory leak when a worker thread exits** ([#53510](https://github.com/electron/electron/pull/53510)).
- **A Windows crash when a file dialog is shown for a window that is closing** ([#53584](https://github.com/electron/electron/pull/53584)) — the download save path.
- **An intermittent Windows access violation when an ASAR integrity violation is detected**, now a clean exit code 1 ([#53456](https://github.com/electron/electron/pull/53456)) — the updater path, alongside the `ValidateIntegrityOrDie` fix taken in 43.5.1.

`setDisplayMediaRequestHandler` also stops crashing when the granted frame has been destroyed ([#53671](https://github.com/electron/electron/pull/53671)). The handler in `packages/app/account.ts` opens a picker window and calls back only when the user chooses, so the requesting Meet frame can be long gone by then; such a request now fails with `INVALID_STATE` rather than resolving against a null capturer.

Smaller and user-visible: a renderer crash printing from an iframe ([#53761](https://github.com/electron/electron/pull/53761)), and three DevTools integrations working again — the Security panel's View certificate button, Ctrl+wheel zoom inside DevTools, and shortcuts such as F8 while the inspected page has focus ([#53631](https://github.com/electron/electron/pull/53631)).

## Read against the code, and not reaching it

Each of these was read rather than assumed, since they shipped in a minor with no breaking-change note.

| Change | Why it doesn't reach Meru |
|---|---|
| File System Access permission scoping ([#53694](https://github.com/electron/electron/pull/53694)) | `fileSystem` is not in the request handler's allow list in `account.ts`, so those requests are already denied |
| `getUserMedia` no longer accepting WebContents source ids for `chromeMediaSource: 'desktop'` ([#53707](https://github.com/electron/electron/pull/53707)) | Only screen and window ids are passed, from `desktopCapturer.getSources` |
| `nodeIntegrationInWorker` scoping to frames with Node integration ([#53712](https://github.com/electron/electron/pull/53712)) | Neither that nor `nodeIntegrationInSubFrames` is set |
| `<webview>` `allowpopups` and IPC-validation hardening ([#53726](https://github.com/electron/electron/pull/53726), [#53718](https://github.com/electron/electron/pull/53718)) | No `<webview>` anywhere |
| Same-process `window.open()` contextIsolation crash ([#53540](https://github.com/electron/electron/pull/53540)), `menu.popup` offscreen crash ([#53432](https://github.com/electron/electron/pull/53432)) | Nothing sets `contextIsolation` or uses offscreen rendering |
| `webContents` `console-message` listeners throwing after destroy ([#53496](https://github.com/electron/electron/pull/53496)) | The only `console-message` listener is on `session.serviceWorkers` in `electron-extensions/extensions.ts`, a different emitter |
| `node::ObjectWrap` aborting under Node 24.19 and later ([#53393](https://github.com/electron/electron/pull/53393)) | No runtime `dependencies`, so no native addons |
| Trailing `frame` argument on `will-download` and `preconnect` ([#53704](https://github.com/electron/electron/pull/53704)) | Additive, and Meru registers neither |

One change does reach the code. `setPermissionCheckHandler` now receives the requesting frame's origin for `hid` and `usb` checks from a subframe ([#53689](https://github.com/electron/electron/pull/53689)), which makes the extension carve-out work as its comment claims: an extension page in a subframe asking for `hid` was checked against the top-level origin, missed `isLoadedExtensionUrl` and fell through to the handler's `return true`; it is now checked against its own origin and denied. A tightening, in the direction the code already intended.

## Checks

`fmt:check`, `lint` and `types` clean. 1027 unit tests pass, 1 skipped. The end-to-end suite is 45 passed, 4 skipped under `xvfb`, against a packaged build. The perf project's memory test passes: main JS heap 7595 KB of the 8000 KB ceiling, cold-launch working set 764.1 MB, no bundle moved.

**The perf project's bundle test fails, and it fails on `main` too.** `tests/bundle-budget.json` has a budget for `renderer/assets/find-in-page.js`, which the build no longer produces, and no budget for `renderer/assets/titlebar.js`, which it now does — a chunk rename from the titlebar work in #1068 and #1069. Electron is `external` in `scripts/build.ts`, so it never enters a bundle, and this branch touches no renderer source. Left alone here because moving that file is its own decision; it wants a follow-up that re-keys the entry.

## Not verified

The three Gmail DOM-coupled features — undo-send toast, promotional banner hiding, verification-code extractor — need a real Gmail session, though Chromium's version is unchanged across this range so the usual DOM risk of an upgrade does not apply. macOS and Windows were not built, so the VoiceOver Braille fix, the Windows file-dialog fix and the ASAR integrity fix are all unexercised here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Incorporated the latest Chromium security and performance fixes for improved application stability and protection.

- **Chores**
  - Updated the application runtime to a newer release, helping ensure continued compatibility and a smoother desktop experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->