### PR TITLE
Let the Gmail tab's unread badge be hidden always, not only while active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file is the draft of the next release, written one line at a time as work l
 ### Changed
 
 - The 1Password extension's description in Settings → Extensions now says it needs the 1Password desktop app, and is no longer cut off after two lines
+- Hide Gmail unread badge when active in Settings → Workspace apps is now Show Gmail unread badge, with a Never choice that hides the unread count on the Gmail tab altogether
 - The Show extensions button setting and the titlebar button it showed are gone: the 1Password popup that button opened isn't fully supported in Meru, and 1Password is meant to be used on the Google sign-in pages, through its inline menu and the prompts it shows there
 - On macOS 12 and earlier, this is the last version of Meru: it stops checking for updates there and gets no further fixes, security fixes included, so continued use on those Macs is at your own risk
 

--- a/packages/app/config.ts
+++ b/packages/app/config.ts
@@ -440,6 +440,20 @@ export const config = new Store<Config>({
         // @ts-expect-error
         store.delete("extensions.showTitlebarButton");
       }
+
+      // @ts-expect-error: `verticalTabs.hideUnreadBadgeWhenActive` is now the
+      // `verticalTabs.gmailUnreadBadge` union
+      const hideUnreadBadgeWhenActive = store.get("verticalTabs.hideUnreadBadgeWhenActive");
+
+      if (typeof hideUnreadBadgeWhenActive === "boolean") {
+        store.set(
+          "verticalTabs.gmailUnreadBadge",
+          hideUnreadBadgeWhenActive ? "whenInactive" : "always",
+        );
+
+        // @ts-expect-error
+        store.delete("verticalTabs.hideUnreadBadgeWhenActive");
+      }
     },
   },
 });

--- a/packages/renderer/components/vertical-tabs.tsx
+++ b/packages/renderer/components/vertical-tabs.tsx
@@ -4,7 +4,12 @@ import { useSortable } from "@dnd-kit/react/sortable";
 import { VERTICAL_TABS_WIDE_WIDTH } from "@meru/shared/constants";
 import { ipc } from "@meru/shared/renderer/ipc";
 import type { AccountConfig } from "@meru/shared/schemas";
-import { GMAIL_TAB_ID, getTabSection, type TabState } from "@meru/shared/tabs";
+import {
+  GMAIL_TAB_ID,
+  getTabSection,
+  showsGmailUnreadCount,
+  type TabState,
+} from "@meru/shared/tabs";
 import { workspaceApps } from "@meru/shared/workspace-apps";
 import { Button } from "@meru/ui/components/button";
 import { ScrollArea } from "@meru/ui/components/scroll-area";
@@ -441,15 +446,16 @@ export function VerticalTabs() {
   const showsWidthToggle = config?.["verticalTabs.showWidthToggle"] ?? true;
 
   // Gmail is already in front while its tab is active, so the count can be
-  // taken as read there. Attention is still flagged either way.
-  const hidesUnreadCount =
-    config?.["verticalTabs.hideUnreadBadgeWhenActive"] &&
-    selectedAccountTabs.some((tab) => tab.id === GMAIL_TAB_ID && tab.active);
+  // taken as read there. Attention is still flagged in every mode.
+  const showsUnreadCount = showsGmailUnreadCount(
+    config?.["verticalTabs.gmailUnreadBadge"] ?? "always",
+    selectedAccountTabs.some((tab) => tab.id === GMAIL_TAB_ID && tab.active),
+  );
 
   const gmailTabStatus = {
     attentionRequired: selectedAccount.gmail.attentionRequired,
     unreadCount:
-      config?.["accounts.unreadBadge"] && !hidesUnreadCount
+      config?.["accounts.unreadBadge"] && showsUnreadCount
         ? selectedAccount.gmail.unreadCount
         : null,
   };

--- a/packages/renderer/routes/settings/workspace-apps.tsx
+++ b/packages/renderer/routes/settings/workspace-apps.tsx
@@ -1,7 +1,7 @@
 import { move } from "@dnd-kit/helpers";
 import { DragDropProvider } from "@dnd-kit/react";
 import { useSortable } from "@dnd-kit/react/sortable";
-import { GMAIL_TAB_ID, verticalTabsWidths } from "@meru/shared/tabs";
+import { GMAIL_TAB_ID, verticalTabsGmailUnreadBadges, verticalTabsWidths } from "@meru/shared/tabs";
 import {
   DEV_WORKSPACE_APPS_HIBERNATION_TIMEOUT,
   launcherAndBookmarksPlacements,
@@ -257,11 +257,15 @@ export function WorkspaceAppsSettings() {
                   configKey="verticalTabs.showWidthToggle"
                   licenseKeyRequired
                 />
-                <ConfigSwitchField
-                  label="Hide Gmail unread badge when active"
-                  description="Hide the unread badge on the Gmail tab while it is the active tab, because the inbox is already in front. Accounts that need attention are still flagged."
-                  configKey="verticalTabs.hideUnreadBadgeWhenActive"
+                <ConfigSelectField
+                  label="Show Gmail unread badge"
+                  description="Show the unread count on the Gmail tab. When another tab is active hides it while Gmail is in front, where the inbox already shows it. Accounts that need attention are still flagged whichever you pick."
+                  configKey="verticalTabs.gmailUnreadBadge"
                   licenseKeyRequired
+                  items={Object.entries(verticalTabsGmailUnreadBadges).map(([value, label]) => ({
+                    value,
+                    label,
+                  }))}
                 />
                 <ConfigSwitchField
                   label="Show app links badge"

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -138,7 +138,7 @@ export function createDefaultConfig({
     "verticalTabs.showWindows": true,
     "verticalTabs.width": "auto",
     "verticalTabs.showWidthToggle": true,
-    "verticalTabs.hideUnreadBadgeWhenActive": false,
+    "verticalTabs.gmailUnreadBadge": "always",
     "verticalTabs.showAppLinksBadge": true,
     "extensions.enabled": false,
     "extensions.installed": [],

--- a/packages/shared/tabs.test.ts
+++ b/packages/shared/tabs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getVisibleVerticalTabs } from "./tabs";
+import { getVisibleVerticalTabs, showsGmailUnreadCount } from "./tabs";
 
 type VerticalTab = { id: string; dormant: boolean; pinned: boolean; windowed: boolean };
 
@@ -51,5 +51,22 @@ describe("getVisibleVerticalTabs", () => {
     });
 
     expect(visibleTabs).toEqual(tabs);
+  });
+});
+
+describe("showsGmailUnreadCount", () => {
+  test("shows the count in always mode whichever tab is active", () => {
+    expect(showsGmailUnreadCount("always", true)).toBe(true);
+    expect(showsGmailUnreadCount("always", false)).toBe(true);
+  });
+
+  test("hides the count in whenInactive mode only while the Gmail tab is active", () => {
+    expect(showsGmailUnreadCount("whenInactive", true)).toBe(false);
+    expect(showsGmailUnreadCount("whenInactive", false)).toBe(true);
+  });
+
+  test("hides the count in never mode whichever tab is active", () => {
+    expect(showsGmailUnreadCount("never", true)).toBe(false);
+    expect(showsGmailUnreadCount("never", false)).toBe(false);
   });
 });

--- a/packages/shared/tabs.ts
+++ b/packages/shared/tabs.ts
@@ -23,6 +23,25 @@ export type VerticalTabsWidth = keyof typeof verticalTabsWidths;
  */
 export type VerticalTabsSessionWidth = Exclude<VerticalTabsWidth, "auto">;
 
+export const verticalTabsGmailUnreadBadges = {
+  always: "Always",
+  whenInactive: "When another tab is active",
+  never: "Never",
+} as const;
+
+export type VerticalTabsGmailUnreadBadge = keyof typeof verticalTabsGmailUnreadBadges;
+
+export function showsGmailUnreadCount(
+  mode: VerticalTabsGmailUnreadBadge,
+  gmailTabActive: boolean,
+): boolean {
+  if (mode === "never") {
+    return false;
+  }
+
+  return !(mode === "whenInactive" && gmailTabActive);
+}
+
 export type TabState = {
   id: string;
   app: SupportedWorkspaceApp | undefined;

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -11,7 +11,12 @@ import type {
   GmailLabelColors,
   GmailSavedSearches,
 } from "./schemas";
-import type { AccountTabsState, VerticalTabsSessionWidth, VerticalTabsWidth } from "./tabs";
+import type {
+  AccountTabsState,
+  VerticalTabsGmailUnreadBadge,
+  VerticalTabsSessionWidth,
+  VerticalTabsWidth,
+} from "./tabs";
 import type { VerificationCodeCopyMode } from "./verification-codes";
 import type {
   LauncherAndBookmarksPlacement,
@@ -179,7 +184,7 @@ export type Config = {
   "verticalTabs.showWindows": boolean;
   "verticalTabs.width": VerticalTabsWidth;
   "verticalTabs.showWidthToggle": boolean;
-  "verticalTabs.hideUnreadBadgeWhenActive": boolean;
+  "verticalTabs.gmailUnreadBadge": VerticalTabsGmailUnreadBadge;
   "verticalTabs.showAppLinksBadge": boolean;
   "extensions.enabled": boolean;
   "extensions.installed": string[];


### PR DESCRIPTION
## Summary
Settings → Workspace apps → Vertical tabs had a switch, Hide Gmail unread badge when active, with one way to hide the count. It is now a select, Show Gmail unread badge, with Always, When another tab is active and Never, so the count can be kept off the Gmail tab altogether. The stored boolean migrates onto the matching choice.

## Problem
Some users want no unread count on the Gmail tab at all. The only ways were turning off `accounts.unreadBadge`, which also empties the titlebar switcher, or living with the count. A boolean cannot hold a third state, so the setting had to change shape.

## Solution
- **`verticalTabs.gmailUnreadBadge`** replaces `verticalTabs.hideUnreadBadgeWhenActive`, a string union declared as an `as const` label map in `@meru/shared/tabs` like `verticalTabsWidths`, default `always`.
- **`showsGmailUnreadCount(mode, gmailTabActive)`** is a pure helper in the same file with unit tests, and the sidebar reads it instead of inlining the rule. `accounts.unreadBadge` still gates the count everywhere and is untouched.
- **Migration** appended to the unshipped `>=3.60.1` block: reads the old key behind a `typeof === "boolean"` guard, maps `true` to `whenInactive` and `false` to `always`, and deletes the old key. Nothing branches on a value equal to a default, and an empty store reads `undefined` and skips it.
- **Settings** swap `ConfigSwitchField` for `ConfigSelectField`, still Pro-gated.

## Try it
`bun run dev`, open Settings → Workspace apps → Vertical tabs and pick Never: the count leaves the Gmail tab whichever tab is active, while an account needing attention is still flagged. `bun test packages/shared/tabs.test.ts` covers the three modes. The migration cannot be run outside Electron; a profile with `"verticalTabs.hideUnreadBadgeWhenActive": true` in its config should come up with When another tab is active selected.